### PR TITLE
fix(ci): accept wrapped squash-merge commit bullets

### DIFF
--- a/tests/unit/test_commit_message_validator.py
+++ b/tests/unit/test_commit_message_validator.py
@@ -92,6 +92,35 @@ Included checkpoints:
     assert not errors
 
 
+def test_squash_merge_commit_message_allows_wrapped_bullet_lines() -> None:
+    message = """\
+feat(docs): reshape repo docs and harden maintenance workflow (#14)
+
+Why:
+- reshape the repo docs into a cleaner human-first structure without
+losing agent routing or mirrored workspace guidance
+- make the public and internal entrypoints easier to navigate and keep
+aligned with the actual TallyLot product surface
+
+What:
+- rewrite the public README, docs homepage, agent routing, and
+supporting standards around the new concepts, guides, reference,
+standards, and status model
+
+Checks:
+- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pytest
+tests/unit/test_docs_maintenance.py
+tests/unit/test_docs_runtime_parity.py -q --no-cov`
+
+Included checkpoints:
+- `docs(roadmap): clarify planning and state docs`
+"""
+
+    errors = validate_commit_message_text(message)
+
+    assert not errors
+
+
 def test_invalid_type_is_rejected() -> None:
     errors = validate_commit_message_text(
         """\

--- a/tests/unit/test_pre_commit_hook.py
+++ b/tests/unit/test_pre_commit_hook.py
@@ -35,9 +35,10 @@ def test_skip_value_appends_formatter_hooks_once() -> None:
 
 def test_install_hook_template_execs_repo_pre_commit_wrapper() -> None:
     assert "-m tools.pre_commit_hook" in HOOK_TEMPLATE
-    assert 'REPO_ROOT="$(cd "$HOOK_DIR/../.." && pwd)"' in HOOK_TEMPLATE
+    assert 'REPO_ROOT="$(git rev-parse --show-toplevel)"' in HOOK_TEMPLATE
     assert 'export UV_PROJECT_ENVIRONMENT="$PROJECT_ENVIRONMENT"' in HOOK_TEMPLATE
     assert "--hook-type=commit-msg" in COMMIT_MSG_HOOK_TEMPLATE
+    assert 'REPO_ROOT="$(git rev-parse --show-toplevel)"' in COMMIT_MSG_HOOK_TEMPLATE
 
 
 def test_install_hooks_uses_pre_commit_overwrite_mode(

--- a/tools/install_git_hooks.py
+++ b/tools/install_git_hooks.py
@@ -12,7 +12,7 @@ HOOK_TEMPLATE = """#!/usr/bin/env bash
 set -euo pipefail
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$HOOK_DIR/../.." && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
 PROJECT_ENVIRONMENT={project_environment}
@@ -37,7 +37,7 @@ COMMIT_MSG_HOOK_TEMPLATE = """#!/usr/bin/env bash
 set -euo pipefail
 
 HOOK_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$HOOK_DIR/../.." && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
 PROJECT_ENVIRONMENT={project_environment}

--- a/tools/message_standards.py
+++ b/tools/message_standards.py
@@ -63,6 +63,13 @@ def _validate_section_bullets(
             break
         bullet_count += 1
         index += 1
+        while (
+            index < len(lines)
+            and lines[index] != ""
+            and not lines[index].startswith("- ")
+            and LABEL_PATTERN.fullmatch(lines[index]) is None
+        ):
+            index += 1
 
     if bullet_count == 0:
         errors.append(f"`{section}:` must contain at least one bullet")


### PR DESCRIPTION
Why:
- main push runs are failing after green PR merges because GitHub wraps
long squash-merge bullet items across multiple lines
- the commit-message validator currently treats those wrapped
continuation lines as malformed section entries, so post-merge CI fails
even though the validated PR body is correct
- linked worktrees also install hooks into the shared hooks directory,
so deriving the repo root from the hook path can execute checks against
the wrong checkout
- that leaves main red after successful merges and weakens the repo's
branch-protection signal

What:
- teach the structured-section parser to accept wrapped continuation
lines under bullet items until the next bullet, blank line, or section
label
- add a regression test that matches the real GitHub-style wrapped
squash-merge body shape seen on main
- resolve the active repo root inside generated hook scripts with `git
rev-parse --show-toplevel` so pre-commit and commit-msg hooks follow the
active worktree instead of the original checkout
- add hook-template regression coverage for the worktree-safe root
resolution

Checks:
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pytest
tests/unit/test_pre_commit_hook.py
tests/unit/test_commit_message_validator.py
tests/unit/test_ci_parity_checks.py -q --no-cov`
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m
tools.run_ci_parity_checks --include-commit-messages`

Included checkpoints:
- `fix(ci): accept wrapped squash-merge commit bullets`
- `fix(hooks): resolve active worktree root at runtime`
