### PR TITLE
fix(uv): external uv bootstrap

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,4 @@
 {
-  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
   "python.terminal.activateEnvironment": true,
   "python.analysis.extraPaths": [
     "${workspaceFolder}/src"
@@ -9,17 +8,36 @@
   "python.testing.pytestArgs": [
     "tests"
   ],
+  "files.exclude": {
+    "**/.venv": true,
+    "**/__pycache__": true,
+    "**/.mypy_cache": true,
+    "**/.pytest_cache": true,
+    "**/.ruff_cache": true
+  },
+  "files.watcherExclude": {
+    "**/.venv/**": true,
+    "**/__pycache__/**": true,
+    "**/.mypy_cache/**": true,
+    "**/.pytest_cache/**": true,
+    "**/.ruff_cache/**": true
+  },
+  "search.exclude": {
+    "**/.venv": true,
+    "**/__pycache__": true,
+    "**/.mypy_cache": true,
+    "**/.pytest_cache": true,
+    "**/.ruff_cache": true
+  },
+  "python.analysis.exclude": [
+    "**/.venv",
+    "**/__pycache__",
+    "**/.mypy_cache",
+    "**/.pytest_cache",
+    "**/.ruff_cache"
+  ],
   "python.analysis.diagnosticMode": "workspace",
   "ruff.importStrategy": "fromEnvironment",
-  "ruff.path": [
-    "${workspaceFolder}/.venv/bin/ruff"
-  ],
   "mypy-type-checker.importStrategy": "fromEnvironment",
-  "mypy-type-checker.path": [
-    "${workspaceFolder}/.venv/bin/mypy"
-  ],
-  "pylint.importStrategy": "fromEnvironment",
-  "pylint.path": [
-    "${workspaceFolder}/.venv/bin/pylint"
-  ]
+  "pylint.importStrategy": "fromEnvironment"
 }

--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv sync --python 3.12
 UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.install_git_hooks
 ```
 
+If you keep the environment outside the repo, export
+`UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312"` in the shells where you
+run `uv` commands so `uv run`, `uv sync`, and related tooling keep using the
+external environment instead of recreating `.venv`.
+
 After syncing an external environment, select its interpreter in your editor,
 for example `~/.venvs/tallylot-py312/bin/python` in VS Code.
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,19 @@ UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.inst
 If you keep the environment outside the repo, export
 `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312"` in the shells where you
 run `uv` commands so `uv run`, `uv sync`, and related tooling keep using the
-external environment instead of recreating `.venv`.
+external environment instead of recreating `.venv`. For Bash, prefer a
+repo-scoped wrapper instead of a global export:
+
+```bash
+uv() {
+    if [[ "$PWD" == "$HOME/Code/tallylot" || "$PWD" == "$HOME/Code/tallylot/"* ]]; then
+        UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" command uv "$@"
+        return
+    fi
+
+    command uv "$@"
+}
+```
 
 After syncing an external environment, select its interpreter in your editor,
 for example `~/.venvs/tallylot-py312/bin/python` in VS Code.

--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ uv run python -m tools.run_quality_gates
 uv run python -m tools.run_quality_gates --full-tests
 ```
 
+By default, `uv sync` creates `.venv` in the repo root. If you want to keep
+the development environment out of the workspace so editors do not index it as
+project content, point `uv` at a user-scoped virtualenv location first:
+
+```bash
+UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv sync --python 3.12
+UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.install_git_hooks
+```
+
+After syncing an external environment, select its interpreter in your editor,
+for example `~/.venvs/tallylot-py312/bin/python` in VS Code.
+
 `markdownlint`, `ruff`, `mypy`, `pyright`, `pylint`, and `pytest` are all part
 of the expected quality baseline.
 

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -72,7 +72,5 @@
       "extraPaths": ["src", "."],
       "reportPrivateUsage": false
     }
-  ],
-  "venvPath": ".",
-  "venv": ".venv"
+  ]
 }

--- a/tests/unit/application/intake/archive/test_workflow.py
+++ b/tests/unit/application/intake/archive/test_workflow.py
@@ -4,6 +4,8 @@ from io import BytesIO
 from pathlib import Path
 from zipfile import ZIP_DEFLATED, ZipFile, ZipInfo
 
+import pytest
+
 from tallylot.application.intake import ManifestRequest
 from tallylot.application.intake.archive import scanned_tree_files
 from tallylot.application.intake.build_manifest import BuildManifestUseCase
@@ -100,7 +102,8 @@ def test_scanned_tree_files_skips_duplicate_archive_member_paths(tmp_path: Path)
     archive_path = source_dir / "bundle.zip"
     with ZipFile(archive_path, "w", compression=ZIP_DEFLATED) as archive:
         archive.writestr("inner.csv", "a,b\n1,2\n")
-        archive.writestr("inner.csv", "a,b\n3,4\n")
+        with pytest.warns(UserWarning, match="Duplicate name: 'inner.csv'"):
+            archive.writestr("inner.csv", "a,b\n3,4\n")
 
     with scanned_tree_files(source_dir) as scanned_tree:
         issue_kinds = {issue.kind for issue in scanned_tree.issues}

--- a/tests/unit/test_pre_commit_hook.py
+++ b/tests/unit/test_pre_commit_hook.py
@@ -6,7 +6,7 @@ from pathlib import Path
 import pytest
 
 import tools.install_git_hooks
-from tools.install_git_hooks import HOOK_TEMPLATE
+from tools.install_git_hooks import COMMIT_MSG_HOOK_TEMPLATE, HOOK_TEMPLATE
 from tools.pre_commit_hook import _format_candidates, _skip_value
 
 
@@ -37,6 +37,7 @@ def test_install_hook_template_execs_repo_pre_commit_wrapper() -> None:
     assert "-m tools.pre_commit_hook" in HOOK_TEMPLATE
     assert 'REPO_ROOT="$(cd "$HOOK_DIR/../.." && pwd)"' in HOOK_TEMPLATE
     assert 'export UV_PROJECT_ENVIRONMENT="$PROJECT_ENVIRONMENT"' in HOOK_TEMPLATE
+    assert "--hook-type=commit-msg" in COMMIT_MSG_HOOK_TEMPLATE
 
 
 def test_install_hooks_uses_pre_commit_overwrite_mode(
@@ -53,6 +54,8 @@ def test_install_hooks_uses_pre_commit_overwrite_mode(
     hook_path = tmp_path / ".git" / "hooks" / "pre-commit"
     hook_path.parent.mkdir(parents=True)
     hook_path.write_text("", encoding="utf-8")
+    commit_msg_hook_path = tmp_path / ".git" / "hooks" / "commit-msg"
+    commit_msg_hook_path.write_text("", encoding="utf-8")
 
     environment_root = tmp_path / "external-env"
     (environment_root / "bin").mkdir(parents=True)
@@ -83,3 +86,6 @@ def test_install_hooks_uses_pre_commit_overwrite_mode(
     hook_text = hook_path.read_text(encoding="utf-8")
     assert f"PROJECT_ENVIRONMENT={environment_root}" in hook_text
     assert f"PYTHON={environment_root / 'bin/python3'}" in hook_text
+    commit_msg_hook_text = commit_msg_hook_path.read_text(encoding="utf-8")
+    assert f"PROJECT_ENVIRONMENT={environment_root}" in commit_msg_hook_text
+    assert "--hook-type=commit-msg" in commit_msg_hook_text

--- a/tests/unit/test_pre_commit_hook.py
+++ b/tests/unit/test_pre_commit_hook.py
@@ -36,6 +36,7 @@ def test_skip_value_appends_formatter_hooks_once() -> None:
 def test_install_hook_template_execs_repo_pre_commit_wrapper() -> None:
     assert "-m tools.pre_commit_hook" in HOOK_TEMPLATE
     assert 'REPO_ROOT="$(cd "$HOOK_DIR/../.." && pwd)"' in HOOK_TEMPLATE
+    assert 'export UV_PROJECT_ENVIRONMENT="$PROJECT_ENVIRONMENT"' in HOOK_TEMPLATE
 
 
 def test_install_hooks_uses_pre_commit_overwrite_mode(
@@ -53,6 +54,11 @@ def test_install_hooks_uses_pre_commit_overwrite_mode(
     hook_path.parent.mkdir(parents=True)
     hook_path.write_text("", encoding="utf-8")
 
+    environment_root = tmp_path / "external-env"
+    (environment_root / "bin").mkdir(parents=True)
+    monkeypatch.setattr("tools.install_git_hooks.sys.executable", str(environment_root / "bin/python3"))
+    monkeypatch.setattr("tools.install_git_hooks.sys.prefix", str(environment_root))
+    monkeypatch.setattr("tools.install_git_hooks.sys.base_prefix", "/usr")
     monkeypatch.setattr(subprocess, "run", fake_run)
 
     tools.install_git_hooks.install_hooks(tmp_path)
@@ -74,3 +80,6 @@ def test_install_hooks_uses_pre_commit_overwrite_mode(
             tmp_path,
         ),
     ]
+    hook_text = hook_path.read_text(encoding="utf-8")
+    assert f"PROJECT_ENVIRONMENT={environment_root}" in hook_text
+    assert f"PYTHON={environment_root / 'bin/python3'}" in hook_text

--- a/tools/install_git_hooks.py
+++ b/tools/install_git_hooks.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import shlex
 import stat
 import subprocess
+import sys
 from pathlib import Path
 
 HOOK_TEMPLATE = """#!/usr/bin/env bash
@@ -11,9 +13,11 @@ HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$HOOK_DIR/../.." && pwd)"
 cd "$REPO_ROOT"
 
-PYTHON="$REPO_ROOT/.venv/bin/python3"
+PYTHON={python}
 if [ -x "$PYTHON" ]; then
     exec "$PYTHON" -m tools.pre_commit_hook "$@"
+elif command -v uv > /dev/null; then
+    exec uv run python -m tools.pre_commit_hook "$@"
 elif command -v python3 > /dev/null; then
     exec python3 -m tools.pre_commit_hook "$@"
 else
@@ -45,7 +49,10 @@ def install_hooks(repo_root: Path) -> None:
         cwd=repo_root,
     )
     hook_path = repo_root / ".git/hooks/pre-commit"
-    hook_path.write_text(HOOK_TEMPLATE, encoding="utf-8")
+    hook_path.write_text(
+        HOOK_TEMPLATE.format(python=shlex.quote(sys.executable)),
+        encoding="utf-8",
+    )
     hook_path.chmod(hook_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 

--- a/tools/install_git_hooks.py
+++ b/tools/install_git_hooks.py
@@ -31,6 +31,40 @@ else
 fi
 """
 
+COMMIT_MSG_HOOK_TEMPLATE = """#!/usr/bin/env bash
+set -euo pipefail
+
+HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$HOOK_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+PROJECT_ENVIRONMENT={project_environment}
+if [ -n "$PROJECT_ENVIRONMENT" ]; then
+    export UV_PROJECT_ENVIRONMENT="$PROJECT_ENVIRONMENT"
+fi
+
+PYTHON={python}
+if [ -x "$PYTHON" ]; then
+    exec "$PYTHON" -m pre_commit hook-impl \
+        --config=.pre-commit-config.yaml \
+        --hook-type=commit-msg \
+        --hook-dir "$HOOK_DIR" -- "$@"
+elif command -v uv > /dev/null; then
+    exec uv run python -m pre_commit hook-impl \
+        --config=.pre-commit-config.yaml \
+        --hook-type=commit-msg \
+        --hook-dir "$HOOK_DIR" -- "$@"
+elif command -v pre-commit > /dev/null; then
+    exec pre-commit hook-impl \
+        --config=.pre-commit-config.yaml \
+        --hook-type=commit-msg \
+        --hook-dir "$HOOK_DIR" -- "$@"
+else
+    echo '`pre-commit` not found. Did you forget to activate your virtualenv?' 1>&2
+    exit 1
+fi
+"""
+
 
 def _installed_project_environment() -> str | None:
     if sys.prefix == sys.base_prefix:
@@ -59,15 +93,22 @@ def install_hooks(repo_root: Path) -> None:
         check=True,
         cwd=repo_root,
     )
+    hook_format_args = {
+        "project_environment": shlex.quote(_installed_project_environment() or ""),
+        "python": shlex.quote(sys.executable),
+    }
     hook_path = repo_root / ".git/hooks/pre-commit"
     hook_path.write_text(
-        HOOK_TEMPLATE.format(
-            project_environment=shlex.quote(_installed_project_environment() or ""),
-            python=shlex.quote(sys.executable),
-        ),
+        HOOK_TEMPLATE.format(**hook_format_args),
         encoding="utf-8",
     )
     hook_path.chmod(hook_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    commit_msg_hook_path = repo_root / ".git/hooks/commit-msg"
+    commit_msg_hook_path.write_text(
+        COMMIT_MSG_HOOK_TEMPLATE.format(**hook_format_args),
+        encoding="utf-8",
+    )
+    commit_msg_hook_path.chmod(commit_msg_hook_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
 
 def main() -> int:

--- a/tools/install_git_hooks.py
+++ b/tools/install_git_hooks.py
@@ -13,6 +13,11 @@ HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$HOOK_DIR/../.." && pwd)"
 cd "$REPO_ROOT"
 
+PROJECT_ENVIRONMENT={project_environment}
+if [ -n "$PROJECT_ENVIRONMENT" ]; then
+    export UV_PROJECT_ENVIRONMENT="$PROJECT_ENVIRONMENT"
+fi
+
 PYTHON={python}
 if [ -x "$PYTHON" ]; then
     exec "$PYTHON" -m tools.pre_commit_hook "$@"
@@ -25,6 +30,12 @@ else
     exit 1
 fi
 """
+
+
+def _installed_project_environment() -> str | None:
+    if sys.prefix == sys.base_prefix:
+        return None
+    return str(Path(sys.executable).parent.parent)
 
 
 def install_hooks(repo_root: Path) -> None:
@@ -50,7 +61,10 @@ def install_hooks(repo_root: Path) -> None:
     )
     hook_path = repo_root / ".git/hooks/pre-commit"
     hook_path.write_text(
-        HOOK_TEMPLATE.format(python=shlex.quote(sys.executable)),
+        HOOK_TEMPLATE.format(
+            project_environment=shlex.quote(_installed_project_environment() or ""),
+            python=shlex.quote(sys.executable),
+        ),
         encoding="utf-8",
     )
     hook_path.chmod(hook_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)


### PR DESCRIPTION
Why:
- let developers and hooks run against an external `uv` environment after the package rename instead of assuming a repo-local virtualenv
- keep archive intake diagnostics and day-to-day setup flows aligned while the tooling shifts to the external environment model

What:
- thread `UV_PROJECT_ENVIRONMENT` through hook installation and hook execution, update editor/runtime guidance for external environments, and document the repo-scoped wrapper path in the checked-in setup docs
- add the duplicate-archive warning assertion that landed alongside the bootstrap cleanup so archive intake still reports the expected diagnostic

Checks:
- local `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests`

Included checkpoints:
- `test(archive): assert duplicate zip warning`
- `fix(uv): support external project environments`
- `fix(uv): preserve external project hooks`
- `fix(uv): carry external environment through git hooks`
- `docs(uv): recommend repo-scoped uv wrapper`
