### PR TITLE
fix(uv): external uv hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,8 @@ env.bak/
 venv/
 venv.bak/
 __pypackages__/
+.uv-env
+.uv-venv
 
 # Editors and notebooks
 .idea/

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,9 @@
 {
   "python.terminal.activateEnvironment": true,
+  "python.defaultInterpreterPath": "${env:HOME}/.venvs/tallylot-py312/bin/python",
+  "terminal.integrated.env.linux": {
+    "UV_PROJECT_ENVIRONMENT": "${env:HOME}/.venvs/tallylot-py312"
+  },
   "python.analysis.extraPaths": [
     "${workspaceFolder}/src"
   ],
@@ -10,6 +14,8 @@
   ],
   "files.exclude": {
     "**/.venv": true,
+    "**/.uv-env": true,
+    "**/.uv-venv": true,
     "**/__pycache__": true,
     "**/.mypy_cache": true,
     "**/.pytest_cache": true,
@@ -17,6 +23,8 @@
   },
   "files.watcherExclude": {
     "**/.venv/**": true,
+    "**/.uv-env/**": true,
+    "**/.uv-venv/**": true,
     "**/__pycache__/**": true,
     "**/.mypy_cache/**": true,
     "**/.pytest_cache/**": true,
@@ -24,6 +32,8 @@
   },
   "search.exclude": {
     "**/.venv": true,
+    "**/.uv-env": true,
+    "**/.uv-venv": true,
     "**/__pycache__": true,
     "**/.mypy_cache": true,
     "**/.pytest_cache": true,
@@ -31,6 +41,8 @@
   },
   "python.analysis.exclude": [
     "**/.venv",
+    "**/.uv-env",
+    "**/.uv-venv",
     "**/__pycache__",
     "**/.mypy_cache",
     "**/.pytest_cache",

--- a/tests/unit/test_pre_commit_hook.py
+++ b/tests/unit/test_pre_commit_hook.py
@@ -44,11 +44,17 @@ def test_install_hooks_uses_pre_commit_overwrite_mode(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    commands: list[tuple[tuple[str, ...], Path]] = []
+    commands: list[tuple[tuple[str, ...], Path, str | None]] = []
 
-    def fake_run(command: list[str], *, check: bool, cwd: Path) -> subprocess.CompletedProcess[str]:
+    def fake_run(
+        command: list[str],
+        *,
+        check: bool,
+        cwd: Path,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
         assert check is True
-        commands.append((tuple(command), cwd))
+        commands.append((tuple(command), cwd, None if env is None else env.get("UV_PROJECT_ENVIRONMENT")))
         return subprocess.CompletedProcess(command, 0)
 
     hook_path = tmp_path / ".git" / "hooks" / "pre-commit"
@@ -67,7 +73,7 @@ def test_install_hooks_uses_pre_commit_overwrite_mode(
     tools.install_git_hooks.install_hooks(tmp_path)
 
     assert commands == [
-        (("git", "config", "--local", "commit.template", ".gitmessage.txt"), tmp_path),
+        (("git", "config", "--local", "commit.template", ".gitmessage.txt"), tmp_path, None),
         (
             (
                 "uv",
@@ -81,6 +87,7 @@ def test_install_hooks_uses_pre_commit_overwrite_mode(
                 "commit-msg",
             ),
             tmp_path,
+            str(Path.home() / ".venvs" / "tallylot-py312"),
         ),
     ]
     hook_text = hook_path.read_text(encoding="utf-8")
@@ -89,3 +96,34 @@ def test_install_hooks_uses_pre_commit_overwrite_mode(
     commit_msg_hook_text = commit_msg_hook_path.read_text(encoding="utf-8")
     assert f"PROJECT_ENVIRONMENT={environment_root}" in commit_msg_hook_text
     assert "--hook-type=commit-msg" in commit_msg_hook_text
+
+
+def test_install_hooks_falls_back_to_default_external_environment(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    hook_path = tmp_path / ".git" / "hooks" / "pre-commit"
+    hook_path.parent.mkdir(parents=True)
+    hook_path.write_text("", encoding="utf-8")
+    commit_msg_hook_path = tmp_path / ".git" / "hooks" / "commit-msg"
+    commit_msg_hook_path.write_text("", encoding="utf-8")
+
+    def fake_run(
+        command: list[str],
+        *,
+        check: bool,
+        cwd: Path,
+        env: dict[str, str] | None = None,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr("tools.install_git_hooks.sys.executable", "/usr/bin/python3")
+    monkeypatch.setattr("tools.install_git_hooks.sys.prefix", "/usr")
+    monkeypatch.setattr("tools.install_git_hooks.sys.base_prefix", "/usr")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    tools.install_git_hooks.install_hooks(tmp_path)
+
+    expected_environment = Path.home() / ".venvs" / "tallylot-py312"
+    assert f"PROJECT_ENVIRONMENT={expected_environment}" in hook_path.read_text(encoding="utf-8")
+    assert f"PROJECT_ENVIRONMENT={expected_environment}" in commit_msg_hook_path.read_text(encoding="utf-8")

--- a/tests/unit/test_quality_gates.py
+++ b/tests/unit/test_quality_gates.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
+import pytest
+
+import tools.run_quality_gates
 from tools.run_quality_gates import DEFAULT_TEST_COMMAND, FULL_TEST_COMMAND, _quality_gates
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -19,6 +23,31 @@ def test_quality_gates_can_switch_to_full_pytest() -> None:
     gates = _quality_gates(full_tests=True)
 
     assert gates[-1].command == FULL_TEST_COMMAND
+
+
+def test_run_gate_exports_external_uv_project_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured_environment: dict[str, str] = {}
+
+    def fake_run(
+        command: tuple[str, ...],
+        *,
+        capture_output: bool,
+        text: bool,
+        check: bool,
+        env: dict[str, str],
+    ) -> subprocess.CompletedProcess[str]:
+        assert capture_output is True
+        assert text is True
+        assert check is False
+        captured_environment.update(env)
+        return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    gate = _quality_gates(full_tests=False)[0]
+    tools.run_quality_gates._run_gate(gate)
+
+    assert captured_environment["UV_PROJECT_ENVIRONMENT"] == str(Path.home() / ".venvs" / "tallylot-py312")
 
 
 def test_pre_commit_config_excludes_pylint_hook() -> None:

--- a/tests/unit/test_uv_environment.py
+++ b/tests/unit/test_uv_environment.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.uv_environment import default_project_environment, repo_uv_environment
+
+
+def test_default_project_environment_uses_home_scoped_external_env() -> None:
+    assert default_project_environment() == str(Path.home() / ".venvs" / "tallylot-py312")
+
+
+def test_repo_uv_environment_preserves_existing_override() -> None:
+    environment = repo_uv_environment({"UV_PROJECT_ENVIRONMENT": "/tmp/custom-env"})
+
+    assert environment["UV_PROJECT_ENVIRONMENT"] == "/tmp/custom-env"
+
+
+def test_repo_uv_environment_sets_default_when_missing() -> None:
+    environment = repo_uv_environment({})
+
+    assert environment["UV_PROJECT_ENVIRONMENT"] == str(Path.home() / ".venvs" / "tallylot-py312")

--- a/tests/unit/test_vscode_settings.py
+++ b/tests/unit/test_vscode_settings.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_workspace_vscode_settings_pin_external_python_environment() -> None:
+    settings_path = Path(__file__).resolve().parents[2] / ".vscode" / "settings.json"
+    settings = json.loads(settings_path.read_text(encoding="utf-8"))
+
+    assert settings["python.defaultInterpreterPath"] == "${env:HOME}/.venvs/tallylot-py312/bin/python"
+    assert settings["terminal.integrated.env.linux"]["UV_PROJECT_ENVIRONMENT"] == "${env:HOME}/.venvs/tallylot-py312"

--- a/tools/install_git_hooks.py
+++ b/tools/install_git_hooks.py
@@ -6,6 +6,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from tools.uv_environment import default_project_environment, repo_uv_environment
+
 HOOK_TEMPLATE = """#!/usr/bin/env bash
 set -euo pipefail
 
@@ -72,6 +74,10 @@ def _installed_project_environment() -> str | None:
     return str(Path(sys.executable).parent.parent)
 
 
+def _hook_project_environment() -> str:
+    return _installed_project_environment() or default_project_environment()
+
+
 def install_hooks(repo_root: Path) -> None:
     subprocess.run(
         ["git", "config", "--local", "commit.template", ".gitmessage.txt"],
@@ -92,9 +98,10 @@ def install_hooks(repo_root: Path) -> None:
         ],
         check=True,
         cwd=repo_root,
+        env=repo_uv_environment(),
     )
     hook_format_args = {
-        "project_environment": shlex.quote(_installed_project_environment() or ""),
+        "project_environment": shlex.quote(_hook_project_environment()),
         "python": shlex.quote(sys.executable),
     }
     hook_path = repo_root / ".git/hooks/pre-commit"

--- a/tools/run_quality_gates.py
+++ b/tools/run_quality_gates.py
@@ -7,6 +7,8 @@ from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 
+from tools.uv_environment import repo_uv_environment
+
 
 @dataclass(frozen=True)
 class QualityGate:
@@ -45,7 +47,13 @@ def _quality_gates(*, full_tests: bool) -> tuple[QualityGate, ...]:
 
 def _run_gate(gate: QualityGate) -> tuple[QualityGate, subprocess.CompletedProcess[str], float]:
     started = time.perf_counter()
-    result = subprocess.run(gate.command, capture_output=True, text=True, check=False)
+    result = subprocess.run(
+        gate.command,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=repo_uv_environment(),
+    )
     return gate, result, time.perf_counter() - started
 
 

--- a/tools/uv_environment.py
+++ b/tools/uv_environment.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from pathlib import Path
+
+
+def default_project_environment() -> str:
+    return str(Path.home() / ".venvs" / "tallylot-py312")
+
+
+def repo_uv_environment(existing: Mapping[str, str] | None = None) -> dict[str, str]:
+    environment = dict(os.environ if existing is None else existing)
+    environment.setdefault("UV_PROJECT_ENVIRONMENT", default_project_environment())
+    return environment


### PR DESCRIPTION
Why:
- lock developer tooling fully onto the external `uv` environment instead of leaving fallback paths that could silently drift back to repo-local state
- capture the editor, hook, and subprocess hardening in one PR-level record so later environment changes have a clear baseline to compare against

What:
- pin the VS Code interpreter and terminal environment to the external uv project, propagate that environment through hook installation and quality-gate subprocesses, and ignore stray uv-environment artifacts
- add focused unit coverage for the external environment helpers, VS Code settings, hook installation, and quality-gate behavior

Checks:
- local `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests`

Included checkpoints:
- `fix(uv): harden external uv defaults`
