### PR TITLE
fix(normalize): restore utc normalization contract

### DIFF
--- a/00_docs/FILE_MAP.md
+++ b/00_docs/FILE_MAP.md
@@ -13,6 +13,7 @@ This repo is built around the canonical CoinTracking full export stored in:
 | `00_docs/TAX_REFERENCE_MAP.md` | Compact source-routing map to the relevant CRA authority for edge cases |
 | `00_docs/OPERATIONS_QUICKSTART.md` | Shortest safe execution path for manual work plus AI/script support |
 | `00_docs/BASELINE_VALIDATION.md` | Durable summary of baseline integrity and cutoff facts |
+| `00_docs/TIMEZONE_VALIDATION.md` | Source-by-source timezone evidence, platform doc links, and intake-gate rules |
 | `00_docs/NEXT_PHASE_EXECUTION_PLAN.md` | Source-by-source execution queue and round checklist for the post-baseline phase |
 | `00_docs/PROJECT_STATE.md` | Current baseline counts, constraints, and decision boundary |
 | `00_docs/EXPORT_CHECKLIST.md` | Smallest efficient export set for each round |

--- a/00_docs/TIMEZONE_VALIDATION.md
+++ b/00_docs/TIMEZONE_VALIDATION.md
@@ -1,0 +1,45 @@
+# Timezone Validation
+
+As of 2026-03-24, the intake pipeline normalizes all canonical timestamps to `UTC` and now records per-file timezone provenance before normalization. This document ties each implemented source family to the platform export capability that exists today, the timezone evidence actually present in the exported files, and the guardrails now enforced in code.
+
+## Source Matrix
+
+| Source family | Platform export capability | Timezone evidence used in this repo | Pipeline policy | Status |
+| ---- | ---- | ---- | ---- | ---- |
+| Coinbase | Coinbase Exchange exposes Accounts, Fills, and Balance statements: <https://help.coinbase.com/en/exchange/managing-my-account/account-history-and-reports> | Retail CSV timestamps include `UTC`; Coinbase Pro fills/statements use ISO timestamps ending in `Z`; Coinbase Commerce docs also describe report times as UTC: <https://help.coinbase.com/en/commerce/managing-account/transaction-reporting> | Require explicit UTC in header or value | Document-backed |
+| Wealthsimple | Wealthsimple documents `Activities export (CSV)` for Crypto accounts: <https://help.wealthsimple.com/hc/en-ca/articles/35654428540571-Request-a-custom-statement> | Current `activities-export` files are date-only (`transaction_date`, optional `settlement_date`) with no time-of-day or timezone column | Treat as date-only evidence and use full-day reconciliation tolerance | Capability doc found; timezone inferred from raw export |
+| Binance | Binance publishes account-history API families and downloadable history endpoints in official docs, including deposit history and futures trade-history download APIs: <https://www.binance.com/en/skills/detail/binance/assets>, <https://www.binance.com/en/skills/detail/binance/derivatives-trading-usds-futures> | Current exports either embed an offset in the filename like `(UTC--6)` or expose `UTC_Time` in the CSV header | Require filename offset or explicit UTC header; reject naive timed rows | Capability doc found; UI export timezone inferred from raw export |
+| Crypto.com | Crypto.com App supports CSV exports for Crypto Wallet and Cash Wallet histories: <https://help.crypto.com/en/articles/3438579-how-do-i-export-my-transaction-history-app> | Current CSVs use `Timestamp (UTC)` | Require explicit UTC in header or value | Document-backed |
+| Shakepay | Shakepay provides downloadable transaction-history CSVs and reports: <https://help.shakepay.com/en/articles/3336094-where-to-find-my-shakepay-reports> | Current cash and crypto CSVs are naive local timestamps with no UTC marker | Interpret as source-local `America/Toronto`; reject conflicting markers | Capability doc found; timezone inferred from raw export and preserved as an explicit adapter policy |
+| MetaMask / EVM explorer | MetaMask directs users to network block explorers for transaction history: <https://support.metamask.io/es/start/how-do-i-find-my-transactions/> | Explorer CSVs used in this repo expose `DateTime (UTC)` | Require explicit UTC in header or value | Document-backed through explorer workflow plus raw export headers |
+| Ledger Live | No stable official Ledger help article documenting CSV export timezone semantics was located during this review | Current `ledgerlive-operations-*.csv` rows use ISO timestamps ending in `Z` | Require explicit UTC in value | Raw-export evidence-backed |
+| NEAR / NearBlocks | NearBlocks account pages expose `CSV Export`: <https://nearblocks.io/address/official-near.near> | Current exported CSVs use a naive `Time` column with no explicit timezone marker | Interpret as UTC for the current NearBlocks export family; reject conflicting markers if the export format changes | Capability doc found; timezone inferred from raw export family |
+| GTrade | No current official platform documentation for report-export timezone semantics was located during this review | Current report CSV exposes only `DATE` values | Treat as date-only evidence and use full-day reconciliation tolerance | Raw-export evidence-backed |
+
+## Automatic Controls
+
+The pipeline now enforces these controls:
+
+1. `profile_source.py` records timezone provenance for every dated CSV row in `profile_inventory.csv`:
+   `timestamp_resolution`, `timezone_mode`, `timezone_value`, `timezone_conflict`
+2. `profile_source.py` also writes `timezone_issues.csv` plus `timezone_summary` in `profile.json`.
+3. `normalize_source.py` runs adapter-specific timezone validation before normalization and refuses to continue when timezone issues exist.
+4. Empty placeholder exports such as Binance `No data matches the criteria.` files are ignored instead of being misclassified as timezone failures.
+5. Date-only sources currently covered by this repo, Wealthsimple and GTrade, now render with `render_match_window_seconds=86399` so reconciliation does not pretend they carry exact-second evidence.
+
+## Accepted Timezone Modes
+
+The validation layer classifies dated files into these modes:
+
+| Mode | Meaning |
+| ---- | ------- |
+| `header_utc` | The CSV header explicitly declares UTC, for example `Timestamp (UTC)` or `DateTime (UTC)` |
+| `value_utc` | The timestamp value itself declares UTC, for example `... UTC` or `...Z` |
+| `filename_offset` | The export filename carries the timezone offset used when the report was generated |
+| `date_only` | The source provides only a calendar date, not a time-of-day |
+| `naive` | The source provides a time-of-day without a timezone marker |
+| `conflict` | The file exposes contradictory timezone hints and must be reviewed before use |
+
+## Operating Rule
+
+If a source format changes and its timezone provenance no longer matches the expected adapter policy, stop at profiling, review `timezone_issues.csv`, and do not stage or import that source until the policy is repaired with evidence.

--- a/02_working/normalized/README.md
+++ b/02_working/normalized/README.md
@@ -8,6 +8,7 @@ Per-source folders should prefer the universal pipeline artifact set:
 
 - `profile.json`
 - `profile_inventory.csv`
+- `timezone_issues.csv`
 - `canonical_events.csv`
 - `canonical_balances.csv`
 - `exceptions.csv`
@@ -16,5 +17,7 @@ Per-source folders should prefer the universal pipeline artifact set:
 
 `cointracking_candidate.csv` is a rendered working candidate, not an approved import batch.
 Only `02_working/import_batches/` and `04_import_ready/` should hold files that have passed overlap screening and are approved for import.
+
+`timezone_issues.csv` must be empty before a source is considered safe to normalize and stage.
 
 Keep legacy source-specific artifacts only while they are still serving as parity fixtures during migration.

--- a/06_scripts/README.md
+++ b/06_scripts/README.md
@@ -5,8 +5,8 @@ Use this folder for small helpers that reduce manual work without hiding logic.
 Current helpers:
 
 - `baseline_check.py` → derive the baseline cutoff, counts, negative balances, and reconciliation artifacts
-- `profile_source.py` → inspect a raw source folder, classify file families, and write `profile.json` plus `profile_inventory.csv`
-- `normalize_source.py` → convert a raw source folder into canonical events, canonical balances, exceptions, and a cached CoinTracking candidate
+- `profile_source.py` → inspect a raw source folder, classify file families, and write `profile.json`, `profile_inventory.csv`, plus `timezone_issues.csv`
+- `normalize_source.py` → convert a raw source folder into canonical events, canonical balances, exceptions, and a cached CoinTracking candidate after timezone validation passes
 - `render_cointracking.py` → translate canonical events into a CoinTracking-ready CSV with reconciliation metadata
 - `stage_import_batch.py` → enforce overlap-screen approval before copying a candidate into `02_working/import_batches/` and optional `04_import_ready/`
 - `reconcile_source.py` → compare canonical source outputs against a CoinTracking Trade Table slice and optional Balance by Exchange slice
@@ -62,3 +62,7 @@ Coverage is split into:
 - `tests/unit/` for individual helper and script-function behavior
 - `tests/e2e/` for CLI-level script execution
 - `tests/support/` for shared test helpers
+
+## Timezone Integrity
+
+The profiling and normalization flow now records timezone provenance per dated file and refuses normalization when a source presents unresolved timezone conflicts or unsupported timestamp semantics. See `00_docs/TIMEZONE_VALIDATION.md` for the current source-by-source policy map.

--- a/06_scripts/binance_unwrap.py
+++ b/06_scripts/binance_unwrap.py
@@ -10,12 +10,12 @@ import json
 import re
 import unicodedata
 import zipfile
-from datetime import datetime
+from datetime import datetime, tzinfo
 from pathlib import Path
 from typing import Sequence
 
 from source_manifest import validate_source_dir
-from script_common import write_csv_rows
+from script_common import parse_datetime_to_utc_naive, source_timezone_from_filename, write_csv_rows
 
 
 ZIP_EXPORT_PATTERN = re.compile(
@@ -43,7 +43,7 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def parse_timestamp(value: str | None) -> datetime | None:
+def parse_timestamp(value: str | None, *, source_timezone: tzinfo | None = None) -> datetime | None:
     if value is None:
         return None
     text = value.strip()
@@ -52,7 +52,7 @@ def parse_timestamp(value: str | None) -> datetime | None:
     text = re.sub(r"\(UTC[^)]*\)$", "", text).strip()
     for fmt in DATE_FORMATS:
         try:
-            return datetime.strptime(text, fmt)
+            return parse_datetime_to_utc_naive(text, (fmt,), source_timezone=source_timezone)
         except ValueError:
             continue
     return None
@@ -114,13 +114,18 @@ def read_csv_payload(path: Path) -> tuple[list[str], list[dict[str, str]], bool]
     return fieldnames, rows, saw_no_data
 
 
-def detect_date_span(fieldnames: list[str], rows: list[dict[str, str]]) -> tuple[str, str, str]:
+def detect_date_span(
+    fieldnames: list[str],
+    rows: list[dict[str, str]],
+    *,
+    source_timezone: tzinfo | None = None,
+) -> tuple[str, str, str]:
     best_field = ""
     best_values: list[datetime] = []
     for field in fieldnames:
         if not DATE_FIELD_PATTERN.search(field):
             continue
-        values = [parse_timestamp(row.get(field)) for row in rows]
+        values = [parse_timestamp(row.get(field), source_timezone=source_timezone) for row in rows]
         parsed = [value for value in values if value is not None]
         if len(parsed) > len(best_values):
             best_field = field
@@ -138,7 +143,8 @@ def build_inventory_rows(source_dir: Path) -> list[dict[str, object]]:
     rows = []
     for path in sorted(source_dir.glob("*.csv")):
         fieldnames, data_rows, saw_no_data = read_csv_payload(path)
-        date_field, min_ts, max_ts = detect_date_span(fieldnames, data_rows)
+        source_timezone = source_timezone_from_filename(path.name)
+        date_field, min_ts, max_ts = detect_date_span(fieldnames, data_rows, source_timezone=source_timezone)
         rows.append(
             {
                 "filename": path.name,
@@ -151,8 +157,6 @@ def build_inventory_rows(source_dir: Path) -> list[dict[str, object]]:
             }
         )
     return rows
-
-
 def build_combined_outputs(source_dir: Path, normalized_dir: Path) -> list[dict[str, object]]:
     grouped: dict[str, list[Path]] = {}
     for path in sorted(source_dir.glob("*.csv")):

--- a/06_scripts/coinbase_common.py
+++ b/06_scripts/coinbase_common.py
@@ -7,16 +7,17 @@ from __future__ import annotations
 import csv
 import re
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from pathlib import Path
 from typing import Iterable
 
 from script_common import (
     COINTRACKING_HEADERS,
+    coerce_datetime_to_utc_naive,
     decimal_text,
     normalize_whitespace,
-    parse_datetime,
+    parse_datetime_to_utc_naive,
     parse_decimal,
     require_file,
 )
@@ -91,15 +92,15 @@ def compact_decimal_text(value: Decimal) -> str:
 
 
 def ct_date_text(value: datetime) -> str:
-    return value.strftime(COINTRACKING_TIME_FORMAT)
+    return coerce_datetime_to_utc_naive(value).strftime(COINTRACKING_TIME_FORMAT)
 
 
 def parse_coinbase_retail_timestamp(value: str) -> datetime:
-    return parse_datetime(value, (COINBASE_RETAIL_TIME_FORMAT,))
+    return parse_datetime_to_utc_naive(value, (COINBASE_RETAIL_TIME_FORMAT,))
 
 
 def parse_coinbase_pro_timestamp(value: str) -> datetime:
-    return parse_datetime(value, (COINBASE_PRO_TIME_FORMAT,))
+    return parse_datetime_to_utc_naive(value, (COINBASE_PRO_TIME_FORMAT,))
 
 
 def format_amount(value: Decimal | None) -> str:
@@ -547,13 +548,21 @@ def coinbase_balance_rows_from_text(text: str, pdf_file: str) -> list[dict[str, 
                 "value_currency": "",
                 "price_amount": "",
                 "price_currency": "",
-                "as_of": cash_match.group("as_of").replace(" UTC", ""),
+                "as_of": parse_datetime_to_utc_naive(
+                    cash_match.group("as_of"),
+                    ("%Y-%m-%d %H:%M:%S UTC",),
+                    source_timezone=timezone.utc,
+                ).strftime(COINTRACKING_TIME_FORMAT),
                 "pdf_file": pdf_file,
                 "notes": "Closing fiat balance from Coinbase statement PDF",
             }
         )
     if portfolio_match:
-        as_of = portfolio_match.group("as_of").replace(" UTC", "")
+        as_of = parse_datetime_to_utc_naive(
+            portfolio_match.group("as_of"),
+            ("%Y-%m-%d %H:%M:%S UTC",),
+            source_timezone=timezone.utc,
+        ).strftime(COINTRACKING_TIME_FORMAT)
         seen_assets: set[str] = set()
         for pattern in (PORTFOLIO_ROW_PATTERN, PORTFOLIO_ROW_FALLBACK_PATTERN):
             for match in pattern.finditer(normalized):

--- a/06_scripts/coinbase_normalize.py
+++ b/06_scripts/coinbase_normalize.py
@@ -17,7 +17,7 @@ from coinbase_common import (
     normalize_coinbase_transactions,
     retail_csv_rows,
 )
-from script_common import extract_pdf_text, write_cointracking_rows, write_csv_rows
+from script_common import CANONICAL_TIMEZONE, COINTRACKING_IMPORT_TIMEZONE, extract_pdf_text, write_cointracking_rows, write_csv_rows
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -69,6 +69,8 @@ def normalize_coinbase_exports(
     return {
         "normalized_transaction_rows": len(normalized_transactions),
         "normalized_balance_rows": len(balance_rows),
+        "canonical_timezone": CANONICAL_TIMEZONE,
+        "cointracking_import_timezone": COINTRACKING_IMPORT_TIMEZONE,
         "tx_output": str(tx_output),
         "balance_output": str(balance_output) if balance_output is not None else "",
     }

--- a/06_scripts/normalize_source.py
+++ b/06_scripts/normalize_source.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import argparse
+from dataclasses import replace
 import json
 from pathlib import Path
 from typing import Sequence
@@ -68,6 +69,13 @@ def normalize_source(
         adapter_name=adapter.name,
         adapter_supported=adapter.supported,
     )
+    timezone_summary, timezone_issues = adapter.validate_profile_timezones(profile)
+    profile = replace(profile, timezone_summary=timezone_summary, timezone_issues=timezone_issues)
+    if timezone_issues:
+        raise ValueError(
+            f"Timezone validation failed for {source}: {len(timezone_issues)} issue(s). "
+            "Run profile_source.py and review timezone_issues.csv before normalization."
+        )
     decisions = load_exception_decisions(exception_decisions, profile.manifest_fingerprint)
     decisions_digest = decisions_fingerprint(decisions)
 
@@ -96,6 +104,8 @@ def normalize_source(
                 "manifest_fingerprint": manifest_fingerprint,
                 "canonical_timezone": CANONICAL_TIMEZONE,
                 "cointracking_import_timezone": COINTRACKING_IMPORT_TIMEZONE,
+                "timezone_status": str(existing.get("timezone_status", "not_checked")),
+                "timezone_issue_count": int(existing.get("timezone_issue_count", 0)),
                 "status": "cached",
                 "canonical_events": int(existing.get("canonical_events", 0)),
                 "exceptions": int(existing.get("exceptions", 0)),
@@ -121,6 +131,8 @@ def normalize_source(
         "manifest_fingerprint": profile.manifest_fingerprint,
         "canonical_timezone": CANONICAL_TIMEZONE,
         "cointracking_import_timezone": COINTRACKING_IMPORT_TIMEZONE,
+        "timezone_status": timezone_summary["status"],
+        "timezone_issue_count": timezone_summary["issue_count"],
         "canonical_events": len(result.canonical_events),
         "canonical_balances": len(result.canonical_balances),
         "exceptions": len(result.exceptions),

--- a/06_scripts/normalize_source.py
+++ b/06_scripts/normalize_source.py
@@ -19,6 +19,7 @@ from pipeline_common import (
     write_json,
 )
 from render_cointracking import render_cointracking_rows
+from script_common import CANONICAL_TIMEZONE, COINTRACKING_IMPORT_TIMEZONE
 from source_adapters import decisions_fingerprint, get_adapter, load_exception_decisions
 
 
@@ -93,6 +94,8 @@ def normalize_source(
                 "source": source,
                 "adapter": adapter_name,
                 "manifest_fingerprint": manifest_fingerprint,
+                "canonical_timezone": CANONICAL_TIMEZONE,
+                "cointracking_import_timezone": COINTRACKING_IMPORT_TIMEZONE,
                 "status": "cached",
                 "canonical_events": int(existing.get("canonical_events", 0)),
                 "exceptions": int(existing.get("exceptions", 0)),
@@ -116,6 +119,8 @@ def normalize_source(
         "adapter": adapter.name,
         "adapter_supported": profile.adapter_supported,
         "manifest_fingerprint": profile.manifest_fingerprint,
+        "canonical_timezone": CANONICAL_TIMEZONE,
+        "cointracking_import_timezone": COINTRACKING_IMPORT_TIMEZONE,
         "canonical_events": len(result.canonical_events),
         "canonical_balances": len(result.canonical_balances),
         "exceptions": len(result.exceptions),

--- a/06_scripts/pipeline_common.py
+++ b/06_scripts/pipeline_common.py
@@ -9,11 +9,20 @@ import hashlib
 import json
 from collections import defaultdict
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, tzinfo
 from pathlib import Path
 from typing import Iterable, Sequence
 
-from script_common import parse_datetime, read_csv_rows, require_directory, require_file, write_csv_rows, write_json
+from script_common import (
+    parse_datetime,
+    parse_datetime_to_utc_naive,
+    read_csv_rows,
+    require_directory,
+    require_file,
+    source_timezone_from_filename,
+    write_csv_rows,
+    write_json,
+)
 
 
 CANONICAL_EVENT_HEADERS = (
@@ -243,13 +252,13 @@ def classify_file_family(path: Path, header: Sequence[str]) -> str:
     return "unknown"
 
 
-def parse_candidate_timestamp(value: str) -> datetime | None:
+def parse_candidate_timestamp(value: str, *, source_timezone: tzinfo | None = None) -> datetime | None:
     text = value.strip()
     if not text:
         return None
     for fmt in DATE_FORMATS:
         try:
-            return parse_datetime(text, (fmt,))
+            return parse_datetime_to_utc_naive(text, (fmt,), source_timezone=source_timezone)
         except ValueError:
             continue
     return None
@@ -273,8 +282,12 @@ def detect_date_span_from_csv(path: Path) -> tuple[str, str, str, int]:
     parsed_values: list[datetime] = []
     candidates = [field for field in header if any(token in field.lower() for token in DATE_FIELD_PATTERN)]
     best_count = -1
+    source_timezone = source_timezone_from_filename(path.name)
     for field in candidates:
-        current = [parse_candidate_timestamp((row.get(field) or "").strip()) for row in normalized_rows]
+        current = [
+            parse_candidate_timestamp((row.get(field) or "").strip(), source_timezone=source_timezone)
+            for row in normalized_rows
+        ]
         parsed = [value for value in current if value is not None]
         if len(parsed) > best_count:
             best_count = len(parsed)

--- a/06_scripts/pipeline_common.py
+++ b/06_scripts/pipeline_common.py
@@ -20,6 +20,7 @@ from script_common import (
     require_directory,
     require_file,
     source_timezone_from_filename,
+    tzinfo_label,
     write_csv_rows,
     write_json,
 )
@@ -98,6 +99,10 @@ PROFILE_INVENTORY_HEADERS = (
     "date_field",
     "min_timestamp",
     "max_timestamp",
+    "timestamp_resolution",
+    "timezone_mode",
+    "timezone_value",
+    "timezone_conflict",
 )
 
 DATE_FIELD_PATTERN = ("date", "time", "timestamp", "created at", "operation date", "settlement_date", "transaction_date")
@@ -114,6 +119,17 @@ DATE_FORMATS = (
     "%d.%m.%Y %H:%M:%S",
 )
 
+TIMEZONE_ISSUE_HEADERS = (
+    "filename",
+    "family",
+    "date_field",
+    "timestamp_resolution",
+    "timezone_mode",
+    "timezone_value",
+    "issue_kind",
+    "message",
+)
+
 
 @dataclass(frozen=True)
 class SourceProfile:
@@ -125,6 +141,17 @@ class SourceProfile:
     adapter: str
     adapter_supported: bool
     file_inventory: list[dict[str, str]]
+    timezone_summary: dict[str, object] | None = None
+    timezone_issues: list[dict[str, str]] | None = None
+
+
+@dataclass(frozen=True)
+class TimestampEvidence:
+    value: datetime
+    fmt: str
+    resolution: str
+    timezone_mode: str
+    timezone_value: str
 
 
 def source_slug(value: str) -> str:
@@ -253,21 +280,99 @@ def classify_file_family(path: Path, header: Sequence[str]) -> str:
 
 
 def parse_candidate_timestamp(value: str, *, source_timezone: tzinfo | None = None) -> datetime | None:
+    evidence = parse_candidate_timestamp_evidence(value, source_timezone=source_timezone)
+    return evidence.value if evidence is not None else None
+
+
+def _header_timezone_hint(header: Sequence[str], date_field: str) -> tuple[str, str]:
+    joined = " | ".join(column.strip().lower() for column in header)
+    field = date_field.strip().lower()
+    if "utc" in field or "utc" in joined:
+        return "header_utc", "UTC"
+    return "", ""
+
+
+def _timestamp_resolution_for_format(fmt: str) -> str:
+    if "%H" not in fmt and "%I" not in fmt:
+        return "date_only"
+    if "%f" in fmt:
+        return "subsecond"
+    return "second"
+
+
+def _timezone_evidence_for_format(
+    fmt: str,
+    parsed: datetime,
+    *,
+    source_timezone: tzinfo | None = None,
+) -> tuple[str, str]:
+    if "%z" in fmt:
+        return "value_offset", tzinfo_label(parsed.tzinfo)
+    if "UTC" in fmt or fmt.endswith("Z"):
+        return "value_utc", "UTC"
+    if _timestamp_resolution_for_format(fmt) == "date_only":
+        return "date_only", ""
+    if source_timezone is not None:
+        return "source_timezone", tzinfo_label(source_timezone)
+    return "naive", ""
+
+
+def parse_candidate_timestamp_evidence(value: str, *, source_timezone: tzinfo | None = None) -> TimestampEvidence | None:
     text = value.strip()
     if not text:
         return None
     for fmt in DATE_FORMATS:
         try:
-            return parse_datetime_to_utc_naive(text, (fmt,), source_timezone=source_timezone)
+            parsed = parse_datetime(text, (fmt,))
         except ValueError:
             continue
+        timezone_mode, timezone_value = _timezone_evidence_for_format(fmt, parsed, source_timezone=source_timezone)
+        return TimestampEvidence(
+            value=parse_datetime_to_utc_naive(text, (fmt,), source_timezone=source_timezone),
+            fmt=fmt,
+            resolution=_timestamp_resolution_for_format(fmt),
+            timezone_mode=timezone_mode,
+            timezone_value=timezone_value,
+        )
     return None
 
 
-def detect_date_span_from_csv(path: Path) -> tuple[str, str, str, int]:
+def _finalize_timezone_metadata(
+    *,
+    filename: str,
+    header: Sequence[str],
+    date_field: str,
+    parsed_values: Sequence[TimestampEvidence],
+) -> tuple[str, str, str, str]:
+    if not parsed_values:
+        return "", "", "", ""
+
+    resolution = parsed_values[0].resolution if len({item.resolution for item in parsed_values}) == 1 else "mixed"
+    header_mode, header_value = _header_timezone_hint(header, date_field)
+    filename_timezone = source_timezone_from_filename(filename)
+    filename_mode = "filename_offset" if filename_timezone is not None else ""
+    filename_value = tzinfo_label(filename_timezone)
+    evidence_mode = parsed_values[0].timezone_mode if len({item.timezone_mode for item in parsed_values}) == 1 else "mixed"
+    evidence_value = parsed_values[0].timezone_value if len({item.timezone_value for item in parsed_values}) == 1 else "mixed"
+
+    hints = [(mode, value) for mode, value in ((header_mode, header_value), (filename_mode, filename_value), (evidence_mode, evidence_value)) if mode]
+    distinct_values = {value for _, value in hints if value}
+    if len(distinct_values) > 1:
+        return resolution, "conflict", " | ".join(sorted(distinct_values)), "yes"
+
+    if evidence_mode in {"value_utc", "value_offset"}:
+        return resolution, evidence_mode, evidence_value, ""
+    if filename_mode:
+        return resolution, filename_mode, filename_value, ""
+    if header_mode:
+        return resolution, header_mode, header_value, ""
+    return resolution, evidence_mode, evidence_value, ""
+
+
+def detect_date_span_from_csv(path: Path) -> tuple[str, str, str, int, str, str, str, str]:
     header, header_index = detect_csv_header(path)
     if header_index == -1 or not header:
-        return "", "", "", 0
+        return "", "", "", 0, "", "", "", ""
 
     with path.open(newline="", encoding="utf-8-sig") as handle:
         reader = csv.reader(handle)
@@ -277,15 +382,16 @@ def detect_date_span_from_csv(path: Path) -> tuple[str, str, str, int]:
         {header[index]: (row[index] if index < len(row) else "") for index in range(len(header))}
         for row in payload
         if any(cell.strip() for cell in row)
+        and not (len(row) == 1 and row[0].strip().lower() == "no data matches the criteria.")
     ]
     date_field = ""
-    parsed_values: list[datetime] = []
+    parsed_values: list[TimestampEvidence] = []
     candidates = [field for field in header if any(token in field.lower() for token in DATE_FIELD_PATTERN)]
     best_count = -1
     source_timezone = source_timezone_from_filename(path.name)
     for field in candidates:
         current = [
-            parse_candidate_timestamp((row.get(field) or "").strip(), source_timezone=source_timezone)
+            parse_candidate_timestamp_evidence((row.get(field) or "").strip(), source_timezone=source_timezone)
             for row in normalized_rows
         ]
         parsed = [value for value in current if value is not None]
@@ -294,12 +400,24 @@ def detect_date_span_from_csv(path: Path) -> tuple[str, str, str, int]:
             parsed_values = parsed
             date_field = field
     if not parsed_values:
-        return date_field, "", "", len(normalized_rows)
+        if not normalized_rows:
+            return "", "", "", 0, "", "", "", ""
+        return date_field, "", "", len(normalized_rows), "", "", "", ""
+    resolution, timezone_mode, timezone_value, timezone_conflict = _finalize_timezone_metadata(
+        filename=path.name,
+        header=header,
+        date_field=date_field,
+        parsed_values=parsed_values,
+    )
     return (
         date_field,
-        min(parsed_values).strftime("%Y-%m-%d %H:%M:%S"),
-        max(parsed_values).strftime("%Y-%m-%d %H:%M:%S"),
+        min(item.value for item in parsed_values).strftime("%Y-%m-%d %H:%M:%S"),
+        max(item.value for item in parsed_values).strftime("%Y-%m-%d %H:%M:%S"),
         len(normalized_rows),
+        resolution,
+        timezone_mode,
+        timezone_value,
+        timezone_conflict,
     )
 
 
@@ -314,11 +432,24 @@ def build_file_inventory(raw_dir: Path) -> list[dict[str, str]]:
         date_field = ""
         min_timestamp = ""
         max_timestamp = ""
+        timestamp_resolution = ""
+        timezone_mode = ""
+        timezone_value = ""
+        timezone_conflict = ""
         if suffix == ".csv":
             header, _ = detect_csv_header(path)
             header_preview = " | ".join(header[:8])
             family = classify_file_family(path, header)
-            date_field, min_timestamp, max_timestamp, row_count = detect_date_span_from_csv(path)
+            (
+                date_field,
+                min_timestamp,
+                max_timestamp,
+                row_count,
+                timestamp_resolution,
+                timezone_mode,
+                timezone_value,
+                timezone_conflict,
+            ) = detect_date_span_from_csv(path)
             data_rows = str(row_count)
         elif suffix == ".pdf":
             family = classify_file_family(path, ())
@@ -332,6 +463,10 @@ def build_file_inventory(raw_dir: Path) -> list[dict[str, str]]:
                 "date_field": date_field,
                 "min_timestamp": min_timestamp,
                 "max_timestamp": max_timestamp,
+                "timestamp_resolution": timestamp_resolution,
+                "timezone_mode": timezone_mode,
+                "timezone_value": timezone_value,
+                "timezone_conflict": timezone_conflict,
             }
         )
     return rows
@@ -366,6 +501,9 @@ def write_profile_artifacts(out_dir: Path, profile: SourceProfile) -> tuple[Path
     out_dir.mkdir(parents=True, exist_ok=True)
     profile_json = out_dir / "profile.json"
     inventory_csv = out_dir / "profile_inventory.csv"
+    timezone_issues_csv = out_dir / "timezone_issues.csv"
+    timezone_summary = profile.timezone_summary or {"status": "not_checked", "issue_count": 0}
+    timezone_issues = profile.timezone_issues or []
     write_json(
         profile_json,
         {
@@ -379,9 +517,13 @@ def write_profile_artifacts(out_dir: Path, profile: SourceProfile) -> tuple[Path
             "file_count": len(profile.file_inventory),
             "file_inventory": profile.file_inventory,
             "family_counts": summarize_family_counts(profile.file_inventory),
+            "timezone_summary": timezone_summary,
+            "timezone_issue_count": len(timezone_issues),
+            "timezone_issues_path": str(timezone_issues_csv),
         },
     )
     write_csv_rows(inventory_csv, list(PROFILE_INVENTORY_HEADERS), profile.file_inventory)
+    write_csv_rows(timezone_issues_csv, list(TIMEZONE_ISSUE_HEADERS), timezone_issues)
     return profile_json, inventory_csv
 
 

--- a/06_scripts/profile_source.py
+++ b/06_scripts/profile_source.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import argparse
+from dataclasses import replace
 import json
 from pathlib import Path
 from typing import Sequence
@@ -31,12 +32,16 @@ def profile_source(source: str, raw_dir: Path, out_dir: Path, manifest: Path | N
         adapter_name=adapter.name,
         adapter_supported=adapter.supported,
     )
+    timezone_summary, timezone_issues = adapter.validate_profile_timezones(profile)
+    profile = replace(profile, timezone_summary=timezone_summary, timezone_issues=timezone_issues)
     profile_json, inventory_csv = write_profile_artifacts(out_dir, profile)
     return {
         "source": profile.source,
         "adapter": profile.adapter,
         "adapter_supported": profile.adapter_supported,
         "manifest_fingerprint": profile.manifest_fingerprint,
+        "timezone_status": timezone_summary["status"],
+        "timezone_issue_count": timezone_summary["issue_count"],
         "profile_json": str(profile_json),
         "profile_inventory_csv": str(inventory_csv),
         "files_profiled": len(profile.file_inventory),
@@ -52,4 +57,3 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main())
-

--- a/06_scripts/script_common.py
+++ b/06_scripts/script_common.py
@@ -6,9 +6,10 @@ from __future__ import annotations
 
 import csv
 import json
+import re
 import subprocess
 from decimal import Decimal
-from datetime import datetime
+from datetime import datetime, timedelta, timezone, tzinfo
 from pathlib import Path
 from typing import Iterable, Sequence
 
@@ -20,6 +21,11 @@ DEFAULT_VERIFICATION_EXPORTS = (
     "Current Balance",
     "Balance by Exchange",
 )
+
+CANONICAL_TIMEZONE = "UTC"
+COINTRACKING_IMPORT_TIMEZONE = "UTC"
+
+UTC_LABEL_PATTERN = re.compile(r"\(UTC(?P<offset>[^)]*)\)")
 
 COINTRACKING_FILE_HEADERS = (
     "Type",
@@ -141,6 +147,58 @@ def parse_datetime(value: str, formats: Sequence[str]) -> datetime:
             return datetime.strptime(value, fmt)
         except ValueError:
             continue
+    format_list = ", ".join(formats)
+    raise ValueError(f"Unable to parse datetime {value!r}; expected one of: {format_list}")
+
+
+def _format_implies_utc(fmt: str) -> bool:
+    return "%z" not in fmt and ("UTC" in fmt or fmt.endswith("Z"))
+
+
+def parse_utc_offset_label(value: str) -> tzinfo:
+    text = value.strip()
+    if text.startswith(("+", "-")) and len(text) > 1 and text[1] in "+-":
+        text = text[1:]
+    if text in {"", "0", "+0", "-0", "+00", "-00", "+00:00", "-00:00"}:
+        return timezone.utc
+    match = re.fullmatch(r"(?P<sign>[+-]?)(?P<hours>\d{1,2})(?::?(?P<minutes>\d{2}))?", text)
+    if match is None:
+        raise ValueError(f"Unsupported UTC offset label: {value!r}")
+    sign = -1 if match.group("sign") == "-" else 1
+    hours = int(match.group("hours"))
+    minutes = int(match.group("minutes") or "0")
+    delta = timedelta(hours=hours, minutes=minutes) * sign
+    return timezone(delta)
+
+
+def source_timezone_from_filename(filename: str) -> tzinfo | None:
+    match = UTC_LABEL_PATTERN.search(filename)
+    if match is None:
+        return None
+    return parse_utc_offset_label(match.group("offset"))
+
+
+def coerce_datetime_to_utc_naive(value: datetime, *, source_timezone: tzinfo | None = None) -> datetime:
+    if value.tzinfo is None:
+        if source_timezone is None:
+            return value
+        value = value.replace(tzinfo=source_timezone)
+    return value.astimezone(timezone.utc).replace(tzinfo=None)
+
+
+def parse_datetime_to_utc_naive(
+    value: str,
+    formats: Sequence[str],
+    *,
+    source_timezone: tzinfo | None = None,
+) -> datetime:
+    for fmt in formats:
+        try:
+            parsed = datetime.strptime(value, fmt)
+        except ValueError:
+            continue
+        implied_timezone = timezone.utc if _format_implies_utc(fmt) else source_timezone
+        return coerce_datetime_to_utc_naive(parsed, source_timezone=implied_timezone)
     format_list = ", ".join(formats)
     raise ValueError(f"Unable to parse datetime {value!r}; expected one of: {format_list}")
 

--- a/06_scripts/script_common.py
+++ b/06_scripts/script_common.py
@@ -178,6 +178,22 @@ def source_timezone_from_filename(filename: str) -> tzinfo | None:
     return parse_utc_offset_label(match.group("offset"))
 
 
+def tzinfo_label(value: tzinfo | None) -> str:
+    if value is None:
+        return ""
+    zone_key = getattr(value, "key", "")
+    if zone_key:
+        return str(zone_key)
+    offset = value.utcoffset(datetime(2000, 1, 1))
+    if offset is None or offset == timedelta(0):
+        return "UTC"
+    total_minutes = int(offset.total_seconds() // 60)
+    sign = "+" if total_minutes >= 0 else "-"
+    total_minutes = abs(total_minutes)
+    hours, minutes = divmod(total_minutes, 60)
+    return f"UTC{sign}{hours:02d}:{minutes:02d}"
+
+
 def coerce_datetime_to_utc_naive(value: datetime, *, source_timezone: tzinfo | None = None) -> datetime:
     if value.tzinfo is None:
         if source_timezone is None:

--- a/06_scripts/source_adapters.py
+++ b/06_scripts/source_adapters.py
@@ -6,12 +6,14 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass
+from datetime import timezone, tzinfo
 from decimal import Decimal
 from pathlib import Path
 from typing import Iterable, Sequence
 import csv
 import json
 import re
+from zoneinfo import ZoneInfo
 
 from coinbase_common import (
     coinbase_balance_rows_from_text,
@@ -25,9 +27,10 @@ from script_common import (
     decimal_or_zero,
     decimal_text,
     extract_pdf_text,
-    parse_datetime,
+    parse_datetime_to_utc_naive,
     read_cointracking_rows,
     read_csv_rows,
+    source_timezone_from_filename,
 )
 
 
@@ -47,6 +50,7 @@ LEDGER_LIVE_TIME_FORMATS = ("%Y-%m-%dT%H:%M:%S.%fZ",)
 CRYPTO_COM_TIME_FORMATS = ("%Y-%m-%d %H:%M:%S",)
 SHAKEPAY_TIME_FORMATS = ("%Y-%m-%d %H:%M:%S",)
 NEAR_TIME_FORMATS = ("%Y-%m-%d %H:%M:%S",)
+SHAKEPAY_SOURCE_TIMEZONE = ZoneInfo("America/Toronto")
 
 
 @dataclass(frozen=True)
@@ -154,8 +158,8 @@ def decisions_fingerprint(decisions: dict[str, dict[str, str]]) -> str:
     return json.dumps(payload, sort_keys=True, separators=(",", ":"))
 
 
-def normalized_timestamp(value: str, formats: Sequence[str]) -> str:
-    return parse_datetime(value.strip(), formats).strftime("%Y-%m-%d %H:%M:%S")
+def normalized_timestamp(value: str, formats: Sequence[str], *, source_timezone: tzinfo | None = None) -> str:
+    return parse_datetime_to_utc_naive(value.strip(), formats, source_timezone=source_timezone).strftime("%Y-%m-%d %H:%M:%S")
 
 
 def event_id_for(adapter: str, raw_file: str, raw_row_ref: str) -> str:
@@ -706,7 +710,11 @@ class BinanceAdapter(SourceAdapter):
             executed_amount, executed_asset = parse_number_asset(row["Executed"])
             quote_amount, quote_asset = parse_number_asset(row["Amount"])
             fee_amount, fee_asset = parse_number_asset(row["Fee"])
-            timestamp = normalized_timestamp(row["Time"], BINANCE_TIME_FORMATS)
+            timestamp = normalized_timestamp(
+                row["Time"],
+                BINANCE_TIME_FORMATS,
+                source_timezone=source_timezone_from_filename(path.name),
+            )
             side = (row.get("Side") or "").strip().upper()
             raw_row_ref = f"row:{index}"
             event_id = event_id_for(self.name, path.name, raw_row_ref)
@@ -747,7 +755,11 @@ class BinanceAdapter(SourceAdapter):
                 continue
             sell_amount, sell_asset = parse_number_asset(row["Sell"])
             buy_amount, buy_asset = parse_number_asset(row["Buy"])
-            timestamp = normalized_timestamp(row["Time"], BINANCE_TIME_FORMATS)
+            timestamp = normalized_timestamp(
+                row["Time"],
+                BINANCE_TIME_FORMATS,
+                source_timezone=source_timezone_from_filename(path.name),
+            )
             raw_row_ref = f"row:{index}"
             events.append(
                 canonical_event(
@@ -786,7 +798,11 @@ class BinanceAdapter(SourceAdapter):
                     wallet="Funding",
                     raw_file=path.name,
                     raw_row_ref=raw_row_ref,
-                    timestamp=normalized_timestamp(row["Time"], BINANCE_TIME_FORMATS),
+                    timestamp=normalized_timestamp(
+                        row["Time"],
+                        BINANCE_TIME_FORMATS,
+                        source_timezone=source_timezone_from_filename(path.name),
+                    ),
                     event_kind="Deposit",
                     description=f"Binance deposit via {row['Network']}",
                     amount_in=decimal_text(decimal_or_zero(row["Amount"])),
@@ -814,7 +830,11 @@ class BinanceAdapter(SourceAdapter):
                     wallet="Funding",
                     raw_file=path.name,
                     raw_row_ref=raw_row_ref,
-                    timestamp=normalized_timestamp(row["Time"], BINANCE_TIME_FORMATS),
+                    timestamp=normalized_timestamp(
+                        row["Time"],
+                        BINANCE_TIME_FORMATS,
+                        source_timezone=source_timezone_from_filename(path.name),
+                    ),
                     event_kind="Withdrawal",
                     description=f"Binance withdrawal via {row['Network']}",
                     amount_out=decimal_text(decimal_or_zero(row["Amount"])),
@@ -846,7 +866,11 @@ class BinanceAdapter(SourceAdapter):
                     wallet="Funding",
                     raw_file=path.name,
                     raw_row_ref=raw_row_ref,
-                    timestamp=normalized_timestamp(row["Time"], BINANCE_TIME_FORMATS),
+                    timestamp=normalized_timestamp(
+                        row["Time"],
+                        BINANCE_TIME_FORMATS,
+                        source_timezone=source_timezone_from_filename(path.name),
+                    ),
                     event_kind="Trade",
                     description=f"Binance fiat buy via {row['Method']}",
                     amount_in=receive_amount,
@@ -881,7 +905,11 @@ class BinanceAdapter(SourceAdapter):
                     wallet="Funding",
                     raw_file=path.name,
                     raw_row_ref=raw_row_ref,
-                    timestamp=normalized_timestamp(row["Time"], BINANCE_TIME_FORMATS),
+                    timestamp=normalized_timestamp(
+                        row["Time"],
+                        BINANCE_TIME_FORMATS,
+                        source_timezone=source_timezone_from_filename(path.name),
+                    ),
                     event_kind="Trade",
                     description=f"Binance fiat sell via {row['Method']}",
                     amount_in=receive_amount,
@@ -919,7 +947,11 @@ class BinanceAdapter(SourceAdapter):
                     wallet="Funding",
                     raw_file=path.name,
                     raw_row_ref=raw_row_ref,
-                    timestamp=normalized_timestamp(row["Created Time"], BINANCE_TIME_FORMATS),
+                    timestamp=normalized_timestamp(
+                        row["Created Time"],
+                        BINANCE_TIME_FORMATS,
+                        source_timezone=source_timezone_from_filename(path.name),
+                    ),
                     event_kind="Trade",
                     description=f"Binance P2P {order_type} {crypto_asset}/{fiat_asset}",
                     amount_in=amount_in,
@@ -1019,7 +1051,11 @@ class BinanceAdapter(SourceAdapter):
             operation = (row.get("Operation") or "").strip()
             amount = decimal_text(abs(decimal_or_zero(row.get("Change"))))
             asset = (row.get("Coin") or "").strip().upper()
-            timestamp = normalized_timestamp(row["Time"], BINANCE_TIME_FORMATS)
+            timestamp = normalized_timestamp(
+                row["Time"],
+                BINANCE_TIME_FORMATS,
+                source_timezone=timezone.utc,
+            )
             raw_row_ref = f"row:{index}"
             event_id = event_id_for(self.name, path.name, raw_row_ref)
             description = row.get("Remark", "") or operation
@@ -1201,7 +1237,11 @@ class BinanceAdapter(SourceAdapter):
         rows = [row for _, row in indexed_rows]
         operations = {(row.get("Operation") or "").strip() for row in rows}
         raw_row_ref = f"group:{timestamp_text}:{account or 'unknown'}"
-        timestamp = normalized_timestamp(timestamp_text, BINANCE_TIME_FORMATS)
+        timestamp = normalized_timestamp(
+            timestamp_text,
+            BINANCE_TIME_FORMATS,
+            source_timezone=timezone.utc,
+        )
 
         if operations == {"Small Assets Exchange BNB"}:
             events, message = self._small_asset_exchange_events(path, profile.source, account, timestamp, indexed_rows)
@@ -1385,7 +1425,11 @@ class CryptoComAdapter(SourceAdapter):
                 kind = (row.get("Transaction Kind") or "").strip().lower()
                 if kind != "viban_deposit":
                     continue
-                timestamp = normalized_timestamp(row["Timestamp (UTC)"], CRYPTO_COM_TIME_FORMATS)
+                timestamp = normalized_timestamp(
+                    row["Timestamp (UTC)"],
+                    CRYPTO_COM_TIME_FORMATS,
+                    source_timezone=timezone.utc,
+                )
                 raw_row_ref = f"row:{index}"
                 event_id = event_id_for(self.name, path.name, raw_row_ref)
                 events.append(
@@ -1410,7 +1454,11 @@ class CryptoComAdapter(SourceAdapter):
         for path in crypto_paths:
             for index, row in enumerate(read_csv_rows(path), start=2):
                 kind = (row.get("Transaction Kind") or "").strip().lower()
-                timestamp = normalized_timestamp(row["Timestamp (UTC)"], CRYPTO_COM_TIME_FORMATS)
+                timestamp = normalized_timestamp(
+                    row["Timestamp (UTC)"],
+                    CRYPTO_COM_TIME_FORMATS,
+                    source_timezone=timezone.utc,
+                )
                 raw_row_ref = f"row:{index}"
                 event_id = event_id_for(self.name, path.name, raw_row_ref)
                 description = (row.get("Transaction Description") or kind or "Crypto.com event").strip()
@@ -1612,7 +1660,11 @@ class EvmExplorerAdapter(SourceAdapter):
         native_asset: str,
         exception_decisions: dict[str, dict[str, str]],
     ) -> tuple[list[dict[str, str]], dict[str, str] | None]:
-        timestamp = normalized_timestamp(self._group_timestamp(group), ("%Y-%m-%d %H:%M:%S",))
+        timestamp = normalized_timestamp(
+            self._group_timestamp(group),
+            ("%Y-%m-%d %H:%M:%S",),
+            source_timezone=timezone.utc,
+        )
         raw_file = self._group_raw_file(group)
         raw_row_ref = self._group_raw_ref(group)
         method = self._group_method(group)
@@ -2179,7 +2231,11 @@ class ShakepayAdapter(SourceAdapter):
         event_type = (row.get("Type") or "").strip()
         raw_row_ref = f"row:{index}"
         event_id = event_id_for(self.name, path.name, raw_row_ref)
-        timestamp = normalized_timestamp(row["Date"], SHAKEPAY_TIME_FORMATS)
+        timestamp = normalized_timestamp(
+            row["Date"],
+            SHAKEPAY_TIME_FORMATS,
+            source_timezone=SHAKEPAY_SOURCE_TIMEZONE,
+        )
         description = (row.get("Description") or event_type or "Shakepay").strip()
 
         if event_type == "Reward":
@@ -2281,7 +2337,11 @@ class ShakepayAdapter(SourceAdapter):
         event_type = (row.get("Type") or "").strip()
         raw_row_ref = f"row:{index}"
         event_id = event_id_for(self.name, path.name, raw_row_ref)
-        timestamp = normalized_timestamp(row["Date"], SHAKEPAY_TIME_FORMATS)
+        timestamp = normalized_timestamp(
+            row["Date"],
+            SHAKEPAY_TIME_FORMATS,
+            source_timezone=SHAKEPAY_SOURCE_TIMEZONE,
+        )
         description = (row.get("Description") or event_type or "Shakepay cash").strip()
         credit = abs(decimal_or_zero(row.get("Credit")))
         debit = abs(decimal_or_zero(row.get("Debit")))
@@ -2630,7 +2690,11 @@ class NearAdapter(SourceAdapter):
                         wallet=profile.source,
                         raw_file=path.name,
                         raw_row_ref=raw_row_ref,
-                        timestamp=normalized_timestamp(row["Time"], NEAR_TIME_FORMATS),
+                        timestamp=normalized_timestamp(
+                            row["Time"],
+                            NEAR_TIME_FORMATS,
+                            source_timezone=timezone.utc,
+                        ),
                         event_kind=event_kind,
                         description=token,
                         amount_in=decimal_text(decimal_or_zero(row.get("Quantity"))),
@@ -2657,7 +2721,11 @@ class NearAdapter(SourceAdapter):
                         wallet=profile.source,
                         raw_file=path.name,
                         raw_row_ref=raw_row_ref,
-                        timestamp=normalized_timestamp(row["Time"], NEAR_TIME_FORMATS),
+                        timestamp=normalized_timestamp(
+                            row["Time"],
+                            NEAR_TIME_FORMATS,
+                            source_timezone=timezone.utc,
+                        ),
                         event_kind="Airdrop",
                         description=token_name or contract or "NEAR NFT mint",
                         amount_in="1.00000000",
@@ -2685,7 +2753,11 @@ class NearAdapter(SourceAdapter):
             wallet=source,
             raw_file=path.name,
             raw_row_ref=raw_row_ref,
-            timestamp=normalized_timestamp(row["Time"], NEAR_TIME_FORMATS),
+            timestamp=normalized_timestamp(
+                row["Time"],
+                NEAR_TIME_FORMATS,
+                source_timezone=timezone.utc,
+            ),
             event_kind="Deposit",
             description=raw_hash_description(f"Transfer into {source}", row.get("Txn Hash") or "", f"Transfer into {source}"),
             amount_in=decimal_text(deposit_value - tx_fee),
@@ -2696,7 +2768,11 @@ class NearAdapter(SourceAdapter):
 
     def _near_stake_events(self, path: Path, source: str, index: int, row: dict[str, str]) -> list[dict[str, str]]:
         raw_row_ref = f"row:{index}"
-        timestamp = normalized_timestamp(row["Time"], NEAR_TIME_FORMATS)
+        timestamp = normalized_timestamp(
+            row["Time"],
+            NEAR_TIME_FORMATS,
+            source_timezone=timezone.utc,
+        )
         tx_hash = (row.get("Txn Hash") or "").strip()
         deposit_value = decimal_or_zero(row.get("Deposit Value"))
         tx_fee = decimal_or_zero(row.get("Txn Fee"))

--- a/06_scripts/source_adapters.py
+++ b/06_scripts/source_adapters.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
+from collections import Counter, defaultdict
 from dataclasses import dataclass
 from datetime import timezone, tzinfo
 from decimal import Decimal
@@ -60,6 +60,57 @@ class AdapterNormalizationResult:
     exceptions: list[dict[str, str]]
 
 
+@dataclass(frozen=True)
+class TimezonePolicy:
+    name: str
+    allowed_modes: frozenset[str]
+    expected_timezone: str
+    note: str
+
+
+STRICT_EXPLICIT_UTC_POLICY = TimezonePolicy(
+    name="explicit_utc",
+    allowed_modes=frozenset({"header_utc", "value_utc"}),
+    expected_timezone="UTC",
+    note="Source exports must declare UTC in the header or encoded timestamp values.",
+)
+
+EXPLICIT_OR_OFFSET_POLICY = TimezonePolicy(
+    name="explicit_or_filename_offset",
+    allowed_modes=frozenset({"header_utc", "value_utc", "filename_offset"}),
+    expected_timezone="UTC or exported filename offset",
+    note="Source exports must either declare UTC in the file itself or embed the export offset in the filename.",
+)
+
+SHAKEPAY_SOURCE_LOCAL_POLICY = TimezonePolicy(
+    name="source_local_toronto",
+    allowed_modes=frozenset({"naive"}),
+    expected_timezone=SHAKEPAY_SOURCE_TIMEZONE.key,
+    note="Shakepay CSV summaries are normalized using the source-local Canada/Eastern account time.",
+)
+
+WEALTHSIMPLE_DATE_ONLY_POLICY = TimezonePolicy(
+    name="date_only",
+    allowed_modes=frozenset({"date_only"}),
+    expected_timezone="date-only",
+    note="Wealthsimple activities exports are treated as date-only records and matched with a full-day tolerance.",
+)
+
+ASSUMED_UTC_NAIVE_POLICY = TimezonePolicy(
+    name="assumed_utc_naive",
+    allowed_modes=frozenset({"naive"}),
+    expected_timezone="UTC",
+    note="This export family emits naive timestamps and the adapter treats them as UTC based on the platform export.",
+)
+
+GTRADE_DATE_ONLY_POLICY = TimezonePolicy(
+    name="date_only",
+    allowed_modes=frozenset({"date_only"}),
+    expected_timezone="date-only",
+    note="The GTrade report only publishes trade dates, not times.",
+)
+
+
 def default_exception_row(
     *,
     manifest_fingerprint: str,
@@ -86,6 +137,75 @@ def default_exception_row(
         "resolution_status": resolution_status,
         "resolution_note": resolution_note,
     }
+
+
+def timezone_issue_row(row: dict[str, str], issue_kind: str, message: str) -> dict[str, str]:
+    return {
+        "filename": row.get("filename", ""),
+        "family": row.get("family", ""),
+        "date_field": row.get("date_field", ""),
+        "timestamp_resolution": row.get("timestamp_resolution", ""),
+        "timezone_mode": row.get("timezone_mode", ""),
+        "timezone_value": row.get("timezone_value", ""),
+        "issue_kind": issue_kind,
+        "message": message,
+    }
+
+
+def summarize_timezone_validation(
+    *,
+    profile: SourceProfile,
+    policy_for_row,
+) -> tuple[dict[str, object], list[dict[str, str]]]:
+    issues: list[dict[str, str]] = []
+    mode_counts: Counter[str] = Counter()
+    rows_with_dates = 0
+
+    for row in profile.file_inventory:
+        if not row.get("date_field"):
+            continue
+        rows_with_dates += 1
+        timezone_mode = row.get("timezone_mode", "")
+        mode_counts[timezone_mode or "blank"] += 1
+        if row.get("timezone_conflict") == "yes":
+            issues.append(
+                timezone_issue_row(
+                    row,
+                    "timezone_conflict",
+                    "Conflicting timezone hints were detected for the same file.",
+                )
+            )
+            continue
+        policy = policy_for_row(row)
+        if policy is None:
+            if timezone_mode in {"", "naive", "date_only", "source_timezone"}:
+                issues.append(
+                    timezone_issue_row(
+                        row,
+                        "timezone_unresolved",
+                        "No adapter timezone policy covers this dated file.",
+                    )
+                )
+            continue
+        if timezone_mode not in policy.allowed_modes:
+            issues.append(
+                timezone_issue_row(
+                    row,
+                    "unexpected_timezone_mode",
+                    (
+                        f"Observed timezone mode {timezone_mode or 'blank'} is not allowed by "
+                        f"{policy.name}; expected {policy.expected_timezone}. {policy.note}"
+                    ),
+                )
+            )
+
+    summary = {
+        "status": "passed" if not issues else "failed",
+        "issue_count": len(issues),
+        "rows_with_dates": rows_with_dates,
+        "mode_counts": dict(sorted(mode_counts.items())),
+    }
+    return summary, issues
 
 
 def ct_row_to_canonical_event(row: dict[str, str], adapter_name: str, source_name: str) -> dict[str, str]:
@@ -187,6 +307,11 @@ def canonical_event(
     tx_hash: str = "",
     render_group: str = "",
     render_notes: str = "",
+    render_match_window_seconds: str = "0",
+    render_fee_tolerance: str = "0.00000000",
+    render_comment_mode: str = "exact",
+    render_tx_id_mode: str = "exact",
+    render_allowed_types: str | None = None,
 ) -> dict[str, str]:
     return {
         "event_id": event_id,
@@ -212,12 +337,12 @@ def canonical_event(
         "render_exchange": source,
         "render_group": render_group,
         "render_comment": description,
-        "render_comment_mode": "exact",
+        "render_comment_mode": render_comment_mode,
         "render_tx_id": tx_hash,
-        "render_tx_id_mode": "exact" if tx_hash else "ignore",
-        "render_allowed_types": event_kind,
-        "render_match_window_seconds": "0",
-        "render_fee_tolerance": "0.00000000",
+        "render_tx_id_mode": render_tx_id_mode if tx_hash else "ignore",
+        "render_allowed_types": render_allowed_types or event_kind,
+        "render_match_window_seconds": render_match_window_seconds,
+        "render_fee_tolerance": render_fee_tolerance,
         "render_notes": render_notes,
     }
 
@@ -337,6 +462,14 @@ class SourceAdapter:
         slug = source.strip().lower()
         return slug == self.name or slug in self.aliases
 
+    def timezone_policy_for_row(self, row: dict[str, str]) -> TimezonePolicy | None:
+        if not row.get("date_field"):
+            return None
+        return STRICT_EXPLICIT_UTC_POLICY
+
+    def validate_profile_timezones(self, profile: SourceProfile) -> tuple[dict[str, object], list[dict[str, str]]]:
+        return summarize_timezone_validation(profile=profile, policy_for_row=self.timezone_policy_for_row)
+
     def normalize(
         self,
         raw_dir: Path,
@@ -364,6 +497,11 @@ class CoinbaseAdapter(SourceAdapter):
     name = "coinbase"
     aliases = ("coinbase",)
     supported = True
+
+    def timezone_policy_for_row(self, row: dict[str, str]) -> TimezonePolicy | None:
+        if not row.get("date_field"):
+            return None
+        return STRICT_EXPLICIT_UTC_POLICY
 
     def normalize(
         self,
@@ -424,6 +562,11 @@ class WealthsimpleAdapter(SourceAdapter):
     name = "wealthsimple"
     aliases = ("wealthsimple", "wealthsimple crypto")
     supported = True
+
+    def timezone_policy_for_row(self, row: dict[str, str]) -> TimezonePolicy | None:
+        if not row.get("date_field"):
+            return None
+        return WEALTHSIMPLE_DATE_ONLY_POLICY
 
     def normalize(
         self,
@@ -493,6 +636,7 @@ class WealthsimpleAdapter(SourceAdapter):
                                 asset_out=currency,
                                 fee_amount=decimal_text(commission),
                                 fee_asset=currency,
+                                render_match_window_seconds="86399",
                                 render_notes=description,
                             )
                         )
@@ -516,6 +660,7 @@ class WealthsimpleAdapter(SourceAdapter):
                                 asset_out=symbol,
                                 fee_amount=decimal_text(commission),
                                 fee_asset=currency,
+                                render_match_window_seconds="86399",
                                 render_notes=description,
                             )
                         )
@@ -537,6 +682,7 @@ class WealthsimpleAdapter(SourceAdapter):
                                 description=f"Wealthsimple money movement {activity_sub_type or 'credit'}",
                                 amount_in=decimal_text(abs(quantity)),
                                 asset_in=currency,
+                                render_match_window_seconds="86399",
                                 render_notes=description,
                             )
                         )
@@ -555,6 +701,7 @@ class WealthsimpleAdapter(SourceAdapter):
                                 description=f"Wealthsimple money movement {activity_sub_type or 'debit'}",
                                 amount_out=decimal_text(abs(quantity)),
                                 asset_out=currency,
+                                render_match_window_seconds="86399",
                                 render_notes=description,
                             )
                         )
@@ -580,6 +727,14 @@ class BinanceAdapter(SourceAdapter):
     name = "binance"
     aliases = ("binance",)
     supported = True
+
+    def timezone_policy_for_row(self, row: dict[str, str]) -> TimezonePolicy | None:
+        if not row.get("date_field"):
+            return None
+        header_preview = (row.get("header_preview") or "").lower()
+        if "utc_time" in header_preview:
+            return STRICT_EXPLICIT_UTC_POLICY
+        return EXPLICIT_OR_OFFSET_POLICY
 
     _trade_operations = {
         "Buy",
@@ -1394,6 +1549,11 @@ class CryptoComAdapter(SourceAdapter):
     aliases = ("crypto.com", "crypto com", "cryptocom")
     supported = True
 
+    def timezone_policy_for_row(self, row: dict[str, str]) -> TimezonePolicy | None:
+        if not row.get("date_field"):
+            return None
+        return STRICT_EXPLICIT_UTC_POLICY
+
     def normalize(
         self,
         raw_dir: Path,
@@ -1538,6 +1698,11 @@ class EvmExplorerAdapter(SourceAdapter):
         "metamask - polygon",
     )
     supported = True
+
+    def timezone_policy_for_row(self, row: dict[str, str]) -> TimezonePolicy | None:
+        if not row.get("date_field"):
+            return None
+        return STRICT_EXPLICIT_UTC_POLICY
 
     _scope_prefixes = (
         ("bsc", "Account1-bsc"),
@@ -2182,6 +2347,11 @@ class ShakepayAdapter(SourceAdapter):
     aliases = ("shakepay",)
     supported = True
 
+    def timezone_policy_for_row(self, row: dict[str, str]) -> TimezonePolicy | None:
+        if not row.get("date_field"):
+            return None
+        return SHAKEPAY_SOURCE_LOCAL_POLICY
+
     def normalize(
         self,
         raw_dir: Path,
@@ -2429,6 +2599,11 @@ class LedgerLiveAdapter(SourceAdapter):
     aliases = ("ledger live", "ada ledger")
     supported = True
 
+    def timezone_policy_for_row(self, row: dict[str, str]) -> TimezonePolicy | None:
+        if not row.get("date_field"):
+            return None
+        return STRICT_EXPLICIT_UTC_POLICY
+
     def normalize(
         self,
         raw_dir: Path,
@@ -2631,6 +2806,11 @@ class NearAdapter(SourceAdapter):
     aliases = ("near", "near wallet", "near wallet - staking")
     supported = True
 
+    def timezone_policy_for_row(self, row: dict[str, str]) -> TimezonePolicy | None:
+        if not row.get("date_field"):
+            return None
+        return ASSUMED_UTC_NAIVE_POLICY
+
     def normalize(
         self,
         raw_dir: Path,
@@ -2820,6 +3000,11 @@ class GTradeAdapter(SourceAdapter):
     aliases = ("gtrade", "gtrade 1ct")
     supported = True
 
+    def timezone_policy_for_row(self, row: dict[str, str]) -> TimezonePolicy | None:
+        if not row.get("date_field"):
+            return None
+        return GTRADE_DATE_ONLY_POLICY
+
     def normalize(
         self,
         raw_dir: Path,
@@ -2866,6 +3051,7 @@ class GTradeAdapter(SourceAdapter):
                         "event_kind": event_kind,
                         "description": description,
                         "tx_hash": event_id,
+                        "render_match_window_seconds": "86399",
                         "render_notes": f"{row.get('PAIR', '')}:{row.get('TYPE', '')}:{row.get('DIR', '')}",
                     }
                     if pnl > 0:

--- a/06_scripts/stage_import_batch.py
+++ b/06_scripts/stage_import_batch.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from typing import Sequence
 
 from overlap_check import summarize_overlap, write_overlap_artifacts
-from script_common import require_file, write_json
+from script_common import CANONICAL_TIMEZONE, COINTRACKING_IMPORT_TIMEZONE, require_file, write_json
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -42,6 +42,8 @@ def stage_import_batch(
         result = {
             "status": "blocked",
             "candidate": str(candidate),
+            "canonical_timezone": CANONICAL_TIMEZONE,
+            "cointracking_import_timezone": COINTRACKING_IMPORT_TIMEZONE,
             "overlap_summary": str(overlap_dir / "overlap_summary.json"),
             "rows_flagged": summary["rows_flagged"],
             "message": "Candidate failed overlap screening and was not staged.",
@@ -64,6 +66,8 @@ def stage_import_batch(
     result = {
         "status": "staged",
         "candidate": str(candidate),
+        "canonical_timezone": CANONICAL_TIMEZONE,
+        "cointracking_import_timezone": COINTRACKING_IMPORT_TIMEZONE,
         "staged_path": str(staged_path),
         "import_ready_path": import_ready_path,
         "overlap_summary": str(overlap_dir / "overlap_summary.json"),

--- a/tests/e2e/test_scripts.py
+++ b/tests/e2e/test_scripts.py
@@ -269,8 +269,11 @@ class ScriptEndToEndTests(unittest.TestCase):
 
         self.assertEqual("coinbase", summary["adapter"])
         self.assertTrue(summary["adapter_supported"])
+        self.assertEqual("passed", summary["timezone_status"])
+        self.assertEqual(0, summary["timezone_issue_count"])
         self.assertEqual(summary["files_profiled"], len(inventory))
         self.assertIn("manifest_fingerprint", profile)
+        self.assertEqual("passed", profile["timezone_summary"]["status"])
 
     def test_normalize_source_cli_supports_wealthsimple_repo_raw_dir(self) -> None:
         raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "wealthsimple" / "raw"
@@ -293,6 +296,8 @@ class ScriptEndToEndTests(unittest.TestCase):
         self.assertEqual("ready", summary["status"])
         self.assertEqual("UTC", summary["canonical_timezone"])
         self.assertEqual("UTC", summary["cointracking_import_timezone"])
+        self.assertEqual("passed", summary["timezone_status"])
+        self.assertEqual(0, summary["timezone_issue_count"])
         self.assertEqual(26, summary["canonical_events"])
         self.assertEqual(0, summary["exceptions"])
         self.assertEqual(26, len(events))

--- a/tests/e2e/test_scripts.py
+++ b/tests/e2e/test_scripts.py
@@ -170,6 +170,8 @@ class ScriptEndToEndTests(unittest.TestCase):
         self.assertEqual(82, len(tx_rows))
         self.assertGreaterEqual(summary["normalized_balance_rows"], 10)
         self.assertEqual(summary["normalized_balance_rows"], len(balance_rows))
+        self.assertEqual("UTC", summary["canonical_timezone"])
+        self.assertEqual("UTC", summary["cointracking_import_timezone"])
 
     def test_pdf_balance_extract_cli_reads_supported_repo_pdfs(self) -> None:
         coinbase_pdf = REPO_ROOT / "01_raw_exports" / "external" / "coinbase" / "raw" / (
@@ -289,6 +291,8 @@ class ScriptEndToEndTests(unittest.TestCase):
             candidate = read_dict_rows(out_dir / "cointracking_candidate.csv")
 
         self.assertEqual("ready", summary["status"])
+        self.assertEqual("UTC", summary["canonical_timezone"])
+        self.assertEqual("UTC", summary["cointracking_import_timezone"])
         self.assertEqual(26, summary["canonical_events"])
         self.assertEqual(0, summary["exceptions"])
         self.assertEqual(26, len(events))
@@ -608,6 +612,8 @@ class ScriptEndToEndTests(unittest.TestCase):
             )
             summary = json.loads(result.stdout)
             self.assertEqual("staged", summary["status"])
+            self.assertEqual("UTC", summary["canonical_timezone"])
+            self.assertEqual("UTC", summary["cointracking_import_timezone"])
             self.assertTrue((out_dir / "candidate.csv").exists())
             self.assertTrue((ready_dir / "candidate.csv").exists())
 

--- a/tests/unit/test_binance_unwrap.py
+++ b/tests/unit/test_binance_unwrap.py
@@ -47,6 +47,15 @@ class BinanceUnwrapTests(unittest.TestCase):
         self.assertIsNotNone(parsed)
         self.assertEqual("2025-12-31 00:00:00", parsed.strftime("%Y-%m-%d %H:%M:%S"))
 
+    def test_parse_timestamp_applies_source_timezone(self) -> None:
+        parsed = binance_unwrap.parse_timestamp(
+            "2024-01-01 01:02:03",
+            source_timezone=binance_unwrap.source_timezone_from_filename("Binance-Futures-Trade-History-202603230520(UTC--6)_aaaa1111.csv"),
+        )
+
+        self.assertIsNotNone(parsed)
+        self.assertEqual("2024-01-01 07:02:03", parsed.strftime("%Y-%m-%d %H:%M:%S"))
+
     def test_unwrap_binance_exports_extracts_inventory_and_combines_rows(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             repo_root = Path(tmpdir)
@@ -99,7 +108,7 @@ class BinanceUnwrapTests(unittest.TestCase):
             self.assertTrue(inventory_csv.exists())
             self.assertTrue(combined_summary_csv.exists())
             self.assertEqual(2, summary["zip_files_processed"])
-            self.assertEqual("2024-01-01 01:02:03", summary["earliest_timestamp"])
+            self.assertEqual("2024-01-01 07:02:03", summary["earliest_timestamp"])
             self.assertEqual("2024-09-10 12:09:17", summary["latest_timestamp"])
 
             combined_rows = read_dict_rows(combined_csv)

--- a/tests/unit/test_coinbase_common.py
+++ b/tests/unit/test_coinbase_common.py
@@ -8,6 +8,13 @@ import coinbase_common
 
 
 class CoinbaseCommonTests(unittest.TestCase):
+    def test_coinbase_timestamp_parsers_preserve_utc_clock_time(self) -> None:
+        retail = coinbase_common.parse_coinbase_retail_timestamp("2025-10-17 13:38:17 UTC")
+        pro = coinbase_common.parse_coinbase_pro_timestamp("2021-05-10T02:37:18.000Z")
+
+        self.assertEqual("2025-10-17 13:38:17", retail.strftime("%Y-%m-%d %H:%M:%S"))
+        self.assertEqual("2021-05-10 02:37:18", pro.strftime("%Y-%m-%d %H:%M:%S"))
+
     def test_retail_csv_rows_skips_preface_and_reads_transactions(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:
             path = Path(tmpdir) / "coinbase.csv"

--- a/tests/unit/test_pipeline_common.py
+++ b/tests/unit/test_pipeline_common.py
@@ -92,6 +92,43 @@ class PipelineCommonTests(unittest.TestCase):
         row = inventory[0]
         self.assertEqual("2023-09-21 00:20:55", row["min_timestamp"])
         self.assertEqual("2023-09-21 00:20:55", row["max_timestamp"])
+        self.assertEqual("filename_offset", row["timezone_mode"])
+        self.assertEqual("UTC-06:00", row["timezone_value"])
+
+    def test_build_file_inventory_detects_header_utc_and_date_only_modes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            raw_dir = Path(tmpdir)
+            (raw_dir / "crypto_transactions.csv").write_text(
+                "Timestamp (UTC),Amount\n2021-07-06 17:37:09,1\n",
+                encoding="utf-8",
+            )
+            (raw_dir / "activities-export.csv").write_text(
+                "transaction_date,settlement_date,account_type\n2021-05-09,,Crypto\n",
+                encoding="utf-8",
+            )
+
+            inventory = pipeline_common.build_file_inventory(raw_dir)
+
+        by_name = {row["filename"]: row for row in inventory}
+        self.assertEqual("header_utc", by_name["crypto_transactions.csv"]["timezone_mode"])
+        self.assertEqual("UTC", by_name["crypto_transactions.csv"]["timezone_value"])
+        self.assertEqual("date_only", by_name["activities-export.csv"]["timezone_mode"])
+        self.assertEqual("date_only", by_name["activities-export.csv"]["timestamp_resolution"])
+
+    def test_build_file_inventory_ignores_placeholder_no_data_rows(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            raw_dir = Path(tmpdir)
+            (raw_dir / "Binance-Futures-Order-History-202603230503(UTC--6)_abcd.csv").write_text(
+                "Uid,Time,Order No\nNo data matches the criteria.\n",
+                encoding="utf-8",
+            )
+
+            inventory = pipeline_common.build_file_inventory(raw_dir)
+
+        row = inventory[0]
+        self.assertEqual("0", row["data_rows"])
+        self.assertEqual("", row["date_field"])
+        self.assertEqual("", row["timezone_mode"])
 
     def test_validate_canonical_event_row_requires_minimum_fields(self) -> None:
         row = {header: "" for header in pipeline_common.CANONICAL_EVENT_HEADERS}

--- a/tests/unit/test_pipeline_common.py
+++ b/tests/unit/test_pipeline_common.py
@@ -69,6 +69,30 @@ class PipelineCommonTests(unittest.TestCase):
         self.assertIsNotNone(parsed)
         self.assertEqual("2023-09-20 18:20:55", parsed.strftime("%Y-%m-%d %H:%M:%S"))
 
+    def test_parse_candidate_timestamp_applies_source_timezone(self) -> None:
+        parsed = pipeline_common.parse_candidate_timestamp(
+            "23-09-20 18:20:55",
+            source_timezone=pipeline_common.source_timezone_from_filename("Binance-Spot-Trade-History-202603230406(UTC--6)_5d63c10c.csv"),
+        )
+
+        self.assertIsNotNone(parsed)
+        self.assertEqual("2023-09-21 00:20:55", parsed.strftime("%Y-%m-%d %H:%M:%S"))
+
+    def test_build_file_inventory_converts_binance_filename_timezone_to_utc(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            raw_dir = Path(tmpdir)
+            (raw_dir / "Binance-Spot-Trade-History-202603230406(UTC--6)_abcd.csv").write_text(
+                "Time,Pair,Side,Price,Executed,Amount,Fee\n"
+                "23-09-20 18:20:55,ALGOUSDT,SELL,0.0997,103ALGO,10.2691USDT,0.00003593BNB\n",
+                encoding="utf-8",
+            )
+
+            inventory = pipeline_common.build_file_inventory(raw_dir)
+
+        row = inventory[0]
+        self.assertEqual("2023-09-21 00:20:55", row["min_timestamp"])
+        self.assertEqual("2023-09-21 00:20:55", row["max_timestamp"])
+
     def test_validate_canonical_event_row_requires_minimum_fields(self) -> None:
         row = {header: "" for header in pipeline_common.CANONICAL_EVENT_HEADERS}
         row.update(

--- a/tests/unit/test_script_common.py
+++ b/tests/unit/test_script_common.py
@@ -4,7 +4,7 @@ import json
 import tempfile
 import unittest
 from decimal import Decimal
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 import script_common
@@ -129,6 +129,43 @@ class ScriptCommonTests(unittest.TestCase):
     def test_parse_datetime_uses_first_matching_format(self) -> None:
         parsed = script_common.parse_datetime("2026-03-24 10:11:12", ("%Y-%m-%d %H:%M:%S",))
         self.assertEqual(datetime(2026, 3, 24, 10, 11, 12), parsed)
+
+    def test_parse_datetime_to_utc_naive_handles_literal_utc_and_offsets(self) -> None:
+        literal_utc = script_common.parse_datetime_to_utc_naive(
+            "2026-03-24 10:11:12 UTC",
+            ("%Y-%m-%d %H:%M:%S UTC",),
+        )
+        offset_value = script_common.parse_datetime_to_utc_naive(
+            "2026-03-24 10:11:12-0600",
+            ("%Y-%m-%d %H:%M:%S%z",),
+        )
+
+        self.assertEqual(datetime(2026, 3, 24, 10, 11, 12), literal_utc)
+        self.assertEqual(datetime(2026, 3, 24, 16, 11, 12), offset_value)
+
+    def test_parse_datetime_to_utc_naive_applies_source_timezone_when_needed(self) -> None:
+        parsed = script_common.parse_datetime_to_utc_naive(
+            "2026-03-24 10:11:12",
+            ("%Y-%m-%d %H:%M:%S",),
+            source_timezone=timezone.utc,
+        )
+
+        self.assertEqual(datetime(2026, 3, 24, 10, 11, 12), parsed)
+
+    def test_parse_utc_offset_label_supports_binance_style_negative_offsets(self) -> None:
+        negative = script_common.parse_utc_offset_label("--6")
+        zero = script_common.parse_utc_offset_label("0")
+        half_hour = script_common.parse_utc_offset_label("+05:30")
+
+        self.assertEqual("-0600", datetime.now(negative).strftime("%z"))
+        self.assertEqual("+0000", datetime.now(zero).strftime("%z"))
+        self.assertEqual("+0530", datetime.now(half_hour).strftime("%z"))
+
+    def test_source_timezone_from_filename_reads_embedded_utc_offset(self) -> None:
+        parsed = script_common.source_timezone_from_filename("Binance-Spot-Trade-History-202603230406(UTC--6)_5d63c10c.csv")
+
+        self.assertIsNotNone(parsed)
+        self.assertEqual("-0600", datetime.now(parsed).strftime("%z"))
 
     def test_normalize_whitespace_collapses_runs(self) -> None:
         self.assertEqual("a b c", script_common.normalize_whitespace(" a \n b\tc "))

--- a/tests/unit/test_source_adapters.py
+++ b/tests/unit/test_source_adapters.py
@@ -63,6 +63,14 @@ class SourceAdapterTests(unittest.TestCase):
         self.assertEqual(82, len(result.canonical_events))
         self.assertGreaterEqual(len(result.canonical_balances), 10)
         self.assertEqual([], result.exceptions)
+        self.assertEqual(
+            "2025-10-17 13:38:17",
+            next(
+                row["timestamp"]
+                for row in result.canonical_events
+                if row["event_id"] == "coinbase-asset-migration-68f246c9a0081dc3b61e422c-68f246c95d5ca606c968fd16"
+            ),
+        )
 
     def test_wealthsimple_adapter_normalizes_repo_exports(self) -> None:
         raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "wealthsimple" / "raw"
@@ -120,6 +128,7 @@ class SourceAdapterTests(unittest.TestCase):
         self.assertEqual([], result.exceptions)
         self.assertEqual("Reward / Bonus", result.canonical_events[0]["event_kind"])
         self.assertEqual("shakingsats", result.canonical_events[0]["description"])
+        self.assertEqual("2022-01-04 18:19:41", result.canonical_events[0]["timestamp"])
 
     def test_ledger_live_adapter_normalizes_repo_exports(self) -> None:
         raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "ledger live" / "raw"
@@ -156,6 +165,32 @@ class SourceAdapterTests(unittest.TestCase):
         self.assertEqual([], result.exceptions)
         self.assertTrue(any(row["source"] == "NEAR Wallet - Staking" for row in result.canonical_events))
         self.assertTrue(any(row["event_kind"] == "Airdrop" for row in result.canonical_events))
+        self.assertIn(
+            "2022-01-30 09:31:41",
+            {row["timestamp"] for row in result.canonical_events},
+        )
+
+    def test_binance_adapter_converts_filename_timezone_to_utc(self) -> None:
+        raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "binance" / "raw"
+        adapter = source_adapters.get_adapter("Binance")
+        profile = pipeline_common.build_source_profile(
+            source="Binance",
+            raw_dir=raw_dir,
+            adapter_name=adapter.name,
+            adapter_supported=adapter.supported,
+        )
+
+        result = adapter.normalize(raw_dir, profile, exception_decisions={})
+
+        self.assertIn(
+            "2023-09-21 00:20:55",
+            {
+                row["timestamp"]
+                for row in result.canonical_events
+                if row["raw_file"] == "Binance-Spot-Trade-History-202603230406(UTC--6)_5d63c10c.csv"
+                and row["raw_row_ref"] == "row:2"
+            },
+        )
 
     def test_evm_explorer_adapter_normalizes_bsc_repo_exports(self) -> None:
         raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "metamask" / "raw"

--- a/tests/unit/test_source_adapters.py
+++ b/tests/unit/test_source_adapters.py
@@ -88,6 +88,7 @@ class SourceAdapterTests(unittest.TestCase):
         self.assertEqual([], result.exceptions)
         self.assertEqual("Withdrawal", result.canonical_events[0]["event_kind"])
         self.assertEqual("Trade", result.canonical_events[2]["event_kind"])
+        self.assertTrue(all(row["render_match_window_seconds"] == "86399" for row in result.canonical_events))
 
     def test_crypto_com_adapter_normalizes_repo_exports(self) -> None:
         raw_dir = REPO_ROOT / "01_raw_exports" / "external" / "crypto.com" / "raw"
@@ -368,6 +369,47 @@ class SourceAdapterTests(unittest.TestCase):
                 )
                 self.assertTrue(profile.file_inventory)
                 self.assertTrue(profile.manifest_fingerprint)
+
+    def test_timezone_validation_passes_for_repo_supported_sources(self) -> None:
+        cases = [
+            ("Coinbase", REPO_ROOT / "01_raw_exports" / "external" / "coinbase" / "raw"),
+            ("WealthSimple", REPO_ROOT / "01_raw_exports" / "external" / "wealthsimple" / "raw"),
+            ("Binance", REPO_ROOT / "01_raw_exports" / "external" / "binance" / "raw"),
+            ("BSC MetaMask Wallet", REPO_ROOT / "01_raw_exports" / "external" / "metamask" / "raw"),
+            ("Crypto.com", REPO_ROOT / "01_raw_exports" / "external" / "crypto.com" / "raw"),
+            ("Shakepay", REPO_ROOT / "01_raw_exports" / "external" / "shakepay" / "raw"),
+            ("Ledger Live", REPO_ROOT / "01_raw_exports" / "external" / "ledger live" / "raw"),
+            ("NEAR Wallet", REPO_ROOT / "01_raw_exports" / "external" / "near" / "raw"),
+            ("GTrade 1CT", REPO_ROOT / "01_raw_exports" / "external" / "gtrade" / "raw"),
+        ]
+
+        for source, raw_dir in cases:
+            with self.subTest(source=source):
+                adapter = source_adapters.get_adapter(source)
+                profile = pipeline_common.build_source_profile(
+                    source=source,
+                    raw_dir=raw_dir,
+                    adapter_name=adapter.name,
+                    adapter_supported=adapter.supported,
+                )
+                summary, issues = adapter.validate_profile_timezones(profile)
+                self.assertEqual("passed", summary["status"])
+                self.assertEqual([], issues)
+
+    def test_normalize_source_rejects_ambiguous_timezone_inventory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            raw_dir = Path(tmpdir) / "binance" / "raw"
+            raw_dir.mkdir(parents=True)
+            (raw_dir / "Binance-Spot-Trade-History.csv").write_text(
+                (
+                    "Time,Pair,Side,Price,Executed,Amount,Fee\n"
+                    "23-09-20 18:20:55,ALGOUSDT,SELL,0.0997,103ALGO,10.2691USDT,0.00003593BNB\n"
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "Timezone validation failed"):
+                normalize_source.normalize_source("Binance", raw_dir, Path(tmpdir) / "normalized")
 
     def test_normalize_source_cache_invalidates_when_exception_decisions_change(self) -> None:
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/unit/test_stage_import_batch.py
+++ b/tests/unit/test_stage_import_batch.py
@@ -28,6 +28,8 @@ class StageImportBatchTests(unittest.TestCase):
 
             summary = stage_import_batch.stage_import_batch(candidate, baseline, root / "batch")
             self.assertEqual("blocked", summary["status"])
+            self.assertEqual("UTC", summary["canonical_timezone"])
+            self.assertEqual("UTC", summary["cointracking_import_timezone"])
             self.assertTrue((root / "batch" / "overlap_check" / "overlap_summary.json").exists())
 
     def test_stage_import_batch_stages_passing_candidate(self) -> None:
@@ -50,6 +52,8 @@ class StageImportBatchTests(unittest.TestCase):
             summary = stage_import_batch.stage_import_batch(candidate, baseline, root / "batch", import_ready_dir=root / "ready")
             written = read_json(root / "batch" / "stage_summary.json")
             self.assertEqual("staged", summary["status"])
+            self.assertEqual("UTC", summary["canonical_timezone"])
+            self.assertEqual("UTC", summary["cointracking_import_timezone"])
             self.assertEqual(summary["staged_path"], written["staged_path"])
             self.assertTrue((root / "batch" / "candidate.csv").exists())
             self.assertTrue((root / "ready" / "candidate.csv").exists())


### PR DESCRIPTION
Why:
- make canonical timestamps deterministic before later inventory and package planning work builds on them
- keep timezone provenance validation explicit across normalization inputs

What:
- enforce UTC canonical timestamps across the normalization pipeline
- harden timezone provenance validation and supporting docs and tests

Checks:
- commit-message validation for the branch range
- sensitive-identifier scan for the branch worktree
- manual review of the tracked slice

Included checkpoints:
- `refactor(normalize): enforce utc canonical timestamps`
- `fix(normalize): harden timezone provenance validation`
