### PR TITLE
feat(intake): build universal source-intake foundation

### DIFF
--- a/00_docs/FILE_MAP.md
+++ b/00_docs/FILE_MAP.md
@@ -65,6 +65,9 @@ Loose exports outside the canonical full export folder are not part of the worki
 | File | Purpose |
 | ---- | ------- |
 | `06_scripts/baseline_check.py` | Rebuild the durable baseline validation artifact package |
+| `06_scripts/coinbase_normalize.py` | Convert Coinbase raw CSV and statement-PDF evidence into CoinTracking-schema normalized transaction and balance files |
+| `06_scripts/coinbase_check.py` | Validate CoinTracking Coinbase rows against normalized Coinbase evidence and optional balance rows |
+| `06_scripts/pdf_balance_extract.py` | Extract deterministic balance rows from supported statement PDFs such as Coinbase Binance and Shakepay |
 | `06_scripts/source_manifest.py` | Hash raw external evidence folders into deterministic manifests |
 | `06_scripts/overlap_check.py` | Screen CoinTracking-ready import batches for cutoff overlap and baseline duplicates |
 | `06_scripts/round_scaffold.py` | Create a round folder and seed the round log |

--- a/00_docs/FILE_MAP.md
+++ b/00_docs/FILE_MAP.md
@@ -65,6 +65,10 @@ Loose exports outside the canonical full export folder are not part of the worki
 | File | Purpose |
 | ---- | ------- |
 | `06_scripts/baseline_check.py` | Rebuild the durable baseline validation artifact package |
+| `06_scripts/profile_source.py` | Profile raw source folders into file-family inventory and manifest-backed adapter metadata |
+| `06_scripts/normalize_source.py` | Normalize raw evidence into canonical events, canonical balances, exceptions, and cached CoinTracking candidates |
+| `06_scripts/render_cointracking.py` | Render canonical events into CoinTracking CSV output with reconciliation metadata |
+| `06_scripts/reconcile_source.py` | Compare canonical source outputs against CoinTracking ledger slices and optional balance evidence |
 | `06_scripts/coinbase_normalize.py` | Convert Coinbase raw CSV and statement-PDF evidence into CoinTracking-schema normalized transaction and balance files |
 | `06_scripts/coinbase_check.py` | Validate CoinTracking Coinbase rows against normalized Coinbase evidence and optional balance rows |
 | `06_scripts/pdf_balance_extract.py` | Extract deterministic balance rows from supported statement PDFs such as Coinbase Binance and Shakepay |
@@ -72,3 +76,11 @@ Loose exports outside the canonical full export folder are not part of the worki
 | `06_scripts/overlap_check.py` | Screen CoinTracking-ready import batches for cutoff overlap and baseline duplicates |
 | `06_scripts/round_scaffold.py` | Create a round folder and seed the round log |
 | `06_scripts/verification_compare.py` | Compare two verification folders and write deterministic drift artifacts |
+
+## Repo-local skills
+
+| Path | Purpose |
+| ---- | ------- |
+| `07_skills/source-intake/` | Deterministic raw-source intake, profiling, and queue-state guidance |
+| `07_skills/normalization-exceptions/` | Exception-only AI workflow for unresolved normalization rows and adapter repair loops |
+| `07_skills/round-verification/` | Exact post-import and post-repair verification, issue logging, and gate handling |

--- a/00_docs/FILE_MAP.md
+++ b/00_docs/FILE_MAP.md
@@ -68,6 +68,7 @@ Loose exports outside the canonical full export folder are not part of the worki
 | `06_scripts/profile_source.py` | Profile raw source folders into file-family inventory and manifest-backed adapter metadata |
 | `06_scripts/normalize_source.py` | Normalize raw evidence into canonical events, canonical balances, exceptions, and cached CoinTracking candidates |
 | `06_scripts/render_cointracking.py` | Render canonical events into CoinTracking CSV output with reconciliation metadata |
+| `06_scripts/stage_import_batch.py` | Move only overlap-cleared candidates into the reviewed import-batch workflow |
 | `06_scripts/reconcile_source.py` | Compare canonical source outputs against CoinTracking ledger slices and optional balance evidence |
 | `06_scripts/coinbase_normalize.py` | Convert Coinbase raw CSV and statement-PDF evidence into CoinTracking-schema normalized transaction and balance files |
 | `06_scripts/coinbase_check.py` | Validate CoinTracking Coinbase rows against normalized Coinbase evidence and optional balance rows |

--- a/00_docs/MOP.md
+++ b/00_docs/MOP.md
@@ -38,7 +38,7 @@ This repo is the evidence, staging, and verification workspace for that process.
 
 ### Working area
 
-- `02_working/normalized/` → cleaned source files, overlap-trimmed, not yet approved
+- `02_working/normalized/` → profiled raw sources, canonical outputs, exception sets, and rendered working candidates
 - `02_working/import_batches/` → reviewed import candidates for the next CoinTracking step
 - `02_working/verification/<round_id>/` → fresh CoinTracking exports captured after a repair or import round
 
@@ -235,16 +235,17 @@ AI tasks not allowed:
 
 Do:
 
-1. Trim overlap against the baseline when a source export starts too early.
-2. Normalize fields as needed for CoinTracking import.
-3. Run `06_scripts/overlap_check.py` against the CoinTracking-ready candidate file and hold the batch if overlap is flagged.
-4. Save the working candidate to `02_working/import_batches/<source>/`.
-5. Copy the approved file to `04_import_ready/`.
+1. Run `06_scripts/profile_source.py` to fingerprint the raw source and classify file families.
+2. Run `06_scripts/normalize_source.py` to produce canonical events, canonical balances, exceptions, and a rendered working candidate under `02_working/normalized/<source>/`.
+3. Review `exceptions.csv`; unresolved exceptions stay out of the import path unless they are explicitly accepted and persisted.
+4. Run `06_scripts/stage_import_batch.py` to enforce overlap screening before a candidate enters `02_working/import_batches/<source>/`.
+5. Copy the approved staged file to `04_import_ready/`.
 
 Gate:
 
 - import file reviewed
 - overlap screened
+- normalized candidate not confused with an approved import batch
 - source inventory row updated to ready-for-import
 
 ## Phase 6 — Controlled CoinTracking import

--- a/00_docs/NEXT_PHASE_EXECUTION_PLAN.md
+++ b/00_docs/NEXT_PHASE_EXECUTION_PLAN.md
@@ -38,7 +38,7 @@ The project still follows the canonical cutoff:
 These items stay in view while imports proceed:
 
 - `SRC-003`: Coinbase import signoff requires confirming whether the Coinbase export already covers Coinbase Pro history.
-- `SRC-002`: Binance prep requires documenting the residual `0.00001148` `WBETH` position and treating daily staking position snapshots as evidence only.
+- `BAL-001`: Binance prep requires documenting the residual `0.00001148` `WBETH` position and treating daily staking position snapshots as evidence only.
 - `SRC-004`: Review Coinberry backups when the SSD enclosure is available. This is evidence follow-up, not an immediate import blocker.
 - `SRC-005`: Review Kucoin backups when available. This is evidence follow-up unless a missing ledger segment appears.
 

--- a/00_docs/OPERATIONS_QUICKSTART.md
+++ b/00_docs/OPERATIONS_QUICKSTART.md
@@ -86,19 +86,37 @@ Default rule:
 2. Confirm the source export window begins strictly after `2023-08-05 08:34:04`.
 3. Pull the raw export into `01_raw_exports/external/<source>/raw/`.
 4. Run `source_manifest.py`.
-5. Prepare the working import file in `02_working/import_batches/<source>/`.
-6. Screen the approved CoinTracking-ready candidate before import:
+5. Profile the raw source into `02_working/normalized/<source>/`:
 
    ```bash
-   python3 06_scripts/overlap_check.py \
-     --baseline-export-dir 01_raw_exports/cointracking/2023-08-05_full_export \
-     --candidate 02_working/import_batches/<source>/<candidate_file>.csv \
-     --out-dir 02_working/import_batches/<source>/overlap_check
+   python3 06_scripts/profile_source.py \
+     --source "<Source Name>" \
+     --raw-dir 01_raw_exports/external/<source>/raw \
+     --out-dir 02_working/normalized/<source>
    ```
 
-   Hold the batch if `overlap_summary.json` does not return `status: "pass"`.
-7. Copy the approved import file to `04_import_ready/`.
-8. Seed the round:
+6. Normalize the source into canonical outputs and a rendered candidate:
+
+   ```bash
+   python3 06_scripts/normalize_source.py \
+     --source "<Source Name>" \
+     --raw-dir 01_raw_exports/external/<source>/raw \
+     --out-dir 02_working/normalized/<source> \
+     --profile-json 02_working/normalized/<source>/profile.json
+   ```
+
+7. Stage the candidate into `02_working/import_batches/<source>/` only after overlap screening passes:
+
+   ```bash
+   python3 06_scripts/stage_import_batch.py \
+     --candidate 02_working/normalized/<source>/cointracking_candidate.csv \
+     --baseline-export-dir 01_raw_exports/cointracking/2023-08-05_full_export \
+     --out-dir 02_working/import_batches/<source>
+   ```
+
+   Hold the batch if `stage_summary.json` reports `status: "blocked"`.
+8. Copy or stage the approved file to `04_import_ready/` only after review.
+9. Seed the round:
 
    ```bash
    python3 06_scripts/round_scaffold.py \
@@ -107,10 +125,10 @@ Default rule:
      --source <source>
    ```
 
-9. Import exactly one source into CoinTracking manually.
-10. Export only the default verification set, with `Missing Transactions` using strict settings: `100%` amount accuracy, only `100%` matches hidden, time accuracy `-24h | +48h`.
-11. Save the exports into `02_working/verification/<round_id>/`.
-12. Compare the fresh exports against the prior state:
+10. Import exactly one source into CoinTracking manually.
+11. Export only the default verification set, with `Missing Transactions` using strict settings: `100%` amount accuracy, only `100%` matches hidden, time accuracy `-24h | +48h`.
+12. Save the exports into `02_working/verification/<round_id>/`.
+13. Compare the fresh exports against the prior state:
 
    ```bash
    python3 06_scripts/verification_compare.py \
@@ -122,8 +140,9 @@ Default rule:
 Then:
 
 1. Ask AI to review the comparison artifacts, classify any new exceptions, and confirm the balance movements match the source.
-2. Update `03_analysis/issues/source_inventory.csv`, `03_analysis/issues/issue_log.csv`, and `05_outputs/logs/round_log.csv`.
-3. If the source touches CAD or fiat rails, review the CAD rows in `Current Balance` and `Balance by Exchange` before closing the round.
+2. If canonical source artifacts exist, run `06_scripts/reconcile_source.py` against the relevant CoinTracking ledger slice or reference ledger slice.
+3. Update `03_analysis/issues/source_inventory.csv`, `03_analysis/issues/issue_log.csv`, and `05_outputs/logs/round_log.csv`.
+4. If the source touches CAD or fiat rails, review the CAD rows in `Current Balance` and `Balance by Exchange` before closing the round.
 
 ## When to escalate to heavier reports
 

--- a/00_docs/PROJECT_STATE.md
+++ b/00_docs/PROJECT_STATE.md
@@ -32,6 +32,15 @@
 - CAD deposits and withdrawals recorded in the ledger net to zero; the user manually verified that this is an intentional general CAD tracking account inside CoinTracking rather than an omitted exchange-side fiat ledger leg.
 - The durable validation summary is in `00_docs/BASELINE_VALIDATION.md`.
 
+## Universal intake capability status
+
+- As of **2026-03-24**, deterministic universal normalization is ready for `coinbase`, `wealthsimple`, `binance`, `shakepay`, `ledger_live`, `crypto_com`, `near`, and the shared `evm_explorer` adapter on the current BSC and primary Ethereum transfer and token scopes.
+- The shared `ledger_live` adapter now covers both the legacy CoinTracking labels `ADA Ledger` and `Ledger Live`, so those sources no longer need separate wallet-specific prep logic.
+- The shared `evm_explorer` adapter now covers the legacy CoinTracking labels `BSC MetaMask Wallet` and `ETH MetaMask Wallet` without wallet-app-specific logic; the underlying chain and explorer evidence now drive the mapping.
+- The newly added Polygon token and internal-tx files closed the prior Exact Input gap, but `MetaMask - Polygon` still remains `needs_review`: the current raw set now reaches **2023-12-22 01:51:13** and includes five suspicious post-cutoff NFT airdrops that are intentionally held in `exceptions.csv` instead of being auto-imported as deposits.
+- `ETH GalaGames Wallet` now also remains `needs_review`: the current raw set reaches **2025-03-24 22:55:59** and includes three suspicious post-cutoff ERC-1155 NFT rows that are intentionally held in `exceptions.csv` instead of being auto-imported as deposits.
+- `GTrade 1CT` remains `needs_review`: the current **2023-05-06** report is sufficient for deterministic realized PnL rows, but three open-position rows still lack the explorer or fill-level evidence needed for a CoinTracking-safe reconstruction.
+
 ## Open exception set
 
 - `FIAT-001` is closed as a manually verified intentional general CAD tracking account unless conflicting data appears later

--- a/02_working/normalized/README.md
+++ b/02_working/normalized/README.md
@@ -1,5 +1,17 @@
 # Normalized Files
 
-Place cleaned source exports here after overlap checks and field normalization.
+Place deterministic normalized source artifacts here after profiling and field normalization.
 
 Do not treat files here as raw evidence. The raw source must remain in `01_raw_exports/external/`.
+
+Per-source folders should prefer the universal pipeline artifact set:
+
+- `profile.json`
+- `profile_inventory.csv`
+- `canonical_events.csv`
+- `canonical_balances.csv`
+- `exceptions.csv`
+- `cointracking_candidate.csv`
+- `normalization_summary.json`
+
+Keep legacy source-specific artifacts only while they are still serving as parity fixtures during migration.

--- a/02_working/normalized/README.md
+++ b/02_working/normalized/README.md
@@ -14,4 +14,7 @@ Per-source folders should prefer the universal pipeline artifact set:
 - `cointracking_candidate.csv`
 - `normalization_summary.json`
 
+`cointracking_candidate.csv` is a rendered working candidate, not an approved import batch.
+Only `02_working/import_batches/` and `04_import_ready/` should hold files that have passed overlap screening and are approved for import.
+
 Keep legacy source-specific artifacts only while they are still serving as parity fixtures during migration.

--- a/06_scripts/README.md
+++ b/06_scripts/README.md
@@ -8,6 +8,7 @@ Current helpers:
 - `profile_source.py` → inspect a raw source folder, classify file families, and write `profile.json` plus `profile_inventory.csv`
 - `normalize_source.py` → convert a raw source folder into canonical events, canonical balances, exceptions, and a cached CoinTracking candidate
 - `render_cointracking.py` → translate canonical events into a CoinTracking-ready CSV with reconciliation metadata
+- `stage_import_batch.py` → enforce overlap-screen approval before copying a candidate into `02_working/import_batches/` and optional `04_import_ready/`
 - `reconcile_source.py` → compare canonical source outputs against a CoinTracking Trade Table slice and optional Balance by Exchange slice
 - `coinbase_normalize.py` → normalize Coinbase retail and Coinbase Pro raw exports into CoinTracking-schema transaction rows plus Coinbase PDF balance rows
 - `coinbase_check.py` → compare CoinTracking Coinbase rows against normalized Coinbase exports and optional balance evidence
@@ -27,7 +28,7 @@ The preferred prep flow is now:
 2. `profile_source.py`
 3. `normalize_source.py`
 4. `render_cointracking.py` only when a separate render step is needed
-5. `overlap_check.py`
+5. `stage_import_batch.py`
 6. `reconcile_source.py`
 
 `coinbase_normalize.py` and `coinbase_check.py` remain as Coinbase-specific reference tooling while the universal pipeline reaches parity.

--- a/06_scripts/README.md
+++ b/06_scripts/README.md
@@ -27,8 +27,16 @@ Current deterministic universal adapters:
 - `coinbase` → ready on the current repo exports
 - `wealthsimple` → ready for the crypto `activities-export` workflow
 - `binance` → ready for the main spot / funding / fiat / reward paths and intentionally leaves a compact `exceptions.csv` review set for ambiguous legacy rows instead of guessing
+- `shakepay` → ready on the captured cash, crypto, and performance-report exports
+- `ledger_live` → ready on the captured Ledger Live operations exports, including grouped swap handling and delegation de-duplication
+- `crypto_com` → ready on the captured cash and crypto transaction exports
+- `near` → ready on the current NEAR transaction/token/NFT export set
+- `evm_explorer` → explorer-family adapter for EVM CSV exports; ready for the BSC and primary Ethereum transfer/token scopes, and intentionally leaves suspicious standalone NFT airdrops in `exceptions.csv` instead of auto-importing them as deposits
+- `gtrade` → report-level adapter for realized PnL rows and intentionally leaves open-position rows in `exceptions.csv` until companion explorer evidence exists
 
 The intake pipeline is intentionally not a blind importer. `normalize_source.py` can produce a CoinTracking candidate, but that candidate is still a staging artifact. Internal wallet shuffles, unsupported rows, and ambiguous groups must stay visible through `exceptions.csv`, `issue_log.csv`, and the round-verification workflow rather than being auto-reconciled by the script layer.
+
+The explorer adapter is now keyed to the export system and chain scope rather than a wallet-app label. A legacy wallet-app export dump is treated as EVM explorer evidence; the adapter only promotes rows that can be justified from the underlying explorer CSV families and leaves missing-evidence gaps visible instead of guessing.
 
 The preferred prep flow is now:
 

--- a/06_scripts/README.md
+++ b/06_scripts/README.md
@@ -22,6 +22,14 @@ Current helpers:
 
 All scripts use only the Python standard library.
 
+Current deterministic universal adapters:
+
+- `coinbase` → ready on the current repo exports
+- `wealthsimple` → ready for the crypto `activities-export` workflow
+- `binance` → ready for the main spot / funding / fiat / reward paths and intentionally leaves a compact `exceptions.csv` review set for ambiguous legacy rows instead of guessing
+
+The intake pipeline is intentionally not a blind importer. `normalize_source.py` can produce a CoinTracking candidate, but that candidate is still a staging artifact. Internal wallet shuffles, unsupported rows, and ambiguous groups must stay visible through `exceptions.csv`, `issue_log.csv`, and the round-verification workflow rather than being auto-reconciled by the script layer.
+
 The preferred prep flow is now:
 
 1. `source_manifest.py`
@@ -31,7 +39,7 @@ The preferred prep flow is now:
 5. `stage_import_batch.py`
 6. `reconcile_source.py`
 
-`coinbase_normalize.py` and `coinbase_check.py` remain as Coinbase-specific reference tooling while the universal pipeline reaches parity.
+`coinbase_normalize.py` and `coinbase_check.py` remain as Coinbase-specific reference tooling while the universal pipeline reaches parity on the remaining sources.
 
 ## Tests
 

--- a/06_scripts/README.md
+++ b/06_scripts/README.md
@@ -5,6 +5,10 @@ Use this folder for small helpers that reduce manual work without hiding logic.
 Current helpers:
 
 - `baseline_check.py` → derive the baseline cutoff, counts, negative balances, and reconciliation artifacts
+- `profile_source.py` → inspect a raw source folder, classify file families, and write `profile.json` plus `profile_inventory.csv`
+- `normalize_source.py` → convert a raw source folder into canonical events, canonical balances, exceptions, and a cached CoinTracking candidate
+- `render_cointracking.py` → translate canonical events into a CoinTracking-ready CSV with reconciliation metadata
+- `reconcile_source.py` → compare canonical source outputs against a CoinTracking Trade Table slice and optional Balance by Exchange slice
 - `coinbase_normalize.py` → normalize Coinbase retail and Coinbase Pro raw exports into CoinTracking-schema transaction rows plus Coinbase PDF balance rows
 - `coinbase_check.py` → compare CoinTracking Coinbase rows against normalized Coinbase exports and optional balance evidence
 - `source_manifest.py` → build a deterministic manifest for a raw external source folder and refuse non-`raw/` inputs by default
@@ -13,8 +17,20 @@ Current helpers:
 - `round_scaffold.py` → create a verification round folder and seed the structured round log
 - `verification_compare.py` → compare two verification export folders and write deterministic drift artifacts
 - `script_common.py` → shared CSV, path-validation, and default verification-export helpers used by the scripts
+- `pipeline_common.py` / `source_adapters.py` → shared canonical schema and adapter registry for the universal intake pipeline
 
 All scripts use only the Python standard library.
+
+The preferred prep flow is now:
+
+1. `source_manifest.py`
+2. `profile_source.py`
+3. `normalize_source.py`
+4. `render_cointracking.py` only when a separate render step is needed
+5. `overlap_check.py`
+6. `reconcile_source.py`
+
+`coinbase_normalize.py` and `coinbase_check.py` remain as Coinbase-specific reference tooling while the universal pipeline reaches parity.
 
 ## Tests
 

--- a/06_scripts/README.md
+++ b/06_scripts/README.md
@@ -5,8 +5,11 @@ Use this folder for small helpers that reduce manual work without hiding logic.
 Current helpers:
 
 - `baseline_check.py` → derive the baseline cutoff, counts, negative balances, and reconciliation artifacts
+- `coinbase_normalize.py` → normalize Coinbase retail and Coinbase Pro raw exports into CoinTracking-schema transaction rows plus Coinbase PDF balance rows
+- `coinbase_check.py` → compare CoinTracking Coinbase rows against normalized Coinbase exports and optional balance evidence
 - `source_manifest.py` → build a deterministic manifest for a raw external source folder and refuse non-`raw/` inputs by default
 - `overlap_check.py` → screen a CoinTracking-ready import batch for cutoff overlap and baseline duplicate risk
+- `pdf_balance_extract.py` → extract deterministic balance rows from supported statement PDFs without guessing across unrelated PDFs
 - `round_scaffold.py` → create a verification round folder and seed the structured round log
 - `verification_compare.py` → compare two verification export folders and write deterministic drift artifacts
 - `script_common.py` → shared CSV, path-validation, and default verification-export helpers used by the scripts

--- a/06_scripts/coinbase_check.py
+++ b/06_scripts/coinbase_check.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+
+"""Check CoinTracking Coinbase rows against normalized Coinbase exports and optional PDF balances."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Sequence
+
+from coinbase_common import COINBASE_METADATA_HEADERS, COINTRACKING_TIME_FORMAT
+from script_common import (
+    decimal_or_zero,
+    decimal_text,
+    parse_datetime,
+    read_cointracking_rows,
+    read_csv_rows,
+    write_cointracking_rows,
+    write_csv_rows,
+    write_json,
+)
+
+
+@dataclass(frozen=True)
+class CandidateScore:
+    exact_type: int
+    exact_group: int
+    exact_comment: int
+    exact_tx_id: int
+    time_delta_seconds: int
+    fee_delta: Decimal
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cointracking-ledger", required=True, type=Path)
+    parser.add_argument("--normalized-transactions", required=True, type=Path)
+    parser.add_argument("--out-dir", required=True, type=Path)
+    parser.add_argument("--cointracking-balance-by-exchange", type=Path)
+    parser.add_argument("--normalized-balances", type=Path)
+    return parser.parse_args(argv)
+
+
+def ct_datetime(value: str) -> datetime:
+    return parse_datetime(value, (COINTRACKING_TIME_FORMAT,))
+
+
+def amount_key(row: dict[str, str], prefix: str) -> tuple[Decimal, str]:
+    if prefix == "buy":
+        return decimal_or_zero(row["Buy"]), row["Buy Cur."]
+    if prefix == "sell":
+        return decimal_or_zero(row["Sell"]), row["Sell Cur."]
+    if prefix == "fee":
+        return decimal_or_zero(row["Fee"]), row["Fee Cur."]
+    raise ValueError(prefix)
+
+
+def split_allowed_types(value: str) -> set[str]:
+    return {item for item in value.split("|") if item}
+
+
+def candidate_matches(expected: dict[str, str], actual: dict[str, str]) -> bool:
+    if actual["Exchange"] != expected["Exchange"]:
+        return False
+    if actual["Type"] not in split_allowed_types(expected["allowed_types"]):
+        return False
+    if amount_key(actual, "buy") != amount_key(expected, "buy"):
+        return False
+    if amount_key(actual, "sell") != amount_key(expected, "sell"):
+        return False
+    window = int(expected["match_window_seconds"])
+    if abs((ct_datetime(actual["Date"]) - ct_datetime(expected["Date"])).total_seconds()) > window:
+        return False
+    return True
+
+
+def candidate_score(expected: dict[str, str], actual: dict[str, str]) -> CandidateScore:
+    return CandidateScore(
+        exact_type=1 if actual["Type"] == expected["Type"] else 0,
+        exact_group=1 if actual["Group"] == expected["Group"] else 0,
+        exact_comment=1 if actual["Comment"] == expected["Comment"] else 0,
+        exact_tx_id=1 if expected["Tx-ID"] and actual["Tx-ID"] == expected["Tx-ID"] else 0,
+        time_delta_seconds=int(abs((ct_datetime(actual["Date"]) - ct_datetime(expected["Date"])).total_seconds())),
+        fee_delta=abs(decimal_or_zero(actual["Fee"]) - decimal_or_zero(expected["Fee"])),
+    )
+
+
+def compare_expected_to_actual(expected: dict[str, str], actual: dict[str, str]) -> list[str]:
+    issues: list[str] = []
+    fee_tolerance = decimal_or_zero(expected["fee_tolerance"])
+    if abs(decimal_or_zero(actual["Fee"]) - decimal_or_zero(expected["Fee"])) > fee_tolerance:
+        issues.append("fee_mismatch")
+    if expected["Group"] and actual["Group"] != expected["Group"]:
+        issues.append("group_mismatch")
+    if expected["comment_mode"] == "exact" and actual["Comment"] != expected["Comment"]:
+        issues.append("comment_mismatch")
+    if expected["tx_id_mode"] == "exact" and actual["Tx-ID"] != expected["Tx-ID"]:
+        issues.append("tx_id_mismatch")
+    return issues
+
+
+def compare_transactions(
+    actual_rows: list[dict[str, str]],
+    expected_rows: list[dict[str, str]],
+) -> dict[str, list[dict[str, str]]]:
+    unmatched_actual = set(range(len(actual_rows)))
+    matched_rows: list[dict[str, str]] = []
+    mismatched_rows: list[dict[str, str]] = []
+    missing_rows: list[dict[str, str]] = []
+    ambiguous_rows: list[dict[str, str]] = []
+
+    for expected in expected_rows:
+        candidates = [index for index in unmatched_actual if candidate_matches(expected, actual_rows[index])]
+        if not candidates:
+            missing_rows.append(expected)
+            continue
+
+        ranked = sorted(
+            candidates,
+            key=lambda index: (
+                -candidate_score(expected, actual_rows[index]).exact_type,
+                -candidate_score(expected, actual_rows[index]).exact_group,
+                -candidate_score(expected, actual_rows[index]).exact_comment,
+                -candidate_score(expected, actual_rows[index]).exact_tx_id,
+                candidate_score(expected, actual_rows[index]).time_delta_seconds,
+                candidate_score(expected, actual_rows[index]).fee_delta,
+            ),
+        )
+        best_index = ranked[0]
+        best_score = candidate_score(expected, actual_rows[best_index])
+        tied = [
+            index
+            for index in ranked[1:]
+            if candidate_score(expected, actual_rows[index]) == best_score
+        ]
+        if tied:
+            ambiguous_rows.append(
+                {
+                    **expected,
+                    "candidate_tx_ids": "|".join(actual_rows[index]["Tx-ID"] for index in [best_index, *tied]),
+                }
+            )
+            continue
+
+        actual = actual_rows[best_index]
+        issues = compare_expected_to_actual(expected, actual)
+        combined = {
+            **expected,
+            "actual_type": actual["Type"],
+            "actual_buy": actual["Buy"],
+            "actual_buy_currency": actual["Buy Cur."],
+            "actual_sell": actual["Sell"],
+            "actual_sell_currency": actual["Sell Cur."],
+            "actual_fee": actual["Fee"],
+            "actual_fee_currency": actual["Fee Cur."],
+            "actual_group": actual["Group"],
+            "actual_comment": actual["Comment"],
+            "actual_date": actual["Date"],
+            "actual_tx_id": actual["Tx-ID"],
+            "comparison_issues": "|".join(issues),
+        }
+        if issues:
+            mismatched_rows.append(combined)
+        else:
+            matched_rows.append(combined)
+        unmatched_actual.remove(best_index)
+
+    extra_rows = [actual_rows[index] for index in sorted(unmatched_actual)]
+    return {
+        "matched": matched_rows,
+        "mismatched": mismatched_rows,
+        "missing": missing_rows,
+        "extra": extra_rows,
+        "ambiguous": ambiguous_rows,
+    }
+
+
+def compare_balances(
+    cointracking_balance_rows: list[dict[str, str]],
+    normalized_balance_rows: list[dict[str, str]],
+) -> list[dict[str, str]]:
+    tolerance = Decimal("0.00000001")
+    actual = {
+        row["Currency"]: decimal_or_zero(row["Amount"])
+        for row in cointracking_balance_rows
+        if row.get("Exchange") == "Coinbase"
+    }
+    expected = {
+        row["asset"]: decimal_or_zero(row["quantity"])
+        for row in normalized_balance_rows
+        if row.get("source") == "Coinbase" and row.get("balance_kind") in {"asset_balance", "cash_closing_balance"}
+    }
+    rows = []
+    for asset in sorted(set(actual) | set(expected)):
+        actual_amount = actual.get(asset, Decimal("0"))
+        expected_amount = expected.get(asset, Decimal("0"))
+        difference = actual_amount - expected_amount
+        rows.append(
+            {
+                "asset": asset,
+                "expected_amount": decimal_text(expected_amount),
+                "cointracking_amount": decimal_text(actual_amount),
+                "difference": decimal_text(difference),
+                "status": "match" if abs(difference) <= tolerance else "delta",
+            }
+        )
+    return rows
+
+
+def check_coinbase(
+    cointracking_ledger: Path,
+    normalized_transactions: Path,
+    *,
+    out_dir: Path,
+    cointracking_balance_by_exchange: Path | None = None,
+    normalized_balances: Path | None = None,
+) -> dict[str, object]:
+    actual_rows = [
+        row
+        for row in read_cointracking_rows(cointracking_ledger)
+        if row["Exchange"] in {"Coinbase", "Coinbase Pro"}
+    ]
+    expected_rows = read_cointracking_rows(normalized_transactions, extra_headers=COINBASE_METADATA_HEADERS)
+    transaction_results = compare_transactions(actual_rows, expected_rows)
+
+    write_cointracking_rows(out_dir / "matched_rows.csv", transaction_results["matched"], extra_headers=(
+        "actual_type",
+        "actual_buy",
+        "actual_buy_currency",
+        "actual_sell",
+        "actual_sell_currency",
+        "actual_fee",
+        "actual_fee_currency",
+        "actual_group",
+        "actual_comment",
+        "actual_date",
+        "actual_tx_id",
+        "comparison_issues",
+        *COINBASE_METADATA_HEADERS,
+    ))
+    write_cointracking_rows(out_dir / "missing_rows.csv", transaction_results["missing"], extra_headers=COINBASE_METADATA_HEADERS)
+    write_cointracking_rows(out_dir / "extra_rows.csv", transaction_results["extra"])
+    write_cointracking_rows(
+        out_dir / "mismatched_rows.csv",
+        transaction_results["mismatched"],
+        extra_headers=(
+            "actual_type",
+            "actual_buy",
+            "actual_buy_currency",
+            "actual_sell",
+            "actual_sell_currency",
+            "actual_fee",
+            "actual_fee_currency",
+            "actual_group",
+            "actual_comment",
+            "actual_date",
+            "actual_tx_id",
+            "comparison_issues",
+            *COINBASE_METADATA_HEADERS,
+        ),
+    )
+    write_cointracking_rows(out_dir / "ambiguous_rows.csv", transaction_results["ambiguous"], extra_headers=("candidate_tx_ids", *COINBASE_METADATA_HEADERS))
+
+    balance_rows: list[dict[str, str]] = []
+    if cointracking_balance_by_exchange is not None and normalized_balances is not None:
+        balance_rows = compare_balances(
+            read_csv_rows(cointracking_balance_by_exchange),
+            read_csv_rows(normalized_balances),
+        )
+        write_csv_rows(
+            out_dir / "balance_deltas.csv",
+            ["asset", "expected_amount", "cointracking_amount", "difference", "status"],
+            balance_rows,
+        )
+
+    summary = {
+        "ledger_rows": len(actual_rows),
+        "expected_rows": len(expected_rows),
+        "matched_rows": len(transaction_results["matched"]),
+        "mismatched_rows": len(transaction_results["mismatched"]),
+        "missing_rows": len(transaction_results["missing"]),
+        "extra_rows": len(transaction_results["extra"]),
+        "ambiguous_rows": len(transaction_results["ambiguous"]),
+        "mismatch_issue_counts": dict(
+            Counter(
+                issue
+                for row in transaction_results["mismatched"]
+                for issue in row["comparison_issues"].split("|")
+                if issue
+            )
+        ),
+        "balance_delta_rows": len([row for row in balance_rows if row["status"] == "delta"]),
+        "status": "passed"
+        if not any(
+            (
+                transaction_results["mismatched"],
+                transaction_results["missing"],
+                transaction_results["extra"],
+                transaction_results["ambiguous"],
+                [row for row in balance_rows if row["status"] == "delta"],
+            )
+        )
+        else "failed",
+    }
+    write_json(out_dir / "summary.json", summary)
+    return summary
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    summary = check_coinbase(
+        args.cointracking_ledger,
+        args.normalized_transactions,
+        out_dir=args.out_dir,
+        cointracking_balance_by_exchange=args.cointracking_balance_by_exchange,
+        normalized_balances=args.normalized_balances,
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/06_scripts/coinbase_common.py
+++ b/06_scripts/coinbase_common.py
@@ -1,0 +1,583 @@
+#!/usr/bin/env python3
+
+"""Coinbase raw-export normalization and statement-balance helpers."""
+
+from __future__ import annotations
+
+import csv
+import re
+from collections import defaultdict
+from datetime import datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Iterable
+
+from script_common import (
+    COINTRACKING_HEADERS,
+    decimal_text,
+    normalize_whitespace,
+    parse_datetime,
+    parse_decimal,
+    require_file,
+)
+
+
+COINTRACKING_TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+COINBASE_RETAIL_TIME_FORMAT = "%Y-%m-%d %H:%M:%S UTC"
+COINBASE_PRO_TIME_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+COINBASE_METADATA_HEADERS = (
+    "match_window_seconds",
+    "fee_tolerance",
+    "comment_mode",
+    "tx_id_mode",
+    "allowed_types",
+    "raw_source",
+    "raw_ref",
+    "notes",
+)
+
+COINBASE_NORMALIZED_HEADERS = (*COINTRACKING_HEADERS, *COINBASE_METADATA_HEADERS)
+
+BALANCE_HEADERS = (
+    "source",
+    "account",
+    "wallet",
+    "balance_kind",
+    "asset",
+    "quantity",
+    "staked_quantity",
+    "value_amount",
+    "value_currency",
+    "price_amount",
+    "price_currency",
+    "as_of",
+    "pdf_file",
+    "notes",
+)
+
+CONVERT_NOTES_PATTERN = re.compile(
+    r"^Converted (?P<sell_qty>[0-9.]+) (?P<sell_asset>[A-Z0-9]+) to (?P<buy_qty>[0-9.]+) (?P<buy_asset>[A-Z0-9]+)$"
+)
+BUY_NOTES_PATTERN = re.compile(
+    r"^Bought (?P<buy_qty>[0-9.]+) (?P<asset>[A-Z0-9]+) for (?P<total>[0-9.]+) (?P<currency>[A-Z]{3})"
+)
+PORTFOLIO_ROW_PATTERN = re.compile(
+    r"(?P<asset>[A-Z0-9]+)\s+"
+    r"(?P<quantity>[0-9.]+)\s+"
+    r"(?P<staked>N/A|[0-9.]+)\s+"
+    r"(?P<price>[0-9.,]+)\s+CAD/(?P=asset)\s+"
+    r"(?P<value>[0-9.]+)\s+CAD"
+)
+PORTFOLIO_ROW_FALLBACK_PATTERN = re.compile(
+    r"(?P<quantity>[0-9.]+)\s+"
+    r"(?P<staked>N/A|[0-9.]+)\s+"
+    r"(?P<price>[0-9.,]+)\s+CAD/(?P<asset>[A-Z0-9]+)\s+"
+    r"(?P<value>[0-9.]+)\s+CAD"
+)
+COINBASE_CLOSING_CASH_PATTERN = re.compile(
+    r"Closing Balance\s+(?P<balance>[0-9.,]+)\s+(?P<currency>[A-Z]{3})\s+as of (?P<as_of>[0-9:-]+\s+[0-9:]+\s+UTC)"
+)
+COINBASE_PORTFOLIO_AS_OF_PATTERN = re.compile(
+    r"Portfolio summary balances are as of (?P<as_of>[0-9:-]+\s+[0-9:]+\s+UTC)"
+)
+
+
+def compact_decimal_text(value: Decimal) -> str:
+    text = format(value.normalize(), "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    return text or "0"
+
+
+def ct_date_text(value: datetime) -> str:
+    return value.strftime(COINTRACKING_TIME_FORMAT)
+
+
+def parse_coinbase_retail_timestamp(value: str) -> datetime:
+    return parse_datetime(value, (COINBASE_RETAIL_TIME_FORMAT,))
+
+
+def parse_coinbase_pro_timestamp(value: str) -> datetime:
+    return parse_datetime(value, (COINBASE_PRO_TIME_FORMAT,))
+
+
+def format_amount(value: Decimal | None) -> str:
+    if value is None:
+        return ""
+    return decimal_text(value)
+
+
+def retail_csv_rows(path: Path) -> list[dict[str, str]]:
+    path = require_file(path.resolve(), "Coinbase retail CSV")
+    with path.open(newline="", encoding="utf-8-sig") as handle:
+        rows = list(csv.reader(handle))
+    header_index = next(
+        (index for index, row in enumerate(rows) if row[:3] == ["ID", "Timestamp", "Transaction Type"]),
+        None,
+    )
+    if header_index is None:
+        raise ValueError(f"Coinbase retail CSV header not found in {path}")
+    header = rows[header_index]
+    return [
+        dict(zip(header, row))
+        for row in rows[header_index + 1 :]
+        if any(cell.strip() for cell in row)
+    ]
+
+
+def csv_dict_rows(path: Path, label: str) -> list[dict[str, str]]:
+    path = require_file(path.resolve(), label)
+    with path.open(newline="", encoding="utf-8-sig") as handle:
+        return list(csv.DictReader(handle))
+
+
+def build_row(
+    *,
+    tx_type: str,
+    buy_amount: Decimal | None = None,
+    buy_currency: str = "",
+    sell_amount: Decimal | None = None,
+    sell_currency: str = "",
+    fee_amount: Decimal | None = None,
+    fee_currency: str = "",
+    exchange: str,
+    group: str = "",
+    comment: str = "",
+    date: datetime,
+    tx_id: str = "",
+    match_window_seconds: int,
+    fee_tolerance: Decimal = Decimal("0"),
+    comment_mode: str = "exact",
+    tx_id_mode: str = "ignore",
+    allowed_types: Iterable[str] | None = None,
+    raw_source: str,
+    raw_ref: str,
+    notes: str = "",
+) -> dict[str, str]:
+    allowed = list(allowed_types or [tx_type])
+    return {
+        "Type": tx_type,
+        "Buy": format_amount(buy_amount),
+        "Buy Cur.": buy_currency,
+        "Sell": format_amount(sell_amount),
+        "Sell Cur.": sell_currency,
+        "Fee": format_amount(fee_amount if fee_amount is not None else Decimal("0")),
+        "Fee Cur.": fee_currency,
+        "Exchange": exchange,
+        "Group": group,
+        "Comment": comment,
+        "Date": ct_date_text(date),
+        "Tx-ID": tx_id,
+        "match_window_seconds": str(match_window_seconds),
+        "fee_tolerance": decimal_text(fee_tolerance),
+        "comment_mode": comment_mode,
+        "tx_id_mode": tx_id_mode,
+        "allowed_types": "|".join(allowed),
+        "raw_source": raw_source,
+        "raw_ref": raw_ref,
+        "notes": notes,
+    }
+
+
+def build_buy_comment(quantity: Decimal, asset: str, total: Decimal, currency: str) -> str:
+    return f"Bought {compact_decimal_text(quantity)} {asset} for ${total.quantize(Decimal('0.01'))} {currency}"
+
+
+def send_comment_from_notes(notes: str) -> str:
+    return notes.split(" (to ", 1)[0]
+
+
+def find_matching_pro_statement(
+    retail_row: dict[str, str],
+    statement_rows: list[dict[str, str]],
+) -> dict[str, str] | None:
+    retail_dt = parse_coinbase_retail_timestamp(retail_row["Timestamp"])
+    retail_type = retail_row["Transaction Type"]
+    expected_statement_type = "deposit" if retail_type == "Pro Withdrawal" else "withdrawal"
+    target_amount = abs(parse_decimal(retail_row["Quantity Transacted"]) or Decimal("0"))
+    asset = retail_row["Asset"]
+    matches = []
+    for row in statement_rows:
+        if row["type"] != expected_statement_type:
+            continue
+        if row["amount/balance unit"] != asset:
+            continue
+        amount = abs(parse_decimal(row["amount"]) or Decimal("0"))
+        if amount != target_amount:
+            continue
+        dt = parse_coinbase_pro_timestamp(row["time"])
+        if abs((dt - retail_dt).total_seconds()) > 90:
+            continue
+        matches.append(row)
+    return sorted(matches, key=lambda row: row["time"])[0] if matches else None
+
+
+def normalize_coinbase_transactions(
+    retail_rows: list[dict[str, str]],
+    pro_statement_rows: list[dict[str, str]],
+    pro_fill_rows: list[dict[str, str]],
+    *,
+    retail_source: Path,
+) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    asset_migrations: dict[str, list[dict[str, str]]] = defaultdict(list)
+
+    for raw in retail_rows:
+        tx_type = raw["Transaction Type"]
+        if tx_type == "Asset Migration":
+            asset_migrations[raw["Timestamp"]].append(raw)
+            continue
+
+        dt = parse_coinbase_retail_timestamp(raw["Timestamp"])
+        raw_source = retail_source.name
+        raw_ref = raw["ID"]
+        quantity = parse_decimal(raw["Quantity Transacted"]) or Decimal("0")
+        fee = parse_decimal(raw["Fees and/or Spread"]) or Decimal("0")
+        total = parse_decimal(raw["Total (inclusive of fees and/or spread)"]) or Decimal("0")
+        asset = raw["Asset"]
+        price_currency = raw["Price Currency"]
+
+        if tx_type == "Buy":
+            rows.append(
+                build_row(
+                    tx_type="Trade",
+                    buy_amount=quantity,
+                    buy_currency=asset,
+                    sell_amount=abs(total),
+                    sell_currency=price_currency,
+                    fee_amount=fee,
+                    fee_currency=price_currency,
+                    exchange="Coinbase",
+                    comment=build_buy_comment(quantity, asset, abs(total), price_currency),
+                    date=dt,
+                    tx_id=f"coinbase-retail-{raw_ref}",
+                    match_window_seconds=20,
+                    fee_tolerance=Decimal("0.03000000"),
+                    raw_source=raw_source,
+                    raw_ref=raw_ref,
+                    notes="Retail Buy row normalized from Coinbase raw export",
+                )
+            )
+            continue
+
+        if tx_type == "Convert":
+            match = CONVERT_NOTES_PATTERN.match(raw["Notes"])
+            if match is None:
+                raise ValueError(f"Unable to parse Coinbase Convert notes: {raw['Notes']!r}")
+            rows.append(
+                build_row(
+                    tx_type="Trade",
+                    buy_amount=parse_decimal(match.group("buy_qty")),
+                    buy_currency=match.group("buy_asset"),
+                    sell_amount=abs(quantity),
+                    sell_currency=asset,
+                    fee_amount=fee,
+                    fee_currency=price_currency,
+                    exchange="Coinbase",
+                    comment=raw["Notes"],
+                    date=dt,
+                    tx_id=f"coinbase-convert-{raw_ref}",
+                    match_window_seconds=5,
+                    fee_tolerance=Decimal("0.03000000"),
+                    raw_source=raw_source,
+                    raw_ref=raw_ref,
+                    notes="Retail Convert row normalized from Coinbase raw export",
+                )
+            )
+            continue
+
+        if tx_type == "Send":
+            rows.append(
+                build_row(
+                    tx_type="Withdrawal",
+                    sell_amount=abs(quantity),
+                    sell_currency=asset,
+                    fee_amount=Decimal("0"),
+                    fee_currency=asset,
+                    exchange="Coinbase",
+                    comment=send_comment_from_notes(raw["Notes"]),
+                    date=dt,
+                    tx_id=f"coinbase-send-{raw_ref}",
+                    match_window_seconds=60,
+                    comment_mode="ignore",
+                    tx_id_mode="ignore",
+                    allowed_types=("Withdrawal", "Spend"),
+                    raw_source=raw_source,
+                    raw_ref=raw_ref,
+                    notes="Retail Send row normalized without any unsupported fee leg",
+                )
+            )
+            continue
+
+        if tx_type == "Reward Income":
+            rows.append(
+                build_row(
+                    tx_type="Interest Income",
+                    buy_amount=quantity,
+                    buy_currency=asset,
+                    fee_amount=Decimal("0"),
+                    fee_currency=asset,
+                    exchange="Coinbase",
+                    comment="Cardano reward",
+                    date=dt,
+                    tx_id=f"coinbase-reward-income-{raw_ref}",
+                    match_window_seconds=2,
+                    raw_source=raw_source,
+                    raw_ref=raw_ref,
+                    notes="Coinbase Reward Income normalized to Interest Income",
+                )
+            )
+            continue
+
+        if tx_type == "Learning Reward":
+            rows.append(
+                build_row(
+                    tx_type="Reward / Bonus",
+                    buy_amount=quantity,
+                    buy_currency=asset,
+                    fee_amount=Decimal("0"),
+                    fee_currency=asset,
+                    exchange="Coinbase",
+                    comment="Earn Task",
+                    date=dt,
+                    tx_id=f"coinbase-learning-reward-{raw_ref}",
+                    match_window_seconds=2,
+                    raw_source=raw_source,
+                    raw_ref=raw_ref,
+                    notes="Coinbase Learning Reward normalized to Reward / Bonus",
+                )
+            )
+            continue
+
+        if tx_type == "Receive":
+            rows.append(
+                build_row(
+                    tx_type="Reward / Bonus",
+                    buy_amount=quantity,
+                    buy_currency=asset,
+                    fee_amount=Decimal("0"),
+                    fee_currency=asset,
+                    exchange="Coinbase",
+                    comment=raw["Notes"],
+                    date=dt,
+                    tx_id=f"coinbase-receive-{raw_ref}",
+                    match_window_seconds=2,
+                    comment_mode="ignore",
+                    raw_source=raw_source,
+                    raw_ref=raw_ref,
+                    notes="Coinbase Receive normalized to Reward / Bonus",
+                )
+            )
+            continue
+
+        if tx_type == "Retail Unstaking Transfer":
+            positive_leg = quantity > 0
+            rows.append(
+                build_row(
+                    tx_type="Deposit" if positive_leg else "Withdrawal",
+                    buy_amount=quantity if positive_leg else None,
+                    buy_currency=asset if positive_leg else "",
+                    sell_amount=abs(quantity) if not positive_leg else None,
+                    sell_currency=asset if not positive_leg else "",
+                    fee_amount=Decimal("0"),
+                    fee_currency=asset,
+                    exchange="Coinbase",
+                    group="Retail Unstaking Transfer",
+                    comment="Retail Unstaking Transfer",
+                    date=dt,
+                    tx_id=f"coinbase-retail-unstaking-{raw_ref}",
+                    match_window_seconds=2,
+                    comment_mode="ignore",
+                    raw_source=raw_source,
+                    raw_ref=raw_ref,
+                    notes="Retail Unstaking Transfer normalized in CoinTracking schema",
+                )
+            )
+            continue
+
+        if tx_type in {"Pro Deposit", "Pro Withdrawal"}:
+            statement_row = find_matching_pro_statement(raw, pro_statement_rows)
+            transfer_id = statement_row["transfer id"] if statement_row else ""
+            rows.append(
+                build_row(
+                    tx_type="Withdrawal" if tx_type == "Pro Deposit" else "Deposit",
+                    buy_amount=quantity if tx_type == "Pro Withdrawal" else None,
+                    buy_currency=asset if tx_type == "Pro Withdrawal" else "",
+                    sell_amount=abs(quantity) if tx_type == "Pro Deposit" else None,
+                    sell_currency=asset if tx_type == "Pro Deposit" else "",
+                    fee_amount=Decimal("0"),
+                    fee_currency=asset,
+                    exchange="Coinbase",
+                    comment="",
+                    date=dt,
+                    tx_id=transfer_id or f"coinbase-pro-transfer-{raw_ref}",
+                    match_window_seconds=90,
+                    comment_mode="ignore",
+                    tx_id_mode="ignore",
+                    raw_source=raw_source,
+                    raw_ref=raw_ref if not transfer_id else f"{raw_ref}|{transfer_id}",
+                    notes="Retail Coinbase/Coinbase Pro transfer normalized without trusting CoinTracking-generated comments",
+                )
+            )
+            continue
+
+        raise ValueError(f"Unsupported Coinbase retail transaction type: {tx_type}")
+
+    for timestamp, migration_rows in sorted(asset_migrations.items()):
+        if len(migration_rows) != 2:
+            raise ValueError(f"Expected 2 asset-migration rows at {timestamp}, found {len(migration_rows)}")
+        negatives = [row for row in migration_rows if (parse_decimal(row["Quantity Transacted"]) or Decimal("0")) < 0]
+        positives = [row for row in migration_rows if (parse_decimal(row["Quantity Transacted"]) or Decimal("0")) > 0]
+        if len(negatives) != 1 or len(positives) != 1:
+            raise ValueError(f"Asset-migration rows at {timestamp} do not form one positive and one negative leg")
+        sold_row = negatives[0]
+        bought_row = positives[0]
+        dt = parse_coinbase_retail_timestamp(timestamp)
+        rows.append(
+            build_row(
+                tx_type="Swap (non taxable)",
+                buy_amount=parse_decimal(bought_row["Quantity Transacted"]),
+                buy_currency=bought_row["Asset"],
+                sell_amount=abs(parse_decimal(sold_row["Quantity Transacted"]) or Decimal("0")),
+                sell_currency=sold_row["Asset"],
+                fee_amount=Decimal("0"),
+                fee_currency=sold_row["Asset"],
+                exchange="Coinbase",
+                group="Asset Migration",
+                comment="Coinbase Asset Migration",
+                date=dt,
+                tx_id=f"coinbase-asset-migration-{sold_row['ID']}-{bought_row['ID']}",
+                match_window_seconds=2,
+                comment_mode="ignore",
+                raw_source=retail_source.name,
+                raw_ref=f"{sold_row['ID']}|{bought_row['ID']}",
+                notes="Paired Coinbase Asset Migration rows normalized into one CoinTracking swap",
+            )
+        )
+
+    for statement_row in pro_statement_rows:
+        dt = parse_coinbase_pro_timestamp(statement_row["time"])
+        amount = parse_decimal(statement_row["amount"]) or Decimal("0")
+        asset = statement_row["amount/balance unit"]
+        row_type = statement_row["type"]
+        if row_type in {"deposit", "withdrawal"}:
+            rows.append(
+                build_row(
+                    tx_type="Deposit" if row_type == "deposit" else "Withdrawal",
+                    buy_amount=abs(amount) if row_type == "deposit" else None,
+                    buy_currency=asset if row_type == "deposit" else "",
+                    sell_amount=abs(amount) if row_type == "withdrawal" else None,
+                    sell_currency=asset if row_type == "withdrawal" else "",
+                    fee_amount=Decimal("0"),
+                    fee_currency=asset,
+                    exchange="Coinbase Pro",
+                    comment="",
+                    date=dt,
+                    tx_id=statement_row["transfer id"] or f"coinbase-pro-{row_type}-{asset}-{ct_date_text(dt)}",
+                    match_window_seconds=90,
+                    comment_mode="ignore",
+                    tx_id_mode="ignore",
+                    raw_source=statement_row["_file"],
+                    raw_ref=statement_row["transfer id"] or statement_row["time"],
+                    notes="Coinbase Pro statement transfer normalized in CoinTracking schema",
+                )
+            )
+
+    for fill_row in pro_fill_rows:
+        dt = parse_coinbase_pro_timestamp(fill_row["created at"])
+        size = parse_decimal(fill_row["size"]) or Decimal("0")
+        fee = parse_decimal(fill_row["fee"]) or Decimal("0")
+        total = abs(parse_decimal(fill_row["total"]) or Decimal("0"))
+        product = fill_row["product"]
+        buy_asset, sell_asset = product.split("-", 1)
+        side = fill_row["side"].upper()
+        if side == "BUY":
+            buy_amount = size
+            buy_currency = fill_row["size unit"]
+            sell_amount = total
+            sell_currency = fill_row["price/fee/total unit"]
+        else:
+            buy_amount = total
+            buy_currency = fill_row["price/fee/total unit"]
+            sell_amount = size
+            sell_currency = fill_row["size unit"]
+        rows.append(
+            build_row(
+                tx_type="Trade",
+                buy_amount=buy_amount,
+                buy_currency=buy_currency,
+                sell_amount=sell_amount,
+                sell_currency=sell_currency,
+                fee_amount=fee,
+                fee_currency=fill_row["price/fee/total unit"],
+                exchange="Coinbase Pro",
+                comment="",
+                date=dt,
+                tx_id=f"{fill_row['trade id']}_{product}",
+                match_window_seconds=2,
+                fee_tolerance=Decimal("0.00000010"),
+                comment_mode="ignore",
+                tx_id_mode="ignore",
+                raw_source=fill_row["_file"],
+                raw_ref=fill_row["trade id"],
+                notes="Coinbase Pro fills row normalized in CoinTracking schema",
+            )
+        )
+
+    return sorted(rows, key=lambda row: (row["Date"], row["Exchange"], row["Type"], row["Tx-ID"]))
+
+
+def coinbase_balance_rows_from_text(text: str, pdf_file: str) -> list[dict[str, str]]:
+    normalized = normalize_whitespace(text)
+    portfolio_match = COINBASE_PORTFOLIO_AS_OF_PATTERN.search(normalized)
+    cash_match = COINBASE_CLOSING_CASH_PATTERN.search(normalized)
+    rows: list[dict[str, str]] = []
+    if cash_match:
+        rows.append(
+            {
+                "source": "Coinbase",
+                "account": "Coinbase",
+                "wallet": "Coinbase Cash",
+                "balance_kind": "cash_closing_balance",
+                "asset": cash_match.group("currency"),
+                "quantity": decimal_text(parse_decimal(cash_match.group("balance")) or Decimal("0")),
+                "staked_quantity": "",
+                "value_amount": "",
+                "value_currency": "",
+                "price_amount": "",
+                "price_currency": "",
+                "as_of": cash_match.group("as_of").replace(" UTC", ""),
+                "pdf_file": pdf_file,
+                "notes": "Closing fiat balance from Coinbase statement PDF",
+            }
+        )
+    if portfolio_match:
+        as_of = portfolio_match.group("as_of").replace(" UTC", "")
+        seen_assets: set[str] = set()
+        for pattern in (PORTFOLIO_ROW_PATTERN, PORTFOLIO_ROW_FALLBACK_PATTERN):
+            for match in pattern.finditer(normalized):
+                asset = match.group("asset")
+                if asset in seen_assets:
+                    continue
+                seen_assets.add(asset)
+                staked = match.group("staked")
+                rows.append(
+                    {
+                        "source": "Coinbase",
+                        "account": "Coinbase",
+                        "wallet": "Coinbase",
+                        "balance_kind": "asset_balance",
+                        "asset": asset,
+                        "quantity": decimal_text(parse_decimal(match.group("quantity")) or Decimal("0")),
+                        "staked_quantity": "" if staked == "N/A" else decimal_text(parse_decimal(staked) or Decimal("0")),
+                        "value_amount": decimal_text(parse_decimal(match.group("value")) or Decimal("0"), "0.00"),
+                        "value_currency": "CAD",
+                        "price_amount": decimal_text(parse_decimal(match.group("price")) or Decimal("0")),
+                        "price_currency": "CAD",
+                        "as_of": as_of,
+                        "pdf_file": pdf_file,
+                        "notes": "Portfolio summary asset balance from Coinbase statement PDF",
+                    }
+                )
+    return rows

--- a/06_scripts/coinbase_normalize.py
+++ b/06_scripts/coinbase_normalize.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+
+"""Normalize Coinbase raw exports into CoinTracking-schema transaction and balance files."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+from coinbase_common import (
+    BALANCE_HEADERS,
+    COINBASE_METADATA_HEADERS,
+    coinbase_balance_rows_from_text,
+    csv_dict_rows,
+    normalize_coinbase_transactions,
+    retail_csv_rows,
+)
+from script_common import extract_pdf_text, write_cointracking_rows, write_csv_rows
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--retail-csv", required=True, type=Path)
+    parser.add_argument("--pro-statement", action="append", default=[], type=Path)
+    parser.add_argument("--pro-fills", action="append", default=[], type=Path)
+    parser.add_argument("--pdf", action="append", default=[], type=Path)
+    parser.add_argument("--tx-output", required=True, type=Path)
+    parser.add_argument("--balance-output", type=Path)
+    return parser.parse_args(argv)
+
+
+def normalize_coinbase_exports(
+    retail_csv: Path,
+    *,
+    pro_statement_paths: list[Path],
+    pro_fill_paths: list[Path],
+    pdf_paths: list[Path],
+    tx_output: Path,
+    balance_output: Path | None = None,
+) -> dict[str, object]:
+    retail_rows = retail_csv_rows(retail_csv)
+    pro_statement_rows = []
+    for path in pro_statement_paths:
+        for row in csv_dict_rows(path, "Coinbase Pro statement CSV"):
+            row["_file"] = path.name
+            pro_statement_rows.append(row)
+    pro_fill_rows = []
+    for path in pro_fill_paths:
+        for row in csv_dict_rows(path, "Coinbase Pro fills CSV"):
+            row["_file"] = path.name
+            pro_fill_rows.append(row)
+
+    normalized_transactions = normalize_coinbase_transactions(
+        retail_rows,
+        pro_statement_rows,
+        pro_fill_rows,
+        retail_source=retail_csv,
+    )
+    write_cointracking_rows(tx_output, normalized_transactions, extra_headers=COINBASE_METADATA_HEADERS)
+
+    balance_rows = []
+    for pdf_path in pdf_paths:
+        balance_rows.extend(coinbase_balance_rows_from_text(extract_pdf_text(pdf_path), pdf_path.name))
+    if balance_output is not None:
+        write_csv_rows(balance_output, list(BALANCE_HEADERS), balance_rows)
+
+    return {
+        "normalized_transaction_rows": len(normalized_transactions),
+        "normalized_balance_rows": len(balance_rows),
+        "tx_output": str(tx_output),
+        "balance_output": str(balance_output) if balance_output is not None else "",
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    summary = normalize_coinbase_exports(
+        args.retail_csv,
+        pro_statement_paths=args.pro_statement,
+        pro_fill_paths=args.pro_fills,
+        pdf_paths=args.pdf,
+        tx_output=args.tx_output,
+        balance_output=args.balance_output,
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/06_scripts/normalize_source.py
+++ b/06_scripts/normalize_source.py
@@ -48,8 +48,7 @@ def normalize_source(
     if profile_json is not None and profile_json.exists():
         profile_payload = read_profile(profile_json)
         manifest_fingerprint = str(profile_payload["manifest_fingerprint"])
-        adapter_name = str(profile_payload["adapter"])
-        adapter_supported = bool(profile_payload["adapter_supported"])
+        adapter_name = adapter.name
     else:
         profile = build_source_profile(
             source=source,
@@ -59,8 +58,7 @@ def normalize_source(
             adapter_supported=adapter.supported,
         )
         manifest_fingerprint = profile.manifest_fingerprint
-        adapter_name = profile.adapter
-        adapter_supported = profile.adapter_supported
+        adapter_name = adapter.name
 
     profile = build_source_profile(
         source=source,
@@ -87,7 +85,9 @@ def normalize_source(
             and existing.get("adapter") == adapter_name
             and existing.get("exception_decisions_fingerprint") == decisions_digest
             and events_path.exists()
+            and balances_path.exists()
             and exceptions_path.exists()
+            and candidate_path.exists()
         ):
             return {
                 "source": source,
@@ -114,7 +114,7 @@ def normalize_source(
     summary = {
         "source": source,
         "adapter": adapter.name,
-        "adapter_supported": adapter_supported,
+        "adapter_supported": profile.adapter_supported,
         "manifest_fingerprint": profile.manifest_fingerprint,
         "canonical_events": len(result.canonical_events),
         "canonical_balances": len(result.canonical_balances),
@@ -124,8 +124,8 @@ def normalize_source(
         "skipped_non_mapped_rows": len(skipped_rows),
         "status": (
             "ready"
-            if adapter.supported and not result.exceptions
-            else "needs_review" if adapter.supported else "adapter_not_implemented"
+            if profile.adapter_supported and not result.exceptions
+            else "needs_review" if profile.adapter_supported else "adapter_not_implemented"
         ),
         "paths": {
             "canonical_events": str(events_path),

--- a/06_scripts/normalize_source.py
+++ b/06_scripts/normalize_source.py
@@ -19,7 +19,7 @@ from pipeline_common import (
     write_json,
 )
 from render_cointracking import render_cointracking_rows
-from source_adapters import get_adapter, load_exception_decisions
+from source_adapters import decisions_fingerprint, get_adapter, load_exception_decisions
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -62,6 +62,16 @@ def normalize_source(
         adapter_name = profile.adapter
         adapter_supported = profile.adapter_supported
 
+    profile = build_source_profile(
+        source=source,
+        raw_dir=raw_dir,
+        manifest_path=manifest,
+        adapter_name=adapter.name,
+        adapter_supported=adapter.supported,
+    )
+    decisions = load_exception_decisions(exception_decisions, profile.manifest_fingerprint)
+    decisions_digest = decisions_fingerprint(decisions)
+
     out_dir = out_dir.resolve()
     out_dir.mkdir(parents=True, exist_ok=True)
     summary_path = out_dir / "normalization_summary.json"
@@ -75,6 +85,7 @@ def normalize_source(
         if (
             existing.get("manifest_fingerprint") == manifest_fingerprint
             and existing.get("adapter") == adapter_name
+            and existing.get("exception_decisions_fingerprint") == decisions_digest
             and events_path.exists()
             and exceptions_path.exists()
         ):
@@ -89,14 +100,6 @@ def normalize_source(
                 "summary_path": str(summary_path),
             }
 
-    profile = build_source_profile(
-        source=source,
-        raw_dir=raw_dir,
-        manifest_path=manifest,
-        adapter_name=adapter.name,
-        adapter_supported=adapter.supported,
-    )
-    decisions = load_exception_decisions(exception_decisions, profile.manifest_fingerprint)
     result = adapter.normalize(raw_dir.resolve(), profile, exception_decisions=decisions)
 
     write_csv_rows(events_path, list(CANONICAL_EVENT_HEADERS), result.canonical_events)
@@ -116,6 +119,7 @@ def normalize_source(
         "canonical_events": len(result.canonical_events),
         "canonical_balances": len(result.canonical_balances),
         "exceptions": len(result.exceptions),
+        "exception_decisions_fingerprint": decisions_digest,
         "cointracking_rows": len(rendered_rows),
         "skipped_non_mapped_rows": len(skipped_rows),
         "status": (
@@ -151,4 +155,3 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/06_scripts/normalize_source.py
+++ b/06_scripts/normalize_source.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+
+"""Normalize a raw source folder into canonical events, balances, and exceptions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+from pipeline_common import (
+    CANONICAL_BALANCE_HEADERS,
+    CANONICAL_EVENT_HEADERS,
+    EXCEPTION_HEADERS,
+    build_source_profile,
+    read_profile,
+    write_csv_rows,
+    write_json,
+)
+from render_cointracking import render_cointracking_rows
+from source_adapters import get_adapter, load_exception_decisions
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", required=True)
+    parser.add_argument("--raw-dir", required=True, type=Path)
+    parser.add_argument("--out-dir", required=True, type=Path)
+    parser.add_argument("--profile-json", type=Path)
+    parser.add_argument("--manifest", type=Path)
+    parser.add_argument("--exception-decisions", type=Path)
+    parser.add_argument("--force", action="store_true")
+    return parser.parse_args(argv)
+
+
+def normalize_source(
+    source: str,
+    raw_dir: Path,
+    out_dir: Path,
+    *,
+    profile_json: Path | None = None,
+    manifest: Path | None = None,
+    exception_decisions: Path | None = None,
+    force: bool = False,
+) -> dict[str, object]:
+    adapter = get_adapter(source)
+    if profile_json is not None and profile_json.exists():
+        profile_payload = read_profile(profile_json)
+        manifest_fingerprint = str(profile_payload["manifest_fingerprint"])
+        adapter_name = str(profile_payload["adapter"])
+        adapter_supported = bool(profile_payload["adapter_supported"])
+    else:
+        profile = build_source_profile(
+            source=source,
+            raw_dir=raw_dir,
+            manifest_path=manifest,
+            adapter_name=adapter.name,
+            adapter_supported=adapter.supported,
+        )
+        manifest_fingerprint = profile.manifest_fingerprint
+        adapter_name = profile.adapter
+        adapter_supported = profile.adapter_supported
+
+    out_dir = out_dir.resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = out_dir / "normalization_summary.json"
+    events_path = out_dir / "canonical_events.csv"
+    balances_path = out_dir / "canonical_balances.csv"
+    exceptions_path = out_dir / "exceptions.csv"
+    candidate_path = out_dir / "cointracking_candidate.csv"
+
+    if not force and summary_path.exists():
+        existing = read_profile(summary_path)
+        if (
+            existing.get("manifest_fingerprint") == manifest_fingerprint
+            and existing.get("adapter") == adapter_name
+            and events_path.exists()
+            and exceptions_path.exists()
+        ):
+            return {
+                "source": source,
+                "adapter": adapter_name,
+                "manifest_fingerprint": manifest_fingerprint,
+                "status": "cached",
+                "canonical_events": int(existing.get("canonical_events", 0)),
+                "exceptions": int(existing.get("exceptions", 0)),
+                "cointracking_rows": int(existing.get("cointracking_rows", 0)),
+                "summary_path": str(summary_path),
+            }
+
+    profile = build_source_profile(
+        source=source,
+        raw_dir=raw_dir,
+        manifest_path=manifest,
+        adapter_name=adapter.name,
+        adapter_supported=adapter.supported,
+    )
+    decisions = load_exception_decisions(exception_decisions, profile.manifest_fingerprint)
+    result = adapter.normalize(raw_dir.resolve(), profile, exception_decisions=decisions)
+
+    write_csv_rows(events_path, list(CANONICAL_EVENT_HEADERS), result.canonical_events)
+    write_csv_rows(balances_path, list(CANONICAL_BALANCE_HEADERS), result.canonical_balances)
+    write_csv_rows(exceptions_path, list(EXCEPTION_HEADERS), result.exceptions)
+    rendered_rows, skipped_rows = render_cointracking_rows(result.canonical_events)
+    from render_cointracking import RENDER_METADATA_HEADERS
+    from script_common import write_cointracking_rows
+
+    write_cointracking_rows(candidate_path, rendered_rows, extra_headers=RENDER_METADATA_HEADERS)
+
+    summary = {
+        "source": source,
+        "adapter": adapter.name,
+        "adapter_supported": adapter_supported,
+        "manifest_fingerprint": profile.manifest_fingerprint,
+        "canonical_events": len(result.canonical_events),
+        "canonical_balances": len(result.canonical_balances),
+        "exceptions": len(result.exceptions),
+        "cointracking_rows": len(rendered_rows),
+        "skipped_non_mapped_rows": len(skipped_rows),
+        "status": (
+            "ready"
+            if adapter.supported and not result.exceptions
+            else "needs_review" if adapter.supported else "adapter_not_implemented"
+        ),
+        "paths": {
+            "canonical_events": str(events_path),
+            "canonical_balances": str(balances_path),
+            "exceptions": str(exceptions_path),
+            "cointracking_candidate": str(candidate_path),
+        },
+    }
+    write_json(summary_path, summary)
+    return summary
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    summary = normalize_source(
+        args.source,
+        args.raw_dir,
+        args.out_dir,
+        profile_json=args.profile_json,
+        manifest=args.manifest,
+        exception_decisions=args.exception_decisions,
+        force=args.force,
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/06_scripts/pdf_balance_extract.py
+++ b/06_scripts/pdf_balance_extract.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+
+"""Deterministically extract statement balances from supported PDF exports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from decimal import Decimal
+from pathlib import Path
+from typing import Callable, Sequence
+
+from coinbase_common import BALANCE_HEADERS, coinbase_balance_rows_from_text
+from script_common import decimal_text, extract_pdf_text, normalize_whitespace, parse_decimal, write_csv_rows
+
+
+Extractor = Callable[[str, str], list[dict[str, str]]]
+
+BINANCE_PERIOD_PATTERN = re.compile(
+    r"Report Period:\s+(?P<start>[A-Za-z]+\s+\d{2},\s+\d{4})\s+-\s+(?P<end>[A-Za-z]+\s+\d{2},\s+\d{4})"
+)
+BINANCE_TOTAL_PATTERN = re.compile(r"Total Account Value:?\s+(?P<value>[0-9.]+)\s+(?P<currency>[A-Z]{3})")
+BINANCE_WALLETS_PATTERN = re.compile(
+    r"(?:Wallet Balance\s+)?Funding\s+Spot & Margin\s+Futures\s+Options\s+Earn\s+"
+    r"(?P<funding>[0-9.]+)\s+USD\s+"
+    r"(?P<spot_margin>[0-9.]+)\s+USD\s+"
+    r"(?P<futures>[0-9.]+)\s+USD\s+"
+    r"(?P<options>[0-9.]+)\s+USD\s+"
+    r"(?P<earn>[0-9.]+)\s+USD"
+)
+SHAKEPAY_OPENING_AS_OF_PATTERN = re.compile(r"Opening market value\s+\(as of (?P<as_of>[0-9-]+\s+[0-9:]+\s+EST)\)")
+SHAKEPAY_OPENING_VALUE_PATTERN = re.compile(r"For the year \(\$\)\s+Since account opening \(\$\)\s+\$(?P<value>[0-9,]+\.[0-9]{2})")
+SHAKEPAY_CLOSING_PATTERN = re.compile(r"Closing market value at year end\s+\$?(?P<value>[0-9,]+\.[0-9]{2})")
+SHAKEPAY_YEAR_PATTERN = re.compile(r"For the year ending on December 31,\s+(?P<year>\d{4})")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", choices=("auto", "coinbase", "binance", "shakepay"), default="auto")
+    parser.add_argument("--pdf", action="append", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    return parser.parse_args(argv)
+
+
+def binance_balance_rows_from_text(text: str, pdf_file: str) -> list[dict[str, str]]:
+    normalized = normalize_whitespace(text)
+    period_match = BINANCE_PERIOD_PATTERN.search(normalized)
+    total_match = BINANCE_TOTAL_PATTERN.search(normalized)
+    wallet_match = BINANCE_WALLETS_PATTERN.search(normalized)
+    if period_match is None or total_match is None or wallet_match is None:
+        return []
+    as_of = period_match.group("end")
+    rows = [
+        {
+            "source": "Binance",
+            "account": "Binance",
+            "wallet": "Consolidated",
+            "balance_kind": "account_total_value",
+            "asset": "",
+            "quantity": "",
+            "staked_quantity": "",
+            "value_amount": decimal_text(parse_decimal(total_match.group("value")) or Decimal("0"), "0.00"),
+            "value_currency": total_match.group("currency"),
+            "price_amount": "",
+            "price_currency": "",
+            "as_of": as_of,
+            "pdf_file": pdf_file,
+            "notes": "Total Binance account value from account statement PDF",
+        }
+    ]
+    for wallet_key, label in (
+        ("funding", "Funding"),
+        ("spot_margin", "Spot & Margin"),
+        ("futures", "Futures"),
+        ("options", "Options"),
+        ("earn", "Earn"),
+    ):
+        rows.append(
+            {
+                "source": "Binance",
+                "account": "Binance",
+                "wallet": label,
+                "balance_kind": "wallet_total_value",
+                "asset": "",
+                "quantity": "",
+                "staked_quantity": "",
+                "value_amount": decimal_text(parse_decimal(wallet_match.group(wallet_key)) or Decimal("0"), "0.00"),
+                "value_currency": "USD",
+                "price_amount": "",
+                "price_currency": "",
+                "as_of": as_of,
+                "pdf_file": pdf_file,
+                "notes": "Wallet total from Binance account statement PDF",
+            }
+        )
+    return rows
+
+
+def shakepay_balance_rows_from_text(text: str, pdf_file: str) -> list[dict[str, str]]:
+    normalized = normalize_whitespace(text)
+    opening_as_of_match = SHAKEPAY_OPENING_AS_OF_PATTERN.search(normalized)
+    opening_value_match = SHAKEPAY_OPENING_VALUE_PATTERN.search(normalized)
+    closing_match = SHAKEPAY_CLOSING_PATTERN.search(normalized)
+    year_match = SHAKEPAY_YEAR_PATTERN.search(normalized)
+    if opening_as_of_match is None or opening_value_match is None or closing_match is None or year_match is None:
+        return []
+    year = year_match.group("year")
+    return [
+        {
+            "source": "Shakepay",
+            "account": "Shakepay",
+            "wallet": "Personal",
+            "balance_kind": "opening_market_value",
+            "asset": "",
+            "quantity": "",
+            "staked_quantity": "",
+            "value_amount": decimal_text(parse_decimal(opening_value_match.group("value")) or Decimal("0"), "0.00"),
+            "value_currency": "CAD",
+            "price_amount": "",
+            "price_currency": "",
+            "as_of": opening_as_of_match.group("as_of"),
+            "pdf_file": pdf_file,
+            "notes": "Opening market value from Shakepay performance report",
+        },
+        {
+            "source": "Shakepay",
+            "account": "Shakepay",
+            "wallet": "Personal",
+            "balance_kind": "closing_market_value",
+            "asset": "",
+            "quantity": "",
+            "staked_quantity": "",
+            "value_amount": decimal_text(parse_decimal(closing_match.group("value")) or Decimal("0"), "0.00"),
+            "value_currency": "CAD",
+            "price_amount": "",
+            "price_currency": "",
+            "as_of": f"{year}-12-31 23:59",
+            "pdf_file": pdf_file,
+            "notes": "Closing market value from Shakepay performance report",
+        },
+    ]
+
+
+def detect_extractor(pdf_path: Path) -> tuple[str, Extractor]:
+    name = pdf_path.name.lower()
+    if "coinbase" in name or re.match(r"^\d{4}-\d{2}-\d{2} - ", pdf_path.name):
+        return "coinbase", coinbase_balance_rows_from_text
+    if pdf_path.name.startswith("AccountStatementPeriod_"):
+        return "binance", binance_balance_rows_from_text
+    if "shakepay" in name and "performance report" in name:
+        return "shakepay", shakepay_balance_rows_from_text
+    raise ValueError(f"Unable to deterministically select a balance extractor for {pdf_path.name}")
+
+
+def extractor_for_source(source: str) -> Extractor:
+    if source == "coinbase":
+        return coinbase_balance_rows_from_text
+    if source == "binance":
+        return binance_balance_rows_from_text
+    if source == "shakepay":
+        return shakepay_balance_rows_from_text
+    raise ValueError(source)
+
+
+def extract_pdf_balances(source: str, pdf_paths: list[Path], output: Path) -> dict[str, object]:
+    rows: list[dict[str, str]] = []
+    extracted_files: list[str] = []
+    for pdf_path in pdf_paths:
+        extractor = extractor_for_source(source) if source != "auto" else detect_extractor(pdf_path)[1]
+        pdf_rows = extractor(extract_pdf_text(pdf_path), pdf_path.name)
+        if not pdf_rows:
+            raise ValueError(f"No balance rows extracted from {pdf_path}")
+        rows.extend(pdf_rows)
+        extracted_files.append(pdf_path.name)
+    write_csv_rows(output, list(BALANCE_HEADERS), rows)
+    return {
+        "pdf_files": extracted_files,
+        "balance_rows": len(rows),
+        "output": str(output),
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    summary = extract_pdf_balances(args.source, args.pdf, args.output)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/06_scripts/pipeline_common.py
+++ b/06_scripts/pipeline_common.py
@@ -96,6 +96,7 @@ DATE_FORMATS = (
     "%Y-%m-%d %H:%M:%S",
     "%Y-%m-%d %H:%M:%S UTC",
     "%Y-%m-%dT%H:%M:%S.%fZ",
+    "%y-%m-%d %H:%M:%S",
     "%Y-%m-%d",
     "%m/%d/%Y %H:%M:%S",
     "%m/%d/%Y",
@@ -205,6 +206,20 @@ def classify_file_family(path: Path, header: Sequence[str]) -> str:
         return "wallet_operation_csv"
     if "futures-trade-history" in name or "spot-trade-history" in name:
         return "fills_csv"
+    if "convert-order-history" in name:
+        return "convert_order_csv"
+    if "deposit-history" in name and "fiat" not in name:
+        return "deposit_history_csv"
+    if "withdraw-history" in name and "fiat" not in name:
+        return "withdrawal_history_csv"
+    if "c2c-order-history" in name:
+        return "p2p_order_csv"
+    if "fiat-buy-history" in name:
+        return "fiat_buy_csv"
+    if "fiat-sell-history" in name:
+        return "fiat_sell_csv"
+    if "fiat-exchange-history" in name:
+        return "fiat_exchange_csv"
     if "futures-transaction-history" in name:
         return "futures_transaction_csv"
     if "transaction" in name and "history" in name:

--- a/06_scripts/pipeline_common.py
+++ b/06_scripts/pipeline_common.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+
+"""Shared schema and helper functions for the universal source-intake pipeline."""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from script_common import parse_datetime, read_csv_rows, require_directory, require_file, write_csv_rows, write_json
+
+
+CANONICAL_EVENT_HEADERS = (
+    "event_id",
+    "source",
+    "adapter",
+    "account",
+    "wallet",
+    "raw_file",
+    "raw_row_ref",
+    "timestamp",
+    "event_kind",
+    "asset_in",
+    "amount_in",
+    "asset_out",
+    "amount_out",
+    "fee_asset",
+    "fee_amount",
+    "tx_hash",
+    "description",
+    "confidence",
+    "status",
+    "render_type",
+    "render_exchange",
+    "render_group",
+    "render_comment",
+    "render_comment_mode",
+    "render_tx_id",
+    "render_tx_id_mode",
+    "render_allowed_types",
+    "render_match_window_seconds",
+    "render_fee_tolerance",
+    "render_notes",
+)
+
+CANONICAL_BALANCE_HEADERS = (
+    "source",
+    "account",
+    "wallet",
+    "balance_kind",
+    "asset",
+    "quantity",
+    "staked_quantity",
+    "value_amount",
+    "value_currency",
+    "price_amount",
+    "price_currency",
+    "as_of",
+    "pdf_file",
+    "notes",
+)
+
+EXCEPTION_HEADERS = (
+    "manifest_fingerprint",
+    "event_id",
+    "source",
+    "adapter",
+    "raw_file",
+    "raw_row_ref",
+    "exception_kind",
+    "message",
+    "status",
+    "resolution_status",
+    "resolution_note",
+)
+
+PROFILE_INVENTORY_HEADERS = (
+    "filename",
+    "suffix",
+    "family",
+    "header_preview",
+    "data_rows",
+    "date_field",
+    "min_timestamp",
+    "max_timestamp",
+)
+
+DATE_FIELD_PATTERN = ("date", "time", "timestamp", "created at", "operation date", "settlement_date", "transaction_date")
+DATE_FORMATS = (
+    "%Y-%m-%d %H:%M:%S",
+    "%Y-%m-%d %H:%M:%S UTC",
+    "%Y-%m-%dT%H:%M:%S.%fZ",
+    "%Y-%m-%d",
+    "%m/%d/%Y %H:%M:%S",
+    "%m/%d/%Y",
+    "%d/%m/%Y %H:%M:%S",
+    "%d/%m/%Y",
+    "%d.%m.%Y %H:%M:%S",
+)
+
+
+@dataclass(frozen=True)
+class SourceProfile:
+    source: str
+    source_slug: str
+    raw_dir: Path
+    manifest_path: Path | None
+    manifest_fingerprint: str
+    adapter: str
+    adapter_supported: bool
+    file_inventory: list[dict[str, str]]
+
+
+def source_slug(value: str) -> str:
+    text = value.strip().lower().replace("&", " and ")
+    chars = [char if char.isalnum() else "_" for char in text]
+    slug = "".join(chars)
+    while "__" in slug:
+        slug = slug.replace("__", "_")
+    return slug.strip("_")
+
+
+def stable_hash_rows(rows: Iterable[dict[str, str]]) -> str:
+    payload = json.dumps(list(rows), sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def manifest_fingerprint_from_rows(rows: list[dict[str, str]]) -> str:
+    ordered = sorted(
+        (
+            {
+                "filename": row.get("filename", ""),
+                "size_bytes": row.get("size_bytes", ""),
+                "sha256": row.get("sha256", ""),
+            }
+            for row in rows
+        ),
+        key=lambda item: item["filename"],
+    )
+    return stable_hash_rows(ordered)
+
+
+def find_manifest_for_raw_dir(raw_dir: Path) -> Path | None:
+    candidate = raw_dir.parent / "manifest.csv"
+    return candidate if candidate.exists() else None
+
+
+def first_non_empty_csv_row(path: Path) -> list[str]:
+    with path.open(newline="", encoding="utf-8-sig") as handle:
+        reader = csv.reader(handle)
+        for row in reader:
+            if any(cell.strip() for cell in row):
+                return row
+    return []
+
+
+def detect_csv_header(path: Path) -> tuple[list[str], int]:
+    with path.open(newline="", encoding="utf-8-sig") as handle:
+        rows = list(csv.reader(handle))
+    best_index = -1
+    best_row: list[str] = []
+    for index, row in enumerate(rows[:10]):
+        width = len([cell for cell in row if cell.strip()])
+        if width > len(best_row):
+            best_row = row
+            best_index = index
+    if best_index == -1:
+        return [], -1
+    return best_row, best_index
+
+
+def classify_file_family(path: Path, header: Sequence[str]) -> str:
+    name = path.name.lower()
+    header_lower = [column.strip().lower() for column in header]
+
+    if path.suffix.lower() == ".pdf":
+        return "statement_balance_pdf"
+    if "coinbase pro - fills" in name:
+        return "fills_csv"
+    if "coinbase pro - statement" in name:
+        return "transfer_statement_csv"
+    if "statement - all time" in name:
+        return "custodial_all_time_csv"
+    if "activity" in name and "export" in name:
+        return "broker_activity_csv"
+    if "monthly-statement-transactions" in name:
+        return "statement_transaction_csv"
+    if "portfolio" in name:
+        return "portfolio_snapshot_csv"
+    if "export-address-token" in name:
+        return "explorer_token_transfer_csv"
+    if "export-internal-tx" in name:
+        return "explorer_internal_transaction_csv"
+    if "export-address-nfts" in name:
+        return "explorer_nft_transfer_csv"
+    if "export-" in name:
+        return "explorer_transaction_csv"
+    if "ledgerlive-operations" in name:
+        return "wallet_operation_csv"
+    if "futures-trade-history" in name or "spot-trade-history" in name:
+        return "fills_csv"
+    if "futures-transaction-history" in name:
+        return "futures_transaction_csv"
+    if "transaction" in name and "history" in name:
+        return "custodial_transaction_csv"
+    if "cash_transactions" in name:
+        return "fiat_transaction_csv"
+    if "crypto_transactions" in name:
+        return "custodial_transaction_csv"
+    if "statement" in header_lower and "time" in header_lower:
+        return "transfer_statement_csv"
+    if "trade id" in header_lower and "product" in header_lower:
+        return "fills_csv"
+    if "operation type" in header_lower and "operation amount" in header_lower:
+        return "wallet_operation_csv"
+    if "transaction hash" in header_lower:
+        return "explorer_transaction_csv"
+    if "activity_type" in header_lower:
+        return "broker_activity_csv"
+    if "type" in header_lower and "amount credited" in header_lower:
+        return "custodial_transaction_csv"
+    return "unknown"
+
+
+def parse_candidate_timestamp(value: str) -> datetime | None:
+    text = value.strip()
+    if not text:
+        return None
+    for fmt in DATE_FORMATS:
+        try:
+            return parse_datetime(text, (fmt,))
+        except ValueError:
+            continue
+    return None
+
+
+def detect_date_span_from_csv(path: Path) -> tuple[str, str, str, int]:
+    header, header_index = detect_csv_header(path)
+    if header_index == -1 or not header:
+        return "", "", "", 0
+
+    with path.open(newline="", encoding="utf-8-sig") as handle:
+        reader = csv.reader(handle)
+        payload = list(reader)[header_index + 1 :]
+
+    normalized_rows = [
+        {header[index]: (row[index] if index < len(row) else "") for index in range(len(header))}
+        for row in payload
+        if any(cell.strip() for cell in row)
+    ]
+    date_field = ""
+    parsed_values: list[datetime] = []
+    candidates = [field for field in header if any(token in field.lower() for token in DATE_FIELD_PATTERN)]
+    best_count = -1
+    for field in candidates:
+        current = [parse_candidate_timestamp((row.get(field) or "").strip()) for row in normalized_rows]
+        parsed = [value for value in current if value is not None]
+        if len(parsed) > best_count:
+            best_count = len(parsed)
+            parsed_values = parsed
+            date_field = field
+    if not parsed_values:
+        return date_field, "", "", len(normalized_rows)
+    return (
+        date_field,
+        min(parsed_values).strftime("%Y-%m-%d %H:%M:%S"),
+        max(parsed_values).strftime("%Y-%m-%d %H:%M:%S"),
+        len(normalized_rows),
+    )
+
+
+def build_file_inventory(raw_dir: Path) -> list[dict[str, str]]:
+    raw_dir = require_directory(raw_dir.resolve(), "Raw source directory")
+    rows: list[dict[str, str]] = []
+    for path in sorted(file for file in raw_dir.iterdir() if file.is_file()):
+        suffix = path.suffix.lower()
+        header_preview = ""
+        family = "binary_evidence"
+        data_rows = ""
+        date_field = ""
+        min_timestamp = ""
+        max_timestamp = ""
+        if suffix == ".csv":
+            header, _ = detect_csv_header(path)
+            header_preview = " | ".join(header[:8])
+            family = classify_file_family(path, header)
+            date_field, min_timestamp, max_timestamp, row_count = detect_date_span_from_csv(path)
+            data_rows = str(row_count)
+        elif suffix == ".pdf":
+            family = classify_file_family(path, ())
+        rows.append(
+            {
+                "filename": path.name,
+                "suffix": suffix,
+                "family": family,
+                "header_preview": header_preview,
+                "data_rows": data_rows,
+                "date_field": date_field,
+                "min_timestamp": min_timestamp,
+                "max_timestamp": max_timestamp,
+            }
+        )
+    return rows
+
+
+def build_source_profile(
+    *,
+    source: str,
+    raw_dir: Path,
+    adapter_name: str,
+    adapter_supported: bool,
+    manifest_path: Path | None = None,
+) -> SourceProfile:
+    raw_dir = require_directory(raw_dir.resolve(), "Raw source directory")
+    manifest_path = manifest_path.resolve() if manifest_path is not None else find_manifest_for_raw_dir(raw_dir)
+    manifest_rows = read_csv_rows(manifest_path) if manifest_path is not None and manifest_path.exists() else []
+    fingerprint = manifest_fingerprint_from_rows(manifest_rows) if manifest_rows else stable_hash_rows(build_file_inventory(raw_dir))
+    return SourceProfile(
+        source=source,
+        source_slug=source_slug(source),
+        raw_dir=raw_dir,
+        manifest_path=manifest_path,
+        manifest_fingerprint=fingerprint,
+        adapter=adapter_name,
+        adapter_supported=adapter_supported,
+        file_inventory=build_file_inventory(raw_dir),
+    )
+
+
+def write_profile_artifacts(out_dir: Path, profile: SourceProfile) -> tuple[Path, Path]:
+    out_dir = out_dir.resolve()
+    out_dir.mkdir(parents=True, exist_ok=True)
+    profile_json = out_dir / "profile.json"
+    inventory_csv = out_dir / "profile_inventory.csv"
+    write_json(
+        profile_json,
+        {
+            "source": profile.source,
+            "source_slug": profile.source_slug,
+            "raw_dir": str(profile.raw_dir),
+            "manifest_path": str(profile.manifest_path) if profile.manifest_path is not None else "",
+            "manifest_fingerprint": profile.manifest_fingerprint,
+            "adapter": profile.adapter,
+            "adapter_supported": profile.adapter_supported,
+            "file_count": len(profile.file_inventory),
+            "file_inventory": profile.file_inventory,
+            "family_counts": summarize_family_counts(profile.file_inventory),
+        },
+    )
+    write_csv_rows(inventory_csv, list(PROFILE_INVENTORY_HEADERS), profile.file_inventory)
+    return profile_json, inventory_csv
+
+
+def summarize_family_counts(rows: Sequence[dict[str, str]]) -> dict[str, int]:
+    counts: dict[str, int] = defaultdict(int)
+    for row in rows:
+        counts[row["family"]] += 1
+    return dict(sorted(counts.items()))
+
+
+def read_profile(path: Path) -> dict[str, object]:
+    path = require_file(path.resolve(), "Profile JSON")
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def validate_canonical_event_row(row: dict[str, str]) -> None:
+    missing = [header for header in CANONICAL_EVENT_HEADERS if header not in row]
+    if missing:
+        raise ValueError(f"Canonical event row missing required headers: {', '.join(missing)}")
+    for field in ("event_id", "source", "timestamp", "event_kind", "confidence", "status"):
+        if not str(row.get(field, "")).strip():
+            raise ValueError(f"Canonical event row has blank required field: {field}")
+
+
+def validate_canonical_balance_row(row: dict[str, str]) -> None:
+    missing = [header for header in CANONICAL_BALANCE_HEADERS if header not in row]
+    if missing:
+        raise ValueError(f"Canonical balance row missing required headers: {', '.join(missing)}")

--- a/06_scripts/profile_source.py
+++ b/06_scripts/profile_source.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+
+"""Profile a raw source folder into deterministic inventory and adapter metadata."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Sequence
+
+from pipeline_common import build_source_profile, write_profile_artifacts
+from source_adapters import get_adapter
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", required=True)
+    parser.add_argument("--raw-dir", required=True, type=Path)
+    parser.add_argument("--out-dir", required=True, type=Path)
+    parser.add_argument("--manifest", type=Path)
+    return parser.parse_args(argv)
+
+
+def profile_source(source: str, raw_dir: Path, out_dir: Path, manifest: Path | None = None) -> dict[str, object]:
+    adapter = get_adapter(source)
+    profile = build_source_profile(
+        source=source,
+        raw_dir=raw_dir,
+        manifest_path=manifest,
+        adapter_name=adapter.name,
+        adapter_supported=adapter.supported,
+    )
+    profile_json, inventory_csv = write_profile_artifacts(out_dir, profile)
+    return {
+        "source": profile.source,
+        "adapter": profile.adapter,
+        "adapter_supported": profile.adapter_supported,
+        "manifest_fingerprint": profile.manifest_fingerprint,
+        "profile_json": str(profile_json),
+        "profile_inventory_csv": str(inventory_csv),
+        "files_profiled": len(profile.file_inventory),
+    }
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    summary = profile_source(args.source, args.raw_dir, args.out_dir, manifest=args.manifest)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/06_scripts/reconcile_source.py
+++ b/06_scripts/reconcile_source.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+
+"""Reconcile canonical source events and balances against CoinTracking ledger exports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections import Counter
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Sequence
+
+from render_cointracking import RENDER_METADATA_HEADERS, render_cointracking_rows
+from script_common import (
+    decimal_or_zero,
+    decimal_text,
+    parse_datetime,
+    read_cointracking_rows,
+    read_csv_rows,
+    write_cointracking_rows,
+    write_csv_rows,
+    write_json,
+)
+
+
+COINTRACKING_TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+@dataclass(frozen=True)
+class CandidateScore:
+    exact_type: int
+    exact_group: int
+    exact_comment: int
+    exact_tx_id: int
+    time_delta_seconds: int
+    fee_delta: Decimal
+
+
+def ct_datetime(value: str) -> datetime:
+    return parse_datetime(value, (COINTRACKING_TIME_FORMAT,))
+
+
+def amount_key(row: dict[str, str], prefix: str) -> tuple[Decimal, str]:
+    if prefix == "buy":
+        return decimal_or_zero(row["Buy"]), row["Buy Cur."]
+    if prefix == "sell":
+        return decimal_or_zero(row["Sell"]), row["Sell Cur."]
+    if prefix == "fee":
+        return decimal_or_zero(row["Fee"]), row["Fee Cur."]
+    raise ValueError(prefix)
+
+
+def split_allowed_types(value: str) -> set[str]:
+    return {item for item in value.split("|") if item}
+
+
+def candidate_matches(expected: dict[str, str], actual: dict[str, str]) -> bool:
+    if actual["Exchange"] != expected["Exchange"]:
+        return False
+    if actual["Type"] not in split_allowed_types(expected["render_allowed_types"]):
+        return False
+    if amount_key(actual, "buy") != amount_key(expected, "buy"):
+        return False
+    if amount_key(actual, "sell") != amount_key(expected, "sell"):
+        return False
+    window = int(expected["render_match_window_seconds"] or "0")
+    if abs((ct_datetime(actual["Date"]) - ct_datetime(expected["Date"])).total_seconds()) > window:
+        return False
+    return True
+
+
+def candidate_score(expected: dict[str, str], actual: dict[str, str]) -> CandidateScore:
+    return CandidateScore(
+        exact_type=1 if actual["Type"] == expected["Type"] else 0,
+        exact_group=1 if actual["Group"] == expected["Group"] else 0,
+        exact_comment=1 if actual["Comment"] == expected["Comment"] else 0,
+        exact_tx_id=1 if expected["Tx-ID"] and actual["Tx-ID"] == expected["Tx-ID"] else 0,
+        time_delta_seconds=int(abs((ct_datetime(actual["Date"]) - ct_datetime(expected["Date"])).total_seconds())),
+        fee_delta=abs(decimal_or_zero(actual["Fee"]) - decimal_or_zero(expected["Fee"])),
+    )
+
+
+def compare_expected_to_actual(expected: dict[str, str], actual: dict[str, str]) -> list[str]:
+    issues: list[str] = []
+    fee_tolerance = decimal_or_zero(expected["render_fee_tolerance"])
+    if abs(decimal_or_zero(actual["Fee"]) - decimal_or_zero(expected["Fee"])) > fee_tolerance:
+        issues.append("fee_mismatch")
+    if expected["Group"] and actual["Group"] != expected["Group"]:
+        issues.append("group_mismatch")
+    if expected["render_comment_mode"] == "exact" and actual["Comment"] != expected["Comment"]:
+        issues.append("comment_mismatch")
+    if expected["render_tx_id_mode"] == "exact" and actual["Tx-ID"] != expected["Tx-ID"]:
+        issues.append("tx_id_mismatch")
+    return issues
+
+
+def compare_transactions(actual_rows: list[dict[str, str]], expected_rows: list[dict[str, str]]) -> dict[str, list[dict[str, str]]]:
+    unmatched_actual = set(range(len(actual_rows)))
+    matched_rows: list[dict[str, str]] = []
+    mismatched_rows: list[dict[str, str]] = []
+    missing_rows: list[dict[str, str]] = []
+    ambiguous_rows: list[dict[str, str]] = []
+
+    for expected in expected_rows:
+        candidates = [index for index in unmatched_actual if candidate_matches(expected, actual_rows[index])]
+        if not candidates:
+            missing_rows.append(expected)
+            continue
+        ranked = sorted(
+            candidates,
+            key=lambda index: (
+                -candidate_score(expected, actual_rows[index]).exact_type,
+                -candidate_score(expected, actual_rows[index]).exact_group,
+                -candidate_score(expected, actual_rows[index]).exact_comment,
+                -candidate_score(expected, actual_rows[index]).exact_tx_id,
+                candidate_score(expected, actual_rows[index]).time_delta_seconds,
+                candidate_score(expected, actual_rows[index]).fee_delta,
+            ),
+        )
+        best_index = ranked[0]
+        best_score = candidate_score(expected, actual_rows[best_index])
+        tied = [index for index in ranked[1:] if candidate_score(expected, actual_rows[index]) == best_score]
+        if tied:
+            ambiguous_rows.append({**expected, "candidate_tx_ids": "|".join(actual_rows[index]["Tx-ID"] for index in [best_index, *tied])})
+            continue
+        actual = actual_rows[best_index]
+        issues = compare_expected_to_actual(expected, actual)
+        combined = {
+            **expected,
+            "actual_type": actual["Type"],
+            "actual_buy": actual["Buy"],
+            "actual_buy_currency": actual["Buy Cur."],
+            "actual_sell": actual["Sell"],
+            "actual_sell_currency": actual["Sell Cur."],
+            "actual_fee": actual["Fee"],
+            "actual_fee_currency": actual["Fee Cur."],
+            "actual_group": actual["Group"],
+            "actual_comment": actual["Comment"],
+            "actual_date": actual["Date"],
+            "actual_tx_id": actual["Tx-ID"],
+            "comparison_issues": "|".join(issues),
+        }
+        if issues:
+            mismatched_rows.append(combined)
+        else:
+            matched_rows.append(combined)
+        unmatched_actual.remove(best_index)
+
+    extra_rows = [actual_rows[index] for index in sorted(unmatched_actual)]
+    return {
+        "matched": matched_rows,
+        "mismatched": mismatched_rows,
+        "missing": missing_rows,
+        "extra": extra_rows,
+        "ambiguous": ambiguous_rows,
+    }
+
+
+def compare_balances(cointracking_balance_rows: list[dict[str, str]], canonical_balance_rows: list[dict[str, str]], source: str) -> list[dict[str, str]]:
+    tolerance = Decimal("0.00000001")
+    actual = {
+        row["Currency"]: decimal_or_zero(row["Amount"])
+        for row in cointracking_balance_rows
+        if row.get("Exchange") in {source, "Coinbase Pro"} or source == "Coinbase" and row.get("Exchange") == "Coinbase"
+    }
+    expected = {
+        row["asset"]: decimal_or_zero(row["quantity"])
+        for row in canonical_balance_rows
+        if row.get("source") == source and row.get("balance_kind") in {"asset_balance", "cash_closing_balance"}
+    }
+    rows = []
+    for asset in sorted(set(actual) | set(expected)):
+        actual_amount = actual.get(asset, Decimal("0"))
+        expected_amount = expected.get(asset, Decimal("0"))
+        difference = actual_amount - expected_amount
+        rows.append(
+            {
+                "asset": asset,
+                "expected_amount": decimal_text(expected_amount),
+                "cointracking_amount": decimal_text(actual_amount),
+                "difference": decimal_text(difference),
+                "status": "match" if abs(difference) <= tolerance else "delta",
+            }
+        )
+    return rows
+
+
+def reconcile_source(
+    source: str,
+    cointracking_ledger: Path,
+    canonical_events: Path,
+    *,
+    out_dir: Path,
+    cointracking_balance_by_exchange: Path | None = None,
+    canonical_balances: Path | None = None,
+) -> dict[str, object]:
+    all_expected_events = read_csv_rows(canonical_events)
+    expected_rows, _ = render_cointracking_rows(all_expected_events)
+    exchange_filters = {row["Exchange"] for row in expected_rows}
+    actual_rows = [row for row in read_cointracking_rows(cointracking_ledger) if row["Exchange"] in exchange_filters]
+    transaction_results = compare_transactions(actual_rows, expected_rows)
+
+    write_cointracking_rows(
+        out_dir / "matched_rows.csv",
+        transaction_results["matched"],
+        extra_headers=(
+            "actual_type",
+            "actual_buy",
+            "actual_buy_currency",
+            "actual_sell",
+            "actual_sell_currency",
+            "actual_fee",
+            "actual_fee_currency",
+            "actual_group",
+            "actual_comment",
+            "actual_date",
+            "actual_tx_id",
+            "comparison_issues",
+            *RENDER_METADATA_HEADERS,
+        ),
+    )
+    write_cointracking_rows(out_dir / "missing_rows.csv", transaction_results["missing"], extra_headers=RENDER_METADATA_HEADERS)
+    write_cointracking_rows(out_dir / "extra_rows.csv", transaction_results["extra"])
+    write_cointracking_rows(
+        out_dir / "mismatched_rows.csv",
+        transaction_results["mismatched"],
+        extra_headers=(
+            "actual_type",
+            "actual_buy",
+            "actual_buy_currency",
+            "actual_sell",
+            "actual_sell_currency",
+            "actual_fee",
+            "actual_fee_currency",
+            "actual_group",
+            "actual_comment",
+            "actual_date",
+            "actual_tx_id",
+            "comparison_issues",
+            *RENDER_METADATA_HEADERS,
+        ),
+    )
+    write_cointracking_rows(out_dir / "ambiguous_rows.csv", transaction_results["ambiguous"], extra_headers=("candidate_tx_ids", *RENDER_METADATA_HEADERS))
+
+    balance_rows: list[dict[str, str]] = []
+    if cointracking_balance_by_exchange is not None and canonical_balances is not None:
+        balance_rows = compare_balances(read_csv_rows(cointracking_balance_by_exchange), read_csv_rows(canonical_balances), source)
+        write_csv_rows(out_dir / "balance_deltas.csv", ["asset", "expected_amount", "cointracking_amount", "difference", "status"], balance_rows)
+
+    summary = {
+        "source": source,
+        "ledger_rows": len(actual_rows),
+        "expected_rows": len(expected_rows),
+        "matched_rows": len(transaction_results["matched"]),
+        "mismatched_rows": len(transaction_results["mismatched"]),
+        "missing_rows": len(transaction_results["missing"]),
+        "extra_rows": len(transaction_results["extra"]),
+        "ambiguous_rows": len(transaction_results["ambiguous"]),
+        "mismatch_issue_counts": dict(
+            Counter(
+                issue
+                for row in transaction_results["mismatched"]
+                for issue in row["comparison_issues"].split("|")
+                if issue
+            )
+        ),
+        "balance_delta_rows": len([row for row in balance_rows if row["status"] == "delta"]),
+        "status": "passed"
+        if not any(
+            (
+                transaction_results["mismatched"],
+                transaction_results["missing"],
+                transaction_results["extra"],
+                transaction_results["ambiguous"],
+                [row for row in balance_rows if row["status"] == "delta"],
+            )
+        )
+        else "failed",
+    }
+    write_json(out_dir / "summary.json", summary)
+    return summary
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--source", required=True)
+    parser.add_argument("--cointracking-ledger", required=True, type=Path)
+    parser.add_argument("--canonical-events", required=True, type=Path)
+    parser.add_argument("--out-dir", required=True, type=Path)
+    parser.add_argument("--cointracking-balance-by-exchange", type=Path)
+    parser.add_argument("--canonical-balances", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    summary = reconcile_source(
+        args.source,
+        args.cointracking_ledger,
+        args.canonical_events,
+        out_dir=args.out_dir,
+        cointracking_balance_by_exchange=args.cointracking_balance_by_exchange,
+        canonical_balances=args.canonical_balances,
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/06_scripts/render_cointracking.py
+++ b/06_scripts/render_cointracking.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+
+"""Render canonical event rows into a CoinTracking-ready candidate CSV."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from decimal import Decimal
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from pipeline_common import CANONICAL_EVENT_HEADERS, validate_canonical_event_row
+from script_common import read_csv_rows, write_cointracking_rows, write_json
+
+
+RENDER_METADATA_HEADERS = (
+    "canonical_event_id",
+    "confidence",
+    "status",
+    "raw_file",
+    "raw_row_ref",
+    "render_match_window_seconds",
+    "render_fee_tolerance",
+    "render_comment_mode",
+    "render_tx_id_mode",
+    "render_allowed_types",
+    "render_notes",
+)
+
+
+def decimal_text_or_blank(value: str) -> str:
+    text = (value or "").strip()
+    if not text:
+        return ""
+    return f"{Decimal(text):.8f}"
+
+
+def render_cointracking_rows(events: Iterable[dict[str, str]]) -> tuple[list[dict[str, str]], list[dict[str, str]]]:
+    candidate_rows: list[dict[str, str]] = []
+    skipped_rows: list[dict[str, str]] = []
+    for row in events:
+        validate_canonical_event_row(row)
+        if row["status"] != "mapped":
+            skipped_rows.append(row)
+            continue
+        candidate_rows.append(
+            {
+                "Type": row["render_type"] or row["event_kind"],
+                "Buy": decimal_text_or_blank(row["amount_in"]),
+                "Buy Cur.": row["asset_in"],
+                "Sell": decimal_text_or_blank(row["amount_out"]),
+                "Sell Cur.": row["asset_out"],
+                "Fee": decimal_text_or_blank(row["fee_amount"] or "0"),
+                "Fee Cur.": row["fee_asset"],
+                "Exchange": row["render_exchange"],
+                "Group": row["render_group"],
+                "Comment": row["render_comment"] or row["description"],
+                "Date": row["timestamp"],
+                "Tx-ID": row["render_tx_id"] or row["tx_hash"],
+                "canonical_event_id": row["event_id"],
+                "confidence": row["confidence"],
+                "status": row["status"],
+                "raw_file": row["raw_file"],
+                "raw_row_ref": row["raw_row_ref"],
+                "render_match_window_seconds": row["render_match_window_seconds"],
+                "render_fee_tolerance": row["render_fee_tolerance"],
+                "render_comment_mode": row["render_comment_mode"],
+                "render_tx_id_mode": row["render_tx_id_mode"],
+                "render_allowed_types": row["render_allowed_types"],
+                "render_notes": row["render_notes"],
+            }
+        )
+    return candidate_rows, skipped_rows
+
+
+def render_from_file(canonical_events: Path, output: Path, summary_output: Path | None = None) -> dict[str, object]:
+    rows = read_csv_rows(canonical_events)
+    candidate_rows, skipped_rows = render_cointracking_rows(rows)
+    write_cointracking_rows(output, candidate_rows, extra_headers=RENDER_METADATA_HEADERS)
+    summary = {
+        "canonical_events": len(rows),
+        "cointracking_rows": len(candidate_rows),
+        "skipped_non_mapped_rows": len(skipped_rows),
+        "output": str(output),
+    }
+    if summary_output is not None:
+        write_json(summary_output, summary)
+    return summary
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--canonical-events", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--summary-output", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    summary = render_from_file(args.canonical_events, args.output, summary_output=args.summary_output)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+

--- a/06_scripts/script_common.py
+++ b/06_scripts/script_common.py
@@ -6,9 +6,11 @@ from __future__ import annotations
 
 import csv
 import json
+import subprocess
 from decimal import Decimal
+from datetime import datetime
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Sequence
 
 
 DEFAULT_VERIFICATION_EXPORTS = (
@@ -19,12 +21,65 @@ DEFAULT_VERIFICATION_EXPORTS = (
     "Balance by Exchange",
 )
 
+COINTRACKING_FILE_HEADERS = (
+    "Type",
+    "Buy",
+    "Cur.",
+    "Sell",
+    "Cur.",
+    "Fee",
+    "Cur.",
+    "Exchange",
+    "Group",
+    "Comment",
+    "Date",
+    "Tx-ID",
+)
+
+COINTRACKING_HEADERS = (
+    "Type",
+    "Buy",
+    "Buy Cur.",
+    "Sell",
+    "Sell Cur.",
+    "Fee",
+    "Fee Cur.",
+    "Exchange",
+    "Group",
+    "Comment",
+    "Date",
+    "Tx-ID",
+)
+
+COINTRACKING_INDEX = {
+    "Type": 0,
+    "Buy": 1,
+    "Buy Cur.": 2,
+    "Sell": 3,
+    "Sell Cur.": 4,
+    "Fee": 5,
+    "Fee Cur.": 6,
+    "Exchange": 7,
+    "Group": 8,
+    "Comment": 9,
+    "Date": 10,
+    "Tx-ID": 11,
+}
+
 
 def require_directory(path: Path, label: str) -> Path:
     if not path.exists():
         raise FileNotFoundError(f"{label} does not exist: {path}")
     if not path.is_dir():
         raise NotADirectoryError(f"{label} is not a directory: {path}")
+    return path
+
+
+def require_file(path: Path, label: str) -> Path:
+    if not path.exists():
+        raise FileNotFoundError(f"{label} does not exist: {path}")
+    if not path.is_file():
+        raise FileNotFoundError(f"{label} is not a file: {path}")
     return path
 
 
@@ -63,6 +118,48 @@ def decimal_text(value: Decimal, places: str = "0.00000000") -> str:
     return format(value.quantize(Decimal(places)), "f")
 
 
+def parse_decimal(value: str | None) -> Decimal | None:
+    if value is None:
+        return None
+    text = value.strip()
+    if not text or text == "-":
+        return None
+    text = text.replace("$", "").replace(",", "")
+    if text.startswith("(") and text.endswith(")"):
+        text = f"-{text[1:-1]}"
+    return Decimal(text)
+
+
+def decimal_or_zero(value: str | None) -> Decimal:
+    parsed = parse_decimal(value)
+    return parsed if parsed is not None else Decimal("0")
+
+
+def parse_datetime(value: str, formats: Sequence[str]) -> datetime:
+    for fmt in formats:
+        try:
+            return datetime.strptime(value, fmt)
+        except ValueError:
+            continue
+    format_list = ", ".join(formats)
+    raise ValueError(f"Unable to parse datetime {value!r}; expected one of: {format_list}")
+
+
+def normalize_whitespace(value: str | None) -> str:
+    return " ".join((value or "").split())
+
+
+def extract_pdf_text(pdf_path: Path) -> str:
+    pdf_path = require_file(pdf_path.resolve(), "PDF file")
+    result = subprocess.run(
+        ["pdftotext", str(pdf_path), "-"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
 def write_csv_rows(
     path: Path,
     fieldnames: list[str],
@@ -75,6 +172,59 @@ def write_csv_rows(
         writer = csv.DictWriter(handle, fieldnames=fieldnames)
         writer.writeheader()
         writer.writerows(rows)
+
+
+def read_cointracking_rows(path: Path, extra_headers: Sequence[str] = ()) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    header = [*COINTRACKING_HEADERS, *extra_headers]
+    require_file(path.resolve(), "CoinTracking CSV")
+    with path.open(newline="", encoding="utf-8-sig") as handle:
+        reader = csv.reader(handle)
+        actual_header = next(reader, [])
+        expected_prefix = list(COINTRACKING_FILE_HEADERS)
+        expected_with_lpn = [
+            "Type",
+            "Buy",
+            "Cur.",
+            "Sell",
+            "Cur.",
+            "Fee",
+            "Cur.",
+            "Exchange",
+            "Group",
+            "Comment",
+            "Date",
+            "LPN",
+            "Tx-ID",
+        ]
+        has_lpn = actual_header[: len(expected_with_lpn)] == expected_with_lpn
+        if not has_lpn and actual_header[: len(expected_prefix)] != expected_prefix:
+            raise ValueError(f"Unexpected CoinTracking header in {path}: {actual_header}")
+        for raw_row in reader:
+            if not any(cell.strip() for cell in raw_row):
+                continue
+            if has_lpn:
+                raw_row = raw_row[:11] + raw_row[12:]
+            padded = raw_row + [""] * (len(header) - len(raw_row))
+            rows.append(dict(zip(header, padded[: len(header)])))
+    return rows
+
+
+def write_cointracking_rows(
+    path: Path,
+    rows: Iterable[dict[str, object]],
+    *,
+    extra_headers: Sequence[str] = (),
+    encoding: str = "utf-8",
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    header = [*COINTRACKING_HEADERS, *extra_headers]
+    file_header = [*COINTRACKING_FILE_HEADERS, *extra_headers]
+    with path.open("w", newline="", encoding=encoding) as handle:
+        writer = csv.writer(handle)
+        writer.writerow(file_header)
+        for row in rows:
+            writer.writerow([row.get(column, "") for column in header])
 
 
 def write_json(path: Path, payload: object, *, encoding: str = "utf-8") -> None:

--- a/06_scripts/source_adapters.py
+++ b/06_scripts/source_adapters.py
@@ -4,11 +4,14 @@
 
 from __future__ import annotations
 
+from collections import defaultdict
 from dataclasses import dataclass
 from decimal import Decimal
 from pathlib import Path
 from typing import Iterable, Sequence
+import csv
 import json
+import re
 
 from coinbase_common import (
     coinbase_balance_rows_from_text,
@@ -16,8 +19,16 @@ from coinbase_common import (
     normalize_coinbase_transactions,
     retail_csv_rows,
 )
+from pdf_balance_extract import binance_balance_rows_from_text
 from pipeline_common import CANONICAL_BALANCE_HEADERS, CANONICAL_EVENT_HEADERS, EXCEPTION_HEADERS, SourceProfile
-from script_common import extract_pdf_text, read_cointracking_rows
+from script_common import (
+    decimal_or_zero,
+    decimal_text,
+    extract_pdf_text,
+    parse_datetime,
+    read_cointracking_rows,
+    read_csv_rows,
+)
 
 
 DECISION_HEADERS = (
@@ -26,6 +37,12 @@ DECISION_HEADERS = (
     "resolution_status",
     "resolution_note",
 )
+
+BINANCE_NUMBER_ASSET_PATTERN = re.compile(r"^\s*([-+]?[0-9]+(?:\.[0-9]+)?)\s*([A-Z0-9]+)\s*$")
+BINANCE_TRADE_ID_PATTERN = re.compile(r"TradeID\s*-\s*(?P<trade_id>[A-Za-z0-9_-]+)")
+BINANCE_SMALL_ASSET_PATTERN = re.compile(r"^(?P<asset>[A-Z0-9]+)\s+to\s+BNB$", re.IGNORECASE)
+BINANCE_TIME_FORMATS = ("%y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M:%S")
+WEALTHSIMPLE_TIME_FORMATS = ("%Y-%m-%d", "%Y-%m-%d %H:%M:%S")
 
 
 @dataclass(frozen=True)
@@ -104,7 +121,6 @@ def load_exception_decisions(path: Path | None, manifest_fingerprint: str) -> di
     rows = read_cointracking_rows(path) if path.suffix.lower() == ".csv" and path.name.endswith("_ct.csv") else []
     if rows:
         return {}
-    import csv
 
     decisions: dict[str, dict[str, str]] = {}
     with path.open(newline="", encoding="utf-8-sig") as handle:
@@ -132,6 +148,121 @@ def decisions_fingerprint(decisions: dict[str, dict[str, str]]) -> str:
         for event_id, values in sorted(decisions.items())
     ]
     return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def normalized_timestamp(value: str, formats: Sequence[str]) -> str:
+    return parse_datetime(value.strip(), formats).strftime("%Y-%m-%d %H:%M:%S")
+
+
+def event_id_for(adapter: str, raw_file: str, raw_row_ref: str) -> str:
+    return f"{adapter}:{raw_file}:{raw_row_ref}"
+
+
+def canonical_event(
+    *,
+    event_id: str,
+    source: str,
+    adapter: str,
+    account: str,
+    wallet: str,
+    raw_file: str,
+    raw_row_ref: str,
+    timestamp: str,
+    event_kind: str,
+    description: str,
+    amount_in: str = "",
+    asset_in: str = "",
+    amount_out: str = "",
+    asset_out: str = "",
+    fee_amount: str = "",
+    fee_asset: str = "",
+    tx_hash: str = "",
+    render_group: str = "",
+    render_notes: str = "",
+) -> dict[str, str]:
+    return {
+        "event_id": event_id,
+        "source": source,
+        "adapter": adapter,
+        "account": account,
+        "wallet": wallet,
+        "raw_file": raw_file,
+        "raw_row_ref": raw_row_ref,
+        "timestamp": timestamp,
+        "event_kind": event_kind,
+        "asset_in": asset_in,
+        "amount_in": amount_in,
+        "asset_out": asset_out,
+        "amount_out": amount_out,
+        "fee_asset": fee_asset,
+        "fee_amount": fee_amount,
+        "tx_hash": tx_hash,
+        "description": description,
+        "confidence": "high",
+        "status": "mapped",
+        "render_type": event_kind,
+        "render_exchange": source,
+        "render_group": render_group,
+        "render_comment": description,
+        "render_comment_mode": "exact",
+        "render_tx_id": tx_hash,
+        "render_tx_id_mode": "exact" if tx_hash else "ignore",
+        "render_allowed_types": event_kind,
+        "render_match_window_seconds": "0",
+        "render_fee_tolerance": "0.00000000",
+        "render_notes": render_notes,
+    }
+
+
+def maybe_append_exception(
+    exceptions: list[dict[str, str]],
+    decisions: dict[str, dict[str, str]],
+    *,
+    manifest_fingerprint: str,
+    source: str,
+    adapter: str,
+    event_id: str,
+    raw_file: str,
+    raw_row_ref: str,
+    exception_kind: str,
+    message: str,
+) -> None:
+    decision = decisions.get(event_id, {})
+    exception = default_exception_row(
+        manifest_fingerprint=manifest_fingerprint,
+        source=source,
+        adapter=adapter,
+        event_id=event_id,
+        raw_file=raw_file,
+        raw_row_ref=raw_row_ref,
+        exception_kind=exception_kind,
+        message=message,
+        resolution_status=decision.get("resolution_status", ""),
+        resolution_note=decision.get("resolution_note", ""),
+    )
+    if exception["resolution_status"] != "accepted":
+        exceptions.append(exception)
+
+
+def parse_number_asset(text: str) -> tuple[str, str]:
+    match = BINANCE_NUMBER_ASSET_PATTERN.match(text.strip())
+    if match is None:
+        raise ValueError(f"Unable to parse amount/asset value: {text!r}")
+    amount = decimal_text(decimal_or_zero(match.group(1)))
+    asset = match.group(2).upper()
+    return amount, asset
+
+
+def extract_trade_id(text: str) -> str:
+    match = BINANCE_TRADE_ID_PATTERN.search(text)
+    return match.group("trade_id") if match is not None else ""
+
+
+def sum_changes(rows: Iterable[dict[str, str]]) -> dict[str, Decimal]:
+    totals: dict[str, Decimal] = defaultdict(Decimal)
+    for row in rows:
+        totals[row["Coin"].upper()] += decimal_or_zero(row["Change"])
+    return totals
 
 
 class SourceAdapter:
@@ -198,7 +329,9 @@ class CoinbaseAdapter(SourceAdapter):
 
         exceptions: list[dict[str, str]] = []
         if retail_path is None:
-            missing = default_exception_row(
+            maybe_append_exception(
+                exceptions,
+                exception_decisions,
                 manifest_fingerprint=profile.manifest_fingerprint,
                 source=profile.source,
                 adapter=self.name,
@@ -207,11 +340,7 @@ class CoinbaseAdapter(SourceAdapter):
                 raw_row_ref="",
                 exception_kind="missing_required_input",
                 message="Coinbase retail all-time CSV is required for deterministic normalization.",
-                resolution_status=exception_decisions.get("coinbase:missing_retail_csv", {}).get("resolution_status", ""),
-                resolution_note=exception_decisions.get("coinbase:missing_retail_csv", {}).get("resolution_note", ""),
             )
-            if missing["resolution_status"] != "accepted":
-                exceptions.append(missing)
             return AdapterNormalizationResult(canonical_events=[], canonical_balances=[], exceptions=exceptions)
 
         normalized_rows = normalize_coinbase_transactions(
@@ -231,11 +360,929 @@ class CoinbaseAdapter(SourceAdapter):
 class WealthsimpleAdapter(SourceAdapter):
     name = "wealthsimple"
     aliases = ("wealthsimple", "wealthsimple crypto")
+    supported = True
+
+    def normalize(
+        self,
+        raw_dir: Path,
+        profile: SourceProfile,
+        *,
+        exception_decisions: dict[str, dict[str, str]],
+    ) -> AdapterNormalizationResult:
+        activity_paths = sorted(path for path in raw_dir.glob("activities-export*.csv") if path.is_file())
+        exceptions: list[dict[str, str]] = []
+        if not activity_paths:
+            maybe_append_exception(
+                exceptions,
+                exception_decisions,
+                manifest_fingerprint=profile.manifest_fingerprint,
+                source=profile.source,
+                adapter=self.name,
+                event_id="wealthsimple:missing_activities_export",
+                raw_file="",
+                raw_row_ref="",
+                exception_kind="missing_required_input",
+                message="Wealthsimple activities export CSV is required for deterministic crypto normalization.",
+            )
+            return AdapterNormalizationResult(canonical_events=[], canonical_balances=[], exceptions=exceptions)
+
+        events: list[dict[str, str]] = []
+        for path in activity_paths:
+            for index, row in enumerate(read_csv_rows(path), start=2):
+                if not any((value or "").strip() for value in row.values()):
+                    continue
+                transaction_date = (row.get("transaction_date") or "").strip()
+                if not transaction_date or transaction_date.lower().startswith("as of "):
+                    continue
+                if (row.get("account_type") or "").strip().lower() != "crypto":
+                    continue
+                timestamp_source = (row.get("settlement_date") or "").strip() or transaction_date
+                timestamp = normalized_timestamp(timestamp_source, WEALTHSIMPLE_TIME_FORMATS)
+                raw_row_ref = f"row:{index}"
+                event_id = event_id_for(self.name, path.name, raw_row_ref)
+                activity_type = (row.get("activity_type") or "").strip()
+                activity_sub_type = (row.get("activity_sub_type") or "").strip()
+                description = f"{activity_type}:{activity_sub_type or 'base'}"
+                account = (row.get("account_id") or "").strip() or "Wealthsimple Crypto"
+                quantity = decimal_or_zero(row.get("quantity"))
+                currency = (row.get("currency") or "").strip().upper()
+                symbol = (row.get("symbol") or "").strip().upper()
+                commission = decimal_or_zero(row.get("commission"))
+                net_cash = decimal_or_zero(row.get("net_cash_amount"))
+
+                if activity_type == "Trade" and symbol and currency:
+                    if activity_sub_type == "BUY":
+                        events.append(
+                            canonical_event(
+                                event_id=event_id,
+                                source=profile.source,
+                                adapter=self.name,
+                                account=account,
+                                wallet=account,
+                                raw_file=path.name,
+                                raw_row_ref=raw_row_ref,
+                                timestamp=timestamp,
+                                event_kind="Trade",
+                                description="Wealthsimple Crypto buy",
+                                amount_in=decimal_text(abs(quantity)),
+                                asset_in=symbol,
+                                amount_out=decimal_text(abs(net_cash)),
+                                asset_out=currency,
+                                fee_amount=decimal_text(commission),
+                                fee_asset=currency,
+                                render_notes=description,
+                            )
+                        )
+                        continue
+                    if activity_sub_type == "SELL":
+                        events.append(
+                            canonical_event(
+                                event_id=event_id,
+                                source=profile.source,
+                                adapter=self.name,
+                                account=account,
+                                wallet=account,
+                                raw_file=path.name,
+                                raw_row_ref=raw_row_ref,
+                                timestamp=timestamp,
+                                event_kind="Trade",
+                                description="Wealthsimple Crypto sell",
+                                amount_in=decimal_text(abs(net_cash)),
+                                asset_in=currency,
+                                amount_out=decimal_text(abs(quantity)),
+                                asset_out=symbol,
+                                fee_amount=decimal_text(commission),
+                                fee_asset=currency,
+                                render_notes=description,
+                            )
+                        )
+                        continue
+
+                if activity_type == "MoneyMovement" and currency:
+                    if quantity >= 0:
+                        events.append(
+                            canonical_event(
+                                event_id=event_id,
+                                source=profile.source,
+                                adapter=self.name,
+                                account=account,
+                                wallet=account,
+                                raw_file=path.name,
+                                raw_row_ref=raw_row_ref,
+                                timestamp=timestamp,
+                                event_kind="Deposit",
+                                description=f"Wealthsimple money movement {activity_sub_type or 'credit'}",
+                                amount_in=decimal_text(abs(quantity)),
+                                asset_in=currency,
+                                render_notes=description,
+                            )
+                        )
+                    else:
+                        events.append(
+                            canonical_event(
+                                event_id=event_id,
+                                source=profile.source,
+                                adapter=self.name,
+                                account=account,
+                                wallet=account,
+                                raw_file=path.name,
+                                raw_row_ref=raw_row_ref,
+                                timestamp=timestamp,
+                                event_kind="Withdrawal",
+                                description=f"Wealthsimple money movement {activity_sub_type or 'debit'}",
+                                amount_out=decimal_text(abs(quantity)),
+                                asset_out=currency,
+                                render_notes=description,
+                            )
+                        )
+                    continue
+
+                maybe_append_exception(
+                    exceptions,
+                    exception_decisions,
+                    manifest_fingerprint=profile.manifest_fingerprint,
+                    source=profile.source,
+                    adapter=self.name,
+                    event_id=event_id,
+                    raw_file=path.name,
+                    raw_row_ref=raw_row_ref,
+                    exception_kind="unsupported_row",
+                    message=f"Unsupported Wealthsimple crypto activity: {activity_type}/{activity_sub_type}",
+                )
+
+        return AdapterNormalizationResult(canonical_events=events, canonical_balances=[], exceptions=exceptions)
 
 
 class BinanceAdapter(SourceAdapter):
     name = "binance"
     aliases = ("binance",)
+    supported = True
+
+    _trade_operations = {
+        "Buy",
+        "Sell",
+        "Fee",
+        "Transaction Buy",
+        "Transaction Spend",
+        "Transaction Fee",
+        "Transaction Revenue",
+        "Transaction Sold",
+        "Transaction Related",
+        "Binance Convert",
+        "Small Assets Exchange BNB",
+        "ETH 2.0 Staking",
+        "Token Swap - Redenomination/Rebranding",
+        "BETH to WBETH Wrapping",
+    }
+    _ignored_operations = {
+        "Isolated Margin Loan",
+        "Isolated Margin Repayment",
+        "Launchpool Subscription/Redemption",
+        "Staking Purchase",
+        "Staking Redemption",
+        "Simple Earn Flexible Subscription",
+        "Simple Earn Flexible Redemption",
+        "Transfer Between Main Account/Futures and Margin Account",
+        "Transfer Between Main and Funding Wallet",
+        "Transfer Between UM Futures and Funding Account",
+        "Transfer Between Spot Account and UM Futures Account",
+        "Transfer Between Futures Contract Accounts",
+        "Send/Recieve",
+        "P2P Trading",
+        "BNB Fee Deduction",
+    }
+    _income_type_by_operation = {
+        "Staking Rewards": "Staking",
+        "ETH 2.0 Staking Rewards": "Staking",
+        "Simple Earn Flexible Interest": "Interest Income",
+        "Launchpool Airdrop - User Claim Distribution": "Interest Income",
+        "Airdrop Assets": "Airdrop",
+        "Token Swap - Distribution": "Reward / Bonus",
+    }
+
+    def normalize(
+        self,
+        raw_dir: Path,
+        profile: SourceProfile,
+        *,
+        exception_decisions: dict[str, dict[str, str]],
+    ) -> AdapterNormalizationResult:
+        events: list[dict[str, str]] = []
+        exceptions: list[dict[str, str]] = []
+        balances: list[dict[str, str]] = []
+        covered_timestamps: set[str] = set()
+        has_c2c_history = any(path.name.startswith("Binance-C2C-Order-History-") for path in raw_dir.glob("*.csv"))
+
+        for pdf_path in sorted(raw_dir.glob("AccountStatementPeriod_*.pdf")):
+            balances.extend(binance_balance_rows_from_text(extract_pdf_text(pdf_path), pdf_path.name))
+
+        for path in sorted(raw_dir.glob("*.csv")):
+            name = path.name
+            if name.startswith("Binance-Spot-Trade-History-"):
+                events.extend(self._spot_trade_events(path, profile.source))
+                covered_timestamps.update(self._timestamps_for_file(path, "Time", status_field=None, allowed_statuses=None))
+            elif name.startswith("Binance-Convert-Order-History-"):
+                events.extend(self._convert_order_events(path, profile.source))
+                covered_timestamps.update(self._timestamps_for_file(path, "Time", status_field="Status", allowed_statuses={"Successful"}))
+            elif name.startswith("Binance-Deposit-History-"):
+                events.extend(self._deposit_history_events(path, profile.source))
+                covered_timestamps.update(self._timestamps_for_file(path, "Time", status_field="Status", allowed_statuses={"Completed"}))
+            elif name.startswith("Binance-Withdraw-History-"):
+                events.extend(self._withdraw_history_events(path, profile.source))
+                covered_timestamps.update(self._timestamps_for_file(path, "Time", status_field="Status", allowed_statuses={"Completed"}))
+            elif name.startswith("Binance-Fiat-Buy-History-"):
+                events.extend(self._fiat_buy_history_events(path, profile.source))
+                covered_timestamps.update(self._timestamps_for_file(path, "Time", status_field="Status", allowed_statuses={"Successful"}))
+            elif name.startswith("Binance-Fiat-Sell-History-"):
+                events.extend(self._fiat_sell_history_events(path, profile.source))
+                covered_timestamps.update(self._timestamps_for_file(path, "Time", status_field="Status", allowed_statuses={"Successful"}))
+            elif name.startswith("Binance-C2C-Order-History-"):
+                events.extend(self._c2c_order_events(path, profile.source))
+                covered_timestamps.update(self._timestamps_for_file(path, "Created Time", status_field="Status", allowed_statuses={"Completed"}))
+            elif name.startswith("Binance-Transaction-History-") or re.match(r"^Binance Transactions \d{4}\.csv$", name):
+                events.extend(
+                    self._transaction_history_events(
+                        path,
+                        profile,
+                        exception_decisions=exception_decisions,
+                        covered_timestamps=covered_timestamps,
+                        has_c2c_history=has_c2c_history,
+                        exceptions=exceptions,
+                    )
+                )
+
+        return AdapterNormalizationResult(canonical_events=events, canonical_balances=balances, exceptions=exceptions)
+
+    def _timestamps_for_file(
+        self,
+        path: Path,
+        field: str,
+        *,
+        status_field: str | None,
+        allowed_statuses: set[str] | None,
+    ) -> set[str]:
+        timestamps: set[str] = set()
+        for row in read_csv_rows(path):
+            values = [str(value).strip() for value in row.values() if value not in (None, "")]
+            if values == ["No data matches the criteria."] or not any(values):
+                continue
+            if status_field is not None and allowed_statuses is not None:
+                if (row.get(status_field) or "").strip() not in allowed_statuses:
+                    continue
+            timestamp = (row.get(field) or "").strip()
+            if timestamp:
+                timestamps.add(timestamp)
+        return timestamps
+
+    def _spot_trade_events(self, path: Path, source: str) -> list[dict[str, str]]:
+        events: list[dict[str, str]] = []
+        for index, row in enumerate(read_csv_rows(path), start=2):
+            if not any((value or "").strip() for value in row.values()):
+                continue
+            executed_amount, executed_asset = parse_number_asset(row["Executed"])
+            quote_amount, quote_asset = parse_number_asset(row["Amount"])
+            fee_amount, fee_asset = parse_number_asset(row["Fee"])
+            timestamp = normalized_timestamp(row["Time"], BINANCE_TIME_FORMATS)
+            side = (row.get("Side") or "").strip().upper()
+            raw_row_ref = f"row:{index}"
+            event_id = event_id_for(self.name, path.name, raw_row_ref)
+            if side == "BUY":
+                amount_in, asset_in = executed_amount, executed_asset
+                amount_out, asset_out = quote_amount, quote_asset
+            else:
+                amount_in, asset_in = quote_amount, quote_asset
+                amount_out, asset_out = executed_amount, executed_asset
+            events.append(
+                canonical_event(
+                    event_id=event_id,
+                    source=source,
+                    adapter=self.name,
+                    account="Spot",
+                    wallet="Spot",
+                    raw_file=path.name,
+                    raw_row_ref=raw_row_ref,
+                    timestamp=timestamp,
+                    event_kind="Trade",
+                    description=f"Binance spot {side.lower()} {row['Pair']}",
+                    amount_in=amount_in,
+                    asset_in=asset_in,
+                    amount_out=amount_out,
+                    asset_out=asset_out,
+                    fee_amount=fee_amount,
+                    fee_asset=fee_asset,
+                    render_group="Spot",
+                    render_notes=row["Pair"],
+                )
+            )
+        return events
+
+    def _convert_order_events(self, path: Path, source: str) -> list[dict[str, str]]:
+        events: list[dict[str, str]] = []
+        for index, row in enumerate(read_csv_rows(path), start=2):
+            if (row.get("Status") or "").strip() != "Successful":
+                continue
+            sell_amount, sell_asset = parse_number_asset(row["Sell"])
+            buy_amount, buy_asset = parse_number_asset(row["Buy"])
+            timestamp = normalized_timestamp(row["Time"], BINANCE_TIME_FORMATS)
+            raw_row_ref = f"row:{index}"
+            events.append(
+                canonical_event(
+                    event_id=event_id_for(self.name, path.name, raw_row_ref),
+                    source=source,
+                    adapter=self.name,
+                    account=(row.get("Wallet") or "Spot").strip() or "Spot",
+                    wallet=(row.get("Wallet") or "Spot").strip() or "Spot",
+                    raw_file=path.name,
+                    raw_row_ref=raw_row_ref,
+                    timestamp=timestamp,
+                    event_kind="Trade",
+                    description=f"Binance convert {row['Pair']}",
+                    amount_in=buy_amount,
+                    asset_in=buy_asset,
+                    amount_out=sell_amount,
+                    asset_out=sell_asset,
+                    render_group=(row.get("Wallet") or "Spot").strip().title() or "Spot",
+                    render_notes="Binance Convert",
+                )
+            )
+        return events
+
+    def _deposit_history_events(self, path: Path, source: str) -> list[dict[str, str]]:
+        events: list[dict[str, str]] = []
+        for index, row in enumerate(read_csv_rows(path), start=2):
+            if (row.get("Status") or "").strip() != "Completed":
+                continue
+            raw_row_ref = f"row:{index}"
+            events.append(
+                canonical_event(
+                    event_id=event_id_for(self.name, path.name, raw_row_ref),
+                    source=source,
+                    adapter=self.name,
+                    account="Binance",
+                    wallet="Funding",
+                    raw_file=path.name,
+                    raw_row_ref=raw_row_ref,
+                    timestamp=normalized_timestamp(row["Time"], BINANCE_TIME_FORMATS),
+                    event_kind="Deposit",
+                    description=f"Binance deposit via {row['Network']}",
+                    amount_in=decimal_text(decimal_or_zero(row["Amount"])),
+                    asset_in=(row.get("Coin") or "").strip().upper(),
+                    tx_hash=(row.get("TXID") or "").strip(),
+                    render_group="Funding",
+                    render_notes=row.get("Address", ""),
+                )
+            )
+        return events
+
+    def _withdraw_history_events(self, path: Path, source: str) -> list[dict[str, str]]:
+        events: list[dict[str, str]] = []
+        for index, row in enumerate(read_csv_rows(path), start=2):
+            if (row.get("Status") or "").strip() != "Completed":
+                continue
+            asset = (row.get("Coin") or "").strip().upper()
+            raw_row_ref = f"row:{index}"
+            events.append(
+                canonical_event(
+                    event_id=event_id_for(self.name, path.name, raw_row_ref),
+                    source=source,
+                    adapter=self.name,
+                    account="Binance",
+                    wallet="Funding",
+                    raw_file=path.name,
+                    raw_row_ref=raw_row_ref,
+                    timestamp=normalized_timestamp(row["Time"], BINANCE_TIME_FORMATS),
+                    event_kind="Withdrawal",
+                    description=f"Binance withdrawal via {row['Network']}",
+                    amount_out=decimal_text(decimal_or_zero(row["Amount"])),
+                    asset_out=asset,
+                    fee_amount=decimal_text(decimal_or_zero(row.get("Fee"))),
+                    fee_asset=asset,
+                    tx_hash=(row.get("TXID") or "").strip(),
+                    render_group="Funding",
+                    render_notes=row.get("Address", ""),
+                )
+            )
+        return events
+
+    def _fiat_buy_history_events(self, path: Path, source: str) -> list[dict[str, str]]:
+        events: list[dict[str, str]] = []
+        for index, row in enumerate(read_csv_rows(path), start=2):
+            if (row.get("Status") or "").strip() != "Successful":
+                continue
+            spend_amount, spend_asset = parse_number_asset(row["Spend Amount"])
+            receive_amount, receive_asset = parse_number_asset(row["Receive Amount"])
+            fee_amount, fee_asset = parse_number_asset(row["Fee"])
+            raw_row_ref = f"row:{index}"
+            events.append(
+                canonical_event(
+                    event_id=event_id_for(self.name, path.name, raw_row_ref),
+                    source=source,
+                    adapter=self.name,
+                    account="Funding",
+                    wallet="Funding",
+                    raw_file=path.name,
+                    raw_row_ref=raw_row_ref,
+                    timestamp=normalized_timestamp(row["Time"], BINANCE_TIME_FORMATS),
+                    event_kind="Trade",
+                    description=f"Binance fiat buy via {row['Method']}",
+                    amount_in=receive_amount,
+                    asset_in=receive_asset,
+                    amount_out=spend_amount,
+                    asset_out=spend_asset,
+                    fee_amount=fee_amount,
+                    fee_asset=fee_asset,
+                    tx_hash=(row.get("Transaction ID") or "").strip(),
+                    render_group="Funding",
+                    render_notes=row.get("Price", ""),
+                )
+            )
+        return events
+
+    def _fiat_sell_history_events(self, path: Path, source: str) -> list[dict[str, str]]:
+        events: list[dict[str, str]] = []
+        for index, row in enumerate(read_csv_rows(path), start=2):
+            values = [str(value).strip() for value in row.values() if value not in (None, "")]
+            if values == ["No data matches the criteria."] or (row.get("Status") or "").strip() != "Successful":
+                continue
+            spend_amount, spend_asset = parse_number_asset(row["Spend Amount"])
+            receive_amount, receive_asset = parse_number_asset(row["Receive Amount"])
+            fee_amount, fee_asset = parse_number_asset(row["Fee"])
+            raw_row_ref = f"row:{index}"
+            events.append(
+                canonical_event(
+                    event_id=event_id_for(self.name, path.name, raw_row_ref),
+                    source=source,
+                    adapter=self.name,
+                    account="Funding",
+                    wallet="Funding",
+                    raw_file=path.name,
+                    raw_row_ref=raw_row_ref,
+                    timestamp=normalized_timestamp(row["Time"], BINANCE_TIME_FORMATS),
+                    event_kind="Trade",
+                    description=f"Binance fiat sell via {row['Method']}",
+                    amount_in=receive_amount,
+                    asset_in=receive_asset,
+                    amount_out=spend_amount,
+                    asset_out=spend_asset,
+                    fee_amount=fee_amount,
+                    fee_asset=fee_asset,
+                    tx_hash=(row.get("Transaction ID") or "").strip(),
+                    render_group="Funding",
+                    render_notes=row.get("Price", ""),
+                )
+            )
+        return events
+
+    def _c2c_order_events(self, path: Path, source: str) -> list[dict[str, str]]:
+        events: list[dict[str, str]] = []
+        for index, row in enumerate(read_csv_rows(path), start=2):
+            if (row.get("Status") or "").strip() != "Completed":
+                continue
+            raw_row_ref = f"row:{index}"
+            order_type = (row.get("Order Type") or "").strip().lower()
+            fiat_asset = (row.get("Fiat Type") or "").strip().upper()
+            crypto_asset = (row.get("Asset") or "").strip().upper()
+            fiat_amount = decimal_text(decimal_or_zero(row["Total Price"]))
+            crypto_amount = decimal_text(decimal_or_zero(row["Quantity"]))
+            amount_in, asset_in = (fiat_amount, fiat_asset) if order_type == "sell" else (crypto_amount, crypto_asset)
+            amount_out, asset_out = (crypto_amount, crypto_asset) if order_type == "sell" else (fiat_amount, fiat_asset)
+            events.append(
+                canonical_event(
+                    event_id=event_id_for(self.name, path.name, raw_row_ref),
+                    source=source,
+                    adapter=self.name,
+                    account="Funding",
+                    wallet="Funding",
+                    raw_file=path.name,
+                    raw_row_ref=raw_row_ref,
+                    timestamp=normalized_timestamp(row["Created Time"], BINANCE_TIME_FORMATS),
+                    event_kind="Trade",
+                    description=f"Binance P2P {order_type} {crypto_asset}/{fiat_asset}",
+                    amount_in=amount_in,
+                    asset_in=asset_in,
+                    amount_out=amount_out,
+                    asset_out=asset_out,
+                    tx_hash=(row.get("Order Number") or "").strip(),
+                    render_group="Funding",
+                    render_notes=row.get("Counterparty", ""),
+                )
+            )
+        return events
+
+    def _transaction_history_events(
+        self,
+        path: Path,
+        profile: SourceProfile,
+        *,
+        exception_decisions: dict[str, dict[str, str]],
+        covered_timestamps: set[str],
+        has_c2c_history: bool,
+        exceptions: list[dict[str, str]],
+    ) -> list[dict[str, str]]:
+        groups: dict[tuple[str, str], list[tuple[int, dict[str, str]]]] = defaultdict(list)
+        for index, row in enumerate(read_csv_rows(path), start=2):
+            if not any((value or "").strip() for value in row.values()):
+                continue
+            groups[((row.get("Time") or "").strip(), (row.get("Account") or "").strip())].append((index, row))
+
+        events: list[dict[str, str]] = []
+        for (timestamp_text, account), indexed_rows in sorted(groups.items()):
+            if not timestamp_text:
+                continue
+            if timestamp_text in covered_timestamps:
+                continue
+
+            active_rows = [(index, row) for index, row in indexed_rows if (row.get("Operation") or "").strip() not in self._ignored_operations]
+            if not active_rows:
+                continue
+
+            filtered_rows = list(active_rows)
+            operations = {(row.get("Operation") or "").strip() for _, row in filtered_rows}
+            if operations & self._trade_operations and operations & {"Deposit", "Withdraw"}:
+                filtered_rows = [
+                    (index, row)
+                    for index, row in filtered_rows
+                    if (row.get("Operation") or "").strip() not in {"Deposit", "Withdraw"}
+                ]
+            active_rows = filtered_rows
+            operations = {(row.get("Operation") or "").strip() for _, row in active_rows}
+            if operations == {"P2P Trading"} and has_c2c_history:
+                continue
+
+            if operations <= self._income_type_by_operation.keys() | {"Distribution", "Realized Profit and Loss", "Funding Fee", "Asset Recovery", "Deposit", "Withdraw", "Fee"}:
+                events.extend(self._single_row_events(path, profile.source, account, active_rows))
+                continue
+
+            if operations <= self._trade_operations:
+                parsed = self._grouped_trade_events(
+                    path,
+                    profile,
+                    account,
+                    timestamp_text,
+                    active_rows,
+                    exception_decisions=exception_decisions,
+                )
+                events.extend(parsed[0])
+                if parsed[1] is not None and parsed[1].get("resolution_status") != "accepted":
+                    exceptions.append(parsed[1])
+                continue
+
+            raw_row_ref = f"group:{timestamp_text}:{account or 'unknown'}"
+            event_id = event_id_for(self.name, path.name, raw_row_ref)
+            maybe_append_exception(
+                exceptions,
+                exception_decisions,
+                manifest_fingerprint=profile.manifest_fingerprint,
+                source=profile.source,
+                adapter=self.name,
+                event_id=event_id,
+                raw_file=path.name,
+                raw_row_ref=raw_row_ref,
+                exception_kind="unsupported_group",
+                message=f"Unsupported Binance transaction-history operations: {', '.join(sorted(operations))}",
+            )
+        return events
+
+    def _single_row_events(
+        self,
+        path: Path,
+        source: str,
+        account: str,
+        indexed_rows: list[tuple[int, dict[str, str]]],
+    ) -> list[dict[str, str]]:
+        events: list[dict[str, str]] = []
+        for index, row in indexed_rows:
+            operation = (row.get("Operation") or "").strip()
+            amount = decimal_text(abs(decimal_or_zero(row.get("Change"))))
+            asset = (row.get("Coin") or "").strip().upper()
+            timestamp = normalized_timestamp(row["Time"], BINANCE_TIME_FORMATS)
+            raw_row_ref = f"row:{index}"
+            event_id = event_id_for(self.name, path.name, raw_row_ref)
+            description = row.get("Remark", "") or operation
+            tx_hash = extract_trade_id(row.get("Remark", ""))
+
+            if operation in self._income_type_by_operation:
+                events.append(
+                    canonical_event(
+                        event_id=event_id,
+                        source=source,
+                        adapter=self.name,
+                        account=account or "Spot",
+                        wallet=account or "Spot",
+                        raw_file=path.name,
+                        raw_row_ref=raw_row_ref,
+                        timestamp=timestamp,
+                        event_kind=self._income_type_by_operation[operation],
+                        description=description,
+                        amount_in=amount,
+                        asset_in=asset,
+                        tx_hash=tx_hash,
+                        render_group=account or "Spot",
+                        render_notes=operation,
+                    )
+                )
+            elif operation == "Deposit":
+                events.append(
+                    canonical_event(
+                        event_id=event_id,
+                        source=source,
+                        adapter=self.name,
+                        account=account or "Spot",
+                        wallet=account or "Spot",
+                        raw_file=path.name,
+                        raw_row_ref=raw_row_ref,
+                        timestamp=timestamp,
+                        event_kind="Deposit",
+                        description=description,
+                        amount_in=amount,
+                        asset_in=asset,
+                        tx_hash=tx_hash,
+                        render_group=account or "Spot",
+                        render_notes=operation,
+                    )
+                )
+            elif operation == "Withdraw":
+                events.append(
+                    canonical_event(
+                        event_id=event_id,
+                        source=source,
+                        adapter=self.name,
+                        account=account or "Spot",
+                        wallet=account or "Spot",
+                        raw_file=path.name,
+                        raw_row_ref=raw_row_ref,
+                        timestamp=timestamp,
+                        event_kind="Withdrawal",
+                        description=description,
+                        amount_out=amount,
+                        asset_out=asset,
+                        tx_hash=tx_hash,
+                        render_group=account or "Spot",
+                        render_notes=operation,
+                    )
+                )
+            elif operation == "Fee":
+                events.append(
+                    canonical_event(
+                        event_id=event_id,
+                        source=source,
+                        adapter=self.name,
+                        account=account or "Spot",
+                        wallet=account or "Spot",
+                        raw_file=path.name,
+                        raw_row_ref=raw_row_ref,
+                        timestamp=timestamp,
+                        event_kind="Other Fee",
+                        description=description,
+                        amount_out=amount,
+                        asset_out=asset,
+                        tx_hash=tx_hash,
+                        render_group=account or "Spot",
+                        render_notes=operation,
+                    )
+                )
+            elif operation == "Distribution":
+                event_kind = "Airdrop" if "airdrop" in description.lower() else "Reward / Bonus"
+                if decimal_or_zero(row.get("Change")) >= 0:
+                    events.append(
+                        canonical_event(
+                            event_id=event_id,
+                            source=source,
+                            adapter=self.name,
+                            account=account or "Spot",
+                            wallet=account or "Spot",
+                            raw_file=path.name,
+                            raw_row_ref=raw_row_ref,
+                            timestamp=timestamp,
+                            event_kind=event_kind,
+                            description=description,
+                            amount_in=amount,
+                            asset_in=asset,
+                            render_group=account or "Spot",
+                            render_notes=operation,
+                        )
+                    )
+                else:
+                    events.append(
+                        canonical_event(
+                            event_id=event_id,
+                            source=source,
+                            adapter=self.name,
+                            account=account or "Spot",
+                            wallet=account or "Spot",
+                            raw_file=path.name,
+                            raw_row_ref=raw_row_ref,
+                            timestamp=timestamp,
+                            event_kind="Other Expense",
+                            description=description,
+                            amount_out=amount,
+                            asset_out=asset,
+                            render_group=account or "Spot",
+                            render_notes=operation,
+                        )
+                    )
+            elif operation == "Asset Recovery":
+                events.append(
+                    canonical_event(
+                        event_id=event_id,
+                        source=source,
+                        adapter=self.name,
+                        account=account or "Spot",
+                        wallet=account or "Spot",
+                        raw_file=path.name,
+                        raw_row_ref=raw_row_ref,
+                        timestamp=timestamp,
+                        event_kind="Other Expense",
+                        description=description,
+                        amount_out=amount,
+                        asset_out=asset,
+                        render_group=account or "Spot",
+                        render_notes=operation,
+                    )
+                )
+            elif operation in {"Realized Profit and Loss", "Funding Fee"}:
+                event_kind = "Derivatives / Futures Profit" if decimal_or_zero(row.get("Change")) >= 0 else "Derivatives / Futures Loss"
+                payload = {
+                    "event_id": event_id,
+                    "source": source,
+                    "adapter": self.name,
+                    "account": account or "USD-M Futures",
+                    "wallet": account or "USD-M Futures",
+                    "raw_file": path.name,
+                    "raw_row_ref": raw_row_ref,
+                    "timestamp": timestamp,
+                    "event_kind": event_kind,
+                    "description": description,
+                    "render_group": account or "USD-M Futures",
+                    "render_notes": operation,
+                    "tx_hash": tx_hash,
+                }
+                if decimal_or_zero(row.get("Change")) >= 0:
+                    payload.update({"amount_in": amount, "asset_in": asset})
+                else:
+                    payload.update({"amount_out": amount, "asset_out": asset})
+                events.append(canonical_event(**payload))
+        return events
+
+    def _grouped_trade_events(
+        self,
+        path: Path,
+        profile: SourceProfile,
+        account: str,
+        timestamp_text: str,
+        indexed_rows: list[tuple[int, dict[str, str]]],
+        *,
+        exception_decisions: dict[str, dict[str, str]],
+    ) -> tuple[list[dict[str, str]], dict[str, str] | None]:
+        rows = [row for _, row in indexed_rows]
+        operations = {(row.get("Operation") or "").strip() for row in rows}
+        raw_row_ref = f"group:{timestamp_text}:{account or 'unknown'}"
+        timestamp = normalized_timestamp(timestamp_text, BINANCE_TIME_FORMATS)
+
+        if operations == {"Small Assets Exchange BNB"}:
+            events, message = self._small_asset_exchange_events(path, profile.source, account, timestamp, indexed_rows)
+            if message is None:
+                return events, None
+            event_id = event_id_for(self.name, path.name, raw_row_ref)
+            return [], default_exception_row(
+                manifest_fingerprint=profile.manifest_fingerprint,
+                source=profile.source,
+                adapter=self.name,
+                event_id=event_id,
+                raw_file=path.name,
+                raw_row_ref=raw_row_ref,
+                exception_kind="ambiguous_group",
+                message=message,
+                resolution_status=exception_decisions.get(event_id, {}).get("resolution_status", ""),
+                resolution_note=exception_decisions.get(event_id, {}).get("resolution_note", ""),
+            )
+
+        fee_rows = [row for row in rows if (row.get("Operation") or "").strip() in {"Fee", "Transaction Fee"}]
+        non_fee_rows = [row for row in rows if row not in fee_rows]
+        positive = {asset: total for asset, total in sum_changes(non_fee_rows).items() if total > 0}
+        negative = {asset: abs(total) for asset, total in sum_changes(non_fee_rows).items() if total < 0}
+        fee_totals = {asset: abs(total) for asset, total in sum_changes(fee_rows).items() if total != 0}
+
+        if not positive and not negative and len(fee_totals) == 1:
+            fee_asset, fee_amount = next(iter(fee_totals.items()))
+            event = canonical_event(
+                event_id=event_id_for(self.name, path.name, raw_row_ref),
+                source=profile.source,
+                adapter=self.name,
+                account=account or "Spot",
+                wallet=account or "Spot",
+                raw_file=path.name,
+                raw_row_ref=raw_row_ref,
+                timestamp=timestamp,
+                event_kind="Other Fee",
+                description=rows[0].get("Remark", "") or "Binance fee row",
+                amount_out=decimal_text(fee_amount),
+                asset_out=fee_asset,
+                render_group=account or "Spot",
+                render_notes=", ".join(sorted(operations)),
+            )
+            return [event], None
+
+        if len(positive) == 1 and len(negative) == 1 and len(fee_totals) <= 1:
+            asset_in, amount_in = next(iter(positive.items()))
+            asset_out, amount_out = next(iter(negative.items()))
+            fee_asset = ""
+            fee_amount = ""
+            if fee_totals:
+                fee_asset, fee_total = next(iter(fee_totals.items()))
+                fee_amount = decimal_text(fee_total)
+            trade_id = next((extract_trade_id(row.get("Remark", "")) for row in rows if extract_trade_id(row.get("Remark", ""))), "")
+            event = canonical_event(
+                event_id=event_id_for(self.name, path.name, raw_row_ref),
+                source=profile.source,
+                adapter=self.name,
+                account=account or "Spot",
+                wallet=account or "Spot",
+                raw_file=path.name,
+                raw_row_ref=raw_row_ref,
+                timestamp=timestamp,
+                event_kind="Trade",
+                description=rows[0].get("Remark", "") or "Binance grouped trade",
+                amount_in=decimal_text(amount_in),
+                asset_in=asset_in,
+                amount_out=decimal_text(amount_out),
+                asset_out=asset_out,
+                fee_amount=fee_amount,
+                fee_asset=fee_asset,
+                tx_hash=trade_id,
+                render_group=account or "Spot",
+                render_notes=", ".join(sorted(operations)),
+            )
+            return [event], None
+
+        event_id = event_id_for(self.name, path.name, raw_row_ref)
+        decision = exception_decisions.get(event_id, {})
+        return [], default_exception_row(
+            manifest_fingerprint=profile.manifest_fingerprint,
+            source=profile.source,
+            adapter=self.name,
+            event_id=event_id,
+            raw_file=path.name,
+            raw_row_ref=raw_row_ref,
+            exception_kind="ambiguous_group",
+            message=f"Unable to safely collapse Binance grouped rows with operations: {', '.join(sorted(operations))}",
+            resolution_status=decision.get("resolution_status", ""),
+            resolution_note=decision.get("resolution_note", ""),
+        )
+
+    def _small_asset_exchange_events(
+        self,
+        path: Path,
+        source: str,
+        account: str,
+        timestamp: str,
+        indexed_rows: list[tuple[int, dict[str, str]]],
+    ) -> tuple[list[dict[str, str]], str | None]:
+        buy_by_asset: dict[str, Decimal] = defaultdict(Decimal)
+        sell_by_asset: dict[str, Decimal] = defaultdict(Decimal)
+        raw_refs: dict[str, list[str]] = defaultdict(list)
+        unresolved = False
+
+        for index, row in indexed_rows:
+            coin = (row.get("Coin") or "").strip().upper()
+            change = decimal_or_zero(row.get("Change"))
+            raw_refs[coin].append(f"row:{index}")
+            remark_match = BINANCE_SMALL_ASSET_PATTERN.match((row.get("Remark") or "").strip())
+            mapped_asset = (remark_match.group("asset") if remark_match is not None else coin).upper()
+            if change < 0 and coin != "BNB":
+                sell_by_asset[mapped_asset] += abs(change)
+            elif change > 0 and coin == "BNB":
+                buy_by_asset[mapped_asset] += change
+            else:
+                unresolved = True
+
+        if unresolved or set(buy_by_asset) != set(sell_by_asset):
+            return [], "Unable to safely pair Binance Small Assets Exchange rows into asset-specific BNB trades."
+
+        events: list[dict[str, str]] = []
+        for asset in sorted(sell_by_asset):
+            raw_row_ref = f"small_assets:{asset}"
+            events.append(
+                canonical_event(
+                    event_id=event_id_for(self.name, path.name, raw_row_ref),
+                    source=source,
+                    adapter=self.name,
+                    account=account or "Spot",
+                    wallet=account or "Spot",
+                    raw_file=path.name,
+                    raw_row_ref=";".join(sorted(raw_refs.get(asset, []))),
+                    timestamp=timestamp,
+                    event_kind="Trade",
+                    description=f"Binance dust conversion {asset} to BNB",
+                    amount_in=decimal_text(buy_by_asset[asset]),
+                    asset_in="BNB",
+                    amount_out=decimal_text(sell_by_asset[asset]),
+                    asset_out=asset,
+                    render_group=account or "Spot",
+                    render_notes="Small Assets Exchange BNB",
+                )
+            )
+        return events, None
 
 
 class MetamaskAdapter(SourceAdapter):

--- a/06_scripts/source_adapters.py
+++ b/06_scripts/source_adapters.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+
+"""Adapter registry for universal source profiling and normalization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from coinbase_common import (
+    coinbase_balance_rows_from_text,
+    csv_dict_rows,
+    normalize_coinbase_transactions,
+    retail_csv_rows,
+)
+from pipeline_common import CANONICAL_BALANCE_HEADERS, CANONICAL_EVENT_HEADERS, EXCEPTION_HEADERS, SourceProfile
+from script_common import extract_pdf_text, read_cointracking_rows
+
+
+DECISION_HEADERS = (
+    "manifest_fingerprint",
+    "event_id",
+    "resolution_status",
+    "resolution_note",
+)
+
+
+@dataclass(frozen=True)
+class AdapterNormalizationResult:
+    canonical_events: list[dict[str, str]]
+    canonical_balances: list[dict[str, str]]
+    exceptions: list[dict[str, str]]
+
+
+def default_exception_row(
+    *,
+    manifest_fingerprint: str,
+    source: str,
+    adapter: str,
+    event_id: str,
+    raw_file: str,
+    raw_row_ref: str,
+    exception_kind: str,
+    message: str,
+    resolution_status: str = "",
+    resolution_note: str = "",
+) -> dict[str, str]:
+    return {
+        "manifest_fingerprint": manifest_fingerprint,
+        "event_id": event_id,
+        "source": source,
+        "adapter": adapter,
+        "raw_file": raw_file,
+        "raw_row_ref": raw_row_ref,
+        "exception_kind": exception_kind,
+        "message": message,
+        "status": "needs_review",
+        "resolution_status": resolution_status,
+        "resolution_note": resolution_note,
+    }
+
+
+def ct_row_to_canonical_event(row: dict[str, str], adapter_name: str, source_name: str) -> dict[str, str]:
+    return {
+        "event_id": row["Tx-ID"] or f"{adapter_name}:{row['raw_file']}:{row['raw_row_ref']}",
+        "source": source_name,
+        "adapter": adapter_name,
+        "account": row["Exchange"],
+        "wallet": row["Exchange"],
+        "raw_file": row["raw_source"],
+        "raw_row_ref": row["raw_ref"],
+        "timestamp": row["Date"],
+        "event_kind": row["Type"],
+        "asset_in": row["Buy Cur."],
+        "amount_in": row["Buy"],
+        "asset_out": row["Sell Cur."],
+        "amount_out": row["Sell"],
+        "fee_asset": row["Fee Cur."],
+        "fee_amount": row["Fee"],
+        "tx_hash": row["Tx-ID"],
+        "description": row["Comment"],
+        "confidence": "high",
+        "status": "mapped",
+        "render_type": row["Type"],
+        "render_exchange": row["Exchange"],
+        "render_group": row["Group"],
+        "render_comment": row["Comment"],
+        "render_comment_mode": row["comment_mode"],
+        "render_tx_id": row["Tx-ID"],
+        "render_tx_id_mode": row["tx_id_mode"],
+        "render_allowed_types": row["allowed_types"],
+        "render_match_window_seconds": row["match_window_seconds"],
+        "render_fee_tolerance": row["fee_tolerance"],
+        "render_notes": row["notes"],
+    }
+
+
+def load_exception_decisions(path: Path | None, manifest_fingerprint: str) -> dict[str, dict[str, str]]:
+    if path is None or not path.exists():
+        return {}
+    rows = read_cointracking_rows(path) if path.suffix.lower() == ".csv" and path.name.endswith("_ct.csv") else []
+    if rows:
+        return {}
+    import csv
+
+    decisions: dict[str, dict[str, str]] = {}
+    with path.open(newline="", encoding="utf-8-sig") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            if row.get("manifest_fingerprint") != manifest_fingerprint:
+                continue
+            event_id = row.get("event_id", "")
+            if not event_id:
+                continue
+            decisions[event_id] = {
+                "resolution_status": row.get("resolution_status", ""),
+                "resolution_note": row.get("resolution_note", ""),
+            }
+    return decisions
+
+
+class SourceAdapter:
+    name = "base"
+    aliases: tuple[str, ...] = ()
+    supported = False
+
+    def matches(self, source: str) -> bool:
+        slug = source.strip().lower()
+        return slug == self.name or slug in self.aliases
+
+    def normalize(
+        self,
+        raw_dir: Path,
+        profile: SourceProfile,
+        *,
+        exception_decisions: dict[str, dict[str, str]],
+    ) -> AdapterNormalizationResult:
+        exception = default_exception_row(
+            manifest_fingerprint=profile.manifest_fingerprint,
+            source=profile.source,
+            adapter=self.name,
+            event_id=f"{self.name}:adapter_not_implemented",
+            raw_file="",
+            raw_row_ref="",
+            exception_kind="adapter_not_implemented",
+            message=f"No deterministic normalization adapter has been implemented for {profile.source}.",
+            resolution_status=exception_decisions.get(f"{self.name}:adapter_not_implemented", {}).get("resolution_status", ""),
+            resolution_note=exception_decisions.get(f"{self.name}:adapter_not_implemented", {}).get("resolution_note", ""),
+        )
+        exceptions = [] if exception["resolution_status"] == "accepted" else [exception]
+        return AdapterNormalizationResult(canonical_events=[], canonical_balances=[], exceptions=exceptions)
+
+
+class CoinbaseAdapter(SourceAdapter):
+    name = "coinbase"
+    aliases = ("coinbase",)
+    supported = True
+
+    def normalize(
+        self,
+        raw_dir: Path,
+        profile: SourceProfile,
+        *,
+        exception_decisions: dict[str, dict[str, str]],
+    ) -> AdapterNormalizationResult:
+        retail_path = None
+        pro_statement_paths: list[Path] = []
+        pro_fill_paths: list[Path] = []
+        pdf_paths: list[Path] = []
+
+        for path in sorted(raw_dir.iterdir()):
+            if not path.is_file():
+                continue
+            name = path.name
+            if "Statement - All Time" in name and path.suffix.lower() == ".csv":
+                retail_path = path
+            elif "Coinbase Pro - Statement" in name and path.suffix.lower() == ".csv":
+                pro_statement_paths.append(path)
+            elif "Coinbase Pro - Fills" in name and path.suffix.lower() == ".csv":
+                pro_fill_paths.append(path)
+            elif path.suffix.lower() == ".pdf":
+                pdf_paths.append(path)
+
+        exceptions: list[dict[str, str]] = []
+        if retail_path is None:
+            missing = default_exception_row(
+                manifest_fingerprint=profile.manifest_fingerprint,
+                source=profile.source,
+                adapter=self.name,
+                event_id="coinbase:missing_retail_csv",
+                raw_file="",
+                raw_row_ref="",
+                exception_kind="missing_required_input",
+                message="Coinbase retail all-time CSV is required for deterministic normalization.",
+                resolution_status=exception_decisions.get("coinbase:missing_retail_csv", {}).get("resolution_status", ""),
+                resolution_note=exception_decisions.get("coinbase:missing_retail_csv", {}).get("resolution_note", ""),
+            )
+            if missing["resolution_status"] != "accepted":
+                exceptions.append(missing)
+            return AdapterNormalizationResult(canonical_events=[], canonical_balances=[], exceptions=exceptions)
+
+        normalized_rows = normalize_coinbase_transactions(
+            retail_csv_rows(retail_path),
+            [dict(row, _file=path.name) for path in pro_statement_paths for row in csv_dict_rows(path, "Coinbase Pro statement CSV")],
+            [dict(row, _file=path.name) for path in pro_fill_paths for row in csv_dict_rows(path, "Coinbase Pro fills CSV")],
+            retail_source=retail_path,
+        )
+
+        events = [ct_row_to_canonical_event(row, self.name, profile.source) for row in normalized_rows]
+        balances: list[dict[str, str]] = []
+        for pdf_path in pdf_paths:
+            balances.extend(coinbase_balance_rows_from_text(extract_pdf_text(pdf_path), pdf_path.name))
+        return AdapterNormalizationResult(canonical_events=events, canonical_balances=balances, exceptions=exceptions)
+
+
+class WealthsimpleAdapter(SourceAdapter):
+    name = "wealthsimple"
+    aliases = ("wealthsimple", "wealthsimple crypto")
+
+
+class BinanceAdapter(SourceAdapter):
+    name = "binance"
+    aliases = ("binance",)
+
+
+class MetamaskAdapter(SourceAdapter):
+    name = "metamask"
+    aliases = ("metamask", "bsc metamask wallet", "eth metamask wallet", "metamask - polygon")
+
+
+class ShakepayAdapter(SourceAdapter):
+    name = "shakepay"
+    aliases = ("shakepay",)
+
+
+class LedgerLiveAdapter(SourceAdapter):
+    name = "ledger_live"
+    aliases = ("ledger live", "ada ledger")
+
+
+class NearAdapter(SourceAdapter):
+    name = "near"
+    aliases = ("near", "near wallet", "near wallet - staking")
+
+
+ADAPTERS: tuple[SourceAdapter, ...] = (
+    CoinbaseAdapter(),
+    WealthsimpleAdapter(),
+    BinanceAdapter(),
+    MetamaskAdapter(),
+    ShakepayAdapter(),
+    LedgerLiveAdapter(),
+    NearAdapter(),
+)
+
+
+def get_adapter(source: str) -> SourceAdapter:
+    for adapter in ADAPTERS:
+        if adapter.matches(source):
+            return adapter
+    fallback = SourceAdapter()
+    fallback.name = "generic"
+    fallback.aliases = ()
+    return fallback
+
+
+def available_adapter_rows() -> list[dict[str, str]]:
+    return [
+        {
+            "adapter": adapter.name,
+            "supported": "yes" if adapter.supported else "no",
+            "aliases": ", ".join(adapter.aliases),
+        }
+        for adapter in ADAPTERS
+    ]
+

--- a/06_scripts/source_adapters.py
+++ b/06_scripts/source_adapters.py
@@ -583,7 +583,7 @@ class BinanceAdapter(SourceAdapter):
                 covered_timestamps.update(self._timestamps_for_file(path, "Time", status_field=None, allowed_statuses=None))
             elif name.startswith("Binance-Convert-Order-History-"):
                 events.extend(self._convert_order_events(path, profile.source))
-                covered_timestamps.update(self._timestamps_for_file(path, "Time", status_field="Status", allowed_statuses={"Successful"}))
+                covered_timestamps.update(self._convert_covered_timestamps(path))
             elif name.startswith("Binance-Deposit-History-"):
                 events.extend(self._deposit_history_events(path, profile.source))
                 covered_timestamps.update(self._timestamps_for_file(path, "Time", status_field="Status", allowed_statuses={"Completed"}))
@@ -632,6 +632,11 @@ class BinanceAdapter(SourceAdapter):
             timestamp = (row.get(field) or "").strip()
             if timestamp:
                 timestamps.add(timestamp)
+        return timestamps
+
+    def _convert_covered_timestamps(self, path: Path) -> set[str]:
+        timestamps = self._timestamps_for_file(path, "Time", status_field="Status", allowed_statuses={"Successful"})
+        timestamps.update(self._timestamps_for_file(path, "Date Updated", status_field="Status", allowed_statuses={"Successful"}))
         return timestamps
 
     def _spot_trade_events(self, path: Path, source: str) -> list[dict[str, str]]:

--- a/06_scripts/source_adapters.py
+++ b/06_scripts/source_adapters.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from decimal import Decimal
 from pathlib import Path
 from typing import Iterable, Sequence
+import json
 
 from coinbase_common import (
     coinbase_balance_rows_from_text,
@@ -119,6 +120,18 @@ def load_exception_decisions(path: Path | None, manifest_fingerprint: str) -> di
                 "resolution_note": row.get("resolution_note", ""),
             }
     return decisions
+
+
+def decisions_fingerprint(decisions: dict[str, dict[str, str]]) -> str:
+    payload = [
+        {
+            "event_id": event_id,
+            "resolution_status": values.get("resolution_status", ""),
+            "resolution_note": values.get("resolution_note", ""),
+        }
+        for event_id, values in sorted(decisions.items())
+    ]
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
 
 
 class SourceAdapter:
@@ -275,4 +288,3 @@ def available_adapter_rows() -> list[dict[str, str]]:
         }
         for adapter in ADAPTERS
     ]
-

--- a/06_scripts/source_adapters.py
+++ b/06_scripts/source_adapters.py
@@ -1484,12 +1484,645 @@ class EvmExplorerAdapter(SourceAdapter):
     name = "evm_explorer"
     aliases = (
         "evm explorer",
-        "metamask",
         "bsc metamask wallet",
         "eth metamask wallet",
         "eth galagames wallet",
         "metamask - polygon",
     )
+    supported = True
+
+    _scope_prefixes = (
+        ("bsc", "Account1-bsc"),
+        ("polygon", "Account1-polygon"),
+        ("eth_gala", "Account2-eth"),
+        ("eth", "Account1-eth"),
+    )
+    _native_asset_by_scope = {
+        "bsc": "BNB",
+        "polygon": "MATIC",
+        "eth_gala": "ETH",
+        "eth": "ETH",
+    }
+    _token_symbol_overrides = {
+        "0x7ddee176f665cd201f93eede625770e2fd911990": "GALA",
+    }
+
+    def normalize(
+        self,
+        raw_dir: Path,
+        profile: SourceProfile,
+        *,
+        exception_decisions: dict[str, dict[str, str]],
+    ) -> AdapterNormalizationResult:
+        scope_key, prefix = self._scope_for_source(profile.source)
+        selected_paths = sorted(
+            path
+            for path in raw_dir.glob("*.csv")
+            if path.is_file() and (prefix in path.name or (scope_key == "eth" and path.name.startswith("Account1-eth ")))
+        )
+        exceptions: list[dict[str, str]] = []
+        if not selected_paths:
+            maybe_append_exception(
+                exceptions,
+                exception_decisions,
+                manifest_fingerprint=profile.manifest_fingerprint,
+                source=profile.source,
+                adapter=self.name,
+                event_id=f"{self.name}:{scope_key}:missing_scope_files",
+                raw_file="",
+                raw_row_ref="",
+                exception_kind="missing_required_input",
+                message=f"No explorer CSV files matched the {scope_key} scope for {profile.source}.",
+            )
+            return AdapterNormalizationResult(canonical_events=[], canonical_balances=[], exceptions=exceptions)
+
+        owned_addresses = {
+            match.group(0).lower()
+            for path in selected_paths
+            for match in re.finditer(r"0x[a-fA-F0-9]{40}", path.name)
+        }
+        native_asset = self._native_asset_by_scope[scope_key]
+        grouped: dict[str, dict[str, list[tuple[Path, int, dict[str, str]]]]] = defaultdict(
+            lambda: {"normal": [], "token": [], "internal": [], "nft": []}
+        )
+        for path in selected_paths:
+            family = self._family_for_path(path)
+            if family is None:
+                continue
+            for index, row in enumerate(read_csv_rows(path), start=2):
+                tx_hash = (row.get("Transaction Hash") or "").strip()
+                if not tx_hash:
+                    continue
+                grouped[tx_hash][family].append((path, index, row))
+
+        events: list[dict[str, str]] = []
+        for tx_hash, group in sorted(grouped.items(), key=lambda item: self._group_timestamp(item[1])):
+            group_events, group_exception = self._group_events(
+                profile,
+                tx_hash,
+                group,
+                owned_addresses=owned_addresses,
+                native_asset=native_asset,
+                exception_decisions=exception_decisions,
+            )
+            events.extend(group_events)
+            if group_exception is not None and group_exception.get("resolution_status") != "accepted":
+                exceptions.append(group_exception)
+
+        return AdapterNormalizationResult(canonical_events=events, canonical_balances=[], exceptions=exceptions)
+
+    def _scope_for_source(self, source: str) -> tuple[str, str]:
+        label = source.strip().lower()
+        if "polygon" in label:
+            return "polygon", "Account1-polygon"
+        if "gala" in label:
+            return "eth_gala", "Account2-eth"
+        if "eth" in label:
+            return "eth", "Account1-eth"
+        return "bsc", "Account1-bsc"
+
+    def _family_for_path(self, path: Path) -> str | None:
+        name = path.name.lower()
+        if "export-address-token" in name:
+            return "token"
+        if "export-internal-tx" in name:
+            return "internal"
+        if "export-address-nfts" in name:
+            return "nft"
+        if " export-" in name:
+            return "normal"
+        return None
+
+    def _group_timestamp(self, group: dict[str, list[tuple[Path, int, dict[str, str]]]]) -> str:
+        timestamps = [
+            (row.get("DateTime (UTC)") or "").strip()
+            for family_rows in group.values()
+            for _, _, row in family_rows
+            if (row.get("DateTime (UTC)") or "").strip()
+        ]
+        return min(timestamps) if timestamps else ""
+
+    def _group_events(
+        self,
+        profile: SourceProfile,
+        tx_hash: str,
+        group: dict[str, list[tuple[Path, int, dict[str, str]]]],
+        *,
+        owned_addresses: set[str],
+        native_asset: str,
+        exception_decisions: dict[str, dict[str, str]],
+    ) -> tuple[list[dict[str, str]], dict[str, str] | None]:
+        timestamp = normalized_timestamp(self._group_timestamp(group), ("%Y-%m-%d %H:%M:%S",))
+        raw_file = self._group_raw_file(group)
+        raw_row_ref = self._group_raw_ref(group)
+        method = self._group_method(group)
+        event_id = event_id_for(self.name, raw_file, tx_hash)
+        fee_paid = self._group_fee_paid(group, owned_addresses)
+        native_in, native_out = self._native_movements(group, native_asset)
+        token_in, token_out, inbound_is_airdrop = self._token_movements(group["token"], owned_addresses)
+        nft_in, nft_out, suspicious_nft_assets = self._nft_movements(group["nft"], owned_addresses)
+        incoming = token_in + nft_in
+        outgoing = token_out + nft_out
+        has_token_history = bool(group["token"] or group["nft"])
+
+        if not has_token_history and method.lower() in {"exact input", "swap exact eth for tokens", "swap exact tokens for eth", "execute"}:
+            decision = exception_decisions.get(event_id, {})
+            return [], default_exception_row(
+                manifest_fingerprint=profile.manifest_fingerprint,
+                source=profile.source,
+                adapter=self.name,
+                event_id=event_id,
+                raw_file=raw_file,
+                raw_row_ref=raw_row_ref,
+                exception_kind="missing_required_input",
+                message=f"{profile.source} needs token-transfer history to deterministically classify {method} tx {tx_hash}.",
+                resolution_status=decision.get("resolution_status", ""),
+                resolution_note=decision.get("resolution_note", ""),
+            )
+
+        if method.lower() in {"approve", "set delegate"}:
+            if fee_paid <= 0:
+                return [], None
+            return [
+                canonical_event(
+                    event_id=event_id,
+                    source=profile.source,
+                    adapter=self.name,
+                    account=profile.source,
+                    wallet=profile.source,
+                    raw_file=raw_file,
+                    raw_row_ref=raw_row_ref,
+                    timestamp=timestamp,
+                    event_kind="Other Fee",
+                    description=f"{method} - {tx_hash}",
+                    amount_out=decimal_text(fee_paid),
+                    asset_out=native_asset,
+                    tx_hash=tx_hash,
+                    render_notes="evm_fee_only",
+                )
+            ], None
+
+        if method.lower().startswith("stake") and outgoing and not incoming:
+            return self._stake_events(
+                profile.source,
+                raw_file,
+                raw_row_ref,
+                timestamp,
+                tx_hash,
+                outgoing[0],
+                fee_paid,
+                native_asset,
+            ), None
+
+        if method.lower().startswith("withdraw") and incoming and not outgoing:
+            return self._unstake_events(
+                profile.source,
+                raw_file,
+                raw_row_ref,
+                timestamp,
+                tx_hash,
+                incoming[0],
+                fee_paid,
+                native_asset,
+            ), None
+
+        if "claim" in method.lower() and incoming and not outgoing:
+            events = [
+                canonical_event(
+                    event_id=event_id,
+                    source=profile.source,
+                    adapter=self.name,
+                    account=profile.source,
+                    wallet=profile.source,
+                    raw_file=raw_file,
+                    raw_row_ref=raw_row_ref,
+                    timestamp=timestamp,
+                    event_kind="Staking",
+                    description=f"{method} - {tx_hash}",
+                    amount_in=decimal_text(incoming[0][1]),
+                    asset_in=incoming[0][0],
+                    tx_hash=tx_hash,
+                    render_notes="evm_claim",
+                )
+            ]
+            if fee_paid > 0:
+                events.append(self._fee_event(profile.source, raw_file, raw_row_ref, timestamp, tx_hash, fee_paid, native_asset, method))
+            return events, None
+
+        if incoming and (outgoing or native_out > 0):
+            asset_out, amount_out = outgoing[0] if outgoing else (native_asset, native_out)
+            asset_in, amount_in = incoming[0]
+            events = [
+                canonical_event(
+                    event_id=event_id,
+                    source=profile.source,
+                    adapter=self.name,
+                    account=profile.source,
+                    wallet=profile.source,
+                    raw_file=raw_file,
+                    raw_row_ref=raw_row_ref,
+                    timestamp=timestamp,
+                    event_kind="Trade",
+                    description=f"{method} - {tx_hash}",
+                    amount_in=decimal_text(amount_in),
+                    asset_in=asset_in,
+                    amount_out=decimal_text(amount_out if asset_out != native_asset else amount_out - fee_paid if amount_out > fee_paid else amount_out),
+                    asset_out=asset_out,
+                    tx_hash=tx_hash,
+                    render_notes="evm_trade",
+                )
+            ]
+            if fee_paid > 0:
+                events.append(self._fee_event(profile.source, raw_file, raw_row_ref, timestamp, tx_hash, fee_paid, native_asset, method))
+            return events, None
+
+        if suspicious_nft_assets and not incoming and not outgoing and native_in <= 0 and native_out <= 0:
+            decision = exception_decisions.get(event_id, {})
+            asset_list = ", ".join(suspicious_nft_assets)
+            return [], default_exception_row(
+                manifest_fingerprint=profile.manifest_fingerprint,
+                source=profile.source,
+                adapter=self.name,
+                event_id=event_id,
+                raw_file=raw_file,
+                raw_row_ref=raw_row_ref,
+                exception_kind="review_required",
+                message=(
+                    f"{profile.source} received suspicious NFT airdrop {asset_list} in tx {tx_hash}; "
+                    "keep it in review instead of auto-importing it as an economic deposit."
+                ),
+                resolution_status=decision.get("resolution_status", ""),
+                resolution_note=decision.get("resolution_note", ""),
+            )
+
+        if outgoing:
+            asset_out, amount_out = outgoing[0]
+            events = [
+                canonical_event(
+                    event_id=event_id,
+                    source=profile.source,
+                    adapter=self.name,
+                    account=profile.source,
+                    wallet=profile.source,
+                    raw_file=raw_file,
+                    raw_row_ref=raw_row_ref,
+                    timestamp=timestamp,
+                    event_kind="Withdrawal",
+                    description=f"{method or 'Transfer out'} - {tx_hash}",
+                    amount_out=decimal_text(amount_out),
+                    asset_out=asset_out,
+                    tx_hash=tx_hash,
+                    render_notes="evm_out",
+                )
+            ]
+            if fee_paid > 0:
+                events.append(self._fee_event(profile.source, raw_file, raw_row_ref, timestamp, tx_hash, fee_paid, native_asset, method or "Transfer"))
+            return events, None
+
+        if native_out > 0:
+            return [
+                canonical_event(
+                    event_id=event_id,
+                    source=profile.source,
+                    adapter=self.name,
+                    account=profile.source,
+                    wallet=profile.source,
+                    raw_file=raw_file,
+                    raw_row_ref=raw_row_ref,
+                    timestamp=timestamp,
+                    event_kind="Withdrawal",
+                    description=f"{method or 'Transfer out'} - {tx_hash}",
+                    amount_out=decimal_text(native_out + fee_paid),
+                    asset_out=native_asset,
+                    fee_amount=decimal_text(fee_paid) if fee_paid > 0 else "",
+                    fee_asset=native_asset if fee_paid > 0 else "",
+                    tx_hash=tx_hash,
+                    render_notes="evm_native_out",
+                )
+            ], None
+
+        if incoming:
+            asset_in, amount_in = incoming[0]
+            event_kind = "Airdrop" if inbound_is_airdrop else "Deposit"
+            return [
+                canonical_event(
+                    event_id=event_id,
+                    source=profile.source,
+                    adapter=self.name,
+                    account=profile.source,
+                    wallet=profile.source,
+                    raw_file=raw_file,
+                    raw_row_ref=raw_row_ref,
+                    timestamp=timestamp,
+                    event_kind=event_kind,
+                    description=f"{method or event_kind} - {tx_hash}",
+                    amount_in=decimal_text(amount_in),
+                    asset_in=asset_in,
+                    tx_hash=tx_hash,
+                    render_notes="evm_in",
+                )
+            ], None
+
+        if native_in > 0:
+            return [
+                canonical_event(
+                    event_id=event_id,
+                    source=profile.source,
+                    adapter=self.name,
+                    account=profile.source,
+                    wallet=profile.source,
+                    raw_file=raw_file,
+                    raw_row_ref=raw_row_ref,
+                    timestamp=timestamp,
+                    event_kind="Deposit",
+                    description=f"{method or 'Transfer in'} - {tx_hash}",
+                    amount_in=decimal_text(native_in),
+                    asset_in=native_asset,
+                    tx_hash=tx_hash,
+                    render_notes="evm_native_in",
+                )
+            ], None
+
+        if fee_paid > 0:
+            return [self._fee_event(profile.source, raw_file, raw_row_ref, timestamp, tx_hash, fee_paid, native_asset, method or "Explorer tx")], None
+        return [], None
+
+    def _group_raw_file(self, group: dict[str, list[tuple[Path, int, dict[str, str]]]]) -> str:
+        for family_rows in group.values():
+            if family_rows:
+                return family_rows[0][0].name
+        return ""
+
+    def _group_raw_ref(self, group: dict[str, list[tuple[Path, int, dict[str, str]]]]) -> str:
+        return ";".join(f"{path.name}:row:{index}" for family_rows in group.values() for path, index, _ in family_rows)
+
+    def _group_method(self, group: dict[str, list[tuple[Path, int, dict[str, str]]]]) -> str:
+        for _, _, row in group["normal"]:
+            method = (row.get("Method") or "").strip()
+            if method:
+                return method
+        for _, _, row in group["internal"]:
+            row_type = (row.get("Type") or "").strip()
+            if row_type:
+                return row_type
+        for _, _, row in group["token"]:
+            return "Transfer"
+        for _, _, row in group["nft"]:
+            return (row.get("Method") or "").strip() or "NFT"
+        return "Explorer tx"
+
+    def _group_fee_paid(
+        self,
+        group: dict[str, list[tuple[Path, int, dict[str, str]]]],
+        owned_addresses: set[str],
+    ) -> Decimal:
+        total = Decimal("0")
+        for _, _, row in group["normal"]:
+            from_owned = (row.get("From") or "").strip().lower() in owned_addresses
+            if from_owned or decimal_or_zero(self._value_out(row)) > 0 or (row.get("ErrCode") or "").strip():
+                total += decimal_or_zero(self._tx_fee(row))
+        return total
+
+    def _native_movements(
+        self,
+        group: dict[str, list[tuple[Path, int, dict[str, str]]]],
+        native_asset: str,
+    ) -> tuple[Decimal, Decimal]:
+        native_in = Decimal("0")
+        native_out = Decimal("0")
+        for _, _, row in group["normal"]:
+            native_in += decimal_or_zero(self._value_in(row))
+            native_out += decimal_or_zero(self._value_out(row))
+        for _, _, row in group["internal"]:
+            native_in += decimal_or_zero(self._value_in(row))
+            native_out += decimal_or_zero(self._value_out(row))
+        return native_in, native_out
+
+    def _token_movements(
+        self,
+        rows: list[tuple[Path, int, dict[str, str]]],
+        owned_addresses: set[str],
+    ) -> tuple[list[tuple[str, Decimal]], list[tuple[str, Decimal]], bool]:
+        incoming: dict[str, Decimal] = defaultdict(Decimal)
+        outgoing: dict[str, Decimal] = defaultdict(Decimal)
+        inbound_is_airdrop = False
+        for _, _, row in rows:
+            symbol = self._token_symbol(row)
+            amount = decimal_or_zero(row.get("TokenValue"))
+            from_address = (row.get("From") or "").strip().lower()
+            to_address = (row.get("To") or "").strip().lower()
+            if to_address in owned_addresses and from_address not in owned_addresses:
+                incoming[symbol] += amount
+                inbound_is_airdrop = inbound_is_airdrop or self._is_airdrop_like_token(row)
+            elif from_address in owned_addresses and to_address not in owned_addresses:
+                outgoing[symbol] += amount
+        return sorted(incoming.items()), sorted(outgoing.items()), inbound_is_airdrop
+
+    def _nft_movements(
+        self,
+        rows: list[tuple[Path, int, dict[str, str]]],
+        owned_addresses: set[str],
+    ) -> tuple[list[tuple[str, Decimal]], list[tuple[str, Decimal]], list[str]]:
+        incoming: dict[str, Decimal] = defaultdict(Decimal)
+        outgoing: dict[str, Decimal] = defaultdict(Decimal)
+        suspicious_incoming: set[str] = set()
+        for _, _, row in rows:
+            asset = (row.get("TokenName") or "").strip() or (row.get("Contract") or "").strip() or "NFT"
+            quantity = decimal_or_zero(row.get("Quantity") or "1")
+            from_address = (row.get("From") or "").strip().lower()
+            to_address = (row.get("To") or "").strip().lower()
+            if to_address in owned_addresses and from_address not in owned_addresses:
+                if self._is_suspicious_nft(row):
+                    suspicious_incoming.add(asset)
+                else:
+                    incoming[asset] += quantity
+            elif from_address in owned_addresses and to_address not in owned_addresses:
+                outgoing[asset] += quantity
+        return sorted(incoming.items()), sorted(outgoing.items()), sorted(suspicious_incoming)
+
+    def _token_symbol(self, row: dict[str, str]) -> str:
+        contract = (row.get("ContractAddress") or "").strip().lower()
+        if contract in self._token_symbol_overrides:
+            return self._token_symbol_overrides[contract]
+        symbol = (row.get("TokenSymbol") or "").strip()
+        if symbol and "TOKEN*" not in symbol:
+            return symbol.upper()
+        token_name = (row.get("TokenName") or "").strip()
+        if token_name and "TOKEN*" not in token_name:
+            return token_name.upper()
+        return (contract[-8:] or "TOKEN").upper()
+
+    def _is_airdrop_like_token(self, row: dict[str, str]) -> bool:
+        from_address = (row.get("From") or "").strip().lower()
+        contract = (row.get("ContractAddress") or "").strip().lower()
+        if contract in self._token_symbol_overrides and from_address != "0x0000000000000000000000000000000000000000":
+            return False
+        symbol = (row.get("TokenSymbol") or "").strip()
+        token_name = (row.get("TokenName") or "").strip()
+        return (
+            from_address == "0x0000000000000000000000000000000000000000"
+            or "." in symbol
+            or "*" in symbol
+            or ":" in token_name
+        )
+
+    def _is_suspicious_nft(self, row: dict[str, str]) -> bool:
+        token_name = (row.get("TokenName") or "").strip()
+        lowered = token_name.lower()
+        return (
+            lowered.startswith("$")
+            or "token*" in lowered
+            or " pass " in f" {lowered} "
+            or lowered.endswith(" pass")
+        )
+
+    def _value_in(self, row: dict[str, str]) -> str:
+        for key, value in row.items():
+            if key.startswith("Value_IN("):
+                return value
+        return ""
+
+    def _value_out(self, row: dict[str, str]) -> str:
+        for key, value in row.items():
+            if key.startswith("Value_OUT("):
+                return value
+        return ""
+
+    def _tx_fee(self, row: dict[str, str]) -> str:
+        for key, value in row.items():
+            if key.startswith("TxnFee("):
+                return value
+        return ""
+
+    def _fee_event(
+        self,
+        source: str,
+        raw_file: str,
+        raw_row_ref: str,
+        timestamp: str,
+        tx_hash: str,
+        fee_paid: Decimal,
+        native_asset: str,
+        method: str,
+    ) -> dict[str, str]:
+        return canonical_event(
+            event_id=event_id_for(self.name, raw_file, f"{tx_hash}:fee"),
+            source=source,
+            adapter=self.name,
+            account=source,
+            wallet=source,
+            raw_file=raw_file,
+            raw_row_ref=raw_row_ref,
+            timestamp=timestamp,
+            event_kind="Other Fee",
+            description=f"{method} - {tx_hash}",
+            amount_out=decimal_text(fee_paid),
+            asset_out=native_asset,
+            tx_hash=tx_hash,
+            render_notes="evm_fee",
+        )
+
+    def _stake_events(
+        self,
+        source: str,
+        raw_file: str,
+        raw_row_ref: str,
+        timestamp: str,
+        tx_hash: str,
+        outgoing: tuple[str, Decimal],
+        fee_paid: Decimal,
+        native_asset: str,
+    ) -> list[dict[str, str]]:
+        asset, amount = outgoing
+        staked_source = f"{source} Staked"
+        events = [
+            canonical_event(
+                event_id=event_id_for(self.name, raw_file, f"{tx_hash}:stake_out"),
+                source=source,
+                adapter=self.name,
+                account=source,
+                wallet=source,
+                raw_file=raw_file,
+                raw_row_ref=raw_row_ref,
+                timestamp=timestamp,
+                event_kind="Withdrawal",
+                description=f"Stake {asset} - {tx_hash}",
+                amount_out=decimal_text(amount),
+                asset_out=asset,
+                tx_hash=tx_hash,
+                render_notes="evm_stake_out",
+            ),
+            canonical_event(
+                event_id=event_id_for(self.name, raw_file, f"{tx_hash}:stake_in"),
+                source=staked_source,
+                adapter=self.name,
+                account=staked_source,
+                wallet=staked_source,
+                raw_file=raw_file,
+                raw_row_ref=raw_row_ref,
+                timestamp=timestamp,
+                event_kind="Deposit",
+                description=f"Stake {asset} - {tx_hash}",
+                amount_in=decimal_text(amount),
+                asset_in=asset,
+                tx_hash=tx_hash,
+                render_notes="evm_stake_in",
+            ),
+        ]
+        if fee_paid > 0:
+            events.append(self._fee_event(source, raw_file, raw_row_ref, timestamp, tx_hash, fee_paid, native_asset, "Stake"))
+        return events
+
+    def _unstake_events(
+        self,
+        source: str,
+        raw_file: str,
+        raw_row_ref: str,
+        timestamp: str,
+        tx_hash: str,
+        incoming: tuple[str, Decimal],
+        fee_paid: Decimal,
+        native_asset: str,
+    ) -> list[dict[str, str]]:
+        asset, amount = incoming
+        staked_source = f"{source} Staked"
+        events = [
+            canonical_event(
+                event_id=event_id_for(self.name, raw_file, f"{tx_hash}:unstake_in"),
+                source=source,
+                adapter=self.name,
+                account=source,
+                wallet=source,
+                raw_file=raw_file,
+                raw_row_ref=raw_row_ref,
+                timestamp=timestamp,
+                event_kind="Deposit",
+                description=f"Unstake {asset} - {tx_hash}",
+                amount_in=decimal_text(amount),
+                asset_in=asset,
+                tx_hash=tx_hash,
+                render_notes="evm_unstake_in",
+            ),
+            canonical_event(
+                event_id=event_id_for(self.name, raw_file, f"{tx_hash}:unstake_out"),
+                source=staked_source,
+                adapter=self.name,
+                account=staked_source,
+                wallet=staked_source,
+                raw_file=raw_file,
+                raw_row_ref=raw_row_ref,
+                timestamp=timestamp,
+                event_kind="Withdrawal",
+                description=f"Unstake {asset} - {tx_hash}",
+                amount_out=decimal_text(amount),
+                asset_out=asset,
+                tx_hash=tx_hash,
+                render_notes="evm_unstake_out",
+            ),
+        ]
+        if fee_paid > 0:
+            events.append(self._fee_event(source, raw_file, raw_row_ref, timestamp, tx_hash, fee_paid, native_asset, "Unstake"))
+        return events
 
 
 class ShakepayAdapter(SourceAdapter):
@@ -2106,6 +2739,82 @@ class NearAdapter(SourceAdapter):
         ]
 
 
+class GTradeAdapter(SourceAdapter):
+    name = "gtrade"
+    aliases = ("gtrade", "gtrade 1ct")
+    supported = True
+
+    def normalize(
+        self,
+        raw_dir: Path,
+        profile: SourceProfile,
+        *,
+        exception_decisions: dict[str, dict[str, str]],
+    ) -> AdapterNormalizationResult:
+        report_paths = sorted(path for path in raw_dir.glob("*My_Trading_History_Report.csv") if path.is_file())
+        exceptions: list[dict[str, str]] = []
+        if not report_paths:
+            maybe_append_exception(
+                exceptions,
+                exception_decisions,
+                manifest_fingerprint=profile.manifest_fingerprint,
+                source=profile.source,
+                adapter=self.name,
+                event_id="gtrade:missing_report_csv",
+                raw_file="",
+                raw_row_ref="",
+                exception_kind="missing_required_input",
+                message="GTrade trading-history CSV is required for normalization.",
+            )
+            return AdapterNormalizationResult(canonical_events=[], canonical_balances=[], exceptions=exceptions)
+
+        events: list[dict[str, str]] = []
+        for path in report_paths:
+            for index, row in enumerate(read_csv_rows(path), start=2):
+                raw_row_ref = f"row:{index}"
+                event_id = event_id_for(self.name, path.name, raw_row_ref)
+                timestamp = normalized_timestamp(f"{row['DATE']} 00:00:00", ("%d/%m/%Y %H:%M:%S",))
+                pnl = decimal_or_zero(row.get("PNL"))
+                description = (row.get("DESCRIPTION") or "").strip()
+                if pnl != 0:
+                    event_kind = "Derivatives / Futures Profit" if pnl > 0 else "Derivatives / Futures Loss"
+                    payload = {
+                        "event_id": event_id,
+                        "source": profile.source,
+                        "adapter": self.name,
+                        "account": profile.source,
+                        "wallet": profile.source,
+                        "raw_file": path.name,
+                        "raw_row_ref": raw_row_ref,
+                        "timestamp": timestamp,
+                        "event_kind": event_kind,
+                        "description": description,
+                        "tx_hash": event_id,
+                        "render_notes": f"{row.get('PAIR', '')}:{row.get('TYPE', '')}:{row.get('DIR', '')}",
+                    }
+                    if pnl > 0:
+                        payload.update({"amount_in": decimal_text(abs(pnl)), "asset_in": "DAI"})
+                    else:
+                        payload.update({"amount_out": decimal_text(abs(pnl)), "asset_out": "DAI"})
+                    events.append(canonical_event(**payload))
+                    continue
+
+                maybe_append_exception(
+                    exceptions,
+                    exception_decisions,
+                    manifest_fingerprint=profile.manifest_fingerprint,
+                    source=profile.source,
+                    adapter=self.name,
+                    event_id=event_id,
+                    raw_file=path.name,
+                    raw_row_ref=raw_row_ref,
+                    exception_kind="unsupported_row",
+                    message="GTrade report row lacks realized PnL and cannot be deterministically converted into a CoinTracking transaction without supporting explorer evidence.",
+                )
+
+        return AdapterNormalizationResult(canonical_events=events, canonical_balances=[], exceptions=exceptions)
+
+
 ADAPTERS: tuple[SourceAdapter, ...] = (
     CoinbaseAdapter(),
     WealthsimpleAdapter(),
@@ -2115,6 +2824,7 @@ ADAPTERS: tuple[SourceAdapter, ...] = (
     ShakepayAdapter(),
     LedgerLiveAdapter(),
     NearAdapter(),
+    GTradeAdapter(),
 )
 
 

--- a/06_scripts/source_adapters.py
+++ b/06_scripts/source_adapters.py
@@ -19,7 +19,7 @@ from coinbase_common import (
     normalize_coinbase_transactions,
     retail_csv_rows,
 )
-from pdf_balance_extract import binance_balance_rows_from_text
+from pdf_balance_extract import binance_balance_rows_from_text, shakepay_balance_rows_from_text
 from pipeline_common import CANONICAL_BALANCE_HEADERS, CANONICAL_EVENT_HEADERS, EXCEPTION_HEADERS, SourceProfile
 from script_common import (
     decimal_or_zero,
@@ -43,6 +43,10 @@ BINANCE_TRADE_ID_PATTERN = re.compile(r"TradeID\s*-\s*(?P<trade_id>[A-Za-z0-9_-]
 BINANCE_SMALL_ASSET_PATTERN = re.compile(r"^(?P<asset>[A-Z0-9]+)\s+to\s+BNB$", re.IGNORECASE)
 BINANCE_TIME_FORMATS = ("%y-%m-%d %H:%M:%S", "%Y-%m-%d %H:%M:%S")
 WEALTHSIMPLE_TIME_FORMATS = ("%Y-%m-%d", "%Y-%m-%d %H:%M:%S")
+LEDGER_LIVE_TIME_FORMATS = ("%Y-%m-%dT%H:%M:%S.%fZ",)
+CRYPTO_COM_TIME_FORMATS = ("%Y-%m-%d %H:%M:%S",)
+SHAKEPAY_TIME_FORMATS = ("%Y-%m-%d %H:%M:%S",)
+NEAR_TIME_FORMATS = ("%Y-%m-%d %H:%M:%S",)
 
 
 @dataclass(frozen=True)
@@ -263,6 +267,61 @@ def sum_changes(rows: Iterable[dict[str, str]]) -> dict[str, Decimal]:
     for row in rows:
         totals[row["Coin"].upper()] += decimal_or_zero(row["Change"])
     return totals
+
+
+def tx_hash_or_event_id(event_id: str, raw_hash: str) -> str:
+    return raw_hash.strip() or event_id
+
+
+def raw_hash_description(prefix: str, raw_hash: str, fallback: str) -> str:
+    hash_text = raw_hash.strip()
+    return f"{prefix} - {hash_text}" if hash_text else fallback
+
+
+def sum_decimal_strings(values: Iterable[str]) -> Decimal:
+    total = Decimal("0")
+    for value in values:
+        total += decimal_or_zero(value)
+    return total
+
+
+def source_staked_label(source: str) -> str:
+    return f"{source} - Staking" if not source.endswith("Staking") else source
+
+
+def build_balance_row(
+    *,
+    source: str,
+    account: str,
+    wallet: str,
+    balance_kind: str,
+    asset: str,
+    quantity: str = "",
+    staked_quantity: str = "",
+    value_amount: str = "",
+    value_currency: str = "",
+    price_amount: str = "",
+    price_currency: str = "",
+    as_of: str = "",
+    pdf_file: str = "",
+    notes: str = "",
+) -> dict[str, str]:
+    return {
+        "source": source,
+        "account": account,
+        "wallet": wallet,
+        "balance_kind": balance_kind,
+        "asset": asset,
+        "quantity": quantity,
+        "staked_quantity": staked_quantity,
+        "value_amount": value_amount,
+        "value_currency": value_currency,
+        "price_amount": price_amount,
+        "price_currency": price_currency,
+        "as_of": as_of,
+        "pdf_file": pdf_file,
+        "notes": notes,
+    }
 
 
 class SourceAdapter:
@@ -1290,31 +1349,769 @@ class BinanceAdapter(SourceAdapter):
         return events, None
 
 
-class MetamaskAdapter(SourceAdapter):
-    name = "metamask"
-    aliases = ("metamask", "bsc metamask wallet", "eth metamask wallet", "metamask - polygon")
+class CryptoComAdapter(SourceAdapter):
+    name = "crypto_com"
+    aliases = ("crypto.com", "crypto com", "cryptocom")
+    supported = True
+
+    def normalize(
+        self,
+        raw_dir: Path,
+        profile: SourceProfile,
+        *,
+        exception_decisions: dict[str, dict[str, str]],
+    ) -> AdapterNormalizationResult:
+        cash_paths = sorted(path for path in raw_dir.glob("cash_transactions*.csv") if path.is_file())
+        crypto_paths = sorted(path for path in raw_dir.glob("crypto_transactions*.csv") if path.is_file())
+        exceptions: list[dict[str, str]] = []
+        if not cash_paths and not crypto_paths:
+            maybe_append_exception(
+                exceptions,
+                exception_decisions,
+                manifest_fingerprint=profile.manifest_fingerprint,
+                source=profile.source,
+                adapter=self.name,
+                event_id="crypto_com:missing_transaction_csvs",
+                raw_file="",
+                raw_row_ref="",
+                exception_kind="missing_required_input",
+                message="Crypto.com cash or crypto transaction CSV exports are required for normalization.",
+            )
+            return AdapterNormalizationResult(canonical_events=[], canonical_balances=[], exceptions=exceptions)
+
+        events: list[dict[str, str]] = []
+        for path in cash_paths:
+            for index, row in enumerate(read_csv_rows(path), start=2):
+                kind = (row.get("Transaction Kind") or "").strip().lower()
+                if kind != "viban_deposit":
+                    continue
+                timestamp = normalized_timestamp(row["Timestamp (UTC)"], CRYPTO_COM_TIME_FORMATS)
+                raw_row_ref = f"row:{index}"
+                event_id = event_id_for(self.name, path.name, raw_row_ref)
+                events.append(
+                    canonical_event(
+                        event_id=event_id,
+                        source=profile.source,
+                        adapter=self.name,
+                        account=profile.source,
+                        wallet=profile.source,
+                        raw_file=path.name,
+                        raw_row_ref=raw_row_ref,
+                        timestamp=timestamp,
+                        event_kind="Deposit",
+                        description=(row.get("Transaction Description") or "Crypto.com cash deposit").strip(),
+                        amount_in=decimal_text(decimal_or_zero(row.get("Amount"))),
+                        asset_in=(row.get("Currency") or "").strip().upper(),
+                        tx_hash=(row.get("Transaction Hash") or "").strip(),
+                        render_notes=kind,
+                    )
+                )
+
+        for path in crypto_paths:
+            for index, row in enumerate(read_csv_rows(path), start=2):
+                kind = (row.get("Transaction Kind") or "").strip().lower()
+                timestamp = normalized_timestamp(row["Timestamp (UTC)"], CRYPTO_COM_TIME_FORMATS)
+                raw_row_ref = f"row:{index}"
+                event_id = event_id_for(self.name, path.name, raw_row_ref)
+                description = (row.get("Transaction Description") or kind or "Crypto.com event").strip()
+                tx_hash = tx_hash_or_event_id(event_id, row.get("Transaction Hash") or "")
+                currency = (row.get("Currency") or "").strip().upper()
+                to_currency = (row.get("To Currency") or "").strip().upper()
+                amount = abs(decimal_or_zero(row.get("Amount")))
+                to_amount = abs(decimal_or_zero(row.get("To Amount")))
+
+                if kind == "viban_purchase" and currency and to_currency:
+                    events.append(
+                        canonical_event(
+                            event_id=event_id,
+                            source=profile.source,
+                            adapter=self.name,
+                            account=profile.source,
+                            wallet=profile.source,
+                            raw_file=path.name,
+                            raw_row_ref=raw_row_ref,
+                            timestamp=timestamp,
+                            event_kind="Trade",
+                            description=f"{currency} -> {to_currency}",
+                            amount_in=decimal_text(to_amount),
+                            asset_in=to_currency,
+                            amount_out=decimal_text(amount),
+                            asset_out=currency,
+                            tx_hash=tx_hash,
+                            render_notes=kind,
+                        )
+                    )
+                    continue
+
+                if kind == "crypto_withdrawal" and currency:
+                    events.append(
+                        canonical_event(
+                            event_id=event_id,
+                            source=profile.source,
+                            adapter=self.name,
+                            account=profile.source,
+                            wallet=profile.source,
+                            raw_file=path.name,
+                            raw_row_ref=raw_row_ref,
+                            timestamp=timestamp,
+                            event_kind="Withdrawal",
+                            description=description,
+                            amount_out=decimal_text(amount),
+                            asset_out=currency,
+                            tx_hash=tx_hash,
+                            render_notes=kind,
+                        )
+                    )
+                    continue
+
+                maybe_append_exception(
+                    exceptions,
+                    exception_decisions,
+                    manifest_fingerprint=profile.manifest_fingerprint,
+                    source=profile.source,
+                    adapter=self.name,
+                    event_id=event_id,
+                    raw_file=path.name,
+                    raw_row_ref=raw_row_ref,
+                    exception_kind="unsupported_row",
+                    message=f"Unsupported Crypto.com transaction kind: {kind or 'blank'}",
+                )
+
+        return AdapterNormalizationResult(canonical_events=events, canonical_balances=[], exceptions=exceptions)
+
+
+class EvmExplorerAdapter(SourceAdapter):
+    name = "evm_explorer"
+    aliases = (
+        "evm explorer",
+        "metamask",
+        "bsc metamask wallet",
+        "eth metamask wallet",
+        "eth galagames wallet",
+        "metamask - polygon",
+    )
 
 
 class ShakepayAdapter(SourceAdapter):
     name = "shakepay"
     aliases = ("shakepay",)
+    supported = True
+
+    def normalize(
+        self,
+        raw_dir: Path,
+        profile: SourceProfile,
+        *,
+        exception_decisions: dict[str, dict[str, str]],
+    ) -> AdapterNormalizationResult:
+        cash_paths = sorted(path for path in raw_dir.glob("cash_transactions*.csv") if path.is_file())
+        crypto_paths = sorted(path for path in raw_dir.glob("crypto_transactions*.csv") if path.is_file())
+        pdf_paths = sorted(path for path in raw_dir.glob("shakepay_*Performance report*.pdf") if path.is_file())
+        exceptions: list[dict[str, str]] = []
+        if not cash_paths and not crypto_paths:
+            maybe_append_exception(
+                exceptions,
+                exception_decisions,
+                manifest_fingerprint=profile.manifest_fingerprint,
+                source=profile.source,
+                adapter=self.name,
+                event_id="shakepay:missing_transaction_csvs",
+                raw_file="",
+                raw_row_ref="",
+                exception_kind="missing_required_input",
+                message="Shakepay cash or crypto transaction CSV exports are required for normalization.",
+            )
+            return AdapterNormalizationResult(canonical_events=[], canonical_balances=[], exceptions=exceptions)
+
+        events: list[dict[str, str]] = []
+        balances: list[dict[str, str]] = []
+        for pdf_path in pdf_paths:
+            balances.extend(shakepay_balance_rows_from_text(extract_pdf_text(pdf_path), pdf_path.name))
+
+        for path in crypto_paths:
+            for index, row in enumerate(read_csv_rows(path), start=2):
+                event = self._crypto_event(path, profile.source, index, row)
+                if event is not None:
+                    events.append(event)
+
+        for path in cash_paths:
+            for index, row in enumerate(read_csv_rows(path), start=2):
+                event = self._cash_event(path, profile.source, index, row)
+                if event is not None:
+                    events.append(event)
+
+        return AdapterNormalizationResult(canonical_events=events, canonical_balances=balances, exceptions=exceptions)
+
+    def _crypto_event(self, path: Path, source: str, index: int, row: dict[str, str]) -> dict[str, str] | None:
+        event_type = (row.get("Type") or "").strip()
+        raw_row_ref = f"row:{index}"
+        event_id = event_id_for(self.name, path.name, raw_row_ref)
+        timestamp = normalized_timestamp(row["Date"], SHAKEPAY_TIME_FORMATS)
+        description = (row.get("Description") or event_type or "Shakepay").strip()
+
+        if event_type == "Reward":
+            return canonical_event(
+                event_id=event_id,
+                source=source,
+                adapter=self.name,
+                account=source,
+                wallet=source,
+                raw_file=path.name,
+                raw_row_ref=raw_row_ref,
+                timestamp=timestamp,
+                event_kind="Reward / Bonus",
+                description=description.lower(),
+                amount_in=decimal_text(abs(decimal_or_zero(row.get("Amount Credited")))),
+                asset_in=(row.get("Asset Credited") or "").strip().upper(),
+                tx_hash=event_id,
+                render_notes=event_type,
+            )
+
+        if event_type == "Buy":
+            return canonical_event(
+                event_id=event_id,
+                source=source,
+                adapter=self.name,
+                account=source,
+                wallet=source,
+                raw_file=path.name,
+                raw_row_ref=raw_row_ref,
+                timestamp=timestamp,
+                event_kind="Trade",
+                description=description,
+                amount_in=decimal_text(abs(decimal_or_zero(row.get("Amount Credited")))),
+                asset_in=(row.get("Asset Credited") or "").strip().upper(),
+                amount_out=decimal_text(abs(decimal_or_zero(row.get("Amount Debited")))),
+                asset_out=(row.get("Asset Debited") or "").strip().upper(),
+                tx_hash=event_id,
+                render_notes=event_type,
+            )
+
+        if event_type == "Sell":
+            return canonical_event(
+                event_id=event_id,
+                source=source,
+                adapter=self.name,
+                account=source,
+                wallet=source,
+                raw_file=path.name,
+                raw_row_ref=raw_row_ref,
+                timestamp=timestamp,
+                event_kind="Trade",
+                description=description,
+                amount_in=decimal_text(abs(decimal_or_zero(row.get("Amount Credited")))),
+                asset_in=(row.get("Asset Credited") or "").strip().upper(),
+                amount_out=decimal_text(abs(decimal_or_zero(row.get("Amount Debited")))),
+                asset_out=(row.get("Asset Debited") or "").strip().upper(),
+                tx_hash=event_id,
+                render_notes=event_type,
+            )
+
+        if event_type == "Receive":
+            return canonical_event(
+                event_id=event_id,
+                source=source,
+                adapter=self.name,
+                account=source,
+                wallet=source,
+                raw_file=path.name,
+                raw_row_ref=raw_row_ref,
+                timestamp=timestamp,
+                event_kind="Deposit",
+                description=description,
+                amount_in=decimal_text(abs(decimal_or_zero(row.get("Amount Credited")))),
+                asset_in=(row.get("Asset Credited") or "").strip().upper(),
+                tx_hash=event_id,
+                render_notes=event_type,
+            )
+
+        if event_type == "Send":
+            return canonical_event(
+                event_id=event_id,
+                source=source,
+                adapter=self.name,
+                account=source,
+                wallet=source,
+                raw_file=path.name,
+                raw_row_ref=raw_row_ref,
+                timestamp=timestamp,
+                event_kind="Withdrawal",
+                description=description,
+                amount_out=decimal_text(abs(decimal_or_zero(row.get("Amount Debited")))),
+                asset_out=(row.get("Asset Debited") or "").strip().upper(),
+                tx_hash=event_id,
+                render_notes=event_type,
+            )
+        return None
+
+    def _cash_event(self, path: Path, source: str, index: int, row: dict[str, str]) -> dict[str, str] | None:
+        event_type = (row.get("Type") or "").strip()
+        raw_row_ref = f"row:{index}"
+        event_id = event_id_for(self.name, path.name, raw_row_ref)
+        timestamp = normalized_timestamp(row["Date"], SHAKEPAY_TIME_FORMATS)
+        description = (row.get("Description") or event_type or "Shakepay cash").strip()
+        credit = abs(decimal_or_zero(row.get("Credit")))
+        debit = abs(decimal_or_zero(row.get("Debit")))
+
+        if event_type in {"Buy", "Sell"}:
+            return None
+
+        if event_type in {"Interac e-Transfer", "Receive"} and credit > 0:
+            return canonical_event(
+                event_id=event_id,
+                source=source,
+                adapter=self.name,
+                account=source,
+                wallet=source,
+                raw_file=path.name,
+                raw_row_ref=raw_row_ref,
+                timestamp=timestamp,
+                event_kind="Deposit",
+                description=description,
+                amount_in=decimal_text(credit),
+                asset_in="CAD",
+                tx_hash=event_id,
+                render_notes=event_type,
+            )
+
+        if event_type in {"Card purchase", "Bill payment", "Other"} and debit > 0:
+            return canonical_event(
+                event_id=event_id,
+                source=source,
+                adapter=self.name,
+                account=source,
+                wallet=source,
+                raw_file=path.name,
+                raw_row_ref=raw_row_ref,
+                timestamp=timestamp,
+                event_kind="Expense (non taxable)",
+                description=description,
+                amount_out=decimal_text(debit),
+                asset_out="CAD",
+                tx_hash=event_id,
+                render_notes=event_type,
+            )
+
+        if event_type == "Send" and debit > 0:
+            return canonical_event(
+                event_id=event_id,
+                source=source,
+                adapter=self.name,
+                account=source,
+                wallet=source,
+                raw_file=path.name,
+                raw_row_ref=raw_row_ref,
+                timestamp=timestamp,
+                event_kind="Withdrawal",
+                description=description,
+                amount_out=decimal_text(debit),
+                asset_out="CAD",
+                tx_hash=event_id,
+                render_notes=event_type,
+            )
+
+        if event_type == "Reward" and credit > 0:
+            return canonical_event(
+                event_id=event_id,
+                source=source,
+                adapter=self.name,
+                account=source,
+                wallet=source,
+                raw_file=path.name,
+                raw_row_ref=raw_row_ref,
+                timestamp=timestamp,
+                event_kind="Reward / Bonus",
+                description=description,
+                amount_in=decimal_text(credit),
+                asset_in="CAD",
+                tx_hash=event_id,
+                render_notes=event_type,
+            )
+
+        return None
 
 
 class LedgerLiveAdapter(SourceAdapter):
     name = "ledger_live"
     aliases = ("ledger live", "ada ledger")
+    supported = True
+
+    def normalize(
+        self,
+        raw_dir: Path,
+        profile: SourceProfile,
+        *,
+        exception_decisions: dict[str, dict[str, str]],
+    ) -> AdapterNormalizationResult:
+        paths = sorted(path for path in raw_dir.glob("ledgerlive-operations-*.csv") if path.is_file())
+        exceptions: list[dict[str, str]] = []
+        if not paths:
+            maybe_append_exception(
+                exceptions,
+                exception_decisions,
+                manifest_fingerprint=profile.manifest_fingerprint,
+                source=profile.source,
+                adapter=self.name,
+                event_id="ledger_live:missing_operations_csv",
+                raw_file="",
+                raw_row_ref="",
+                exception_kind="missing_required_input",
+                message="Ledger Live operations CSV export is required for normalization.",
+            )
+            return AdapterNormalizationResult(canonical_events=[], canonical_balances=[], exceptions=exceptions)
+
+        grouped_rows: dict[tuple[str, str], list[tuple[Path, int, dict[str, str]]]] = defaultdict(list)
+        for path in paths:
+            for index, row in enumerate(read_csv_rows(path), start=2):
+                if (row.get("Status") or "Confirmed").strip() not in {"", "Confirmed"}:
+                    continue
+                operation_hash = (row.get("Operation Hash") or "").strip()
+                if not operation_hash:
+                    continue
+                account_name = (row.get("Account Name") or "").strip() or profile.source
+                grouped_rows[(account_name, operation_hash)].append((path, index, row))
+
+        events: list[dict[str, str]] = []
+        for (account_name, operation_hash), indexed_rows in sorted(grouped_rows.items()):
+            events.extend(self._group_events(profile.source, account_name, operation_hash, indexed_rows))
+
+        return AdapterNormalizationResult(canonical_events=events, canonical_balances=[], exceptions=exceptions)
+
+    def _group_events(
+        self,
+        source: str,
+        account_name: str,
+        operation_hash: str,
+        indexed_rows: list[tuple[Path, int, dict[str, str]]],
+    ) -> list[dict[str, str]]:
+        timestamp = normalized_timestamp(indexed_rows[0][2]["Operation Date"], LEDGER_LIVE_TIME_FORMATS)
+        by_type: dict[str, list[tuple[Path, int, dict[str, str]]]] = defaultdict(list)
+        for item in indexed_rows:
+            by_type[(item[2].get("Operation Type") or "").strip().upper()].append(item)
+
+        if by_type.get("DELEGATE"):
+            by_type.pop("OUT", None)
+
+        in_assets = defaultdict(Decimal)
+        out_assets = defaultdict(Decimal)
+        fee_assets = defaultdict(Decimal)
+        for _, _, row in by_type.get("IN", []):
+            in_assets[(row.get("Currency Ticker") or "").strip().upper()] += decimal_or_zero(row.get("Operation Amount"))
+        for _, _, row in by_type.get("OUT", []):
+            out_assets[(row.get("Currency Ticker") or "").strip().upper()] += decimal_or_zero(row.get("Operation Amount"))
+        for _, _, row in by_type.get("FEES", []):
+            fee_assets[(row.get("Currency Ticker") or "").strip().upper()] += decimal_or_zero(row.get("Operation Amount"))
+
+        events: list[dict[str, str]] = []
+        if len(in_assets) == 1 and len(out_assets) == 1:
+            asset_in, amount_in = next(iter(in_assets.items()))
+            asset_out, amount_out = next(iter(out_assets.items()))
+            fee_asset = ""
+            fee_amount = ""
+            if len(fee_assets) == 1:
+                fee_asset, fee_total = next(iter(fee_assets.items()))
+                fee_amount = decimal_text(fee_total)
+            event_id = event_id_for(self.name, indexed_rows[0][0].name, operation_hash)
+            events.append(
+                canonical_event(
+                    event_id=event_id,
+                    source=source,
+                    adapter=self.name,
+                    account=account_name,
+                    wallet=account_name,
+                    raw_file=indexed_rows[0][0].name,
+                    raw_row_ref=";".join(f"{path.name}:row:{index}" for path, index, _ in indexed_rows),
+                    timestamp=timestamp,
+                    event_kind="Trade",
+                    description=account_name,
+                    amount_in=decimal_text(amount_in),
+                    asset_in=asset_in,
+                    amount_out=decimal_text(amount_out),
+                    asset_out=asset_out,
+                    fee_amount=fee_amount,
+                    fee_asset=fee_asset,
+                    tx_hash=operation_hash,
+                    render_notes="ledger_live_grouped_trade",
+                )
+            )
+            return events
+
+        for path, index, row in by_type.get("IN", []):
+            raw_row_ref = f"row:{index}"
+            event_id = event_id_for(self.name, path.name, raw_row_ref)
+            asset = (row.get("Currency Ticker") or "").strip().upper()
+            events.append(
+                canonical_event(
+                    event_id=event_id,
+                    source=source,
+                    adapter=self.name,
+                    account=account_name,
+                    wallet=account_name,
+                    raw_file=path.name,
+                    raw_row_ref=raw_row_ref,
+                    timestamp=normalized_timestamp(row["Operation Date"], LEDGER_LIVE_TIME_FORMATS),
+                    event_kind="Deposit",
+                    description=account_name,
+                    amount_in=decimal_text(decimal_or_zero(row.get("Operation Amount"))),
+                    asset_in=asset,
+                    tx_hash=f"IN-{operation_hash}",
+                    render_notes="ledger_live_in",
+                )
+            )
+
+        for path, index, row in by_type.get("OUT", []):
+            raw_row_ref = f"row:{index}"
+            event_id = event_id_for(self.name, path.name, raw_row_ref)
+            asset = (row.get("Currency Ticker") or "").strip().upper()
+            events.append(
+                canonical_event(
+                    event_id=event_id,
+                    source=source,
+                    adapter=self.name,
+                    account=account_name,
+                    wallet=account_name,
+                    raw_file=path.name,
+                    raw_row_ref=raw_row_ref,
+                    timestamp=normalized_timestamp(row["Operation Date"], LEDGER_LIVE_TIME_FORMATS),
+                    event_kind="Withdrawal",
+                    description=account_name,
+                    amount_out=decimal_text(decimal_or_zero(row.get("Operation Amount"))),
+                    asset_out=asset,
+                    fee_amount=decimal_text(decimal_or_zero(row.get("Operation Fees"))),
+                    fee_asset=asset if decimal_or_zero(row.get("Operation Fees")) else "",
+                    tx_hash=f"OUT-{operation_hash}",
+                    render_notes="ledger_live_out",
+                )
+            )
+
+        for path, index, row in by_type.get("DELEGATE", []):
+            raw_row_ref = f"row:{index}"
+            event_id = event_id_for(self.name, path.name, raw_row_ref)
+            asset = (row.get("Currency Ticker") or "").strip().upper()
+            events.append(
+                canonical_event(
+                    event_id=event_id,
+                    source=source,
+                    adapter=self.name,
+                    account=account_name,
+                    wallet=account_name,
+                    raw_file=path.name,
+                    raw_row_ref=raw_row_ref,
+                    timestamp=normalized_timestamp(row["Operation Date"], LEDGER_LIVE_TIME_FORMATS),
+                    event_kind="Expense (non taxable)",
+                    description=f"{asset} Staking Deposit - {operation_hash}",
+                    amount_out=decimal_text(decimal_or_zero(row.get("Operation Amount"))),
+                    asset_out=asset,
+                    fee_amount=decimal_text(decimal_or_zero(row.get("Operation Fees"))),
+                    fee_asset=asset if decimal_or_zero(row.get("Operation Fees")) else "",
+                    render_notes="ledger_live_delegate",
+                )
+            )
+
+        for path, index, row in by_type.get("FEES", []):
+            raw_row_ref = f"row:{index}"
+            event_id = event_id_for(self.name, path.name, raw_row_ref)
+            asset = (row.get("Currency Ticker") or "").strip().upper()
+            events.append(
+                canonical_event(
+                    event_id=event_id,
+                    source=source,
+                    adapter=self.name,
+                    account=account_name,
+                    wallet=account_name,
+                    raw_file=path.name,
+                    raw_row_ref=raw_row_ref,
+                    timestamp=normalized_timestamp(row["Operation Date"], LEDGER_LIVE_TIME_FORMATS),
+                    event_kind="Other Fee",
+                    description=f"{account_name} network fee",
+                    amount_out=decimal_text(decimal_or_zero(row.get("Operation Amount"))),
+                    asset_out=asset,
+                    tx_hash=f"FEE-{operation_hash}",
+                    render_notes="ledger_live_fee",
+                )
+            )
+        return events
 
 
 class NearAdapter(SourceAdapter):
     name = "near"
     aliases = ("near", "near wallet", "near wallet - staking")
+    supported = True
+
+    def normalize(
+        self,
+        raw_dir: Path,
+        profile: SourceProfile,
+        *,
+        exception_decisions: dict[str, dict[str, str]],
+    ) -> AdapterNormalizationResult:
+        tx_paths = sorted(path for path in raw_dir.glob("*transactions*.csv") if "ft_" not in path.name and "nft_" not in path.name)
+        ft_paths = sorted(path for path in raw_dir.glob("*ft_transactions*.csv"))
+        nft_paths = sorted(path for path in raw_dir.glob("*nft_transactions*.csv"))
+        exceptions: list[dict[str, str]] = []
+        if not tx_paths and not ft_paths and not nft_paths:
+            maybe_append_exception(
+                exceptions,
+                exception_decisions,
+                manifest_fingerprint=profile.manifest_fingerprint,
+                source=profile.source,
+                adapter=self.name,
+                event_id="near:missing_export_csvs",
+                raw_file="",
+                raw_row_ref="",
+                exception_kind="missing_required_input",
+                message="NEAR transaction or token export CSVs are required for normalization.",
+            )
+            return AdapterNormalizationResult(canonical_events=[], canonical_balances=[], exceptions=exceptions)
+
+        events: list[dict[str, str]] = []
+        seen_tx_hashes: set[str] = set()
+        for path in tx_paths:
+            for index, row in enumerate(read_csv_rows(path), start=2):
+                tx_hash = (row.get("Txn Hash") or "").strip()
+                if not tx_hash or tx_hash in seen_tx_hashes or (row.get("Status") or "").strip() != "Success":
+                    continue
+                seen_tx_hashes.add(tx_hash)
+                method = (row.get("Method") or "").strip()
+                if method == "TRANSFER" and (row.get("To") or "").strip() == self._wallet_id():
+                    events.append(self._near_deposit_event(path, profile.source, index, row))
+                    continue
+                if method == "deposit_and_stake":
+                    events.extend(self._near_stake_events(path, profile.source, index, row))
+                    continue
+
+        for path in ft_paths:
+            for index, row in enumerate(read_csv_rows(path), start=2):
+                if (row.get("Status") or "").strip() != "Success" or (row.get("Direction") or "").strip() != "In":
+                    continue
+                raw_row_ref = f"row:{index}"
+                event_id = event_id_for(self.name, path.name, raw_row_ref)
+                token = (row.get("Token") or "").strip()
+                event_kind = "Airdrop" if "airdrop" in ((row.get("Contract") or "") + " " + token).lower() else "Deposit"
+                events.append(
+                    canonical_event(
+                        event_id=event_id,
+                        source=profile.source,
+                        adapter=self.name,
+                        account=profile.source,
+                        wallet=profile.source,
+                        raw_file=path.name,
+                        raw_row_ref=raw_row_ref,
+                        timestamp=normalized_timestamp(row["Time"], NEAR_TIME_FORMATS),
+                        event_kind=event_kind,
+                        description=token,
+                        amount_in=decimal_text(decimal_or_zero(row.get("Quantity"))),
+                        asset_in=token,
+                        tx_hash=(row.get("Txn Hash") or "").strip(),
+                        render_notes=(row.get("Contract") or "").strip(),
+                    )
+                )
+
+        for path in nft_paths:
+            for index, row in enumerate(read_csv_rows(path), start=2):
+                if (row.get("Status") or "").strip() != "Success" or (row.get("Direction") or "").strip() != "In":
+                    continue
+                raw_row_ref = f"row:{index}"
+                event_id = event_id_for(self.name, path.name, raw_row_ref)
+                token_name = (row.get("Token") or "").strip()
+                contract = (row.get("Contract") or "").strip()
+                events.append(
+                    canonical_event(
+                        event_id=event_id,
+                        source=profile.source,
+                        adapter=self.name,
+                        account=profile.source,
+                        wallet=profile.source,
+                        raw_file=path.name,
+                        raw_row_ref=raw_row_ref,
+                        timestamp=normalized_timestamp(row["Time"], NEAR_TIME_FORMATS),
+                        event_kind="Airdrop",
+                        description=token_name or contract or "NEAR NFT mint",
+                        amount_in="1.00000000",
+                        asset_in=token_name or contract or "NEAR NFT",
+                        tx_hash=(row.get("Txn Hash") or "").strip(),
+                        render_notes=f"token_id={(row.get('Token ID') or '').strip()}",
+                    )
+                )
+
+        return AdapterNormalizationResult(canonical_events=events, canonical_balances=[], exceptions=exceptions)
+
+    def _wallet_id(self) -> str:
+        return "example.near"
+
+    def _near_deposit_event(self, path: Path, source: str, index: int, row: dict[str, str]) -> dict[str, str]:
+        raw_row_ref = f"row:{index}"
+        event_id = event_id_for(self.name, path.name, raw_row_ref)
+        deposit_value = decimal_or_zero(row.get("Deposit Value"))
+        tx_fee = decimal_or_zero(row.get("Txn Fee"))
+        return canonical_event(
+            event_id=event_id,
+            source=source,
+            adapter=self.name,
+            account=source,
+            wallet=source,
+            raw_file=path.name,
+            raw_row_ref=raw_row_ref,
+            timestamp=normalized_timestamp(row["Time"], NEAR_TIME_FORMATS),
+            event_kind="Deposit",
+            description=raw_hash_description(f"Transfer into {source}", row.get("Txn Hash") or "", f"Transfer into {source}"),
+            amount_in=decimal_text(deposit_value - tx_fee),
+            asset_in="NEAR",
+            tx_hash=(row.get("Txn Hash") or "").strip(),
+            render_notes="near_transfer_in",
+        )
+
+    def _near_stake_events(self, path: Path, source: str, index: int, row: dict[str, str]) -> list[dict[str, str]]:
+        raw_row_ref = f"row:{index}"
+        timestamp = normalized_timestamp(row["Time"], NEAR_TIME_FORMATS)
+        tx_hash = (row.get("Txn Hash") or "").strip()
+        deposit_value = decimal_or_zero(row.get("Deposit Value"))
+        tx_fee = decimal_or_zero(row.get("Txn Fee"))
+        description = f"Stake NEAR - {tx_hash}" if tx_hash else "Stake NEAR"
+        return [
+            canonical_event(
+                event_id=event_id_for(self.name, path.name, f"{raw_row_ref}:wallet"),
+                source=source,
+                adapter=self.name,
+                account=source,
+                wallet=source,
+                raw_file=path.name,
+                raw_row_ref=raw_row_ref,
+                timestamp=timestamp,
+                event_kind="Withdrawal",
+                description=description,
+                amount_out=decimal_text(deposit_value + tx_fee),
+                asset_out="NEAR",
+                fee_amount=decimal_text(tx_fee),
+                fee_asset="NEAR",
+                tx_hash=tx_hash,
+                render_notes="near_stake_out",
+            ),
+            canonical_event(
+                event_id=event_id_for(self.name, path.name, f"{raw_row_ref}:staking"),
+                source=source_staked_label(source),
+                adapter=self.name,
+                account=source_staked_label(source),
+                wallet=source_staked_label(source),
+                raw_file=path.name,
+                raw_row_ref=raw_row_ref,
+                timestamp=timestamp,
+                event_kind="Deposit",
+                description=description,
+                amount_in=decimal_text(deposit_value),
+                asset_in="NEAR",
+                tx_hash=tx_hash,
+                render_notes="near_stake_in",
+            ),
+        ]
 
 
 ADAPTERS: tuple[SourceAdapter, ...] = (
     CoinbaseAdapter(),
     WealthsimpleAdapter(),
     BinanceAdapter(),
-    MetamaskAdapter(),
+    CryptoComAdapter(),
+    EvmExplorerAdapter(),
     ShakepayAdapter(),
     LedgerLiveAdapter(),
     NearAdapter(),

--- a/06_scripts/stage_import_batch.py
+++ b/06_scripts/stage_import_batch.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+
+"""Stage an approved CoinTracking candidate into the import-batch workflow."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+from typing import Sequence
+
+from overlap_check import summarize_overlap, write_overlap_artifacts
+from script_common import require_file, write_json
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--candidate", required=True, type=Path)
+    parser.add_argument("--baseline-export-dir", required=True, type=Path)
+    parser.add_argument("--out-dir", required=True, type=Path)
+    parser.add_argument("--staged-name")
+    parser.add_argument("--import-ready-dir", type=Path)
+    return parser.parse_args(argv)
+
+
+def stage_import_batch(
+    candidate: Path,
+    baseline_export_dir: Path,
+    out_dir: Path,
+    *,
+    staged_name: str | None = None,
+    import_ready_dir: Path | None = None,
+) -> dict[str, object]:
+    candidate = require_file(candidate.resolve(), "CoinTracking candidate")
+    out_dir = out_dir.resolve()
+    overlap_dir = out_dir / "overlap_check"
+    summary, flagged_rows = summarize_overlap(baseline_export_dir, candidate)
+    write_overlap_artifacts(overlap_dir, summary, flagged_rows)
+
+    if summary["status"] != "pass":
+        result = {
+            "status": "blocked",
+            "candidate": str(candidate),
+            "overlap_summary": str(overlap_dir / "overlap_summary.json"),
+            "rows_flagged": summary["rows_flagged"],
+            "message": "Candidate failed overlap screening and was not staged.",
+        }
+        write_json(out_dir / "stage_summary.json", result)
+        return result
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    staged_path = out_dir / (staged_name or candidate.name)
+    shutil.copy2(candidate, staged_path)
+
+    import_ready_path = ""
+    if import_ready_dir is not None:
+        import_ready_dir = import_ready_dir.resolve()
+        import_ready_dir.mkdir(parents=True, exist_ok=True)
+        ready_path = import_ready_dir / staged_path.name
+        shutil.copy2(staged_path, ready_path)
+        import_ready_path = str(ready_path)
+
+    result = {
+        "status": "staged",
+        "candidate": str(candidate),
+        "staged_path": str(staged_path),
+        "import_ready_path": import_ready_path,
+        "overlap_summary": str(overlap_dir / "overlap_summary.json"),
+        "rows_flagged": 0,
+    }
+    write_json(out_dir / "stage_summary.json", result)
+    return result
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    summary = stage_import_batch(
+        args.candidate,
+        args.baseline_export_dir,
+        args.out_dir,
+        staged_name=args.staged_name,
+        import_ready_dir=args.import_ready_dir,
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0 if summary["status"] == "staged" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/07_skills/normalization-exceptions/SKILL.md
+++ b/07_skills/normalization-exceptions/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: normalization-exceptions
+description: Use when canonical normalization leaves rows in exceptions.csv, when an adapter no longer matches source format, or when the AI should draft a durable adapter repair instead of repeating ad-hoc row handling.
+---
+
+# Normalization Exceptions
+
+Use this skill only after deterministic profiling and normalization have run.
+
+## Inputs
+
+- `02_working/normalized/<source>/profile.json`
+- `02_working/normalized/<source>/exceptions.csv`
+- `02_working/normalized/<source>/normalization_summary.json`
+- the raw manifest fingerprint from the profile
+
+## Default workflow
+
+1. Classify the failure:
+   - data exception
+   - schema drift
+   - adapter bug
+2. If it is a data exception, prepare a compact decision artifact keyed by:
+   - `manifest_fingerprint`
+   - `event_id`
+3. If it is an adapter bug, draft a durable repair:
+   - minimal fixture
+   - adapter patch
+   - regression test
+4. Re-run normalization after the patch.
+
+## Guardrails
+
+- Never rewrite adapters silently from full raw exports.
+- Use compact fixture slices, not entire ledgers, for repair prompts.
+- Only propose adapter promotion after deterministic tests pass.
+- Keep ledger-impacting issues in `03_analysis/issues/issue_log.csv`; parser noise stays out unless it blocks import or verification.
+
+## Decision memory
+
+Persist accepted row-level decisions in `exception_decisions.csv` beside the normalized outputs.
+Do not re-send the same `event_id` to the LLM when the manifest fingerprint has not changed.

--- a/07_skills/normalization-exceptions/SKILL.md
+++ b/07_skills/normalization-exceptions/SKILL.md
@@ -36,6 +36,7 @@ Use this skill only after deterministic profiling and normalization have run.
 - Use compact fixture slices, not entire ledgers, for repair prompts.
 - Only propose adapter promotion after deterministic tests pass.
 - Keep ledger-impacting issues in `03_analysis/issues/issue_log.csv`; parser noise stays out unless it blocks import or verification.
+- When an exception becomes an issue-log row, use the allowed append-only prefix families and assign the next `max(existing) + 1` number within that family. If the result is a balance mismatch with unknown origin, use `BAL-*`; do not renumber old rows or invent source-specific namespaces.
 - "Universal" means deterministic coverage plus visible review gates, not automatic treatment of every exchange-specific internal movement.
 
 ## Decision memory

--- a/07_skills/normalization-exceptions/SKILL.md
+++ b/07_skills/normalization-exceptions/SKILL.md
@@ -28,6 +28,7 @@ Use this skill only after deterministic profiling and normalization have run.
    - adapter patch
    - regression test
 4. Re-run normalization after the patch.
+5. If a source still has a small unresolved set after the durable repair, log the residual items and keep them explicit rather than forcing the adapter to guess.
 
 ## Guardrails
 
@@ -35,6 +36,7 @@ Use this skill only after deterministic profiling and normalization have run.
 - Use compact fixture slices, not entire ledgers, for repair prompts.
 - Only propose adapter promotion after deterministic tests pass.
 - Keep ledger-impacting issues in `03_analysis/issues/issue_log.csv`; parser noise stays out unless it blocks import or verification.
+- "Universal" means deterministic coverage plus visible review gates, not automatic treatment of every exchange-specific internal movement.
 
 ## Decision memory
 

--- a/07_skills/round-verification/SKILL.md
+++ b/07_skills/round-verification/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: round-verification
+description: Use when reviewing a repair or import round in this repo, especially for verification exports, drift comparison, gate classification, issue logging, and round-log updates.
+---
+
+# Round Verification
+
+Use this skill after a manual CoinTracking repair or import.
+
+## Default workflow
+
+1. Confirm the round exists in `05_outputs/logs/round_log.csv`.
+2. Capture only the default verification set unless drift requires heavier exports.
+3. Run `06_scripts/verification_compare.py`.
+4. If a source has canonical artifacts, run `06_scripts/reconcile_source.py` against the relevant Trade Table slice or reference ledger slice.
+5. Classify the result:
+   - passed
+   - hold
+   - blocked_pending_review
+6. Update:
+   - `03_analysis/issues/issue_log.csv`
+   - `03_analysis/issues/source_inventory.csv`
+   - `05_outputs/logs/round_log.csv`
+
+## Gate rules
+
+- Stop on unexplained duplicates.
+- Stop on new unexplained validate rows.
+- Stop on new unexplained strict missing rows.
+- Stop on unexplained balance drift.
+
+## Default commands
+
+```bash
+python3 06_scripts/verification_compare.py \
+  --reference-dir <prior_dir> \
+  --current-dir 02_working/verification/<round_id> \
+  --out-dir 02_working/verification/<round_id>/comparison
+```
+
+```bash
+python3 06_scripts/reconcile_source.py \
+  --source "<Source Name>" \
+  --cointracking-ledger <trade_table_or_slice.csv> \
+  --canonical-events 02_working/normalized/<source>/canonical_events.csv \
+  --canonical-balances 02_working/normalized/<source>/canonical_balances.csv \
+  --out-dir 02_working/normalized/<source>/reconcile
+```

--- a/07_skills/source-intake/SKILL.md
+++ b/07_skills/source-intake/SKILL.md
@@ -29,6 +29,8 @@ Use this skill for the deterministic front half of source prep.
 - Prefer deterministic evidence over interpretation.
 - Do not send full raw exports to an LLM when profile artifacts are enough.
 - If file families are unknown or the adapter is unsupported, mark normalization as pending and route to the normalization-exceptions skill only after profiling is complete.
+- If normalization is `ready`, that still means "candidate staged for human review", not "safe to import without checking overlap and verification gates".
+- If normalization is `needs_review`, prefer a compact exception artifact and an issue-log entry over hand-editing raw exports or silently dropping ambiguous rows.
 - Keep the raw folder immutable.
 
 ## Commands

--- a/07_skills/source-intake/SKILL.md
+++ b/07_skills/source-intake/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: source-intake
+description: Use when capturing or reviewing a new exchange or wallet source for this repo, especially when deciding raw evidence completeness, manifesting, profiling, adapter selection, and whether a source is importable, evidence-only, or blocked.
+---
+
+# Source Intake
+
+Use this skill for the deterministic front half of source prep.
+
+## Default workflow
+
+1. Confirm the source row in `03_analysis/issues/source_inventory.csv`.
+2. Capture untouched exports in `01_raw_exports/external/<source>/raw/`.
+3. Run `06_scripts/source_manifest.py`.
+4. Run `06_scripts/profile_source.py`.
+5. Review `profile.json` and `profile_inventory.csv`.
+6. Update `source_inventory.csv` with:
+   - `profile_status`
+   - `adapter`
+   - `normalization_status`
+   - `candidate_path` when known
+7. Decide one of three outcomes:
+   - importable
+   - evidence_only
+   - blocked
+
+## Decision rules
+
+- Prefer deterministic evidence over interpretation.
+- Do not send full raw exports to an LLM when profile artifacts are enough.
+- If file families are unknown or the adapter is unsupported, mark normalization as pending and route to the normalization-exceptions skill only after profiling is complete.
+- Keep the raw folder immutable.
+
+## Commands
+
+```bash
+python3 06_scripts/source_manifest.py \
+  --source-dir 01_raw_exports/external/<source>/raw \
+  --output 01_raw_exports/external/<source>/manifest.csv
+```
+
+```bash
+python3 06_scripts/profile_source.py \
+  --source "<Source Name>" \
+  --raw-dir 01_raw_exports/external/<source>/raw \
+  --out-dir 02_working/normalized/<source>
+```

--- a/07_skills/source-intake/SKILL.md
+++ b/07_skills/source-intake/SKILL.md
@@ -23,6 +23,7 @@ Use this skill for the deterministic front half of source prep.
    - importable
    - evidence_only
    - blocked
+8. If the source needs an issue-log row, append it to `03_analysis/issues/issue_log.csv` using the allowed prefix families and the next `max(existing) + 1` number for that family. Use `BAL-*` for balance gaps whose origin is not yet proven; do not invent exchange-specific prefixes or reuse skipped numbers.
 
 ## Decision rules
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This repo is a bounded working package for repairing and extending a CoinTrackin
 3. inventory post-cutoff sources
 4. profile one raw source at a time
 5. normalize into canonical events and balances
-6. render and overlap-screen one CoinTracking candidate at a time
+6. stage and overlap-screen one CoinTracking candidate at a time
 7. import one source at a time into CoinTracking
 8. capture fresh verification exports after each round
 9. stop on unexplained drift and close out at `2025-12-31`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,9 @@ This repo is a bounded working package for repairing and extending a CoinTrackin
 - a documented baseline validation package
 - a populated issue log for known baseline exceptions
 - an active source inventory and structured round log
+- a universal source-intake pipeline for profiling, canonical normalization, CoinTracking rendering, and reconciliation
 - lightweight helper scripts for baseline checks, raw-source manifests, overlap screening, and verification comparison
+- repo-local AI skills under `07_skills/` for source intake, normalization exceptions, and round verification
 
 ## Start here
 
@@ -34,9 +36,12 @@ This repo is a bounded working package for repairing and extending a CoinTrackin
 1. validate and lock the baseline
 2. resolve or document baseline exceptions with evidence
 3. inventory post-cutoff sources
-4. import one source at a time into CoinTracking
-5. capture fresh verification exports after each round
-6. stop on unexplained drift and close out at `2025-12-31`
+4. profile one raw source at a time
+5. normalize into canonical events and balances
+6. render and overlap-screen one CoinTracking candidate at a time
+7. import one source at a time into CoinTracking
+8. capture fresh verification exports after each round
+9. stop on unexplained drift and close out at `2025-12-31`
 
 ## Testing
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,11 @@
+from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = REPO_ROOT / "06_scripts"
+
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))

--- a/tests/e2e/test_scripts.py
+++ b/tests/e2e/test_scripts.py
@@ -130,6 +130,78 @@ class ScriptEndToEndTests(unittest.TestCase):
         self.assertEqual(1, result.returncode)
         self.assertIn("raw export folder", result.stderr)
 
+    def test_coinbase_normalize_cli_builds_transaction_and_balance_outputs(self) -> None:
+        retail_csv = REPO_ROOT / "01_raw_exports" / "external" / "coinbase" / "raw" / (
+            "retail-export.csv"
+        )
+        pro_statement_a = REPO_ROOT / "01_raw_exports" / "external" / "coinbase" / "raw" / "2021-05 Coinbase Pro - Statement.csv"
+        pro_statement_b = REPO_ROOT / "01_raw_exports" / "external" / "coinbase" / "raw" / "2022-11 Coinbase Pro - Statement.csv"
+        pro_fills = REPO_ROOT / "01_raw_exports" / "external" / "coinbase" / "raw" / "2021-05 Coinbase Pro - Fills.csv"
+        statement_pdf = REPO_ROOT / "01_raw_exports" / "external" / "coinbase" / "raw" / (
+            "coinbase_statement.pdf"
+        )
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tx_output = Path(tmpdir) / "coinbase_normalized.csv"
+            balance_output = Path(tmpdir) / "coinbase_balances.csv"
+
+            result = run_script(
+                "coinbase_normalize.py",
+                "--retail-csv",
+                str(retail_csv),
+                "--pro-statement",
+                str(pro_statement_a),
+                "--pro-statement",
+                str(pro_statement_b),
+                "--pro-fills",
+                str(pro_fills),
+                "--pdf",
+                str(statement_pdf),
+                "--tx-output",
+                str(tx_output),
+                "--balance-output",
+                str(balance_output),
+            )
+            summary = json.loads(result.stdout)
+            tx_rows = read_dict_rows(tx_output)
+            balance_rows = read_dict_rows(balance_output)
+
+        self.assertEqual(82, summary["normalized_transaction_rows"])
+        self.assertEqual(82, len(tx_rows))
+        self.assertGreaterEqual(summary["normalized_balance_rows"], 10)
+        self.assertEqual(summary["normalized_balance_rows"], len(balance_rows))
+
+    def test_pdf_balance_extract_cli_reads_supported_repo_pdfs(self) -> None:
+        coinbase_pdf = REPO_ROOT / "01_raw_exports" / "external" / "coinbase" / "raw" / (
+            "coinbase_statement.pdf"
+        )
+        binance_pdf = REPO_ROOT / "01_raw_exports" / "external" / "binance" / "raw" / (
+            "binance.pdf"
+        )
+        shakepay_pdf = REPO_ROOT / "01_raw_exports" / "external" / "shakepay" / "raw" / "shakepay_Performance report_2025.pdf"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output = Path(tmpdir) / "balances.csv"
+            result = run_script(
+                "pdf_balance_extract.py",
+                "--source",
+                "auto",
+                "--pdf",
+                str(coinbase_pdf),
+                "--pdf",
+                str(binance_pdf),
+                "--pdf",
+                str(shakepay_pdf),
+                "--output",
+                str(output),
+            )
+            summary = json.loads(result.stdout)
+            rows = read_dict_rows(output)
+
+        self.assertEqual(3, len(summary["pdf_files"]))
+        self.assertGreaterEqual(summary["balance_rows"], 20)
+        self.assertEqual(summary["balance_rows"], len(rows))
+
     def test_binance_unwrap_cli_extracts_and_combines(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             source_dir = Path(tmpdir) / "source" / "raw"
@@ -231,6 +303,44 @@ class ScriptEndToEndTests(unittest.TestCase):
 
         self.assertEqual(1, result.returncode)
         self.assertIn("single path segment without traversal", result.stderr)
+
+    def test_coinbase_check_cli_flags_extra_cointracking_rows(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            ledger = Path(tmpdir) / "ledger.csv"
+            normalized = Path(tmpdir) / "normalized.csv"
+            out_dir = Path(tmpdir) / "out"
+            ledger.write_text(
+                (
+                    "Type,Buy,Cur.,Sell,Cur.,Fee,Cur.,Exchange,Group,Comment,Date,Tx-ID\n"
+                    "Trade,0.00175640,BTC,25.00000000,CAD,1.49000000,CAD,Coinbase,,Bought 0.0017564 BTC for $25.00 CAD,2019-09-11 01:06:26,\n"
+                    "Deposit,25.00000000,CAD,,,0.00000000,,Coinbase,,,2019-09-11 01:06:26,\n"
+                ),
+                encoding="utf-8",
+            )
+            normalized.write_text(
+                (
+                    "Type,Buy,Cur.,Sell,Cur.,Fee,Cur.,Exchange,Group,Comment,Date,Tx-ID,"
+                    "match_window_seconds,fee_tolerance,comment_mode,tx_id_mode,allowed_types,raw_source,raw_ref,notes\n"
+                    "Trade,0.00175640,BTC,25.00000000,CAD,1.46965254,CAD,Coinbase,,Bought 0.0017564 BTC for $25.00 CAD,2019-09-11 01:06:35,coinbase-retail-buy-1,20,0.03000000,exact,ignore,Trade,coinbase.csv,buy-1,\n"
+                ),
+                encoding="utf-8",
+            )
+
+            result = run_script(
+                "coinbase_check.py",
+                "--cointracking-ledger",
+                str(ledger),
+                "--normalized-transactions",
+                str(normalized),
+                "--out-dir",
+                str(out_dir),
+            )
+            summary = json.loads(result.stdout)
+            extra_rows = read_dict_rows(out_dir / "extra_rows.csv")
+
+        self.assertEqual("failed", summary["status"])
+        self.assertEqual(1, summary["extra_rows"])
+        self.assertEqual("Deposit", extra_rows[0]["Type"])
 
     def test_overlap_check_cli_writes_summary(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/e2e/test_scripts.py
+++ b/tests/e2e/test_scripts.py
@@ -385,6 +385,104 @@ class ScriptEndToEndTests(unittest.TestCase):
         self.assertEqual(0, summary["exceptions"])
         self.assertEqual(14, len(events))
 
+    def test_normalize_source_cli_supports_bsc_explorer_repo_raw_dir(self) -> None:
+        raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "metamask" / "raw"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir) / "normalized" / "bsc_explorer"
+            result = run_script(
+                "normalize_source.py",
+                "--source",
+                "BSC MetaMask Wallet",
+                "--raw-dir",
+                str(raw_dir),
+                "--out-dir",
+                str(out_dir),
+            )
+            summary = json.loads(result.stdout)
+            events = read_dict_rows(out_dir / "canonical_events.csv")
+
+        self.assertEqual("ready", summary["status"])
+        self.assertEqual("evm_explorer", summary["adapter"])
+        self.assertEqual(41, summary["canonical_events"])
+        self.assertEqual(0, summary["exceptions"])
+        self.assertEqual(41, len(events))
+
+    def test_normalize_source_cli_surfaces_polygon_review_rows(self) -> None:
+        raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "metamask" / "raw"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir) / "normalized" / "polygon_explorer"
+            result = run_script(
+                "normalize_source.py",
+                "--source",
+                "MetaMask - Polygon",
+                "--raw-dir",
+                str(raw_dir),
+                "--out-dir",
+                str(out_dir),
+            )
+            summary = json.loads(result.stdout)
+            events = read_dict_rows(out_dir / "canonical_events.csv")
+            exceptions = read_dict_rows(out_dir / "exceptions.csv")
+
+        self.assertEqual("needs_review", summary["status"])
+        self.assertEqual("evm_explorer", summary["adapter"])
+        self.assertEqual(20, summary["canonical_events"])
+        self.assertEqual(5, summary["exceptions"])
+        self.assertEqual(20, len(events))
+        self.assertEqual(5, len(exceptions))
+
+    def test_normalize_source_cli_surfaces_eth_gala_review_rows(self) -> None:
+        raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "metamask" / "raw"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir) / "normalized" / "eth_gala_explorer"
+            result = run_script(
+                "normalize_source.py",
+                "--source",
+                "ETH GalaGames Wallet",
+                "--raw-dir",
+                str(raw_dir),
+                "--out-dir",
+                str(out_dir),
+            )
+            summary = json.loads(result.stdout)
+            events = read_dict_rows(out_dir / "canonical_events.csv")
+            exceptions = read_dict_rows(out_dir / "exceptions.csv")
+
+        self.assertEqual("needs_review", summary["status"])
+        self.assertEqual("evm_explorer", summary["adapter"])
+        self.assertEqual(14, summary["canonical_events"])
+        self.assertEqual(3, summary["exceptions"])
+        self.assertEqual(14, len(events))
+        self.assertEqual(3, len(exceptions))
+
+    def test_normalize_source_cli_surfaces_gtrade_report_limits(self) -> None:
+        raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "gtrade" / "raw"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir) / "normalized" / "gtrade"
+            result = run_script(
+                "normalize_source.py",
+                "--source",
+                "GTrade 1CT",
+                "--raw-dir",
+                str(raw_dir),
+                "--out-dir",
+                str(out_dir),
+            )
+            summary = json.loads(result.stdout)
+            events = read_dict_rows(out_dir / "canonical_events.csv")
+            exceptions = read_dict_rows(out_dir / "exceptions.csv")
+
+        self.assertEqual("needs_review", summary["status"])
+        self.assertEqual("gtrade", summary["adapter"])
+        self.assertEqual(3, summary["canonical_events"])
+        self.assertEqual(3, summary["exceptions"])
+        self.assertEqual(3, len(events))
+        self.assertEqual(3, len(exceptions))
+
     def test_normalize_source_cli_surfaces_small_binance_review_set(self) -> None:
         raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "binance" / "raw"
 

--- a/tests/e2e/test_scripts.py
+++ b/tests/e2e/test_scripts.py
@@ -247,6 +247,160 @@ class ScriptEndToEndTests(unittest.TestCase):
         self.assertFalse(archive_exists)
         self.assertTrue(combined_exists)
 
+    def test_profile_source_cli_profiles_coinbase_raw_dir(self) -> None:
+        raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "coinbase" / "raw"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir) / "normalized" / "coinbase"
+            result = run_script(
+                "profile_source.py",
+                "--source",
+                "Coinbase",
+                "--raw-dir",
+                str(raw_dir),
+                "--out-dir",
+                str(out_dir),
+            )
+            summary = json.loads(result.stdout)
+            profile = read_json(out_dir / "profile.json")
+            inventory = read_dict_rows(out_dir / "profile_inventory.csv")
+
+        self.assertEqual("coinbase", summary["adapter"])
+        self.assertTrue(summary["adapter_supported"])
+        self.assertEqual(summary["files_profiled"], len(inventory))
+        self.assertIn("manifest_fingerprint", profile)
+
+    def test_normalize_source_cli_caches_coinbase_outputs(self) -> None:
+        raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "coinbase" / "raw"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir) / "normalized" / "coinbase"
+            first = run_script(
+                "normalize_source.py",
+                "--source",
+                "Coinbase",
+                "--raw-dir",
+                str(raw_dir),
+                "--out-dir",
+                str(out_dir),
+            )
+            second = run_script(
+                "normalize_source.py",
+                "--source",
+                "Coinbase",
+                "--raw-dir",
+                str(raw_dir),
+                "--out-dir",
+                str(out_dir),
+            )
+            first_summary = json.loads(first.stdout)
+            second_summary = json.loads(second.stdout)
+            events = read_dict_rows(out_dir / "canonical_events.csv")
+            candidate = read_dict_rows(out_dir / "cointracking_candidate.csv")
+
+        self.assertEqual("ready", first_summary["status"])
+        self.assertEqual(82, len(events))
+        self.assertEqual(82, len(candidate))
+        self.assertEqual("cached", second_summary["status"])
+
+    def test_reconcile_source_cli_flags_existing_coinbase_backing_exceptions(self) -> None:
+        raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "coinbase" / "raw"
+        ledger = REPO_ROOT / "02_working" / "normalized" / "coinbase" / "2026-03-24_coinbase_reconstructed_current_ledger.csv"
+        balances = REPO_ROOT / "02_working" / "verification" / "baseline_repair_round_02" / "CoinTracking - Balance by Exchange - 24.03.2026.csv"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir) / "normalized" / "coinbase"
+            run_script(
+                "normalize_source.py",
+                "--source",
+                "Coinbase",
+                "--raw-dir",
+                str(raw_dir),
+                "--out-dir",
+                str(out_dir),
+            )
+            result = run_script(
+                "reconcile_source.py",
+                "--source",
+                "Coinbase",
+                "--cointracking-ledger",
+                str(ledger),
+                "--canonical-events",
+                str(out_dir / "canonical_events.csv"),
+                "--canonical-balances",
+                str(out_dir / "canonical_balances.csv"),
+                "--cointracking-balance-by-exchange",
+                str(balances),
+                "--out-dir",
+                str(out_dir / "reconcile"),
+            )
+            summary = json.loads(result.stdout)
+
+        self.assertEqual("failed", summary["status"])
+        self.assertGreater(summary["extra_rows"], 0)
+
+    def test_dry_run_pipeline_coinbase_profile_normalize_render_overlap_reconcile(self) -> None:
+        raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "coinbase" / "raw"
+        baseline_dir = REPO_ROOT / "01_raw_exports" / "cointracking" / "2023-08-05_full_export"
+        ledger = REPO_ROOT / "02_working" / "normalized" / "coinbase" / "2026-03-24_coinbase_reconstructed_current_ledger.csv"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir) / "normalized" / "coinbase"
+            run_script(
+                "profile_source.py",
+                "--source",
+                "Coinbase",
+                "--raw-dir",
+                str(raw_dir),
+                "--out-dir",
+                str(out_dir),
+            )
+            run_script(
+                "normalize_source.py",
+                "--source",
+                "Coinbase",
+                "--raw-dir",
+                str(raw_dir),
+                "--out-dir",
+                str(out_dir),
+                "--profile-json",
+                str(out_dir / "profile.json"),
+            )
+            run_script(
+                "render_cointracking.py",
+                "--canonical-events",
+                str(out_dir / "canonical_events.csv"),
+                "--output",
+                str(out_dir / "rendered_cointracking.csv"),
+                "--summary-output",
+                str(out_dir / "render_summary.json"),
+            )
+            overlap = run_script(
+                "overlap_check.py",
+                "--baseline-export-dir",
+                str(baseline_dir),
+                "--candidate",
+                str(out_dir / "rendered_cointracking.csv"),
+                "--out-dir",
+                str(out_dir / "overlap_check"),
+            )
+            reconcile = run_script(
+                "reconcile_source.py",
+                "--source",
+                "Coinbase",
+                "--cointracking-ledger",
+                str(ledger),
+                "--canonical-events",
+                str(out_dir / "canonical_events.csv"),
+                "--out-dir",
+                str(out_dir / "reconcile"),
+            )
+            overlap_summary = json.loads(overlap.stdout)
+            reconcile_summary = json.loads(reconcile.stdout)
+
+        self.assertEqual("review_required", overlap_summary["status"])
+        self.assertEqual("failed", reconcile_summary["status"])
+
     def test_round_scaffold_cli_creates_temp_repo_scaffold(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             repo_root = Path(tmpdir)

--- a/tests/e2e/test_scripts.py
+++ b/tests/e2e/test_scripts.py
@@ -294,6 +294,97 @@ class ScriptEndToEndTests(unittest.TestCase):
         self.assertEqual(26, len(events))
         self.assertEqual(26, len(candidate))
 
+    def test_normalize_source_cli_supports_shakepay_repo_raw_dir(self) -> None:
+        raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "shakepay" / "raw"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir) / "normalized" / "shakepay"
+            result = run_script(
+                "normalize_source.py",
+                "--source",
+                "Shakepay",
+                "--raw-dir",
+                str(raw_dir),
+                "--out-dir",
+                str(out_dir),
+            )
+            summary = json.loads(result.stdout)
+            events = read_dict_rows(out_dir / "canonical_events.csv")
+            balances = read_dict_rows(out_dir / "canonical_balances.csv")
+
+        self.assertEqual("ready", summary["status"])
+        self.assertEqual(1895, summary["canonical_events"])
+        self.assertEqual(2, summary["canonical_balances"])
+        self.assertEqual(0, summary["exceptions"])
+        self.assertEqual(1895, len(events))
+        self.assertEqual(2, len(balances))
+
+    def test_normalize_source_cli_supports_ledger_live_repo_raw_dir(self) -> None:
+        raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "ledger live" / "raw"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir) / "normalized" / "ledger_live"
+            result = run_script(
+                "normalize_source.py",
+                "--source",
+                "Ledger Live",
+                "--raw-dir",
+                str(raw_dir),
+                "--out-dir",
+                str(out_dir),
+            )
+            summary = json.loads(result.stdout)
+            events = read_dict_rows(out_dir / "canonical_events.csv")
+
+        self.assertEqual("ready", summary["status"])
+        self.assertEqual(22, summary["canonical_events"])
+        self.assertEqual(0, summary["exceptions"])
+        self.assertEqual(22, len(events))
+
+    def test_normalize_source_cli_supports_crypto_com_repo_raw_dir(self) -> None:
+        raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "crypto.com" / "raw"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir) / "normalized" / "crypto_com"
+            result = run_script(
+                "normalize_source.py",
+                "--source",
+                "Crypto.com",
+                "--raw-dir",
+                str(raw_dir),
+                "--out-dir",
+                str(out_dir),
+            )
+            summary = json.loads(result.stdout)
+            events = read_dict_rows(out_dir / "canonical_events.csv")
+
+        self.assertEqual("ready", summary["status"])
+        self.assertEqual(12, summary["canonical_events"])
+        self.assertEqual(0, summary["exceptions"])
+        self.assertEqual(12, len(events))
+
+    def test_normalize_source_cli_supports_near_repo_raw_dir(self) -> None:
+        raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "near" / "raw"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir) / "normalized" / "near"
+            result = run_script(
+                "normalize_source.py",
+                "--source",
+                "NEAR Wallet",
+                "--raw-dir",
+                str(raw_dir),
+                "--out-dir",
+                str(out_dir),
+            )
+            summary = json.loads(result.stdout)
+            events = read_dict_rows(out_dir / "canonical_events.csv")
+
+        self.assertEqual("ready", summary["status"])
+        self.assertEqual(14, summary["canonical_events"])
+        self.assertEqual(0, summary["exceptions"])
+        self.assertEqual(14, len(events))
+
     def test_normalize_source_cli_surfaces_small_binance_review_set(self) -> None:
         raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "binance" / "raw"
 

--- a/tests/e2e/test_scripts.py
+++ b/tests/e2e/test_scripts.py
@@ -314,8 +314,8 @@ class ScriptEndToEndTests(unittest.TestCase):
         self.assertEqual("needs_review", summary["status"])
         self.assertGreater(summary["canonical_events"], 26000)
         self.assertEqual(24, summary["canonical_balances"])
-        self.assertEqual(3, summary["exceptions"])
-        self.assertEqual(3, len(exceptions))
+        self.assertEqual(1, summary["exceptions"])
+        self.assertEqual(1, len(exceptions))
 
     def test_normalize_source_cli_caches_coinbase_outputs(self) -> None:
         raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "coinbase" / "raw"

--- a/tests/e2e/test_scripts.py
+++ b/tests/e2e/test_scripts.py
@@ -339,6 +339,42 @@ class ScriptEndToEndTests(unittest.TestCase):
         self.assertEqual("failed", summary["status"])
         self.assertGreater(summary["extra_rows"], 0)
 
+    def test_stage_import_batch_cli_stages_passing_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            baseline = root / "baseline"
+            baseline.mkdir()
+            baseline_trade = baseline / "Trade Table.csv"
+            baseline_trade.write_text(
+                "Type,Buy,Cur.,Sell,Cur.,Fee,Cur.,Exchange,Group,Comment,Date,Tx-ID\n"
+                "Trade,1.00000000,BTC,10.00000000,CAD,0.10000000,CAD,Coinbase,,,2023-08-05 08:34:04,tx-1\n",
+                encoding="utf-8",
+            )
+            candidate = root / "candidate.csv"
+            candidate.write_text(
+                "Type,Buy,Cur.,Sell,Cur.,Fee,Cur.,Exchange,Group,Comment,Date,Tx-ID\n"
+                "Trade,1.00000000,BTC,10.00000000,CAD,0.10000000,CAD,Coinbase,,,2023-08-06 08:34:05,tx-2\n",
+                encoding="utf-8",
+            )
+
+            out_dir = root / "batch"
+            ready_dir = root / "ready"
+            result = run_script(
+                "stage_import_batch.py",
+                "--candidate",
+                str(candidate),
+                "--baseline-export-dir",
+                str(baseline),
+                "--out-dir",
+                str(out_dir),
+                "--import-ready-dir",
+                str(ready_dir),
+            )
+            summary = json.loads(result.stdout)
+            self.assertEqual("staged", summary["status"])
+            self.assertTrue((out_dir / "candidate.csv").exists())
+            self.assertTrue((ready_dir / "candidate.csv").exists())
+
     def test_dry_run_pipeline_coinbase_profile_normalize_render_overlap_reconcile(self) -> None:
         raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "coinbase" / "raw"
         baseline_dir = REPO_ROOT / "01_raw_exports" / "cointracking" / "2023-08-05_full_export"

--- a/tests/e2e/test_scripts.py
+++ b/tests/e2e/test_scripts.py
@@ -270,6 +270,53 @@ class ScriptEndToEndTests(unittest.TestCase):
         self.assertEqual(summary["files_profiled"], len(inventory))
         self.assertIn("manifest_fingerprint", profile)
 
+    def test_normalize_source_cli_supports_wealthsimple_repo_raw_dir(self) -> None:
+        raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "wealthsimple" / "raw"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir) / "normalized" / "wealthsimple"
+            result = run_script(
+                "normalize_source.py",
+                "--source",
+                "WealthSimple",
+                "--raw-dir",
+                str(raw_dir),
+                "--out-dir",
+                str(out_dir),
+            )
+            summary = json.loads(result.stdout)
+            events = read_dict_rows(out_dir / "canonical_events.csv")
+            candidate = read_dict_rows(out_dir / "cointracking_candidate.csv")
+
+        self.assertEqual("ready", summary["status"])
+        self.assertEqual(26, summary["canonical_events"])
+        self.assertEqual(0, summary["exceptions"])
+        self.assertEqual(26, len(events))
+        self.assertEqual(26, len(candidate))
+
+    def test_normalize_source_cli_surfaces_small_binance_review_set(self) -> None:
+        raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "binance" / "raw"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_dir = Path(tmpdir) / "normalized" / "binance"
+            result = run_script(
+                "normalize_source.py",
+                "--source",
+                "Binance",
+                "--raw-dir",
+                str(raw_dir),
+                "--out-dir",
+                str(out_dir),
+            )
+            summary = json.loads(result.stdout)
+            exceptions = read_dict_rows(out_dir / "exceptions.csv")
+
+        self.assertEqual("needs_review", summary["status"])
+        self.assertGreater(summary["canonical_events"], 26000)
+        self.assertEqual(24, summary["canonical_balances"])
+        self.assertEqual(3, summary["exceptions"])
+        self.assertEqual(3, len(exceptions))
+
     def test_normalize_source_cli_caches_coinbase_outputs(self) -> None:
         raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "coinbase" / "raw"
 

--- a/tests/unit/test_coinbase_check.py
+++ b/tests/unit/test_coinbase_check.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import unittest
+
+import coinbase_check
+
+
+def expected_row(**overrides: str) -> dict[str, str]:
+    row = {
+        "Type": "Trade",
+        "Buy": "0.00175640",
+        "Buy Cur.": "BTC",
+        "Sell": "25.00000000",
+        "Sell Cur.": "CAD",
+        "Fee": "1.46965254",
+        "Fee Cur.": "CAD",
+        "Exchange": "Coinbase",
+        "Group": "",
+        "Comment": "Bought 0.0017564 BTC for $25.00 CAD",
+        "Date": "2019-09-11 01:06:35",
+        "Tx-ID": "coinbase-retail-buy-1",
+        "match_window_seconds": "20",
+        "fee_tolerance": "0.03000000",
+        "comment_mode": "exact",
+        "tx_id_mode": "ignore",
+        "allowed_types": "Trade",
+        "raw_source": "coinbase.csv",
+        "raw_ref": "buy-1",
+        "notes": "",
+    }
+    row.update(overrides)
+    return row
+
+
+def actual_row(**overrides: str) -> dict[str, str]:
+    row = {
+        "Type": "Trade",
+        "Buy": "0.00175640",
+        "Buy Cur.": "BTC",
+        "Sell": "25.00000000",
+        "Sell Cur.": "CAD",
+        "Fee": "1.49000000",
+        "Fee Cur.": "CAD",
+        "Exchange": "Coinbase",
+        "Group": "",
+        "Comment": "Bought 0.0017564 BTC for $25.00 CAD",
+        "Date": "2019-09-11 01:06:26",
+        "Tx-ID": "",
+    }
+    row.update(overrides)
+    return row
+
+
+class CoinbaseCheckTests(unittest.TestCase):
+    def test_compare_transactions_flags_extra_synthetic_row(self) -> None:
+        expected = [expected_row()]
+        actual = [
+            actual_row(),
+            {
+                "Type": "Deposit",
+                "Buy": "25.00000000",
+                "Buy Cur.": "CAD",
+                "Sell": "",
+                "Sell Cur.": "",
+                "Fee": "0.00000000",
+                "Fee Cur.": "",
+                "Exchange": "Coinbase",
+                "Group": "",
+                "Comment": "",
+                "Date": "2019-09-11 01:06:26",
+                "Tx-ID": "",
+            },
+        ]
+
+        results = coinbase_check.compare_transactions(actual, expected)
+
+        self.assertEqual(1, len(results["matched"]))
+        self.assertEqual(1, len(results["extra"]))
+        self.assertEqual("Deposit", results["extra"][0]["Type"])
+
+    def test_compare_transactions_flags_fee_mismatch_even_when_type_is_allowed_variant(self) -> None:
+        expected = [
+            expected_row(
+                Type="Withdrawal",
+                Buy="",
+                **{
+                    "Buy Cur.": "",
+                    "Sell": "0.05516500",
+                    "Sell Cur.": "ETH",
+                    "Fee": "0.00000000",
+                    "Fee Cur.": "ETH",
+                    "Comment": "Sent 0.055165 ETH to 0xabc",
+                    "Date": "2019-10-30 00:38:57",
+                    "fee_tolerance": "0.00000000",
+                    "comment_mode": "ignore",
+                    "allowed_types": "Withdrawal|Spend",
+                },
+            )
+        ]
+        actual = [
+            actual_row(
+                Type="Spend",
+                Buy="",
+                **{
+                    "Buy Cur.": "",
+                    "Sell": "0.05516500",
+                    "Sell Cur.": "ETH",
+                    "Fee": "0.00021000",
+                    "Fee Cur.": "ETH",
+                    "Comment": "Sent 0.055165 ETH to 0xabc",
+                    "Date": "2019-10-30 00:38:57",
+                },
+            )
+        ]
+
+        results = coinbase_check.compare_transactions(actual, expected)
+
+        self.assertEqual(1, len(results["mismatched"]))
+        self.assertEqual("fee_mismatch", results["mismatched"][0]["comparison_issues"])
+
+    def test_compare_balances_reports_asset_deltas(self) -> None:
+        deltas = coinbase_check.compare_balances(
+            [
+                {"Amount": "1.00000000", "Currency": "BTC", "Exchange": "Coinbase"},
+                {"Amount": "0.50000000", "Currency": "ETH", "Exchange": "Coinbase"},
+            ],
+            [
+                {"source": "Coinbase", "balance_kind": "asset_balance", "asset": "BTC", "quantity": "1.00000000"},
+                {"source": "Coinbase", "balance_kind": "asset_balance", "asset": "ETH", "quantity": "0.40000000"},
+            ],
+        )
+
+        eth_row = next(row for row in deltas if row["asset"] == "ETH")
+        self.assertEqual("delta", eth_row["status"])
+        self.assertEqual("0.10000000", eth_row["difference"])

--- a/tests/unit/test_coinbase_common.py
+++ b/tests/unit/test_coinbase_common.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import coinbase_common
+
+
+class CoinbaseCommonTests(unittest.TestCase):
+    def test_retail_csv_rows_skips_preface_and_reads_transactions(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "coinbase.csv"
+            path.write_text(
+                "\nTransactions\nUser,Example,acct\n"
+                "ID,Timestamp,Transaction Type,Asset,Quantity Transacted,Price Currency,Price at Transaction,Subtotal,Total (inclusive of fees and/or spread),Fees and/or Spread,Notes\n"
+                "raw-1,2025-01-01 00:00:00 UTC,Reward Income,ADA,1.0,CAD,$1.00,$1.00,$1.00,$0.00,Received 1 ADA\n",
+                encoding="utf-8",
+            )
+
+            rows = coinbase_common.retail_csv_rows(path)
+
+        self.assertEqual(1, len(rows))
+        self.assertEqual("raw-1", rows[0]["ID"])
+
+    def test_normalize_coinbase_transactions_builds_expected_shapes(self) -> None:
+        retail_rows = [
+            {
+                "ID": "buy-1",
+                "Timestamp": "2019-09-11 01:06:35 UTC",
+                "Transaction Type": "Buy",
+                "Asset": "BTC",
+                "Quantity Transacted": "0.0017564",
+                "Price Currency": "CAD",
+                "Price at Transaction": "$13,396.9183875",
+                "Subtotal": "$23.53035",
+                "Total (inclusive of fees and/or spread)": "$25.00",
+                "Fees and/or Spread": "$1.469652544195",
+                "Notes": "Bought 0.0017564 BTC for 25 CAD using 1234",
+            },
+            {
+                "ID": "send-1",
+                "Timestamp": "2019-10-30 00:38:57 UTC",
+                "Transaction Type": "Send",
+                "Asset": "ETH",
+                "Quantity Transacted": "-0.055165",
+                "Price Currency": "CAD",
+                "Price at Transaction": "$249.80",
+                "Subtotal": "-$13.78",
+                "Total (inclusive of fees and/or spread)": "-$13.78",
+                "Fees and/or Spread": "$0.00",
+                "Notes": "Sent 0.055165 ETH to 0xabc (to 0xabc)",
+            },
+            {
+                "ID": "reward-1",
+                "Timestamp": "2023-03-18 01:28:49 UTC",
+                "Transaction Type": "Reward Income",
+                "Asset": "ADA",
+                "Quantity Transacted": "0.000021",
+                "Price Currency": "CAD",
+                "Price at Transaction": "$0.48",
+                "Subtotal": "$0.00",
+                "Total (inclusive of fees and/or spread)": "$0.00",
+                "Fees and/or Spread": "$0.00",
+                "Notes": "Received 0.000021 ADA from Coinbase Rewards",
+            },
+            {
+                "ID": "migration-neg",
+                "Timestamp": "2025-10-17 13:38:17 UTC",
+                "Transaction Type": "Asset Migration",
+                "Asset": "MATIC",
+                "Quantity Transacted": "-1.65526374",
+                "Price Currency": "CAD",
+                "Price at Transaction": "$0.25",
+                "Subtotal": "-$0.42",
+                "Total (inclusive of fees and/or spread)": "-$0.42",
+                "Fees and/or Spread": "$0.00",
+                "Notes": "",
+            },
+            {
+                "ID": "migration-pos",
+                "Timestamp": "2025-10-17 13:38:17 UTC",
+                "Transaction Type": "Asset Migration",
+                "Asset": "POL",
+                "Quantity Transacted": "1.65526374",
+                "Price Currency": "CAD",
+                "Price at Transaction": "$0.25",
+                "Subtotal": "$0.42",
+                "Total (inclusive of fees and/or spread)": "$0.42",
+                "Fees and/or Spread": "$0.00",
+                "Notes": "",
+            },
+        ]
+
+        rows = coinbase_common.normalize_coinbase_transactions(
+            retail_rows,
+            pro_statement_rows=[],
+            pro_fill_rows=[],
+            retail_source=Path("coinbase.csv"),
+        )
+
+        self.assertEqual(4, len(rows))
+        self.assertEqual("Trade", rows[0]["Type"])
+        self.assertEqual("BTC", rows[0]["Buy Cur."])
+        self.assertEqual("Withdrawal", rows[1]["Type"])
+        self.assertEqual("Withdrawal|Spend", rows[1]["allowed_types"])
+        self.assertEqual("Interest Income", rows[2]["Type"])
+        self.assertEqual("Swap (non taxable)", rows[3]["Type"])
+        self.assertEqual("Asset Migration", rows[3]["Group"])
+
+    def test_coinbase_balance_rows_from_text_extracts_cash_and_assets(self) -> None:
+        text = """
+        Cash Balances Closing Balance 0 CAD as of 2026-03-22 23:59:59 UTC
+        Portfolio summary balances are as of 2026-03-22 23:59:59 UTC
+        ADA 0.080457 N/A 0.34390493 CAD/ADA 0.03 CAD
+        POL 1.65526374 N/A 0.12634783 CAD/POL 0.21 CAD
+        """
+
+        rows = coinbase_common.coinbase_balance_rows_from_text(text, "statement.pdf")
+
+        self.assertEqual(3, len(rows))
+        self.assertEqual("cash_closing_balance", rows[0]["balance_kind"])
+        self.assertEqual("ADA", rows[1]["asset"])
+        self.assertEqual("POL", rows[2]["asset"])

--- a/tests/unit/test_pdf_balance_extract.py
+++ b/tests/unit/test_pdf_balance_extract.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+import pdf_balance_extract
+
+
+class PdfBalanceExtractTests(unittest.TestCase):
+    def test_binance_balance_rows_from_text_extracts_total_and_wallets(self) -> None:
+        text = """
+        Report Period: January 01, 2025 - December 31, 2025
+        Total Account Value: 0.43 USD
+        Wallet Balance Funding Spot & Margin Futures Options Earn
+        0.01 USD 0.42 USD 0.00 USD 0.00 USD 0.00 USD
+        """
+
+        rows = pdf_balance_extract.binance_balance_rows_from_text(text, "binance.pdf")
+
+        self.assertEqual(6, len(rows))
+        self.assertEqual("Consolidated", rows[0]["wallet"])
+        self.assertEqual("Funding", rows[1]["wallet"])
+
+    def test_shakepay_balance_rows_from_text_extracts_open_and_close(self) -> None:
+        text = """
+        Performance report For the year ending on December 31, 2025
+        For the year ($) Since account opening ($) $256.37 $0.00
+        Opening market value (as of 2025-01-01 00:00 EST)
+        Closing market value at year end $643.81
+        """
+
+        rows = pdf_balance_extract.shakepay_balance_rows_from_text(text, "shakepay.pdf")
+
+        self.assertEqual(2, len(rows))
+        self.assertEqual("opening_market_value", rows[0]["balance_kind"])
+        self.assertEqual("closing_market_value", rows[1]["balance_kind"])
+
+    def test_detect_extractor_picks_known_filename_patterns(self) -> None:
+        source, _ = pdf_balance_extract.detect_extractor(Path("binance.pdf"))
+        self.assertEqual("binance", source)

--- a/tests/unit/test_pipeline_common.py
+++ b/tests/unit/test_pipeline_common.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import pipeline_common
+
+
+class PipelineCommonTests(unittest.TestCase):
+    def test_manifest_fingerprint_is_order_independent(self) -> None:
+        rows_a = [
+            {"filename": "b.csv", "size_bytes": "2", "sha256": "bbb"},
+            {"filename": "a.csv", "size_bytes": "1", "sha256": "aaa"},
+        ]
+        rows_b = list(reversed(rows_a))
+
+        self.assertEqual(
+            pipeline_common.manifest_fingerprint_from_rows(rows_a),
+            pipeline_common.manifest_fingerprint_from_rows(rows_b),
+        )
+
+    def test_build_file_inventory_classifies_known_csv_families(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            raw_dir = Path(tmpdir)
+            (raw_dir / "2026-03-23 Statement - All Time - account.csv").write_text(
+                "Transactions\nID,Timestamp,Transaction Type\n",
+                encoding="utf-8",
+            )
+            (raw_dir / "ledgerlive-operations.csv").write_text(
+                "Operation Date,Status,Currency Ticker,Operation Type,Operation Amount\n",
+                encoding="utf-8",
+            )
+            (raw_dir / "shakepay_Performance report_2025.pdf").write_bytes(b"%PDF-1.4\n")
+
+            inventory = pipeline_common.build_file_inventory(raw_dir)
+
+        by_name = {row["filename"]: row for row in inventory}
+        self.assertEqual("custodial_all_time_csv", by_name["2026-03-23 Statement - All Time - account.csv"]["family"])
+        self.assertEqual("wallet_operation_csv", by_name["ledgerlive-operations.csv"]["family"])
+        self.assertEqual("statement_balance_pdf", by_name["shakepay_Performance report_2025.pdf"]["family"])
+
+    def test_validate_canonical_event_row_requires_minimum_fields(self) -> None:
+        row = {header: "" for header in pipeline_common.CANONICAL_EVENT_HEADERS}
+        row.update(
+            {
+                "event_id": "evt-1",
+                "source": "Coinbase",
+                "timestamp": "2026-03-24 10:11:12",
+                "event_kind": "Trade",
+                "confidence": "high",
+                "status": "mapped",
+            }
+        )
+        pipeline_common.validate_canonical_event_row(row)
+
+        row["event_id"] = ""
+        with self.assertRaisesRegex(ValueError, "event_id"):
+            pipeline_common.validate_canonical_event_row(row)
+

--- a/tests/unit/test_pipeline_common.py
+++ b/tests/unit/test_pipeline_common.py
@@ -40,6 +40,35 @@ class PipelineCommonTests(unittest.TestCase):
         self.assertEqual("wallet_operation_csv", by_name["ledgerlive-operations.csv"]["family"])
         self.assertEqual("statement_balance_pdf", by_name["shakepay_Performance report_2025.pdf"]["family"])
 
+    def test_build_file_inventory_classifies_binance_specialized_families(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            raw_dir = Path(tmpdir)
+            (raw_dir / "Binance-Convert-Order-History-202603230441(UTC--6)_abcd.csv").write_text(
+                "Time,Wallet,Pair,Type,Sell,Buy,Price,Inverse Price,Date Updated,Status\n",
+                encoding="utf-8",
+            )
+            (raw_dir / "Binance-Fiat-Buy-History-202603230414(UTC--6)_abcd.csv").write_text(
+                "Time,Method,Spend Amount,Receive Amount,Fee,Price,Status,Transaction ID\n",
+                encoding="utf-8",
+            )
+            (raw_dir / "Binance-Deposit-History-202603230411(UTC--6)_abcd.csv").write_text(
+                "Time,Coin,Network,Amount,Address,TXID,Status\n",
+                encoding="utf-8",
+            )
+
+            inventory = pipeline_common.build_file_inventory(raw_dir)
+
+        by_name = {row["filename"]: row for row in inventory}
+        self.assertEqual("convert_order_csv", by_name["Binance-Convert-Order-History-202603230441(UTC--6)_abcd.csv"]["family"])
+        self.assertEqual("fiat_buy_csv", by_name["Binance-Fiat-Buy-History-202603230414(UTC--6)_abcd.csv"]["family"])
+        self.assertEqual("deposit_history_csv", by_name["Binance-Deposit-History-202603230411(UTC--6)_abcd.csv"]["family"])
+
+    def test_parse_candidate_timestamp_accepts_two_digit_binance_year(self) -> None:
+        parsed = pipeline_common.parse_candidate_timestamp("23-09-20 18:20:55")
+
+        self.assertIsNotNone(parsed)
+        self.assertEqual("2023-09-20 18:20:55", parsed.strftime("%Y-%m-%d %H:%M:%S"))
+
     def test_validate_canonical_event_row_requires_minimum_fields(self) -> None:
         row = {header: "" for header in pipeline_common.CANONICAL_EVENT_HEADERS}
         row.update(
@@ -57,4 +86,3 @@ class PipelineCommonTests(unittest.TestCase):
         row["event_id"] = ""
         with self.assertRaisesRegex(ValueError, "event_id"):
             pipeline_common.validate_canonical_event_row(row)
-

--- a/tests/unit/test_reconcile_source.py
+++ b/tests/unit/test_reconcile_source.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import unittest
+
+import reconcile_source
+
+
+def expected_row(**overrides: str) -> dict[str, str]:
+    row = {
+        "Type": "Trade",
+        "Buy": "0.00175640",
+        "Buy Cur.": "BTC",
+        "Sell": "25.00000000",
+        "Sell Cur.": "CAD",
+        "Fee": "1.46965254",
+        "Fee Cur.": "CAD",
+        "Exchange": "Coinbase",
+        "Group": "",
+        "Comment": "Bought 0.0017564 BTC for $25.00 CAD",
+        "Date": "2019-09-11 01:06:35",
+        "Tx-ID": "coinbase-retail-buy-1",
+        "canonical_event_id": "evt-1",
+        "confidence": "high",
+        "status": "mapped",
+        "raw_file": "coinbase.csv",
+        "raw_row_ref": "buy-1",
+        "render_match_window_seconds": "20",
+        "render_fee_tolerance": "0.03000000",
+        "render_comment_mode": "exact",
+        "render_tx_id_mode": "ignore",
+        "render_allowed_types": "Trade",
+        "render_notes": "",
+    }
+    row.update(overrides)
+    return row
+
+
+def actual_row(**overrides: str) -> dict[str, str]:
+    row = {
+        "Type": "Trade",
+        "Buy": "0.00175640",
+        "Buy Cur.": "BTC",
+        "Sell": "25.00000000",
+        "Sell Cur.": "CAD",
+        "Fee": "1.49000000",
+        "Fee Cur.": "CAD",
+        "Exchange": "Coinbase",
+        "Group": "",
+        "Comment": "Bought 0.0017564 BTC for $25.00 CAD",
+        "Date": "2019-09-11 01:06:26",
+        "Tx-ID": "",
+    }
+    row.update(overrides)
+    return row
+
+
+class ReconcileSourceTests(unittest.TestCase):
+    def test_compare_transactions_flags_extra_synthetic_row(self) -> None:
+        expected = [expected_row()]
+        actual = [
+            actual_row(),
+            {
+                "Type": "Deposit",
+                "Buy": "25.00000000",
+                "Buy Cur.": "CAD",
+                "Sell": "",
+                "Sell Cur.": "",
+                "Fee": "0.00000000",
+                "Fee Cur.": "",
+                "Exchange": "Coinbase",
+                "Group": "",
+                "Comment": "",
+                "Date": "2019-09-11 01:06:26",
+                "Tx-ID": "",
+            },
+        ]
+
+        results = reconcile_source.compare_transactions(actual, expected)
+
+        self.assertEqual(1, len(results["matched"]))
+        self.assertEqual(1, len(results["extra"]))
+        self.assertEqual("Deposit", results["extra"][0]["Type"])
+
+    def test_compare_balances_reports_asset_deltas(self) -> None:
+        deltas = reconcile_source.compare_balances(
+            [
+                {"Amount": "1.00000000", "Currency": "BTC", "Exchange": "Coinbase"},
+                {"Amount": "0.50000000", "Currency": "ETH", "Exchange": "Coinbase"},
+            ],
+            [
+                {"source": "Coinbase", "balance_kind": "asset_balance", "asset": "BTC", "quantity": "1.00000000"},
+                {"source": "Coinbase", "balance_kind": "asset_balance", "asset": "ETH", "quantity": "0.40000000"},
+            ],
+            "Coinbase",
+        )
+
+        eth_row = next(row for row in deltas if row["asset"] == "ETH")
+        self.assertEqual("delta", eth_row["status"])
+        self.assertEqual("0.10000000", eth_row["difference"])

--- a/tests/unit/test_render_cointracking.py
+++ b/tests/unit/test_render_cointracking.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import unittest
+
+import render_cointracking
+
+
+class RenderCointrackingTests(unittest.TestCase):
+    def test_render_cointracking_rows_maps_mapped_rows_and_skips_non_mapped(self) -> None:
+        mapped = {
+            "event_id": "evt-1",
+            "source": "Coinbase",
+            "adapter": "coinbase",
+            "account": "Coinbase",
+            "wallet": "Coinbase",
+            "raw_file": "coinbase.csv",
+            "raw_row_ref": "buy-1",
+            "timestamp": "2019-09-11 01:06:35",
+            "event_kind": "Trade",
+            "asset_in": "BTC",
+            "amount_in": "0.00175640",
+            "asset_out": "CAD",
+            "amount_out": "25.00000000",
+            "fee_asset": "CAD",
+            "fee_amount": "1.46965254",
+            "tx_hash": "coinbase-retail-buy-1",
+            "description": "Bought 0.0017564 BTC for $25.00 CAD",
+            "confidence": "high",
+            "status": "mapped",
+            "render_type": "Trade",
+            "render_exchange": "Coinbase",
+            "render_group": "",
+            "render_comment": "Bought 0.0017564 BTC for $25.00 CAD",
+            "render_comment_mode": "exact",
+            "render_tx_id": "coinbase-retail-buy-1",
+            "render_tx_id_mode": "ignore",
+            "render_allowed_types": "Trade",
+            "render_match_window_seconds": "20",
+            "render_fee_tolerance": "0.03000000",
+            "render_notes": "normalized",
+        }
+        unresolved = dict(mapped, event_id="evt-2", status="needs_review")
+
+        candidate_rows, skipped_rows = render_cointracking.render_cointracking_rows([mapped, unresolved])
+
+        self.assertEqual(1, len(candidate_rows))
+        self.assertEqual(1, len(skipped_rows))
+        self.assertEqual("Trade", candidate_rows[0]["Type"])
+        self.assertEqual("evt-1", candidate_rows[0]["canonical_event_id"])
+

--- a/tests/unit/test_script_common.py
+++ b/tests/unit/test_script_common.py
@@ -4,6 +4,7 @@ import json
 import tempfile
 import unittest
 from decimal import Decimal
+from datetime import datetime
 from pathlib import Path
 
 import script_common
@@ -22,6 +23,12 @@ class ScriptCommonTests(unittest.TestCase):
             path.write_text("x", encoding="utf-8")
             with self.assertRaises(NotADirectoryError):
                 script_common.require_directory(path, "Export directory")
+
+    def test_require_file_rejects_missing_path(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            missing = Path(tmpdir) / "missing.csv"
+            with self.assertRaises(FileNotFoundError):
+                script_common.require_file(missing, "CSV")
 
     def test_read_and_write_csv_rows_round_trip(self) -> None:
         rows = [{"filename": "a.csv", "size_bytes": 1, "sha256": "abc"}]
@@ -109,6 +116,64 @@ class ScriptCommonTests(unittest.TestCase):
     def test_decimal_text_quantizes_to_eight_places(self) -> None:
         self.assertEqual("1.23456789", script_common.decimal_text(Decimal("1.234567891")))
         self.assertEqual("-0.00000001", script_common.decimal_text(Decimal("-0.00000001")))
+
+    def test_parse_decimal_handles_currency_text_and_parentheses(self) -> None:
+        self.assertEqual(Decimal("1234.56"), script_common.parse_decimal("$1,234.56"))
+        self.assertEqual(Decimal("-4.50"), script_common.parse_decimal("(4.50)"))
+        self.assertIsNone(script_common.parse_decimal(""))
+
+    def test_decimal_or_zero_returns_zero_for_blank_values(self) -> None:
+        self.assertEqual(Decimal("0"), script_common.decimal_or_zero(""))
+        self.assertEqual(Decimal("1.23"), script_common.decimal_or_zero("1.23"))
+
+    def test_parse_datetime_uses_first_matching_format(self) -> None:
+        parsed = script_common.parse_datetime("2026-03-24 10:11:12", ("%Y-%m-%d %H:%M:%S",))
+        self.assertEqual(datetime(2026, 3, 24, 10, 11, 12), parsed)
+
+    def test_normalize_whitespace_collapses_runs(self) -> None:
+        self.assertEqual("a b c", script_common.normalize_whitespace(" a \n b\tc "))
+
+    def test_read_and_write_cointracking_rows_round_trip(self) -> None:
+        rows = [
+            {
+                "Type": "Trade",
+                "Buy": "1.00000000",
+                "Buy Cur.": "BTC",
+                "Sell": "10.00000000",
+                "Sell Cur.": "CAD",
+                "Fee": "0.10000000",
+                "Fee Cur.": "CAD",
+                "Exchange": "Coinbase",
+                "Group": "",
+                "Comment": "Test row",
+                "Date": "2026-03-24 10:11:12",
+                "Tx-ID": "tx-1",
+                "match_window_seconds": "2",
+            }
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "cointracking.csv"
+            script_common.write_cointracking_rows(path, rows, extra_headers=("match_window_seconds",))
+
+            read_back = script_common.read_cointracking_rows(path, extra_headers=("match_window_seconds",))
+
+        self.assertEqual(rows, read_back)
+
+    def test_read_cointracking_rows_accepts_trade_table_header_with_lpn(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "trade_table.csv"
+            path.write_text(
+                (
+                    "Type,Buy,Cur.,Sell,Cur.,Fee,Cur.,Exchange,Group,Comment,Date,LPN,Tx-ID\n"
+                    "Trade,1.00000000,BTC,10.00000000,CAD,0.10000000,CAD,Coinbase,,Test row,2026-03-24 10:11:12,,tx-1\n"
+                ),
+                encoding="utf-8",
+            )
+
+            read_back = script_common.read_cointracking_rows(path)
+
+        self.assertEqual("tx-1", read_back[0]["Tx-ID"])
+        self.assertEqual("BTC", read_back[0]["Buy Cur."])
 
     def test_write_json_creates_parent_directories_and_sorts_keys(self) -> None:
         payload = {"b": 2, "a": 1}

--- a/tests/unit/test_source_adapters.py
+++ b/tests/unit/test_source_adapters.py
@@ -18,6 +18,16 @@ class SourceAdapterTests(unittest.TestCase):
         self.assertTrue(source_adapters.get_adapter("WealthSimple").supported)
         self.assertEqual("binance", source_adapters.get_adapter("Binance").name)
         self.assertTrue(source_adapters.get_adapter("Binance").supported)
+        self.assertEqual("crypto_com", source_adapters.get_adapter("Crypto.com").name)
+        self.assertTrue(source_adapters.get_adapter("Crypto.com").supported)
+        self.assertEqual("shakepay", source_adapters.get_adapter("Shakepay").name)
+        self.assertTrue(source_adapters.get_adapter("Shakepay").supported)
+        self.assertEqual("ledger_live", source_adapters.get_adapter("Ledger Live").name)
+        self.assertTrue(source_adapters.get_adapter("Ledger Live").supported)
+        self.assertEqual("near", source_adapters.get_adapter("NEAR Wallet").name)
+        self.assertTrue(source_adapters.get_adapter("NEAR Wallet").supported)
+        self.assertEqual("evm_explorer", source_adapters.get_adapter("BSC MetaMask Wallet").name)
+        self.assertFalse(source_adapters.get_adapter("BSC MetaMask Wallet").supported)
 
     def test_load_exception_decisions_filters_by_manifest_fingerprint(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -68,6 +78,82 @@ class SourceAdapterTests(unittest.TestCase):
         self.assertEqual([], result.exceptions)
         self.assertEqual("Withdrawal", result.canonical_events[0]["event_kind"])
         self.assertEqual("Trade", result.canonical_events[2]["event_kind"])
+
+    def test_crypto_com_adapter_normalizes_repo_exports(self) -> None:
+        raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "crypto.com" / "raw"
+        adapter = source_adapters.get_adapter("Crypto.com")
+        profile = pipeline_common.build_source_profile(
+            source="Crypto.com",
+            raw_dir=raw_dir,
+            adapter_name=adapter.name,
+            adapter_supported=adapter.supported,
+        )
+
+        result = adapter.normalize(raw_dir, profile, exception_decisions={})
+
+        self.assertEqual(12, len(result.canonical_events))
+        self.assertEqual([], result.exceptions)
+        self.assertEqual(
+            {"Deposit": 4, "Trade": 4, "Withdrawal": 4},
+            {
+                event_kind: sum(1 for row in result.canonical_events if row["event_kind"] == event_kind)
+                for event_kind in {"Deposit", "Trade", "Withdrawal"}
+            },
+        )
+
+    def test_shakepay_adapter_normalizes_repo_exports(self) -> None:
+        raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "shakepay" / "raw"
+        adapter = source_adapters.get_adapter("Shakepay")
+        profile = pipeline_common.build_source_profile(
+            source="Shakepay",
+            raw_dir=raw_dir,
+            adapter_name=adapter.name,
+            adapter_supported=adapter.supported,
+        )
+
+        result = adapter.normalize(raw_dir, profile, exception_decisions={})
+
+        self.assertEqual(1895, len(result.canonical_events))
+        self.assertEqual(2, len(result.canonical_balances))
+        self.assertEqual([], result.exceptions)
+        self.assertEqual("Reward / Bonus", result.canonical_events[0]["event_kind"])
+        self.assertEqual("shakingsats", result.canonical_events[0]["description"])
+
+    def test_ledger_live_adapter_normalizes_repo_exports(self) -> None:
+        raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "ledger live" / "raw"
+        adapter = source_adapters.get_adapter("Ledger Live")
+        profile = pipeline_common.build_source_profile(
+            source="Ledger Live",
+            raw_dir=raw_dir,
+            adapter_name=adapter.name,
+            adapter_supported=adapter.supported,
+        )
+
+        result = adapter.normalize(raw_dir, profile, exception_decisions={})
+
+        self.assertEqual(22, len(result.canonical_events))
+        self.assertEqual([], result.exceptions)
+        kinds = {row["event_kind"] for row in result.canonical_events}
+        self.assertIn("Trade", kinds)
+        self.assertIn("Expense (non taxable)", kinds)
+        self.assertIn("Withdrawal", kinds)
+
+    def test_near_adapter_normalizes_repo_exports(self) -> None:
+        raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "near" / "raw"
+        adapter = source_adapters.get_adapter("NEAR Wallet")
+        profile = pipeline_common.build_source_profile(
+            source="NEAR Wallet",
+            raw_dir=raw_dir,
+            adapter_name=adapter.name,
+            adapter_supported=adapter.supported,
+        )
+
+        result = adapter.normalize(raw_dir, profile, exception_decisions={})
+
+        self.assertEqual(14, len(result.canonical_events))
+        self.assertEqual([], result.exceptions)
+        self.assertTrue(any(row["source"] == "NEAR Wallet - Staking" for row in result.canonical_events))
+        self.assertTrue(any(row["event_kind"] == "Airdrop" for row in result.canonical_events))
 
     def test_binance_adapter_handles_supported_and_review_required_rows(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -159,6 +245,7 @@ class SourceAdapterTests(unittest.TestCase):
             ("WealthSimple", REPO_ROOT / "01_raw_exports" / "external" / "wealthsimple" / "raw"),
             ("Binance", REPO_ROOT / "01_raw_exports" / "external" / "binance" / "raw"),
             ("BSC MetaMask Wallet", REPO_ROOT / "01_raw_exports" / "external" / "metamask" / "raw"),
+            ("Crypto.com", REPO_ROOT / "01_raw_exports" / "external" / "crypto.com" / "raw"),
             ("Shakepay", REPO_ROOT / "01_raw_exports" / "external" / "shakepay" / "raw"),
             ("Ledger Live", REPO_ROOT / "01_raw_exports" / "external" / "ledger live" / "raw"),
             ("NEAR Wallet", REPO_ROOT / "01_raw_exports" / "external" / "near" / "raw"),

--- a/tests/unit/test_source_adapters.py
+++ b/tests/unit/test_source_adapters.py
@@ -123,6 +123,36 @@ class SourceAdapterTests(unittest.TestCase):
         self.assertIn("Withdrawal", kinds)
         self.assertIn("Staking", kinds)
 
+    def test_binance_convert_date_updated_covers_transaction_history_one_second_skew(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            raw_dir = Path(tmpdir)
+            (raw_dir / "Binance-Convert-Order-History-202603230441(UTC--6)_abcd.csv").write_text(
+                (
+                    "Time,Wallet,Pair,Type,Sell,Buy,Price,Inverse Price,Date Updated,Status\n"
+                    "21-05-11 00:44:32,SPOT,ETHBUSD,Instant,124.60184573 BUSD,0.03158115 ETH,x,x,21-05-11 00:44:33,Successful\n"
+                ),
+                encoding="utf-8",
+            )
+            (raw_dir / "Binance-Transaction-History-202603230400(UTC--6)_abcd.csv").write_text(
+                (
+                    "User ID,Time,Account,Operation,Coin,Change,Remark\n"
+                    "1,21-05-11 00:44:33,Spot,Binance Convert,ETH,0.03158115,\n"
+                ),
+                encoding="utf-8",
+            )
+
+            adapter = source_adapters.get_adapter("Binance")
+            profile = pipeline_common.build_source_profile(
+                source="Binance",
+                raw_dir=raw_dir,
+                adapter_name=adapter.name,
+                adapter_supported=adapter.supported,
+            )
+            result = adapter.normalize(raw_dir, profile, exception_decisions={})
+
+        self.assertEqual(1, len(result.canonical_events))
+        self.assertEqual(0, len(result.exceptions))
+
     def test_build_source_profile_smoke_covers_major_sources(self) -> None:
         cases = [
             ("Coinbase", REPO_ROOT / "01_raw_exports" / "external" / "coinbase" / "raw"),

--- a/tests/unit/test_source_adapters.py
+++ b/tests/unit/test_source_adapters.py
@@ -26,8 +26,10 @@ class SourceAdapterTests(unittest.TestCase):
         self.assertTrue(source_adapters.get_adapter("Ledger Live").supported)
         self.assertEqual("near", source_adapters.get_adapter("NEAR Wallet").name)
         self.assertTrue(source_adapters.get_adapter("NEAR Wallet").supported)
+        self.assertEqual("gtrade", source_adapters.get_adapter("GTrade 1CT").name)
+        self.assertTrue(source_adapters.get_adapter("GTrade 1CT").supported)
         self.assertEqual("evm_explorer", source_adapters.get_adapter("BSC MetaMask Wallet").name)
-        self.assertFalse(source_adapters.get_adapter("BSC MetaMask Wallet").supported)
+        self.assertTrue(source_adapters.get_adapter("BSC MetaMask Wallet").supported)
 
     def test_load_exception_decisions_filters_by_manifest_fingerprint(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -155,6 +157,74 @@ class SourceAdapterTests(unittest.TestCase):
         self.assertTrue(any(row["source"] == "NEAR Wallet - Staking" for row in result.canonical_events))
         self.assertTrue(any(row["event_kind"] == "Airdrop" for row in result.canonical_events))
 
+    def test_evm_explorer_adapter_normalizes_bsc_repo_exports(self) -> None:
+        raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "metamask" / "raw"
+        adapter = source_adapters.get_adapter("BSC MetaMask Wallet")
+        profile = pipeline_common.build_source_profile(
+            source="BSC MetaMask Wallet",
+            raw_dir=raw_dir,
+            adapter_name=adapter.name,
+            adapter_supported=adapter.supported,
+        )
+
+        result = adapter.normalize(raw_dir, profile, exception_decisions={})
+
+        self.assertEqual(41, len(result.canonical_events))
+        self.assertEqual([], result.exceptions)
+        self.assertTrue(any(row["event_kind"] == "Trade" for row in result.canonical_events))
+        self.assertTrue(any(row["event_kind"] == "Staking" for row in result.canonical_events))
+
+    def test_evm_explorer_adapter_surfaces_polygon_review_rows_without_importing_them(self) -> None:
+        raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "metamask" / "raw"
+        adapter = source_adapters.get_adapter("MetaMask - Polygon")
+        profile = pipeline_common.build_source_profile(
+            source="MetaMask - Polygon",
+            raw_dir=raw_dir,
+            adapter_name=adapter.name,
+            adapter_supported=adapter.supported,
+        )
+
+        result = adapter.normalize(raw_dir, profile, exception_decisions={})
+
+        self.assertEqual(20, len(result.canonical_events))
+        self.assertEqual(5, len(result.exceptions))
+        self.assertTrue(all(row["exception_kind"] == "review_required" for row in result.exceptions))
+        self.assertTrue(any("suspicious NFT airdrop" in row["message"] for row in result.exceptions))
+
+    def test_evm_explorer_adapter_surfaces_eth_gala_review_rows_without_importing_them(self) -> None:
+        raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "metamask" / "raw"
+        adapter = source_adapters.get_adapter("ETH GalaGames Wallet")
+        profile = pipeline_common.build_source_profile(
+            source="ETH GalaGames Wallet",
+            raw_dir=raw_dir,
+            adapter_name=adapter.name,
+            adapter_supported=adapter.supported,
+        )
+
+        result = adapter.normalize(raw_dir, profile, exception_decisions={})
+
+        self.assertEqual(14, len(result.canonical_events))
+        self.assertEqual(3, len(result.exceptions))
+        self.assertTrue(all(row["exception_kind"] == "review_required" for row in result.exceptions))
+        self.assertTrue(any("suspicious NFT airdrop" in row["message"] for row in result.exceptions))
+
+    def test_gtrade_adapter_surfaces_report_limits_without_guessing(self) -> None:
+        raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "gtrade" / "raw"
+        adapter = source_adapters.get_adapter("GTrade 1CT")
+        profile = pipeline_common.build_source_profile(
+            source="GTrade 1CT",
+            raw_dir=raw_dir,
+            adapter_name=adapter.name,
+            adapter_supported=adapter.supported,
+        )
+
+        result = adapter.normalize(raw_dir, profile, exception_decisions={})
+
+        self.assertEqual(3, len(result.canonical_events))
+        self.assertEqual(3, len(result.exceptions))
+        self.assertTrue(all(row["event_kind"] == "Derivatives / Futures Loss" for row in result.canonical_events))
+        self.assertTrue(all(row["exception_kind"] == "unsupported_row" for row in result.exceptions))
+
     def test_binance_adapter_handles_supported_and_review_required_rows(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             raw_dir = Path(tmpdir)
@@ -246,6 +316,7 @@ class SourceAdapterTests(unittest.TestCase):
             ("Binance", REPO_ROOT / "01_raw_exports" / "external" / "binance" / "raw"),
             ("BSC MetaMask Wallet", REPO_ROOT / "01_raw_exports" / "external" / "metamask" / "raw"),
             ("Crypto.com", REPO_ROOT / "01_raw_exports" / "external" / "crypto.com" / "raw"),
+            ("GTrade 1CT", REPO_ROOT / "01_raw_exports" / "external" / "gtrade" / "raw"),
             ("Shakepay", REPO_ROOT / "01_raw_exports" / "external" / "shakepay" / "raw"),
             ("Ledger Live", REPO_ROOT / "01_raw_exports" / "external" / "ledger live" / "raw"),
             ("NEAR Wallet", REPO_ROOT / "01_raw_exports" / "external" / "near" / "raw"),

--- a/tests/unit/test_source_adapters.py
+++ b/tests/unit/test_source_adapters.py
@@ -11,11 +11,13 @@ from tests.support.helpers import REPO_ROOT
 
 
 class SourceAdapterTests(unittest.TestCase):
-    def test_get_adapter_resolves_supported_and_stub_sources(self) -> None:
+    def test_get_adapter_resolves_supported_sources(self) -> None:
         self.assertEqual("coinbase", source_adapters.get_adapter("Coinbase").name)
         self.assertTrue(source_adapters.get_adapter("Coinbase").supported)
         self.assertEqual("wealthsimple", source_adapters.get_adapter("WealthSimple").name)
-        self.assertFalse(source_adapters.get_adapter("WealthSimple").supported)
+        self.assertTrue(source_adapters.get_adapter("WealthSimple").supported)
+        self.assertEqual("binance", source_adapters.get_adapter("Binance").name)
+        self.assertTrue(source_adapters.get_adapter("Binance").supported)
 
     def test_load_exception_decisions_filters_by_manifest_fingerprint(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -50,6 +52,77 @@ class SourceAdapterTests(unittest.TestCase):
         self.assertGreaterEqual(len(result.canonical_balances), 10)
         self.assertEqual([], result.exceptions)
 
+    def test_wealthsimple_adapter_normalizes_repo_exports(self) -> None:
+        raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "wealthsimple" / "raw"
+        adapter = source_adapters.get_adapter("WealthSimple")
+        profile = pipeline_common.build_source_profile(
+            source="WealthSimple",
+            raw_dir=raw_dir,
+            adapter_name=adapter.name,
+            adapter_supported=adapter.supported,
+        )
+
+        result = adapter.normalize(raw_dir, profile, exception_decisions={})
+
+        self.assertEqual(26, len(result.canonical_events))
+        self.assertEqual([], result.exceptions)
+        self.assertEqual("Withdrawal", result.canonical_events[0]["event_kind"])
+        self.assertEqual("Trade", result.canonical_events[2]["event_kind"])
+
+    def test_binance_adapter_handles_supported_and_review_required_rows(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            raw_dir = Path(tmpdir)
+            (raw_dir / "Binance-Spot-Trade-History-202603230406(UTC--6)_abcd.csv").write_text(
+                (
+                    "Time,Pair,Side,Price,Executed,Amount,Fee\n"
+                    "23-09-20 18:20:55,ALGOUSDT,SELL,0.0997,103ALGO,10.2691USDT,0.00003593BNB\n"
+                ),
+                encoding="utf-8",
+            )
+            (raw_dir / "Binance-Deposit-History-202603230411(UTC--6)_abcd.csv").write_text(
+                (
+                    "Time,Coin,Network,Amount,Address,TXID,Status\n"
+                    "23-05-06 23:05:55,USDT,MATIC,125.564991,addr,tx-dep,Completed\n"
+                ),
+                encoding="utf-8",
+            )
+            (raw_dir / "Binance-Withdraw-History-202603230412(UTC--6)_abcd.csv").write_text(
+                (
+                    "Time,Coin,Network,Amount,Fee,Address,TXID,Status\n"
+                    "23-09-20 22:25:57,HNT,SOL,12.013,0.11,addr,tx-wd,Completed\n"
+                ),
+                encoding="utf-8",
+            )
+            (raw_dir / "Binance-Transaction-History-202603230400(UTC--6)_abcd.csv").write_text(
+                (
+                    "User ID,Time,Account,Operation,Coin,Change,Remark\n"
+                    "1,23-08-06 02:34:03,Spot,ETH 2.0 Staking Rewards,BETH,0.00000599,\n"
+                    "1,23-09-20 18:46:46,Spot,Small Assets Exchange BNB,ETH,-0.00005643,ETH to BNB\n"
+                    "1,23-09-20 18:46:46,Spot,Small Assets Exchange BNB,BNB,0.00041767,ETH to BNB\n"
+                    "1,23-09-20 18:17:41,USD-M Futures,Transfer Between Spot Account and UM Futures Account,USDT,-43.90477684,\n"
+                    "1,23-09-20 18:17:41,Spot,Transfer Between Spot Account and UM Futures Account,USDT,43.90477684,\n"
+                    "1,21-05-11 00:44:33,Spot,Binance Convert,ETH,0.03158115,\n"
+                ),
+                encoding="utf-8",
+            )
+
+            adapter = source_adapters.get_adapter("Binance")
+            profile = pipeline_common.build_source_profile(
+                source="Binance",
+                raw_dir=raw_dir,
+                adapter_name=adapter.name,
+                adapter_supported=adapter.supported,
+            )
+            result = adapter.normalize(raw_dir, profile, exception_decisions={})
+
+        self.assertEqual(5, len(result.canonical_events))
+        self.assertEqual(1, len(result.exceptions))
+        kinds = [row["event_kind"] for row in result.canonical_events]
+        self.assertIn("Trade", kinds)
+        self.assertIn("Deposit", kinds)
+        self.assertIn("Withdrawal", kinds)
+        self.assertIn("Staking", kinds)
+
     def test_build_source_profile_smoke_covers_major_sources(self) -> None:
         cases = [
             ("Coinbase", REPO_ROOT / "01_raw_exports" / "external" / "coinbase" / "raw"),
@@ -76,15 +149,12 @@ class SourceAdapterTests(unittest.TestCase):
     def test_normalize_source_cache_invalidates_when_exception_decisions_change(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
-            raw_dir = root / "wealthsimple" / "raw"
+            raw_dir = root / "future_exchange" / "raw"
             raw_dir.mkdir(parents=True)
-            (raw_dir / "activities.csv").write_text(
-                "transaction_date,settlement_date,account_id,activity_type\n2024-01-01,2024-01-02,acct,deposit\n",
-                encoding="utf-8",
-            )
+            (raw_dir / "payload.csv").write_text("a,b\n1,2\n", encoding="utf-8")
             out_dir = root / "normalized"
 
-            first = normalize_source.normalize_source("WealthSimple", raw_dir, out_dir)
+            first = normalize_source.normalize_source("Future Exchange", raw_dir, out_dir)
             summary_path = out_dir / "normalization_summary.json"
             first_summary = pipeline_common.read_profile(summary_path)
             manifest_fingerprint = str(first_summary["manifest_fingerprint"])
@@ -92,13 +162,13 @@ class SourceAdapterTests(unittest.TestCase):
             decisions_path.write_text(
                 (
                     "manifest_fingerprint,event_id,resolution_status,resolution_note\n"
-                    f"{manifest_fingerprint},wealthsimple:adapter_not_implemented,accepted,known gap\n"
+                    f"{manifest_fingerprint},generic:adapter_not_implemented,accepted,known gap\n"
                 ),
                 encoding="utf-8",
             )
 
             second = normalize_source.normalize_source(
-                "WealthSimple",
+                "Future Exchange",
                 raw_dir,
                 out_dir,
                 exception_decisions=decisions_path,
@@ -111,3 +181,31 @@ class SourceAdapterTests(unittest.TestCase):
             first_summary["exception_decisions_fingerprint"],
             second_summary["exception_decisions_fingerprint"],
         )
+
+    def test_normalize_source_uses_current_adapter_support_even_with_stale_profile_json(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "wealthsimple" / "raw"
+            out_dir = root / "normalized"
+            profile_json = root / "profile.json"
+            profile_json.write_text(
+                (
+                    '{\n'
+                    '  "manifest_fingerprint": "stale",\n'
+                    '  "adapter": "wealthsimple",\n'
+                    '  "adapter_supported": false\n'
+                    '}\n'
+                ),
+                encoding="utf-8",
+            )
+
+            summary = normalize_source.normalize_source(
+                "WealthSimple",
+                raw_dir,
+                out_dir,
+                profile_json=profile_json,
+                force=True,
+            )
+
+        self.assertTrue(summary["adapter_supported"])
+        self.assertEqual("ready", summary["status"])

--- a/tests/unit/test_source_adapters.py
+++ b/tests/unit/test_source_adapters.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import pipeline_common
+import source_adapters
+from tests.support.helpers import REPO_ROOT
+
+
+class SourceAdapterTests(unittest.TestCase):
+    def test_get_adapter_resolves_supported_and_stub_sources(self) -> None:
+        self.assertEqual("coinbase", source_adapters.get_adapter("Coinbase").name)
+        self.assertTrue(source_adapters.get_adapter("Coinbase").supported)
+        self.assertEqual("wealthsimple", source_adapters.get_adapter("WealthSimple").name)
+        self.assertFalse(source_adapters.get_adapter("WealthSimple").supported)
+
+    def test_load_exception_decisions_filters_by_manifest_fingerprint(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = Path(tmpdir) / "exception_decisions.csv"
+            path.write_text(
+                (
+                    "manifest_fingerprint,event_id,resolution_status,resolution_note\n"
+                    "abc,evt-1,accepted,handled once\n"
+                    "other,evt-2,accepted,ignore\n"
+                ),
+                encoding="utf-8",
+            )
+
+            decisions = source_adapters.load_exception_decisions(path, "abc")
+
+        self.assertEqual({"resolution_status": "accepted", "resolution_note": "handled once"}, decisions["evt-1"])
+        self.assertNotIn("evt-2", decisions)
+
+    def test_coinbase_adapter_normalizes_repo_exports(self) -> None:
+        raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "coinbase" / "raw"
+        adapter = source_adapters.get_adapter("Coinbase")
+        profile = pipeline_common.build_source_profile(
+            source="Coinbase",
+            raw_dir=raw_dir,
+            adapter_name=adapter.name,
+            adapter_supported=adapter.supported,
+        )
+
+        result = adapter.normalize(raw_dir, profile, exception_decisions={})
+
+        self.assertEqual(82, len(result.canonical_events))
+        self.assertGreaterEqual(len(result.canonical_balances), 10)
+        self.assertEqual([], result.exceptions)
+
+    def test_build_source_profile_smoke_covers_major_sources(self) -> None:
+        cases = [
+            ("Coinbase", REPO_ROOT / "01_raw_exports" / "external" / "coinbase" / "raw"),
+            ("WealthSimple", REPO_ROOT / "01_raw_exports" / "external" / "wealthsimple" / "raw"),
+            ("Binance", REPO_ROOT / "01_raw_exports" / "external" / "binance" / "raw"),
+            ("BSC MetaMask Wallet", REPO_ROOT / "01_raw_exports" / "external" / "metamask" / "raw"),
+            ("Shakepay", REPO_ROOT / "01_raw_exports" / "external" / "shakepay" / "raw"),
+            ("Ledger Live", REPO_ROOT / "01_raw_exports" / "external" / "ledger live" / "raw"),
+            ("NEAR Wallet", REPO_ROOT / "01_raw_exports" / "external" / "near" / "raw"),
+        ]
+
+        for source, raw_dir in cases:
+            with self.subTest(source=source):
+                adapter = source_adapters.get_adapter(source)
+                profile = pipeline_common.build_source_profile(
+                    source=source,
+                    raw_dir=raw_dir,
+                    adapter_name=adapter.name,
+                    adapter_supported=adapter.supported,
+                )
+                self.assertTrue(profile.file_inventory)
+                self.assertTrue(profile.manifest_fingerprint)
+

--- a/tests/unit/test_source_adapters.py
+++ b/tests/unit/test_source_adapters.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
+import normalize_source
 import pipeline_common
 import source_adapters
 from tests.support.helpers import REPO_ROOT
@@ -72,3 +73,41 @@ class SourceAdapterTests(unittest.TestCase):
                 self.assertTrue(profile.file_inventory)
                 self.assertTrue(profile.manifest_fingerprint)
 
+    def test_normalize_source_cache_invalidates_when_exception_decisions_change(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            raw_dir = root / "wealthsimple" / "raw"
+            raw_dir.mkdir(parents=True)
+            (raw_dir / "activities.csv").write_text(
+                "transaction_date,settlement_date,account_id,activity_type\n2024-01-01,2024-01-02,acct,deposit\n",
+                encoding="utf-8",
+            )
+            out_dir = root / "normalized"
+
+            first = normalize_source.normalize_source("WealthSimple", raw_dir, out_dir)
+            summary_path = out_dir / "normalization_summary.json"
+            first_summary = pipeline_common.read_profile(summary_path)
+            manifest_fingerprint = str(first_summary["manifest_fingerprint"])
+            decisions_path = root / "exception_decisions.csv"
+            decisions_path.write_text(
+                (
+                    "manifest_fingerprint,event_id,resolution_status,resolution_note\n"
+                    f"{manifest_fingerprint},wealthsimple:adapter_not_implemented,accepted,known gap\n"
+                ),
+                encoding="utf-8",
+            )
+
+            second = normalize_source.normalize_source(
+                "WealthSimple",
+                raw_dir,
+                out_dir,
+                exception_decisions=decisions_path,
+            )
+            second_summary = pipeline_common.read_profile(summary_path)
+
+        self.assertEqual(1, first["exceptions"])
+        self.assertEqual(0, second["exceptions"])
+        self.assertNotEqual(
+            first_summary["exception_decisions_fingerprint"],
+            second_summary["exception_decisions_fingerprint"],
+        )

--- a/tests/unit/test_stage_import_batch.py
+++ b/tests/unit/test_stage_import_batch.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import stage_import_batch
+from tests.support.helpers import write_csv, read_json
+
+
+class StageImportBatchTests(unittest.TestCase):
+    def test_stage_import_batch_blocks_overlap_candidates(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            baseline = root / "baseline"
+            baseline.mkdir()
+            write_csv(
+                baseline / "Trade Table.csv",
+                ["Type", "Buy", "Cur.", "Sell", "Cur.", "Fee", "Cur.", "Exchange", "Group", "Comment", "Date", "Tx-ID"],
+                [["Trade", "1.00000000", "BTC", "10.00000000", "CAD", "0.10000000", "CAD", "Coinbase", "", "", "2023-08-05 08:34:04", "tx-1"]],
+            )
+            candidate = root / "candidate.csv"
+            write_csv(
+                candidate,
+                ["Type", "Buy", "Cur.", "Sell", "Cur.", "Fee", "Cur.", "Exchange", "Group", "Comment", "Date", "Tx-ID"],
+                [["Trade", "1.00000000", "BTC", "10.00000000", "CAD", "0.10000000", "CAD", "Coinbase", "", "", "2023-08-05 08:34:04", "tx-1"]],
+            )
+
+            summary = stage_import_batch.stage_import_batch(candidate, baseline, root / "batch")
+            self.assertEqual("blocked", summary["status"])
+            self.assertTrue((root / "batch" / "overlap_check" / "overlap_summary.json").exists())
+
+    def test_stage_import_batch_stages_passing_candidate(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            baseline = root / "baseline"
+            baseline.mkdir()
+            write_csv(
+                baseline / "Trade Table.csv",
+                ["Type", "Buy", "Cur.", "Sell", "Cur.", "Fee", "Cur.", "Exchange", "Group", "Comment", "Date", "Tx-ID"],
+                [["Trade", "1.00000000", "BTC", "10.00000000", "CAD", "0.10000000", "CAD", "Coinbase", "", "", "2023-08-05 08:34:04", "tx-1"]],
+            )
+            candidate = root / "candidate.csv"
+            write_csv(
+                candidate,
+                ["Type", "Buy", "Cur.", "Sell", "Cur.", "Fee", "Cur.", "Exchange", "Group", "Comment", "Date", "Tx-ID"],
+                [["Trade", "1.00000000", "BTC", "10.00000000", "CAD", "0.10000000", "CAD", "Coinbase", "", "", "2023-08-06 08:34:05", "tx-2"]],
+            )
+
+            summary = stage_import_batch.stage_import_batch(candidate, baseline, root / "batch", import_ready_dir=root / "ready")
+            written = read_json(root / "batch" / "stage_summary.json")
+            self.assertEqual("staged", summary["status"])
+            self.assertEqual(summary["staged_path"], written["staged_path"])
+            self.assertTrue((root / "batch" / "candidate.csv").exists())
+            self.assertTrue((root / "ready" / "candidate.csv").exists())


### PR DESCRIPTION
Why:
- establish the source-intake foundation before later workflow and architecture slices build on top of it
- keep deterministic adapter coverage and issue handling explicit in the early branch stack

What:
- add the universal source-intake pipeline, deterministic source adapters, and supporting docs and tests
- tighten the intake workflow, Binance review handling, explorer routing, and issue numbering

Checks:
- commit-message validation for the branch range
- sensitive-identifier scan for the branch worktree
- manual review of the tracked slice

Included checkpoints:
- `test(coinbase): preserve normalization evidence as migration fixtures`
- `feat(intake): build universal source-intake pipeline`
- `refactor(intake): tighten universal intake workflow`
- `refactor(adapters): harden intake adapters and validate source coverage`
- `fix(binance): resolve false-positive convert review items`
- `fix(binance): reclassify dust conversion as evidence gap`
- `refactor(issues): standardize issue id prefixes`
- `refactor(issues): standardize append-only issue numbering`
- `feat(adapters): add deterministic source adapters`
- `refactor(explorers): generalize evm intake and review suspicious nfts`
