### PR TITLE
ci(workflow): harden merge metadata and verification policy

### DIFF
--- a/.claude/commands/implementation-checkpoint.md
+++ b/.claude/commands/implementation-checkpoint.md
@@ -21,9 +21,12 @@ Use this route before closing any non-trivial coding task.
    - new parser or renderer contracts
    - fixed edge cases
 5. Run the appropriate verification path:
+   - use fresh VS Code Problems diagnostics first when they are available and current
    - targeted tests while iterating
    - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests` before closing
      substantial work
+   - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_ci_parity_checks` when the change touches CI,
+     packaging, release, or other workflow surfaces
 6. If architecture, schema, or sequencing changed, update:
    - `ROADMAP.md`
    - `docs/architecture/reconciliation-tax-implementation-plan.md`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+## Why
+
+- explain the problem or constraint this PR resolves
+
+## What
+
+- summarize the engineering changes that matter for review
+
+## Checks
+
+- list the verification you actually ran
+
+## Included checkpoints
+
+- list the branch commit subjects in chronological order

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+<!-- markdownlint-disable-file MD041 MD032 -->
+
 Why:
 - explain the problem or constraint this PR resolves
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,15 +1,11 @@
-## Why
-
+Why:
 - explain the problem or constraint this PR resolves
 
-## What
-
+What:
 - summarize the engineering changes that matter for review
 
-## Checks
-
+Checks:
 - list the verification you actually ran
 
-## Included checkpoints
-
+Included checkpoints:
 - list the branch commit subjects in chronological order

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,24 @@ on:
     branches:
       - main
   pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+      - ready_for_review
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   commit-messages:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
@@ -19,7 +33,7 @@ jobs:
       - name: Install uv
         run: python -m pip install uv
       - name: Sync dependencies
-        run: uv sync --python 3.12
+        run: uv sync --python 3.12 --frozen
       - name: Validate commit messages
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -47,6 +61,7 @@ jobs:
   quality:
     needs: commit-messages
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -55,7 +70,7 @@ jobs:
       - name: Install uv
         run: python -m pip install uv
       - name: Sync dependencies
-        run: uv sync --python 3.12
+        run: uv sync --python 3.12 --frozen
       - name: Markdownlint
         run: uv run pre-commit run markdownlint --all-files
       - name: Ruff

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,12 @@ jobs:
             RANGE="$BEFORE_SHA..$CURRENT_SHA"
           fi
           uv run python -m tools.validate_commit_message --rev-range "$RANGE"
+      - name: Validate PR metadata
+        if: github.event_name == 'pull_request'
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: uv run python -m tools.validate_pr_metadata --title "$PR_TITLE" --body "$PR_BODY"
 
   quality:
     needs: commit-messages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Pyright
         run: uv run pyright
       - name: Pylint
-        run: uv run pylint src tests tools
+        run: uv run python -m tools.run_pylint
       - name: Pytest
         run: uv run pytest
       - name: Build distributions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,14 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_BODY: ${{ github.event.pull_request.body }}
-        run: uv run python -m tools.validate_pr_metadata --title "$PR_TITLE" --body "$PR_BODY"
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          uv run python -m tools.validate_pr_metadata \
+            --title "$PR_TITLE" \
+            --body "$PR_BODY" \
+            --base-sha "$BASE_SHA" \
+            --head-sha "$HEAD_SHA"
 
   quality:
     needs: commit-messages
@@ -73,6 +80,8 @@ jobs:
         run: uv sync --python 3.12 --frozen
       - name: Markdownlint
         run: uv run pre-commit run markdownlint --all-files
+      - name: Actionlint
+        run: uv run actionlint -color
       - name: Ruff
         run: uv run ruff check .
       - name: Mypy

--- a/.gitmessage.txt
+++ b/.gitmessage.txt
@@ -7,15 +7,7 @@
 # - summary of the implementation
 #
 # Checks:
-# - uv run pre-commit run --all-files
-# - uv run pre-commit run markdownlint --all-files
-# - uv run ruff check .
-# - uv run mypy
-# - uv run pyright
-# - uv run python -m tools.run_pylint
-# - uv run pytest
-#
-# Stable checkpoint:
-# - yes, if the tree is coherent, verified, and ready to keep
+# - UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pytest -q --no-cov <focused-tests>
+# - UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates
 #
 # BREAKING CHANGE: describe any incompatible behavior change

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,12 +54,21 @@ Do not pre-load every repo doc by default.
   already exists.
 - Bootstrap the checked-in hooks:
   - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.install_git_hooks`
+- Prefer fresh VS Code workspace diagnostics for instant static-analysis feedback when the
+  `vscode-problems` skill or MCP snapshot is available and current.
+  Treat that signal as advisory only.
 - For explicit local verification, prefer:
-  - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pre-commit run markdownlint --all-files`
   - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates`
   - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests`
+  - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_ci_parity_checks`
 - Do not run `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pre-commit run --all-files` in addition to the parallel
   quality-gate runner unless you are debugging hook behavior itself.
+- Use `tools.run_quality_gates --full-tests` as the normal final local verification command.
+- Use `tools.run_ci_parity_checks` only when changes touch CI, packaging, release, or other
+  workflow surfaces where local parity with GitHub Actions is worth the extra time.
+- Do not run `tools.run_quality_gates --full-tests` immediately before
+  `tools.run_ci_parity_checks`; the parity runner already includes the full
+  quality gate pass.
 - The commit-time `pytest` hook is intentionally fast:
   - `unit and not slow`
   - no coverage

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -208,6 +208,10 @@ decisions that should not be rediscovered from scratch.
 - Keep docs-to-runtime capability parity as an explicit invariant. If a command,
   artifact, or agent entrypoint is documented as active, it must exist and be
   tested.
+- Keep `main` squash-merged through PRs only. PR titles must use the
+  Conventional Commit subject format, and PR bodies must include `Why:`,
+  `What:`, `Checks:`, and chronological `Included checkpoints:` sections
+  because that metadata becomes the mainline commit record.
 - Keep the retired legacy workspace roots out of git:
   `00_docs/`, `01_raw_exports/`, `02_working/`, `03_analysis/`,
   `04_import_ready/`, and `05_outputs/`.

--- a/docs/architecture/commit-standards.md
+++ b/docs/architecture/commit-standards.md
@@ -213,8 +213,8 @@ quality gate pass.
 Example:
 
 ```bash
-gh pr view 12 --json title,body --jq '.title' > /tmp/pr-title.txt
-gh pr view 12 --json title,body --jq '.body' > /tmp/pr-body.md
+gh pr view <pr-number> --json title,body --jq '.title' > /tmp/pr-title.txt
+gh pr view <pr-number> --json title,body --jq '.body' > /tmp/pr-body.md
 UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_ci_parity_checks \
   --include-commit-messages \
   --pr-title "$(cat /tmp/pr-title.txt)" \

--- a/docs/architecture/commit-standards.md
+++ b/docs/architecture/commit-standards.md
@@ -99,6 +99,11 @@ PR body rules:
 - for a one-commit PR, still list that single checkpoint under
   `Included checkpoints:`
 
+The GitHub-generated squash commit on `main` may retain the validated
+`Included checkpoints:` section from the PR body. Treat that as allowed for the
+generated mainline commit record, even though authored checkpoint commits
+should only use `Why:`, `What:`, and `Checks:` sections.
+
 Preferred PR body template:
 
 ```text
@@ -195,7 +200,9 @@ UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_
 Use `tools.run_quality_gates --full-tests` as the default final local
 verification command. Use `tools.run_ci_parity_checks` only when changing CI,
 packaging, release, or other workflow surfaces where exact local parity with
-GitHub Actions is worth the extra time.
+GitHub Actions is worth the extra time. Add `--include-commit-messages` when
+you also want the parity run to validate the current branch commit-message
+range before running the full quality and build path.
 Do not run `tools.run_quality_gates --full-tests` immediately before
 `tools.run_ci_parity_checks`; the parity runner already includes the full
 quality gate pass.

--- a/docs/architecture/commit-standards.md
+++ b/docs/architecture/commit-standards.md
@@ -92,6 +92,8 @@ PR body rules:
 - use flat `- ` bullets under every section
 - keep `Included checkpoints:` in chronological order using the exact
   checkpoint subjects from the branch
+- wrap every `Included checkpoints:` entry in backticks using the exact commit
+  subject, because CI validates that the list matches the branch history
 - describe the engineering outcome and reviewable behavior, not branch
   choreography or replay mechanics
 - for a one-commit PR, still list that single checkpoint under

--- a/docs/architecture/commit-standards.md
+++ b/docs/architecture/commit-standards.md
@@ -70,6 +70,50 @@ Checks:
 
 Standard footers are allowed, including `BREAKING CHANGE:`.
 
+## Pull Request And Squash Merge Standard
+
+`main` uses squash merges. Treat the pull request title and description as the
+canonical source for the commit that lands on `main`.
+
+PR title rules:
+
+- use the same Conventional Commit subject format required for authored commits
+- keep the title history-ready on its own because the squash subject becomes
+  `<pr title> (#<pr number>)`
+- do not use generic titles such as `update branch`, `cleanup`, or `misc fixes`
+
+PR body rules:
+
+- include these sections in this exact order:
+  - `Why:`
+  - `What:`
+  - `Checks:`
+  - `Included checkpoints:`
+- use flat `- ` bullets under every section
+- keep `Included checkpoints:` in chronological order using the exact
+  checkpoint subjects from the branch
+- describe the engineering outcome and reviewable behavior, not branch
+  choreography or replay mechanics
+- for a one-commit PR, still list that single checkpoint under
+  `Included checkpoints:`
+
+Preferred PR body template:
+
+```text
+Why:
+- explain the problem or constraint this PR resolves
+
+What:
+- summarize the engineering changes that matter for review
+
+Checks:
+- list the verification you actually ran
+
+Included checkpoints:
+- `refactor(example): first checkpoint subject`
+- `fix(example): second checkpoint subject`
+```
+
 ## Stable Checkpoint Commits
 
 Commit at stable checkpoints by default. In this repo that is an expected

--- a/docs/architecture/commit-standards.md
+++ b/docs/architecture/commit-standards.md
@@ -202,10 +202,24 @@ verification command. Use `tools.run_ci_parity_checks` only when changing CI,
 packaging, release, or other workflow surfaces where exact local parity with
 GitHub Actions is worth the extra time. Add `--include-commit-messages` when
 you also want the parity run to validate the current branch commit-message
-range before running the full quality and build path.
+range before running the full quality and build path. Add `--pr-title` plus
+`--pr-body-file` when you also want the parity run to validate the current
+branch PR title, body, and `Included checkpoints:` list against the branch
+history.
 Do not run `tools.run_quality_gates --full-tests` immediately before
 `tools.run_ci_parity_checks`; the parity runner already includes the full
 quality gate pass.
+
+Example:
+
+```bash
+gh pr view 12 --json title,body --jq '.title' > /tmp/pr-title.txt
+gh pr view 12 --json title,body --jq '.body' > /tmp/pr-body.md
+UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_ci_parity_checks \
+  --include-commit-messages \
+  --pr-title "$(cat /tmp/pr-title.txt)" \
+  --pr-body-file /tmp/pr-body.md
+```
 
 `pylint` remains part of the parallel quality-gate runner, but it is not part
 of the `pre-commit` hook path because it is materially slower than the other

--- a/docs/architecture/commit-standards.md
+++ b/docs/architecture/commit-standards.md
@@ -89,7 +89,7 @@ PR body rules:
   - `What:`
   - `Checks:`
   - `Included checkpoints:`
-- use flat `- ` bullets under every section
+- use flat hyphen bullets under every section
 - keep `Included checkpoints:` in chronological order using the exact
   checkpoint subjects from the branch
 - wrap every `Included checkpoints:` entry in backticks using the exact commit
@@ -170,7 +170,6 @@ coverage, contract tests, or end-to-end CLI flows on every commit. Full
 verification still means running:
 
 ```bash
-UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pre-commit run markdownlint --all-files
 UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests
 ```
 
@@ -190,7 +189,16 @@ parallel quality-gate runner:
 ```bash
 UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates
 UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests
+UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_ci_parity_checks
 ```
+
+Use `tools.run_quality_gates --full-tests` as the default final local
+verification command. Use `tools.run_ci_parity_checks` only when changing CI,
+packaging, release, or other workflow surfaces where exact local parity with
+GitHub Actions is worth the extra time.
+Do not run `tools.run_quality_gates --full-tests` immediately before
+`tools.run_ci_parity_checks`; the parity runner already includes the full
+quality gate pass.
 
 `pylint` remains part of the parallel quality-gate runner, but it is not part
 of the `pre-commit` hook path because it is materially slower than the other

--- a/docs/architecture/implementation-working-agreement.md
+++ b/docs/architecture/implementation-working-agreement.md
@@ -147,6 +147,9 @@ Expected behavior:
 - do not bundle unrelated fixes
 - do not wait for the user to remind you to commit once the task has reached a
   real checkpoint
+- when opening a PR, use a Conventional Commit title and the structured PR body
+  defined in `docs/architecture/commit-standards.md` because that metadata
+  becomes the squash commit on `main`
 - before closing a non-trivial task, ensure the commit already exists rather
   than leaving commit creation as follow-up work
 

--- a/docs/architecture/implementation-working-agreement.md
+++ b/docs/architecture/implementation-working-agreement.md
@@ -21,12 +21,18 @@ commands so `uv` does not create a workspace-local environment.
 
 Prefer the repo's built-in tooling before inventing local workflows:
 
+- inspect a fresh VS Code Problems snapshot first when the `vscode-problems`
+  skill or MCP server is available, then fall back to CLI checks when the
+  snapshot is stale, missing, or incomplete
 - bootstrap hooks in each clone with
   `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.install_git_hooks`
 - run broad verification with
   `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates`
 - run full verification before closing substantial work with
   `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests`
+- mirror GitHub Actions locally when changing workflow, packaging, or release
+  behavior with
+  `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_ci_parity_checks`
 - scaffold new adapters with
   `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.scaffold_adapter ...`
 - refresh adapter golden fixtures with
@@ -163,6 +169,8 @@ When not to commit:
 
 Default verification expectations:
 
+- use fresh VS Code Problems diagnostics first for instant editor-grounded
+  lint and type feedback when they are available and current
 - targeted tests during development
 - full relevant checks before closing substantial work
 
@@ -171,7 +179,12 @@ is:
 
 - do not call work done with only local reasoning
 - verify the changed behavior at the smallest useful level first
-- then run the broader quality gates before closing the task
+- then run `tools.run_quality_gates --full-tests` before closing the task
+- escalate to `tools.run_ci_parity_checks` only when the change touches CI,
+  packaging, release, or other workflow surfaces where exact GitHub Actions
+  parity matters
+- do not run `tools.run_quality_gates --full-tests` again immediately before
+  `tools.run_ci_parity_checks`; the parity runner already includes it
 
 If you are changing commit-time or suite-selection policy, benchmark first
 instead of guessing:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,11 @@ dev = [
     "reportlab>=4.4.0,<5.0.0",
     "ruff>=0.11.2,<0.12.0",
 ]
+ci = [
+    "actionlint-py>=1.7.12.24,<2.0.0",
+    "pyflakes>=3.4.0,<4.0.0",
+    "shellcheck-py>=0.11.0.1,<1.0.0",
+]
 
 [project.scripts]
 tallylot = "tallylot.interfaces.cli:app"
@@ -79,4 +84,4 @@ exclude_lines = [
 ]
 
 [tool.uv]
-default-groups = ["dev"]
+default-groups = ["dev", "ci"]

--- a/tests/unit/test_ci_parity_checks.py
+++ b/tests/unit/test_ci_parity_checks.py
@@ -50,6 +50,14 @@ def test_ci_parity_stops_when_commit_message_step_fails(monkeypatch: MonkeyPatch
     assert ci_parity.main(["--include-commit-messages"]) == 1
 
 
+def test_ci_parity_requires_full_pr_metadata_input(tmp_path: Path) -> None:
+    pr_body = tmp_path / "pr.md"
+    pr_body.write_text("Why:\n- explain\n", encoding="utf-8")
+
+    assert ci_parity.main(["--pr-title", "ci: tighten parity"]) == 2
+    assert ci_parity.main(["--pr-body-file", str(pr_body)]) == 2
+
+
 def test_ci_parity_runs_quality_build_and_verify(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.chdir(tmp_path)
     dist_dir = tmp_path / "dist"
@@ -103,3 +111,45 @@ def test_ci_parity_can_include_commit_messages(monkeypatch: MonkeyPatch, tmp_pat
 
     assert ci_parity.main(["--include-commit-messages"]) == 0
     assert steps_seen == ["commit-messages", "quality", "build"]
+
+
+def test_ci_parity_can_include_pr_metadata(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(ci_parity, "_pr_validation_shas", lambda: ("base", "head"))
+    pr_body = tmp_path / "pr.md"
+    pr_body_text = (
+        "Why:\n- explain\n\n"
+        "What:\n- change\n\n"
+        "Checks:\n- uv run pytest\n\n"
+        "Included checkpoints:\n- `ci: tighten parity`\n"
+    )
+    pr_body.write_text(
+        pr_body_text,
+        encoding="utf-8",
+    )
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    wheel_path = dist_dir / "tallylot-0.1.0-py3-none-any.whl"
+    wheel_path.write_text("stub", encoding="utf-8")
+
+    steps_seen: list[ci_parity.ParityStep] = []
+
+    def fake_run_step(step: ci_parity.ParityStep) -> int:
+        steps_seen.append(step)
+        if step.name == "build":
+            dist_dir.mkdir(exist_ok=True)
+            wheel_path.write_text("rebuilt", encoding="utf-8")
+        return 0
+
+    def fake_verify_built_wheel(dist_path: Path) -> tuple[int, str, str]:
+        assert dist_path.resolve() == dist_dir.resolve()
+        return 0, "", ""
+
+    monkeypatch.setattr(ci_parity, "_run_step", fake_run_step)
+    monkeypatch.setattr(ci_parity, "_verify_built_wheel", fake_verify_built_wheel)
+
+    assert ci_parity.main(["--pr-title", "ci: tighten parity", "--pr-body-file", str(pr_body)]) == 0
+    assert [step.name for step in steps_seen] == ["pr-metadata", "quality", "build"]
+    assert steps_seen[0].command[4] == "tools.validate_pr_metadata"
+    assert "--base-sha" in steps_seen[0].command
+    assert "--head-sha" in steps_seen[0].command

--- a/tests/unit/test_ci_parity_checks.py
+++ b/tests/unit/test_ci_parity_checks.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from pytest import MonkeyPatch
+
+import tools.run_ci_parity_checks as ci_parity
+
+
+def test_ci_parity_stops_when_quality_step_fails(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    def fake_run_step(step: ci_parity.ParityStep) -> int:
+        assert step.name == "quality"
+        return 1
+
+    monkeypatch.setattr(ci_parity, "_run_step", fake_run_step)
+
+    assert ci_parity.main([]) == 1
+
+
+def test_ci_parity_runs_quality_build_and_verify(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    wheel_path = dist_dir / "tallylot-0.1.0-py3-none-any.whl"
+    wheel_path.write_text("stub", encoding="utf-8")
+
+    steps_seen: list[str] = []
+
+    def fake_run_step(step: ci_parity.ParityStep) -> int:
+        steps_seen.append(step.name)
+        if step.name == "build":
+            dist_dir.mkdir(exist_ok=True)
+            wheel_path.write_text("rebuilt", encoding="utf-8")
+        return 0
+
+    def fake_verify_built_wheel(dist_path: Path) -> tuple[int, str, str]:
+        assert dist_path.resolve() == dist_dir.resolve()
+        return 0, "", ""
+
+    monkeypatch.setattr(ci_parity, "_run_step", fake_run_step)
+    monkeypatch.setattr(ci_parity, "_verify_built_wheel", fake_verify_built_wheel)
+
+    assert ci_parity.main([]) == 0
+    assert steps_seen == ["quality", "build"]

--- a/tests/unit/test_ci_parity_checks.py
+++ b/tests/unit/test_ci_parity_checks.py
@@ -7,16 +7,47 @@ from pytest import MonkeyPatch
 import tools.run_ci_parity_checks as ci_parity
 
 
-def test_ci_parity_stops_when_quality_step_fails(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+def test_commit_message_range_uses_merge_base(monkeypatch: MonkeyPatch) -> None:
+    def fake_git_stdout(*args: str) -> str:
+        if args == ("symbolic-ref", "--short", "refs/remotes/origin/HEAD"):
+            return "origin/main"
+        if args == ("merge-base", "HEAD", "origin/main"):
+            return "abc123"
+        if args == ("rev-parse", "HEAD"):
+            return "def456"
+        raise AssertionError(args)
+
+    monkeypatch.setattr(ci_parity, "_git_stdout", fake_git_stdout)
+
+    assert ci_parity._commit_message_range() == "abc123..def456"
+
+
+def test_commit_message_range_falls_back_to_head_commit(monkeypatch: MonkeyPatch) -> None:
+    def fake_git_stdout(*args: str) -> str:
+        if args == ("symbolic-ref", "--short", "refs/remotes/origin/HEAD"):
+            return "origin/main"
+        if args == ("merge-base", "HEAD", "origin/main"):
+            return "abc123"
+        if args == ("rev-parse", "HEAD"):
+            return "abc123"
+        raise AssertionError(args)
+
+    monkeypatch.setattr(ci_parity, "_git_stdout", fake_git_stdout)
+
+    assert ci_parity._commit_message_range() == "HEAD^!"
+
+
+def test_ci_parity_stops_when_commit_message_step_fails(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(ci_parity, "_commit_message_range", lambda: "base..head")
 
     def fake_run_step(step: ci_parity.ParityStep) -> int:
-        assert step.name == "quality"
+        assert step.name == "commit-messages"
         return 1
 
     monkeypatch.setattr(ci_parity, "_run_step", fake_run_step)
 
-    assert ci_parity.main([]) == 1
+    assert ci_parity.main(["--include-commit-messages"]) == 1
 
 
 def test_ci_parity_runs_quality_build_and_verify(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
@@ -44,3 +75,31 @@ def test_ci_parity_runs_quality_build_and_verify(monkeypatch: MonkeyPatch, tmp_p
 
     assert ci_parity.main([]) == 0
     assert steps_seen == ["quality", "build"]
+
+
+def test_ci_parity_can_include_commit_messages(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(ci_parity, "_commit_message_range", lambda: "base..head")
+    dist_dir = tmp_path / "dist"
+    dist_dir.mkdir()
+    wheel_path = dist_dir / "tallylot-0.1.0-py3-none-any.whl"
+    wheel_path.write_text("stub", encoding="utf-8")
+
+    steps_seen: list[str] = []
+
+    def fake_run_step(step: ci_parity.ParityStep) -> int:
+        steps_seen.append(step.name)
+        if step.name == "build":
+            dist_dir.mkdir(exist_ok=True)
+            wheel_path.write_text("rebuilt", encoding="utf-8")
+        return 0
+
+    def fake_verify_built_wheel(dist_path: Path) -> tuple[int, str, str]:
+        assert dist_path.resolve() == dist_dir.resolve()
+        return 0, "", ""
+
+    monkeypatch.setattr(ci_parity, "_run_step", fake_run_step)
+    monkeypatch.setattr(ci_parity, "_verify_built_wheel", fake_verify_built_wheel)
+
+    assert ci_parity.main(["--include-commit-messages"]) == 0
+    assert steps_seen == ["commit-messages", "quality", "build"]

--- a/tests/unit/test_commit_message_validator.py
+++ b/tests/unit/test_commit_message_validator.py
@@ -118,7 +118,7 @@ Checks:
 def test_missing_summary_is_rejected() -> None:
     errors = validate_commit_message_text(
         """\
-docs(scope): 
+docs(scope):
 
 Why:
 - tighten docs

--- a/tests/unit/test_commit_message_validator.py
+++ b/tests/unit/test_commit_message_validator.py
@@ -69,6 +69,29 @@ def test_merge_commit_message_is_allowed() -> None:
     assert not errors
 
 
+def test_squash_merge_commit_message_with_included_checkpoints_is_valid() -> None:
+    message = """\
+refactor: source verification and routing (#11)
+
+Why:
+- keep the squash-merge record reviewable on main
+
+What:
+- preserve the validated pull request summary
+
+Checks:
+- GitHub Actions `ci` workflow on this PR
+
+Included checkpoints:
+- `fix(sources): harden live export parsing and verification`
+- `refactor(sources): harden on-chain ids and family routing`
+"""
+
+    errors = validate_commit_message_text(message)
+
+    assert not errors
+
+
 def test_invalid_type_is_rejected() -> None:
     errors = validate_commit_message_text(
         """\
@@ -180,3 +203,28 @@ def test_missing_structured_body_is_rejected() -> None:
     errors = validate_commit_message_text("docs: route agents to narrow standards\n")
 
     assert errors == ("commit message body is required with `Why:`, `What:`, `Checks:` sections",)
+
+
+def test_authored_commit_message_rejects_included_checkpoints_section() -> None:
+    errors = validate_commit_message_text(
+        """\
+docs: route agents to narrow standards
+
+Why:
+- keep routing guidance explicit
+
+What:
+- point agents to the narrowest applicable standards doc
+
+Checks:
+- uv run python -m tools.validate_commit_message .git/COMMIT_EDITMSG
+
+Included checkpoints:
+- `docs: route agents to narrow standards`
+"""
+    )
+
+    assert errors == (
+        "unsupported structured label: Included checkpoints:",
+        "unexpected trailing content: - `docs: route agents to narrow standards`",
+    )

--- a/tests/unit/test_commit_message_validator.py
+++ b/tests/unit/test_commit_message_validator.py
@@ -4,13 +4,39 @@ from tools.validate_commit_message import validate_commit_message_text
 
 
 def test_commit_message_without_scope_is_valid() -> None:
-    errors = validate_commit_message_text("docs: route agents to narrow standards\n")
+    message = """\
+docs: route agents to narrow standards
+
+Why:
+- keep routing guidance explicit
+
+What:
+- point agents to the narrowest applicable standards doc
+
+Checks:
+- uv run python -m tools.validate_commit_message .git/COMMIT_EDITMSG
+"""
+
+    errors = validate_commit_message_text(message)
 
     assert not errors
 
 
 def test_commit_message_with_scope_is_valid() -> None:
-    errors = validate_commit_message_text("refactor(adapters): split structured CSV parsing\n")
+    message = """\
+refactor(adapters): split structured CSV parsing
+
+Why:
+- keep adapter parsing seams reviewable
+
+What:
+- move structured CSV parsing into bounded helpers
+
+Checks:
+- uv run pytest tests/unit/test_commit_message_validator.py
+"""
+
+    errors = validate_commit_message_text(message)
 
     assert not errors
 
@@ -44,7 +70,20 @@ def test_merge_commit_message_is_allowed() -> None:
 
 
 def test_invalid_type_is_rejected() -> None:
-    errors = validate_commit_message_text("update: change commit docs\n")
+    errors = validate_commit_message_text(
+        """\
+update: change commit docs
+
+Why:
+- tighten docs
+
+What:
+- rewrite the standard
+
+Checks:
+- uv run pytest
+"""
+    )
 
     assert errors == (
         "subject must match `type(scope): imperative summary` or "
@@ -54,7 +93,20 @@ def test_invalid_type_is_rejected() -> None:
 
 
 def test_missing_summary_is_rejected() -> None:
-    errors = validate_commit_message_text("docs(scope): \n")
+    errors = validate_commit_message_text(
+        """\
+docs(scope): 
+
+Why:
+- tighten docs
+
+What:
+- rewrite the standard
+
+Checks:
+- uv run pytest
+"""
+    )
 
     assert errors == (
         "subject must match `type(scope): imperative summary` or "
@@ -65,23 +117,66 @@ def test_missing_summary_is_rejected() -> None:
 
 def test_subject_over_72_characters_is_rejected() -> None:
     errors = validate_commit_message_text(
-        "refactor(adapters): split structured CSV normalization into smaller modules today\n"
+        """\
+refactor(adapters): split structured CSV normalization into smaller modules today
+
+Why:
+- keep adapter seams small
+
+What:
+- split the parser
+
+Checks:
+- uv run pytest
+"""
     )
 
     assert errors == ("subject must be 72 characters or fewer",)
 
 
 def test_trailing_period_is_rejected() -> None:
-    errors = validate_commit_message_text("docs: update commit guidance.\n")
+    errors = validate_commit_message_text(
+        """\
+docs: update commit guidance.
+
+Why:
+- tighten docs
+
+What:
+- rewrite the standard
+
+Checks:
+- uv run pytest
+"""
+    )
 
     assert errors == ("subject must not end with a period",)
 
 
 def test_malformed_scope_is_rejected() -> None:
-    errors = validate_commit_message_text("docs(agent_router): tighten commit rules\n")
+    errors = validate_commit_message_text(
+        """\
+docs(agent_router): tighten commit rules
+
+Why:
+- tighten docs
+
+What:
+- rewrite the standard
+
+Checks:
+- uv run pytest
+"""
+    )
 
     assert errors == (
         "subject must match `type(scope): imperative summary` or "
         "`type: imperative summary` using one of: feat, fix, refactor, docs, "
         "test, chore, build, ci, perf, revert",
     )
+
+
+def test_missing_structured_body_is_rejected() -> None:
+    errors = validate_commit_message_text("docs: route agents to narrow standards\n")
+
+    assert errors == ("commit message body is required with `Why:`, `What:`, `Checks:` sections",)

--- a/tests/unit/test_pr_metadata_validator.py
+++ b/tests/unit/test_pr_metadata_validator.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from tools.validate_pr_metadata import validate_pr_body, validate_pr_title
+
+
+def test_pr_title_with_conventional_commit_subject_is_valid() -> None:
+    errors = validate_pr_title("refactor: preserve fact model guardrails")
+
+    assert not errors
+
+
+def test_pr_title_without_conventional_commit_subject_is_rejected() -> None:
+    errors = validate_pr_title("cleanup repo history")
+
+    assert errors == (
+        "subject must match `type(scope): imperative summary` or "
+        "`type: imperative summary` using one of: feat, fix, refactor, docs, "
+        "test, chore, build, ci, perf, revert",
+    )
+
+
+def test_pr_body_with_required_sections_is_valid() -> None:
+    body = """\
+Why:
+- keep mainline history concise
+
+What:
+- document and validate squash-merge metadata
+
+Checks:
+- uv run python -m tools.run_quality_gates
+
+Included checkpoints:
+- `docs: codify pull request standards`
+"""
+
+    errors = validate_pr_body(body)
+
+    assert not errors
+
+
+def test_pr_body_rejects_missing_section() -> None:
+    body = """\
+Why:
+- keep mainline history concise
+
+What:
+- document and validate squash-merge metadata
+
+Checks:
+- uv run python -m tools.run_quality_gates
+"""
+
+    errors = validate_pr_body(body)
+
+    assert errors == ("missing `Included checkpoints:` section",)
+
+
+def test_pr_body_rejects_non_bullet_content() -> None:
+    body = """\
+Why:
+keep mainline history concise
+
+What:
+- document and validate squash-merge metadata
+
+Checks:
+- uv run python -m tools.run_quality_gates
+
+Included checkpoints:
+- `docs: codify pull request standards`
+"""
+
+    errors = validate_pr_body(body)
+
+    assert errors == ("`Why:` entries must use `- ` bullets", "`Why:` must contain at least one bullet")

--- a/tests/unit/test_pr_metadata_validator.py
+++ b/tests/unit/test_pr_metadata_validator.py
@@ -41,6 +41,28 @@ Included checkpoints:
     assert not errors
 
 
+def test_pr_body_tolerates_leading_html_comment() -> None:
+    body = """\
+<!-- markdownlint-disable-file MD041 MD032 -->
+
+Why:
+- keep mainline history concise
+
+What:
+- document and validate squash-merge metadata
+
+Checks:
+- uv run python -m tools.run_quality_gates
+
+Included checkpoints:
+- `docs: codify pull request standards`
+"""
+
+    errors = validate_pr_body(body)
+
+    assert not errors
+
+
 def test_pr_body_rejects_missing_section() -> None:
     body = """\
 Why:
@@ -108,6 +130,34 @@ Included checkpoints:
         base_sha="0000000",
         head_sha="1111111",
     )
+
+    assert errors == ()
+
+
+def test_pr_checkpoints_ignore_leading_html_comment(monkeypatch: MonkeyPatch) -> None:
+    body = """\
+<!-- markdownlint-disable-file MD041 MD032 -->
+
+Why:
+- keep mainline history concise
+
+What:
+- document and validate squash-merge metadata
+
+Checks:
+- uv run python -m tools.run_quality_gates
+
+Included checkpoints:
+- `docs: codify pull request standards`
+"""
+
+    def fake_loader(base_sha: str, head_sha: str) -> tuple[str, ...]:
+        del base_sha, head_sha
+        return ("docs: codify pull request standards",)
+
+    monkeypatch.setattr("tools.validate_pr_metadata._load_commit_subjects", fake_loader)
+
+    errors = validate_pr_checkpoints(body, base_sha="base", head_sha="head")
 
     assert errors == ()
 

--- a/tests/unit/test_pr_metadata_validator.py
+++ b/tests/unit/test_pr_metadata_validator.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from tools.validate_pr_metadata import validate_pr_body, validate_pr_title
+from pytest import MonkeyPatch
+
+from tools.validate_pr_metadata import validate_pr_body, validate_pr_checkpoints, validate_pr_title
 
 
 def test_pr_title_with_conventional_commit_subject_is_valid() -> None:
@@ -74,3 +76,89 @@ Included checkpoints:
     errors = validate_pr_body(body)
 
     assert errors == ("`Why:` entries must use `- ` bullets", "`Why:` must contain at least one bullet")
+
+
+def test_pr_checkpoints_match_commit_subjects(monkeypatch: MonkeyPatch) -> None:
+    body = """\
+Why:
+- keep mainline history concise
+
+What:
+- document and validate squash-merge metadata
+
+Checks:
+- uv run python -m tools.run_quality_gates
+
+Included checkpoints:
+- `docs: codify pull request standards`
+- `ci: tighten workflow metadata checks`
+"""
+
+    def fake_loader(base_sha: str, head_sha: str) -> tuple[str, ...]:
+        del base_sha, head_sha
+        return (
+            "docs: codify pull request standards",
+            "ci: tighten workflow metadata checks",
+        )
+
+    monkeypatch.setattr("tools.validate_pr_metadata._load_commit_subjects", fake_loader)
+
+    errors = validate_pr_checkpoints(
+        body,
+        base_sha="0000000",
+        head_sha="1111111",
+    )
+
+    assert errors == ()
+
+
+def test_pr_checkpoints_reject_non_exact_commit_subjects(monkeypatch: MonkeyPatch) -> None:
+    body = """\
+Why:
+- keep mainline history concise
+
+What:
+- document and validate squash-merge metadata
+
+Checks:
+- uv run python -m tools.run_quality_gates
+
+Included checkpoints:
+- docs: codify pull request standards
+"""
+
+    def fake_loader(base_sha: str, head_sha: str) -> tuple[str, ...]:
+        del base_sha, head_sha
+        return ("docs: codify pull request standards",)
+
+    monkeypatch.setattr("tools.validate_pr_metadata._load_commit_subjects", fake_loader)
+
+    errors = validate_pr_checkpoints(body, base_sha="base", head_sha="head")
+
+    assert errors == ("`Included checkpoints:` entries must wrap commit subjects in backticks",)
+
+
+def test_pr_checkpoints_reject_subject_mismatch(monkeypatch: MonkeyPatch) -> None:
+    body = """\
+Why:
+- keep mainline history concise
+
+What:
+- document and validate squash-merge metadata
+
+Checks:
+- uv run python -m tools.run_quality_gates
+
+Included checkpoints:
+- `docs: codify pull request standards`
+"""
+
+    def fake_loader(base_sha: str, head_sha: str) -> tuple[str, ...]:
+        del base_sha, head_sha
+        return ("ci: tighten workflow metadata checks",)
+
+    monkeypatch.setattr("tools.validate_pr_metadata._load_commit_subjects", fake_loader)
+
+    errors = validate_pr_checkpoints(body, base_sha="base", head_sha="head")
+
+    assert errors == ("`Included checkpoints:` must exactly match the branch commit subjects in order",)

--- a/tests/unit/test_quality_gates.py
+++ b/tests/unit/test_quality_gates.py
@@ -14,8 +14,9 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 def test_quality_gates_default_to_fast_commit_time_pytest() -> None:
     gates = _quality_gates(full_tests=False)
 
-    assert [gate.name for gate in gates] == ["ruff", "mypy", "pyright", "pylint", "pytest"]
-    assert gates[3].command == ("uv", "run", "python", "-m", "tools.run_pylint")
+    assert [gate.name for gate in gates] == ["actionlint", "ruff", "mypy", "pyright", "pylint", "pytest"]
+    assert gates[0].command == ("uv", "run", "actionlint", "-color")
+    assert gates[4].command == ("uv", "run", "python", "-m", "tools.run_pylint")
     assert gates[-1].command == DEFAULT_TEST_COMMAND
 
 

--- a/tests/unit/test_quality_gates.py
+++ b/tests/unit/test_quality_gates.py
@@ -14,9 +14,18 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 def test_quality_gates_default_to_fast_commit_time_pytest() -> None:
     gates = _quality_gates(full_tests=False)
 
-    assert [gate.name for gate in gates] == ["actionlint", "ruff", "mypy", "pyright", "pylint", "pytest"]
-    assert gates[0].command == ("uv", "run", "actionlint", "-color")
-    assert gates[4].command == ("uv", "run", "python", "-m", "tools.run_pylint")
+    assert [gate.name for gate in gates] == [
+        "markdownlint",
+        "actionlint",
+        "ruff",
+        "mypy",
+        "pyright",
+        "pylint",
+        "pytest",
+    ]
+    assert gates[0].command == ("uv", "run", "pre-commit", "run", "markdownlint", "--all-files")
+    assert gates[1].command == ("uv", "run", "actionlint", "-color")
+    assert gates[5].command == ("uv", "run", "python", "-m", "tools.run_pylint")
     assert gates[-1].command == DEFAULT_TEST_COMMAND
 
 

--- a/tools/message_standards.py
+++ b/tools/message_standards.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+import re
+
+ALLOWED_TYPES = (
+    "feat",
+    "fix",
+    "refactor",
+    "docs",
+    "test",
+    "chore",
+    "build",
+    "ci",
+    "perf",
+    "revert",
+)
+TYPE_PATTERN = "|".join(ALLOWED_TYPES)
+SCOPE_PATTERN = r"[a-z0-9]+(?:-[a-z0-9]+)*"
+SUBJECT_PATTERN = re.compile(rf"^(?:{TYPE_PATTERN})(?:\(({SCOPE_PATTERN})\))?: (?P<summary>.+)$")
+MERGE_SUBJECT_PATTERN = re.compile(r"^Merge (?:branch|pull request) ")
+FOOTER_PATTERN = re.compile(r"^(?:BREAKING CHANGE|[A-Za-z][A-Za-z0-9-]*):(?: .+)?$")
+LABEL_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9 -]*:(?: .+)?$")
+
+
+def validate_subject_line(subject: str, *, allow_merge: bool = True) -> tuple[str, ...]:
+    if allow_merge and MERGE_SUBJECT_PATTERN.match(subject):
+        return ()
+
+    errors: list[str] = []
+    if len(subject) > 72:
+        errors.append("subject must be 72 characters or fewer")
+    if subject.endswith("."):
+        errors.append("subject must not end with a period")
+    if SUBJECT_PATTERN.fullmatch(subject) is None:
+        allowed_types = ", ".join(ALLOWED_TYPES)
+        errors.append(
+            "subject must match `type(scope): imperative summary` or "
+            f"`type: imperative summary` using one of: {allowed_types}"
+        )
+    return tuple(errors)
+
+
+def _skip_blank_lines(lines: tuple[str, ...], index: int) -> int:
+    while index < len(lines) and lines[index] == "":
+        index += 1
+    return index
+
+
+def _validate_section_bullets(
+    lines: tuple[str, ...],
+    *,
+    section: str,
+    start_index: int,
+) -> tuple[int, tuple[str, ...]]:
+    errors: list[str] = []
+    index = start_index
+    bullet_count = 0
+    while index < len(lines) and lines[index] != "":
+        if not lines[index].startswith("- "):
+            errors.append(f"`{section}:` entries must use `- ` bullets")
+            while index < len(lines) and lines[index] != "":
+                index += 1
+            break
+        bullet_count += 1
+        index += 1
+
+    if bullet_count == 0:
+        errors.append(f"`{section}:` must contain at least one bullet")
+    return index, tuple(errors)
+
+
+def _validate_required_section(
+    lines: tuple[str, ...],
+    *,
+    section: str,
+    start_index: int,
+) -> tuple[int, tuple[str, ...]]:
+    index = _skip_blank_lines(lines, start_index)
+    if index >= len(lines) or lines[index] != f"{section}:":
+        return index, (f"missing `{section}:` section",)
+    return _validate_section_bullets(lines, section=section, start_index=index + 1)
+
+
+def _validate_trailing_lines(
+    lines: tuple[str, ...],
+    *,
+    start_index: int,
+    allow_footers: bool,
+) -> tuple[str, ...]:
+    errors: list[str] = []
+    index = start_index
+    while index < len(lines):
+        line = lines[index]
+        if line == "":
+            index += 1
+            continue
+        if allow_footers and FOOTER_PATTERN.fullmatch(line) is not None:
+            index += 1
+            continue
+        if LABEL_PATTERN.fullmatch(line) is not None:
+            errors.append(f"unsupported structured label: {line}")
+        else:
+            errors.append(f"unexpected trailing content: {line}")
+        index += 1
+    return tuple(errors)
+
+
+def validate_structured_sections(
+    lines: tuple[str, ...],
+    *,
+    required_sections: tuple[str, ...],
+    require_body: bool,
+    label: str,
+    allow_footers: bool,
+) -> tuple[str, ...]:
+    errors: list[str] = []
+    if require_body and len(lines) == 1:
+        sections = ", ".join(f"`{section}:`" for section in required_sections)
+        errors.append(f"{label} body is required with {sections} sections")
+        return tuple(errors)
+
+    index = 2
+    if len(lines) > 1 and lines[1] != "":
+        errors.append("insert a blank line between the subject and the body")
+
+    for section in required_sections:
+        index, section_errors = _validate_required_section(lines, section=section, start_index=index)
+        errors.extend(section_errors)
+
+    errors.extend(_validate_trailing_lines(lines, start_index=index, allow_footers=allow_footers))
+    return tuple(errors)

--- a/tools/message_standards.py
+++ b/tools/message_standards.py
@@ -105,10 +105,12 @@ def _validate_trailing_lines(
     return tuple(errors)
 
 
+# pylint: disable=too-many-arguments
 def validate_structured_sections(
     lines: tuple[str, ...],
     *,
     required_sections: tuple[str, ...],
+    optional_sections: tuple[str, ...] = (),
     require_body: bool,
     label: str,
     allow_footers: bool,
@@ -125,6 +127,17 @@ def validate_structured_sections(
 
     for section in required_sections:
         index, section_errors = _validate_required_section(lines, section=section, start_index=index)
+        errors.extend(section_errors)
+
+    for section in optional_sections:
+        section_start = _skip_blank_lines(lines, index)
+        if section_start >= len(lines) or lines[section_start] != f"{section}:":
+            continue
+        index, section_errors = _validate_section_bullets(
+            lines,
+            section=section,
+            start_index=section_start + 1,
+        )
         errors.extend(section_errors)
 
     errors.extend(_validate_trailing_lines(lines, start_index=index, allow_footers=allow_footers))

--- a/tools/run_ci_parity_checks.py
+++ b/tools/run_ci_parity_checks.py
@@ -48,12 +48,29 @@ def _commit_message_range() -> str:
     return f"{merge_base}..{head_sha}"
 
 
+def _pr_validation_shas() -> tuple[str, str]:
+    default_branch = _default_branch_ref()
+    try:
+        base_sha = _git_stdout("merge-base", "HEAD", default_branch)
+    except subprocess.CalledProcessError:
+        return _git_stdout("rev-parse", "HEAD^"), _git_stdout("rev-parse", "HEAD")
+    return base_sha, _git_stdout("rev-parse", "HEAD")
+
+
 def _build_argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Run local checks that mirror the GitHub Actions CI workflow.")
     parser.add_argument(
         "--include-commit-messages",
         action="store_true",
         help="Also validate the current branch commit-message range before running quality and build checks.",
+    )
+    parser.add_argument(
+        "--pr-title",
+        help="Validate pull request metadata for the current branch using this PR title.",
+    )
+    parser.add_argument(
+        "--pr-body-file",
+        help="Path to a file containing the pull request body to validate for the current branch.",
     )
     return parser
 
@@ -110,6 +127,9 @@ def _run_step(step: ParityStep) -> int:
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parse_args(argv)
+    if (args.pr_title is None) != (args.pr_body_file is None):
+        print("provide both --pr-title and --pr-body-file when validating PR metadata", flush=True)
+        return 2
 
     steps: list[ParityStep] = []
     if args.include_commit_messages:
@@ -124,6 +144,29 @@ def main(argv: Sequence[str] | None = None) -> int:
                     "tools.validate_commit_message",
                     "--rev-range",
                     _commit_message_range(),
+                ),
+            )
+        )
+    if args.pr_title is not None and args.pr_body_file is not None:
+        base_sha, head_sha = _pr_validation_shas()
+        pr_body = Path(args.pr_body_file).read_text(encoding="utf-8")
+        steps.append(
+            ParityStep(
+                name="pr-metadata",
+                command=(
+                    "uv",
+                    "run",
+                    "python",
+                    "-m",
+                    "tools.validate_pr_metadata",
+                    "--title",
+                    args.pr_title,
+                    "--body",
+                    pr_body,
+                    "--base-sha",
+                    base_sha,
+                    "--head-sha",
+                    head_sha,
                 ),
             )
         )

--- a/tools/run_ci_parity_checks.py
+++ b/tools/run_ci_parity_checks.py
@@ -18,8 +18,44 @@ class ParityStep:
     command: tuple[str, ...]
 
 
+def _git_stdout(*args: str) -> str:
+    result = subprocess.run(
+        ("git", *args),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _default_branch_ref() -> str:
+    try:
+        return _git_stdout("symbolic-ref", "--short", "refs/remotes/origin/HEAD")
+    except subprocess.CalledProcessError:
+        return "origin/main"
+
+
+def _commit_message_range() -> str:
+    default_branch = _default_branch_ref()
+    try:
+        merge_base = _git_stdout("merge-base", "HEAD", default_branch)
+    except subprocess.CalledProcessError:
+        return "HEAD^!"
+
+    head_sha = _git_stdout("rev-parse", "HEAD")
+    if merge_base == head_sha:
+        return "HEAD^!"
+    return f"{merge_base}..{head_sha}"
+
+
 def _build_argument_parser() -> argparse.ArgumentParser:
-    return argparse.ArgumentParser(description="Run local checks that mirror the GitHub Actions CI workflow.")
+    parser = argparse.ArgumentParser(description="Run local checks that mirror the GitHub Actions CI workflow.")
+    parser.add_argument(
+        "--include-commit-messages",
+        action="store_true",
+        help="Also validate the current branch commit-message range before running quality and build checks.",
+    )
+    return parser
 
 
 def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -73,13 +109,29 @@ def _run_step(step: ParityStep) -> int:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    _parse_args(argv)
+    args = _parse_args(argv)
 
-    steps = (
+    steps: list[ParityStep] = []
+    if args.include_commit_messages:
+        steps.append(
+            ParityStep(
+                name="commit-messages",
+                command=(
+                    "uv",
+                    "run",
+                    "python",
+                    "-m",
+                    "tools.validate_commit_message",
+                    "--rev-range",
+                    _commit_message_range(),
+                ),
+            )
+        )
+    steps.append(
         ParityStep(
             name="quality",
             command=("uv", "run", "python", "-m", "tools.run_quality_gates", "--full-tests"),
-        ),
+        )
     )
 
     for step in steps:

--- a/tools/run_ci_parity_checks.py
+++ b/tools/run_ci_parity_checks.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import tempfile
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from tools.uv_environment import repo_uv_environment
+
+
+@dataclass(frozen=True)
+class ParityStep:
+    name: str
+    command: tuple[str, ...]
+
+
+def _build_argument_parser() -> argparse.ArgumentParser:
+    return argparse.ArgumentParser(description="Run local checks that mirror the GitHub Actions CI workflow.")
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    return _build_argument_parser().parse_args(argv)
+
+
+def _verify_built_wheel(dist_dir: Path) -> tuple[int, str, str]:
+    wheel_paths = sorted(dist_dir.glob("*.whl"))
+    if not wheel_paths:
+        return 1, "", "no wheel found under dist/"
+
+    with tempfile.TemporaryDirectory(prefix="tallylot-wheel-test-") as tempdir:
+        venv_dir = Path(tempdir) / "venv"
+        subprocess.run(("python3.12", "-m", "venv", str(venv_dir)), check=True)
+        pip_path = venv_dir / "bin/pip"
+        cli_path = venv_dir / "bin/tallylot"
+        install_result = subprocess.run(
+            (str(pip_path), "install", str(wheel_paths[-1])),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if install_result.returncode != 0:
+            return install_result.returncode, install_result.stdout, install_result.stderr
+
+        verify_result = subprocess.run(
+            (str(cli_path), "--help"),
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return verify_result.returncode, verify_result.stdout, verify_result.stderr
+
+
+def _run_step(step: ParityStep) -> int:
+    started = time.perf_counter()
+    result = subprocess.run(
+        step.command,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=repo_uv_environment(),
+    )
+    elapsed = time.perf_counter() - started
+    print(f"[{step.name}] exit={result.returncode} elapsed={elapsed:.2f}s")
+    if result.stdout:
+        print(result.stdout.rstrip())
+    if result.stderr:
+        print(result.stderr.rstrip())
+    return result.returncode
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    _parse_args(argv)
+
+    steps = (
+        ParityStep(
+            name="quality",
+            command=("uv", "run", "python", "-m", "tools.run_quality_gates", "--full-tests"),
+        ),
+    )
+
+    for step in steps:
+        if _run_step(step) != 0:
+            return 1
+
+    dist_dir = Path("dist")
+    shutil.rmtree(dist_dir, ignore_errors=True)
+    build_status = _run_step(ParityStep(name="build", command=("uv", "build")))
+    if build_status != 0:
+        return build_status
+
+    started = time.perf_counter()
+    verify_code, stdout, stderr = _verify_built_wheel(dist_dir)
+    elapsed = time.perf_counter() - started
+    print(f"[verify-wheel] exit={verify_code} elapsed={elapsed:.2f}s")
+    if stdout:
+        print(stdout.rstrip())
+    if stderr:
+        print(stderr.rstrip())
+    return verify_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_quality_gates.py
+++ b/tools/run_quality_gates.py
@@ -37,6 +37,7 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 def _quality_gates(*, full_tests: bool) -> tuple[QualityGate, ...]:
     test_command = FULL_TEST_COMMAND if full_tests else DEFAULT_TEST_COMMAND
     return (
+        QualityGate(name="markdownlint", command=("uv", "run", "pre-commit", "run", "markdownlint", "--all-files")),
         QualityGate(name="actionlint", command=("uv", "run", "actionlint", "-color")),
         QualityGate(name="ruff", command=("uv", "run", "ruff", "check", ".")),
         QualityGate(name="mypy", command=("uv", "run", "mypy")),

--- a/tools/run_quality_gates.py
+++ b/tools/run_quality_gates.py
@@ -37,6 +37,7 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 def _quality_gates(*, full_tests: bool) -> tuple[QualityGate, ...]:
     test_command = FULL_TEST_COMMAND if full_tests else DEFAULT_TEST_COMMAND
     return (
+        QualityGate(name="actionlint", command=("uv", "run", "actionlint", "-color")),
         QualityGate(name="ruff", command=("uv", "run", "ruff", "check", ".")),
         QualityGate(name="mypy", command=("uv", "run", "mypy")),
         QualityGate(name="pyright", command=("uv", "run", "pyright")),

--- a/tools/validate_commit_message.py
+++ b/tools/validate_commit_message.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 import subprocess
 import sys
 from collections.abc import Sequence
@@ -8,6 +9,8 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from tools.message_standards import MERGE_SUBJECT_PATTERN, validate_structured_sections, validate_subject_line
+
+SQUASH_PR_SUBJECT_PATTERN = re.compile(r" \(\#\d+\)$")
 
 
 @dataclass(frozen=True)
@@ -38,11 +41,14 @@ def validate_commit_message_text(message: str) -> tuple[str, ...]:
     if MERGE_SUBJECT_PATTERN.match(subject):
         return ()
 
+    optional_sections = ("Included checkpoints",) if SQUASH_PR_SUBJECT_PATTERN.search(subject) else ()
+
     return (
         *validate_subject_line(subject),
         *validate_structured_sections(
             lines,
             required_sections=("Why", "What", "Checks"),
+            optional_sections=optional_sections,
             require_body=True,
             label="commit message",
             allow_footers=True,

--- a/tools/validate_commit_message.py
+++ b/tools/validate_commit_message.py
@@ -1,32 +1,13 @@
 from __future__ import annotations
 
 import argparse
-import re
 import subprocess
 import sys
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
-ALLOWED_TYPES = (
-    "feat",
-    "fix",
-    "refactor",
-    "docs",
-    "test",
-    "chore",
-    "build",
-    "ci",
-    "perf",
-    "revert",
-)
-TYPE_PATTERN = "|".join(ALLOWED_TYPES)
-SCOPE_PATTERN = r"[a-z0-9]+(?:-[a-z0-9]+)*"
-SUBJECT_PATTERN = re.compile(rf"^(?:{TYPE_PATTERN})(?:\(({SCOPE_PATTERN})\))?: (?P<summary>.+)$")
-MERGE_SUBJECT_PATTERN = re.compile(r"^Merge (?:branch|pull request) ")
-SECTION_PATTERN = re.compile(r"^(?:Why|What|Checks):(?: .+)?$")
-FOOTER_PATTERN = re.compile(r"^(?:BREAKING CHANGE|[A-Za-z][A-Za-z0-9-]*):(?: .+)?$")
-LABEL_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9 -]*:(?: .+)?$")
+from tools.message_standards import MERGE_SUBJECT_PATTERN, validate_structured_sections, validate_subject_line
 
 
 @dataclass(frozen=True)
@@ -57,31 +38,16 @@ def validate_commit_message_text(message: str) -> tuple[str, ...]:
     if MERGE_SUBJECT_PATTERN.match(subject):
         return ()
 
-    errors: list[str] = []
-    if len(subject) > 72:
-        errors.append("subject must be 72 characters or fewer")
-    if subject.endswith("."):
-        errors.append("subject must not end with a period")
-    if SUBJECT_PATTERN.fullmatch(subject) is None:
-        allowed_types = ", ".join(ALLOWED_TYPES)
-        errors.append(
-            "subject must match `type(scope): imperative summary` or "
-            f"`type: imperative summary` using one of: {allowed_types}"
-        )
-    if len(lines) > 1 and lines[1] != "":
-        errors.append("insert a blank line between the subject and the body")
-
-    for line in lines[2:]:
-        if line == "":
-            continue
-        if SECTION_PATTERN.fullmatch(line) is not None:
-            continue
-        if FOOTER_PATTERN.fullmatch(line) is not None:
-            continue
-        if LABEL_PATTERN.fullmatch(line) is not None:
-            errors.append(f"unsupported structured label: {line}")
-
-    return tuple(errors)
+    return (
+        *validate_subject_line(subject),
+        *validate_structured_sections(
+            lines,
+            required_sections=("Why", "What", "Checks"),
+            require_body=True,
+            label="commit message",
+            allow_footers=True,
+        ),
+    )
 
 
 def _load_commit_message_file(path: Path) -> CommitMessage:

--- a/tools/validate_pr_metadata.py
+++ b/tools/validate_pr_metadata.py
@@ -9,10 +9,28 @@ from tools.message_standards import validate_structured_sections, validate_subje
 
 
 def _normalize_body_lines(body: str) -> tuple[str, ...]:
-    lines = tuple(line.rstrip() for line in body.splitlines())
+    lines: list[str] = []
+    in_html_comment = False
+
+    for raw_line in body.splitlines():
+        line = raw_line.rstrip()
+        stripped = line.strip()
+
+        if in_html_comment:
+            if "-->" in stripped:
+                in_html_comment = False
+            continue
+
+        if stripped.startswith("<!--"):
+            if "-->" not in stripped:
+                in_html_comment = True
+            continue
+
+        lines.append(line)
+
     while lines and lines[-1] == "":
-        lines = lines[:-1]
-    return lines
+        lines.pop()
+    return tuple(lines)
 
 
 def _parse_required_sections(body: str) -> dict[str, tuple[str, ...]]:

--- a/tools/validate_pr_metadata.py
+++ b/tools/validate_pr_metadata.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+
+from tools.message_standards import validate_structured_sections, validate_subject_line
+
+
+def _normalize_body_lines(body: str) -> tuple[str, ...]:
+    lines = tuple(line.rstrip() for line in body.splitlines())
+    while lines and lines[-1] == "":
+        lines = lines[:-1]
+    return lines
+
+
+def validate_pr_title(title: str) -> tuple[str, ...]:
+    stripped = title.strip()
+    if stripped == "":
+        return ("PR title is required",)
+    return validate_subject_line(stripped, allow_merge=False)
+
+
+def validate_pr_body(body: str) -> tuple[str, ...]:
+    lines = _normalize_body_lines(body)
+    if not lines:
+        return ("PR body is required",)
+    return validate_structured_sections(
+        ("placeholder", "", *lines),
+        required_sections=("Why", "What", "Checks", "Included checkpoints"),
+        require_body=True,
+        label="PR",
+        allow_footers=False,
+    )
+
+
+def _build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Validate pull request title and body for squash merges.")
+    parser.add_argument("--title", required=True, help="Pull request title.")
+    parser.add_argument("--body", required=True, help="Pull request body.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _build_argument_parser().parse_args(argv)
+
+    errors = [*validate_pr_title(args.title), *validate_pr_body(args.body)]
+    if not errors:
+        return 0
+
+    print("pull request metadata failed validation:", file=sys.stderr)
+    for error in errors:
+        print(f"  - {error}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_pr_metadata.py
+++ b/tools/validate_pr_metadata.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import subprocess
 import sys
 from collections.abc import Sequence
 
@@ -12,6 +13,42 @@ def _normalize_body_lines(body: str) -> tuple[str, ...]:
     while lines and lines[-1] == "":
         lines = lines[:-1]
     return lines
+
+
+def _parse_required_sections(body: str) -> dict[str, tuple[str, ...]]:
+    sections = ("Why", "What", "Checks", "Included checkpoints")
+    parsed: dict[str, list[str]] = {section: [] for section in sections}
+    current_section: str | None = None
+
+    for line in _normalize_body_lines(body):
+        if line in {f"{section}:" for section in sections}:
+            current_section = line[:-1]
+            continue
+        if line == "":
+            current_section = None
+            continue
+        if current_section is None:
+            continue
+        parsed[current_section].append(line)
+
+    return {section: tuple(values) for section, values in parsed.items()}
+
+
+def _normalize_checkpoint_entry(entry: str) -> str:
+    text = entry.removeprefix("- ").strip()
+    if text.startswith("`") and text.endswith("`") and len(text) >= 2:
+        return text[1:-1]
+    return text
+
+
+def _load_commit_subjects(base_sha: str, head_sha: str) -> tuple[str, ...]:
+    revision_result = subprocess.run(
+        ["git", "log", "--format=%s", "--reverse", f"{base_sha}..{head_sha}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return tuple(line for line in revision_result.stdout.splitlines() if line)
 
 
 def validate_pr_title(title: str) -> tuple[str, ...]:
@@ -34,10 +71,33 @@ def validate_pr_body(body: str) -> tuple[str, ...]:
     )
 
 
+def validate_pr_checkpoints(body: str, *, base_sha: str, head_sha: str) -> tuple[str, ...]:
+    parsed_sections = _parse_required_sections(body)
+    checkpoint_entries = parsed_sections["Included checkpoints"]
+    normalized_entries = tuple(_normalize_checkpoint_entry(entry) for entry in checkpoint_entries)
+    actual_subjects = _load_commit_subjects(base_sha, head_sha)
+
+    errors: list[str] = []
+    for entry, normalized in zip(checkpoint_entries, normalized_entries, strict=False):
+        if not entry.startswith("- `") or not entry.endswith("`"):
+            errors.append("`Included checkpoints:` entries must wrap commit subjects in backticks")
+            break
+
+        if validate_subject_line(normalized, allow_merge=False):
+            errors.append("`Included checkpoints:` entries must be exact Conventional Commit subjects")
+            break
+
+    if normalized_entries != actual_subjects:
+        errors.append("`Included checkpoints:` must exactly match the branch commit subjects in order")
+    return tuple(errors)
+
+
 def _build_argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Validate pull request title and body for squash merges.")
     parser.add_argument("--title", required=True, help="Pull request title.")
     parser.add_argument("--body", required=True, help="Pull request body.")
+    parser.add_argument("--base-sha", help="Base commit SHA for validating included checkpoints.")
+    parser.add_argument("--head-sha", help="Head commit SHA for validating included checkpoints.")
     return parser
 
 
@@ -45,6 +105,8 @@ def main(argv: Sequence[str] | None = None) -> int:
     args = _build_argument_parser().parse_args(argv)
 
     errors = [*validate_pr_title(args.title), *validate_pr_body(args.body)]
+    if args.base_sha and args.head_sha:
+        errors.extend(validate_pr_checkpoints(args.body, base_sha=args.base_sha, head_sha=args.head_sha))
     if not errors:
         return 0
 

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,12 @@ version = 1
 requires-python = ">=3.12"
 
 [[package]]
+name = "actionlint-py"
+version = "1.7.12.24"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/0b/3f29683dfbe94208fb5c3806806a6ef419972892e25c3c4f95198f68c978/actionlint_py-1.7.12.24.tar.gz", hash = "sha256:7571b0724fde79b2572b98b2b53792c470249d4db29951b57fc49b9cd3eaf11e", size = 12071 }
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -213,49 +219,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/db/51/37221f59a111dca5e85be7dbf09696323b5b9f13ff65e0641d535ed06ea8/coverage-7.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:301e3b7dfefecaca37c9f1aa6f0049b7d4ab8dd933742b607765d757aca77d43", size = 224254 },
     { url = "https://files.pythonhosted.org/packages/54/83/6acacc889de8987441aa7d5adfbdbf33d288dad28704a67e574f1df9bcbb/coverage-7.13.5-cp314-cp314t-win_arm64.whl", hash = "sha256:9dacc2ad679b292709e0f5fc1ac74a6d4d5562e424058962c7bb0c658ad25e45", size = 222276 },
     { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346 },
-]
-
-[[package]]
-name = "tallylot"
-version = "0.1.0"
-source = { editable = "." }
-dependencies = [
-    { name = "pydantic" },
-    { name = "pypdf" },
-    { name = "typer" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "mypy" },
-    { name = "pre-commit" },
-    { name = "pylint" },
-    { name = "pyright" },
-    { name = "pytest" },
-    { name = "pytest-cov" },
-    { name = "pytest-xdist" },
-    { name = "reportlab" },
-    { name = "ruff" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "pydantic", specifier = ">=2.11.0,<3.0.0" },
-    { name = "pypdf", specifier = ">=5.4.0,<6.0.0" },
-    { name = "typer", specifier = ">=0.15.2,<1.0.0" },
-]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "mypy", specifier = ">=1.15.0,<2.0.0" },
-    { name = "pre-commit", specifier = ">=4.2.0,<5.0.0" },
-    { name = "pylint", specifier = ">=3.3.6,<4.0.0" },
-    { name = "pyright", specifier = ">=1.1.399,<2.0.0" },
-    { name = "pytest", specifier = ">=8.3.5,<9.0.0" },
-    { name = "pytest-cov", specifier = ">=6.0.0,<7.0.0" },
-    { name = "pytest-xdist", specifier = ">=3.6.1,<4.0.0" },
-    { name = "reportlab", specifier = ">=4.4.0,<5.0.0" },
-    { name = "ruff", specifier = ">=0.11.2,<0.12.0" },
 ]
 
 [[package]]
@@ -666,6 +629,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyflakes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/dc/fd034dc20b4b264b3d015808458391acbf9df40b1e54750ef175d39180b1/pyflakes-3.4.0.tar.gz", hash = "sha256:b24f96fafb7d2ab0ec5075b7350b3d2d2218eab42003821c06344973d3ea2f58", size = 64669 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/2f/81d580a0fb83baeb066698975cb14a618bdbed7720678566f1b046a95fe8/pyflakes-3.4.0-py2.py3-none-any.whl", hash = "sha256:f742a7dbd0d9cb9ea41e9a24a918996e8170c799fa528688d40dd582c8265f4f", size = 63551 },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -868,12 +840,77 @@ wheels = [
 ]
 
 [[package]]
+name = "shellcheck-py"
+version = "0.11.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/55/455b097417b3df3d330eff029c72c32f08b25739e3010acb30ad06d268ef/shellcheck_py-0.11.0.1.tar.gz", hash = "sha256:5c620c88901e8f1d3be5934b31ea99e3310065e1245253741eafd0a275c8c9cc", size = 3139 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/27/d75b03e5458cefdb6d3b674566cd20476c3e4d3fe6cc9d68b7e3b854b296/shellcheck_py-0.11.0.1-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:b6a3fee28efda2e16e38d6e6d59faf7224300256456639727370d404730849e8", size = 6774472 },
+    { url = "https://files.pythonhosted.org/packages/61/ac/2a84c37171c0cf5a10ea4b0a27d43eb0a1d29bd98b49c2c5ffe17ad24bbe/shellcheck_py-0.11.0.1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:6b88d0a244c82ed07e06a53e444da841f69330ca59ae15d4a66c391655dae7a0", size = 11381835 },
+    { url = "https://files.pythonhosted.org/packages/96/55/250e0e3367613a5c22bd82e33b16b889287d81ab0f7dda67e6514a4cccf4/shellcheck_py-0.11.0.1-py2.py3-none-manylinux1_x86_64.manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:1b274df81de5b000ff78db433e7328b87e52e3c38481c60f8e488c3095beef05", size = 3800600 },
+    { url = "https://files.pythonhosted.org/packages/15/5b/bb14c0a7474463b1aa3c09e866cb172dffc66ed2993b7ea8f1db581e86ee/shellcheck_py-0.11.0.1-py2.py3-none-win_amd64.whl", hash = "sha256:784156289ecb17e91c692cd783ab5152333309588cabb10032a047331c63e759", size = 8027541 },
+]
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755 },
+]
+
+[[package]]
+name = "tallylot"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "pydantic" },
+    { name = "pypdf" },
+    { name = "typer" },
+]
+
+[package.dev-dependencies]
+ci = [
+    { name = "actionlint-py" },
+    { name = "pyflakes" },
+    { name = "shellcheck-py" },
+]
+dev = [
+    { name = "mypy" },
+    { name = "pre-commit" },
+    { name = "pylint" },
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-cov" },
+    { name = "pytest-xdist" },
+    { name = "reportlab" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pydantic", specifier = ">=2.11.0,<3.0.0" },
+    { name = "pypdf", specifier = ">=5.4.0,<6.0.0" },
+    { name = "typer", specifier = ">=0.15.2,<1.0.0" },
+]
+
+[package.metadata.requires-dev]
+ci = [
+    { name = "actionlint-py", specifier = ">=1.7.12.24,<2.0.0" },
+    { name = "pyflakes", specifier = ">=3.4.0,<4.0.0" },
+    { name = "shellcheck-py", specifier = ">=0.11.0.1,<1.0.0" },
+]
+dev = [
+    { name = "mypy", specifier = ">=1.15.0,<2.0.0" },
+    { name = "pre-commit", specifier = ">=4.2.0,<5.0.0" },
+    { name = "pylint", specifier = ">=3.3.6,<4.0.0" },
+    { name = "pyright", specifier = ">=1.1.399,<2.0.0" },
+    { name = "pytest", specifier = ">=8.3.5,<9.0.0" },
+    { name = "pytest-cov", specifier = ">=6.0.0,<7.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.6.1,<4.0.0" },
+    { name = "reportlab", specifier = ">=4.4.0,<5.0.0" },
+    { name = "ruff", specifier = ">=0.11.2,<0.12.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Why:
- the branch turns PR metadata, commit messages, and local verification
into repo-enforced workflow standards instead of relying on memory
- GitHub Actions was still failing after valid squash merges because the
generated `main` commit retained PR checkpoint metadata that the
push-side commit validator did not accept
- local CI parity still missed PR metadata validation and the workflow
still linted tests more strictly than the repo's intended
protected-access policy

What:
- enforce structured commit and PR metadata in CI, add local workflow
and CI-parity checks, and align the docs, templates, and agent guidance
with that policy
- fix PR metadata parsing for template HTML comments, allow
GitHub-generated squash commits on `main` to retain `Included
checkpoints:`, and add current-branch PR metadata validation to the
local CI parity runner
- align the GitHub Actions pylint step with `tools.run_pylint` so tests
keep their allowed private-member access in both local and remote
verification, and clean up the remaining fixture-level whitespace
leftover found during red teaming
- generalize the local PR metadata parity example so the standards doc
does not capture a task-specific PR number

Checks:
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pytest -q
--no-cov tests/unit/test_commit_message_validator.py
tests/unit/test_pr_metadata_validator.py
tests/unit/test_ci_parity_checks.py tests/unit/test_quality_gates.py`
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m
tools.validate_commit_message --rev-range main..ci/harden-merge-metadata-and-verification-policy`
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m
tools.run_ci_parity_checks`

Included checkpoints:
- `ci(workflow): enforce structured commit and pull request metadata`
- `ci(actions): harden workflow triggers and execution guardrails`
- `fix(pr): align template and checkpoint validation`
- `ci(workflow): add local and remote workflow lint parity`
- `docs(commits): refresh local commit template checks`
- `ci(quality): add markdownlint coverage and local ci parity checks`
- `docs(workflow): codify diagnostics-first verification flow`
- `fix(pr): ignore template comments during metadata validation`
- `fix(ci): accept squash merge metadata on main`
- `fix(ci): close workflow parity gaps`
- `docs(commits): generalize PR parity example`
- `test(commits): remove stray fixture whitespace`
