### PR TITLE
refactor(repo-support): centralize repo-side path resolution

### DIFF
--- a/.pylintrc-tests
+++ b/.pylintrc-tests
@@ -1,0 +1,19 @@
+[MAIN]
+py-version = 3.12
+ignore = .venv,__pycache__,.git
+source-roots = src,.
+
+[MESSAGES CONTROL]
+disable =
+    missing-module-docstring,
+    missing-class-docstring,
+    missing-function-docstring,
+    too-few-public-methods,
+    duplicate-code,
+    too-many-instance-attributes,
+    too-many-locals,
+    protected-access
+
+[FORMAT]
+max-line-length = 120
+max-module-lines = 450

--- a/conftest.py
+++ b/conftest.py
@@ -8,21 +8,31 @@ from pytest import Item
 from repo_support.paths import fixtures_root, src_root
 from tallylot.infrastructure.serialization import FilesystemArtifactStore
 
-ADAPTER_ROOT = src_root() / "tallylot" / "adapters"
-ADAPTER_TEST_DIRS = tuple(sorted(path.resolve() for path in ADAPTER_ROOT.glob("**/tests")))
-ADAPTER_TEST_ANCESTORS = frozenset(
-    {
-        ancestor
-        for test_dir in ADAPTER_TEST_DIRS
-        for ancestor in (test_dir, *test_dir.parents)
-        if ancestor.is_relative_to(ADAPTER_ROOT)
-    }
-)
 MARKERS_BY_TEST_DIR = {
     "unit": "unit",
     "contract": "contract",
     "e2e": "e2e",
 }
+
+
+def _adapter_root() -> Path:
+    return src_root() / "tallylot" / "adapters"
+
+
+def _adapter_test_dirs() -> tuple[Path, ...]:
+    return tuple(sorted(path.resolve() for path in _adapter_root().glob("**/tests")))
+
+
+def _adapter_test_ancestors() -> frozenset[Path]:
+    adapter_root = _adapter_root()
+    return frozenset(
+        {
+            ancestor
+            for test_dir in _adapter_test_dirs()
+            for ancestor in (test_dir, *test_dir.parents)
+            if ancestor.is_relative_to(adapter_root)
+        }
+    )
 
 
 @pytest.fixture
@@ -59,11 +69,12 @@ def pytest_collection_modifyitems(items: list[Item]) -> None:
 
 def pytest_ignore_collect(collection_path: Path) -> bool:
     path = collection_path.resolve()
-    if not path.is_relative_to(ADAPTER_ROOT):
+    adapter_root = _adapter_root()
+    if not path.is_relative_to(adapter_root):
         return False
     if path.is_dir():
-        return path not in ADAPTER_TEST_ANCESTORS
-    return not any(path.is_relative_to(test_dir) for test_dir in ADAPTER_TEST_DIRS)
+        return path not in _adapter_test_ancestors()
+    return not any(path.is_relative_to(test_dir) for test_dir in _adapter_test_dirs())
 
 
 def _marker_for_test_path(path: Path) -> str | None:
@@ -71,6 +82,6 @@ def _marker_for_test_path(path: Path) -> str | None:
         marker = MARKERS_BY_TEST_DIR.get(part)
         if marker is not None:
             return marker
-    if any(path.is_relative_to(test_dir) for test_dir in ADAPTER_TEST_DIRS):
+    if any(path.is_relative_to(test_dir) for test_dir in _adapter_test_dirs()):
         return "unit"
     return None

--- a/conftest.py
+++ b/conftest.py
@@ -5,10 +5,10 @@ from pathlib import Path
 import pytest
 from pytest import Item
 
+from repo_support.paths import fixtures_root, src_root
 from tallylot.infrastructure.serialization import FilesystemArtifactStore
 
-REPO_ROOT = Path(__file__).resolve().parent
-ADAPTER_ROOT = REPO_ROOT / "src" / "tallylot" / "adapters"
+ADAPTER_ROOT = src_root() / "tallylot" / "adapters"
 ADAPTER_TEST_DIRS = tuple(sorted(path.resolve() for path in ADAPTER_ROOT.glob("**/tests")))
 ADAPTER_TEST_ANCESTORS = frozenset(
     {
@@ -27,22 +27,22 @@ MARKERS_BY_TEST_DIR = {
 
 @pytest.fixture
 def structured_source_dir() -> Path:
-    return REPO_ROOT / "tests" / "fixtures" / "structured_csv_source" / "raw"
+    return fixtures_root() / "structured_csv_source" / "raw"
 
 
 @pytest.fixture
 def baseline_export_dir() -> Path:
-    return REPO_ROOT / "tests" / "fixtures" / "baseline_exports"
+    return fixtures_root() / "baseline_exports"
 
 
 @pytest.fixture
 def verification_previous_dir() -> Path:
-    return REPO_ROOT / "tests" / "fixtures" / "verification" / "previous"
+    return fixtures_root() / "verification" / "previous"
 
 
 @pytest.fixture
 def verification_current_dir() -> Path:
-    return REPO_ROOT / "tests" / "fixtures" / "verification" / "current"
+    return fixtures_root() / "verification" / "current"
 
 
 @pytest.fixture

--- a/docs/standards/engineering.md
+++ b/docs/standards/engineering.md
@@ -26,9 +26,22 @@ Place code by responsibility, not by convenience:
 - `adapters/`: source and output adapters plus their adapter-local helpers.
 - `interfaces/`: thin entry points such as the CLI. Interfaces orchestrate
   services; they do not own business rules.
+- `repo_support/`: shared support seams for repo-native tooling and repo-side
+  tests. Keep this outside `src/tallylot/` because it is not production/runtime
+  code.
 
 If a change crosses layer boundaries, refactor the boundary instead of
 importing through it.
+
+Repo-native support boundaries:
+
+- `src/tallylot/` remains production/runtime code only.
+- `tools/` remains the home for repo-native entry points and task-specific
+  dev-only modules.
+- `repo_support/` is the shared support seam for repo-native tooling and
+  repo-side tests.
+- `repo_support/` must stay narrow, typed, stdlib-first, and named by concept.
+- `repo_support/` must not become a generic catch-all.
 
 ## Typing Rules
 
@@ -68,6 +81,8 @@ Default to one responsibility per module.
   `misc.py`, or another catch-all `common.py`.
 - Existing generic modules should shrink over time, not absorb more unrelated
   behavior.
+- Apply the same rule to `repo_support/`. Shared repo-only support must be
+  split by named seam, not collected under generic support modules.
 
 When a capability grows, split by stable seams:
 
@@ -87,6 +102,9 @@ When a capability grows, split by stable seams:
   cross-capability concerns such as filesystem guards, serialization, workspace
   persistence, or composition-root wiring. Do not push application policy down
   here just to share code.
+- `repo_support/`: host reusable repo-only support only when it is shared by
+  multiple repo-native surfaces such as `tools/` and `tests/`. Do not move
+  production/runtime concerns here.
 
 Mirror that structure in tests:
 

--- a/docs/standards/implementation.md
+++ b/docs/standards/implementation.md
@@ -51,6 +51,13 @@ Prefer the repo's built-in tooling before inventing local workflows:
 Do not replace these with ad hoc shell habits when the repo already has a
 supported path.
 
+When repo-native tooling and tests need shared support:
+
+- keep production/runtime concerns out of `tools/` and `repo_support/`
+- keep shared repo-only support in `repo_support/`, not in ad hoc duplicated
+  test helpers or tool-local path constants
+- keep `tools/` focused on entry points and task-specific dev modules
+
 ## Default Coding Posture
 
 Agents should assume all of these are expected unless the task explicitly says
@@ -117,6 +124,14 @@ Avoid generic sinks:
 - `utils.py`
 - `common.py`
 - broad cross-layer convenience modules
+
+For repo-native tooling and test support:
+
+- use `repo_support/` only for narrow shared seams that are reused by multiple
+  repo-native surfaces
+- do not create generic `repo_support/helpers.py` or `repo_support/utils.py`
+- if only one tool owns the logic, keep it local to that tool instead of
+  promoting it into `repo_support/`
 
 Shared components must stay owned by one layer and one concept.
 

--- a/repo_support/__init__.py
+++ b/repo_support/__init__.py
@@ -1,0 +1,1 @@
+"""Shared repo-only support for tools and tests."""

--- a/repo_support/paths.py
+++ b/repo_support/paths.py
@@ -5,25 +5,29 @@ from contextlib import contextmanager
 from pathlib import Path
 
 _DEFAULT_REPO_ROOT = Path(__file__).resolve().parents[1]
-_ACTIVE_REPO_ROOT = _DEFAULT_REPO_ROOT
+_STATE = {"repo_root": _DEFAULT_REPO_ROOT}
 
 
 def _normalize_root(path: Path) -> Path:
     return path.expanduser().resolve()
 
 
+def _resolve_repo_path(path: Path) -> Path:
+    if path.is_absolute():
+        return path.resolve()
+    return (repo_root() / path).resolve()
+
+
 def repo_root() -> Path:
-    return _ACTIVE_REPO_ROOT
+    return _STATE["repo_root"]
 
 
 def set_repo_root(path: Path) -> None:
-    global _ACTIVE_REPO_ROOT
-    _ACTIVE_REPO_ROOT = _normalize_root(path)
+    _STATE["repo_root"] = _normalize_root(path)
 
 
 def reset_repo_root() -> None:
-    global _ACTIVE_REPO_ROOT
-    _ACTIVE_REPO_ROOT = _DEFAULT_REPO_ROOT
+    _STATE["repo_root"] = _DEFAULT_REPO_ROOT
 
 
 @contextmanager
@@ -69,7 +73,7 @@ def vscode_settings_path() -> Path:
 
 
 def relative_repo_path(path: Path) -> str:
-    return path.relative_to(repo_root()).as_posix()
+    return _resolve_repo_path(path).relative_to(repo_root()).as_posix()
 
 
 def display_repo_path(path: Path) -> str:

--- a/repo_support/paths.py
+++ b/repo_support/paths.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+
+_DEFAULT_REPO_ROOT = Path(__file__).resolve().parents[1]
+_ACTIVE_REPO_ROOT = _DEFAULT_REPO_ROOT
+
+
+def _normalize_root(path: Path) -> Path:
+    return path.expanduser().resolve()
+
+
+def repo_root() -> Path:
+    return _ACTIVE_REPO_ROOT
+
+
+def set_repo_root(path: Path) -> None:
+    global _ACTIVE_REPO_ROOT
+    _ACTIVE_REPO_ROOT = _normalize_root(path)
+
+
+def reset_repo_root() -> None:
+    global _ACTIVE_REPO_ROOT
+    _ACTIVE_REPO_ROOT = _DEFAULT_REPO_ROOT
+
+
+@contextmanager
+def override_repo_root(path: Path) -> Iterator[Path]:
+    previous_root = repo_root()
+    set_repo_root(path)
+    try:
+        yield repo_root()
+    finally:
+        set_repo_root(previous_root)
+
+
+def src_root() -> Path:
+    return repo_root() / "src"
+
+
+def tests_root() -> Path:
+    return repo_root() / "tests"
+
+
+def fixtures_root() -> Path:
+    return tests_root() / "fixtures"
+
+
+def adapter_packs_root() -> Path:
+    return fixtures_root() / "adapter_packs"
+
+
+def docs_root() -> Path:
+    return repo_root() / "docs"
+
+
+def agents_root() -> Path:
+    return repo_root() / "agents"
+
+
+def claude_commands_root() -> Path:
+    return repo_root() / ".claude" / "commands"
+
+
+def vscode_settings_path() -> Path:
+    return repo_root() / ".vscode" / "settings.json"
+
+
+def relative_repo_path(path: Path) -> str:
+    return path.relative_to(repo_root()).as_posix()
+
+
+def display_repo_path(path: Path) -> str:
+    try:
+        return relative_repo_path(path)
+    except ValueError:
+        return str(path)

--- a/src/tallylot/adapters/sources/platforms/coinbase/tests/test_matching.py
+++ b/src/tallylot/adapters/sources/platforms/coinbase/tests/test_matching.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from decimal import Decimal
 from pathlib import Path
 
+from repo_support.paths import adapter_packs_root
 from tallylot.adapters.sources.platforms.coinbase.adapter import CoinbaseAdapter
 from tallylot.adapters.sources.platforms.coinbase.matching import RETAIL_HEADER
 from tallylot.adapters.sources.platforms.coinbase.timestamps import parse_retail_timestamp
@@ -13,8 +14,6 @@ from tallylot.infrastructure.discovery import build_registry
 from tallylot.infrastructure.serialization.filesystem import FilesystemArtifactStore
 from tallylot.ports.source_adapters import SourceAdapter
 from tallylot.ports.source_profiles import FileInventoryEntry, SourceProfile
-
-FIXTURE_ROOT = Path(__file__).resolve().parents[7] / "tests" / "fixtures" / "adapter_packs"
 
 
 def _profile_and_adapter(source: str, raw_dir: Path) -> tuple[SourceProfile, SourceAdapter]:
@@ -50,7 +49,7 @@ def test_coinbase_adapter_matches_retail_header_without_source_label(tmp_path: P
 
 
 def test_coinbase_adapter_uses_retail_family_without_filename_dependency() -> None:
-    raw_dir = FIXTURE_ROOT / "coinbase" / "retail_buy_renamed" / "raw"
+    raw_dir = adapter_packs_root() / "coinbase" / "retail_buy_renamed" / "raw"
 
     profile, adapter = _profile_and_adapter("Future Exchange", raw_dir)
     result = adapter.translate(profile, raw_dir)

--- a/tests/contract/test_standards_guards.py
+++ b/tests/contract/test_standards_guards.py
@@ -8,10 +8,10 @@ import tomllib
 from collections import defaultdict
 from pathlib import Path
 
+from repo_support.paths import repo_root
 from tallylot.adapters.support.drafts import economic_leg
 from tallylot.domain.transactions import EconomicLeg, ProjectionHint, TransactionFact
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
 CLASSIFICATION_KEYWORDS = frozenset(
     {
         "economic_kind",
@@ -28,6 +28,21 @@ def _module(path: Path) -> ast.Module:
 
 def _python_files(root: Path) -> tuple[Path, ...]:
     return tuple(sorted(root.rglob("*.py")))
+
+
+def _repo_side_python_files() -> tuple[Path, ...]:
+    root = repo_root()
+    repo_side_paths = (
+        root / "conftest.py",
+        *sorted((root / "repo_support").rglob("*.py")),
+        *sorted((root / "tools").rglob("*.py")),
+        *sorted((root / "tests").rglob("*.py")),
+        *sorted((root / "src" / "tallylot").rglob("tests/**/*.py")),
+    )
+    seen: dict[Path, None] = {}
+    for path in repo_side_paths:
+        seen[path] = None
+    return tuple(seen)
 
 
 def _production_python_files(root: Path) -> tuple[Path, ...]:
@@ -61,12 +76,35 @@ def _assert_no_imports(root: Path, forbidden_modules: tuple[str, ...], *, produc
                         )
 
 
+def _uses_direct_repo_root_derivation(path: Path) -> bool:
+    module = _module(path)
+    for node in ast.walk(module):
+        if not isinstance(node, ast.Assign | ast.AnnAssign | ast.NamedExpr | ast.Call | ast.Attribute | ast.Subscript):
+            continue
+        if "Path(__file__).resolve().parents[" in ast.unparse(node):
+            return True
+    return False
+
+
+def _defines_root_constants(path: Path) -> bool:
+    constant_names = {"REPO_ROOT", "DOCS_ROOT", "AGENTS_ROOT"}
+    module = _module(path)
+    for node in module.body:
+        if isinstance(node, ast.Assign) and any(
+            isinstance(target, ast.Name) and target.id in constant_names for target in node.targets
+        ):
+            return True
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.target.id in constant_names:
+            return True
+    return False
+
+
 def test_repo_has_no_type_ignore_comments() -> None:
     python_files = (
-        REPO_ROOT / "conftest.py",
-        *_python_files(REPO_ROOT / "src"),
-        *_python_files(REPO_ROOT / "tests"),
-        *_python_files(REPO_ROOT / "tools"),
+        repo_root() / "conftest.py",
+        *_python_files(repo_root() / "src"),
+        *_python_files(repo_root() / "tests"),
+        *_python_files(repo_root() / "tools"),
     )
     forbidden = ("type:" + " ignore", "pyright:" + " ignore")
 
@@ -76,14 +114,46 @@ def test_repo_has_no_type_ignore_comments() -> None:
             assert needle not in text, f"{path} contains forbidden typing bypass {needle!r}"
 
 
+def test_repo_root_derivation_is_centralized_in_repo_support_paths() -> None:
+    approved = repo_root() / "repo_support" / "paths.py"
+
+    offenders = [
+        path for path in _repo_side_python_files() if path != approved and _uses_direct_repo_root_derivation(path)
+    ]
+
+    assert not offenders, f"repo-side python still derives repo root outside repo_support.paths: {offenders}"
+
+
+def test_repo_side_python_does_not_define_repo_root_constants() -> None:
+    offenders = [path for path in _repo_side_python_files() if _defines_root_constants(path)]
+
+    assert not offenders, f"repo-side python still defines local root constants: {offenders}"
+
+
+def test_production_code_does_not_import_repo_support_or_tools() -> None:
+    src_root = repo_root() / "src" / "tallylot"
+
+    _assert_no_imports(src_root, ("repo_support", "tools"), production_only=True)
+
+
+def test_repo_support_avoids_generic_sink_modules() -> None:
+    forbidden = {"helpers.py", "utils.py", "common.py", "misc.py"}
+    support_root = repo_root() / "repo_support"
+    if not support_root.exists():
+        raise AssertionError("repo_support package is missing")
+    offenders = sorted(path.name for path in support_root.rglob("*.py") if path.name in forbidden)
+
+    assert not offenders, f"repo_support contains forbidden generic sink modules: {offenders}"
+
+
 def test_markdownlint_only_disables_md013() -> None:
-    config = json.loads((REPO_ROOT / ".markdownlint.json").read_text(encoding="utf-8"))
+    config = json.loads((repo_root() / ".markdownlint.json").read_text(encoding="utf-8"))
     assert config == {"default": True, "MD013": False}
 
 
 def test_module_size_policy_remains_aligned() -> None:
-    pylint_text = (REPO_ROOT / ".pylintrc").read_text(encoding="utf-8")
-    standards_text = (REPO_ROOT / "docs/standards/engineering.md").read_text(encoding="utf-8")
+    pylint_text = (repo_root() / ".pylintrc").read_text(encoding="utf-8")
+    standards_text = (repo_root() / "docs/standards/engineering.md").read_text(encoding="utf-8")
 
     assert "max-module-lines = 450" in pylint_text
     assert re.search(r"Refactor before extending beyond 300 lines", standards_text) is not None
@@ -92,7 +162,7 @@ def test_module_size_policy_remains_aligned() -> None:
 
 
 def test_src_does_not_accumulate_flat_same_prefix_clusters() -> None:
-    source_root = REPO_ROOT / "src" / "tallylot"
+    source_root = repo_root() / "src" / "tallylot"
 
     for directory in sorted({path.parent for path in source_root.rglob("*.py")}):
         prefix_groups: dict[str, list[str]] = defaultdict(list)
@@ -108,7 +178,7 @@ def test_src_does_not_accumulate_flat_same_prefix_clusters() -> None:
 
 
 def test_retired_bucket_directories_do_not_exist() -> None:
-    src_root = REPO_ROOT / "src" / "tallylot"
+    src_root = repo_root() / "src" / "tallylot"
 
     assert not (src_root / "application" / "services").exists()
     assert not (src_root / "application" / "models").exists()
@@ -119,7 +189,7 @@ def test_retired_bucket_directories_do_not_exist() -> None:
 
 
 def test_oracle_code_is_not_in_production_package() -> None:
-    src_root = REPO_ROOT / "src" / "tallylot"
+    src_root = repo_root() / "src" / "tallylot"
     forbidden = (
         src_root / "application" / "oracle_review",
         src_root / "adapters" / "oracles",
@@ -135,7 +205,7 @@ def test_oracle_code_is_not_in_production_package() -> None:
 
 
 def test_future_capability_roots_remain_available_for_next_phase() -> None:
-    src_root = REPO_ROOT / "src" / "tallylot"
+    src_root = repo_root() / "src" / "tallylot"
 
     required_packages = (
         src_root / "application" / "reconciliation",
@@ -166,7 +236,7 @@ def test_future_capability_roots_remain_available_for_next_phase() -> None:
 
 
 def test_production_packaging_excludes_dev_only_oracle_tooling() -> None:
-    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    pyproject = tomllib.loads((repo_root() / "pyproject.toml").read_text(encoding="utf-8"))
 
     scripts = pyproject["project"]["scripts"]
     wheel_packages = pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]["packages"]
@@ -177,8 +247,8 @@ def test_production_packaging_excludes_dev_only_oracle_tooling() -> None:
 
 
 def test_typecheck_configs_remain_strict() -> None:
-    mypy_text = (REPO_ROOT / "mypy.ini").read_text(encoding="utf-8")
-    pyright_config = json.loads((REPO_ROOT / "pyrightconfig.json").read_text(encoding="utf-8"))
+    mypy_text = (repo_root() / "mypy.ini").read_text(encoding="utf-8")
+    pyright_config = json.loads((repo_root() / "pyrightconfig.json").read_text(encoding="utf-8"))
 
     assert "strict = true" in mypy_text
     assert "warn_unused_ignores = true" in mypy_text
@@ -187,13 +257,13 @@ def test_typecheck_configs_remain_strict() -> None:
 
 
 def test_application_modules_do_not_import_infrastructure() -> None:
-    application_root = REPO_ROOT / "src" / "tallylot" / "application"
+    application_root = repo_root() / "src" / "tallylot" / "application"
 
     _assert_no_imports(application_root, ("tallylot.infrastructure",))
 
 
 def test_domain_modules_do_not_import_outer_layers_or_pydantic() -> None:
-    domain_root = REPO_ROOT / "src" / "tallylot" / "domain"
+    domain_root = repo_root() / "src" / "tallylot" / "domain"
 
     _assert_no_imports(
         domain_root,
@@ -208,7 +278,7 @@ def test_domain_modules_do_not_import_outer_layers_or_pydantic() -> None:
 
 
 def test_ports_modules_do_not_import_implementation_layers() -> None:
-    ports_root = REPO_ROOT / "src" / "tallylot" / "ports"
+    ports_root = repo_root() / "src" / "tallylot" / "ports"
 
     _assert_no_imports(
         ports_root,
@@ -222,7 +292,7 @@ def test_ports_modules_do_not_import_implementation_layers() -> None:
 
 
 def test_adapter_production_modules_do_not_import_application_or_infrastructure() -> None:
-    adapters_root = REPO_ROOT / "src" / "tallylot" / "adapters"
+    adapters_root = repo_root() / "src" / "tallylot" / "adapters"
 
     _assert_no_imports(
         adapters_root,
@@ -258,13 +328,13 @@ def test_economic_leg_fee_specific_helper_and_flag_are_removed() -> None:
 
 def test_repo_does_not_reference_fact_category_attribute() -> None:
     guarded_roots = (
-        REPO_ROOT / "src" / "tallylot" / "adapters",
-        REPO_ROOT / "src" / "tallylot" / "application" / "outputs",
-        REPO_ROOT / "src" / "tallylot" / "infrastructure" / "storage",
-        REPO_ROOT / "src" / "tallylot" / "adapters" / "support",
-        REPO_ROOT / "tests" / "unit" / "domain",
-        REPO_ROOT / "tests" / "unit" / "application" / "outputs",
-        REPO_ROOT / "tests" / "contract",
+        repo_root() / "src" / "tallylot" / "adapters",
+        repo_root() / "src" / "tallylot" / "application" / "outputs",
+        repo_root() / "src" / "tallylot" / "infrastructure" / "storage",
+        repo_root() / "src" / "tallylot" / "adapters" / "support",
+        repo_root() / "tests" / "unit" / "domain",
+        repo_root() / "tests" / "unit" / "application" / "outputs",
+        repo_root() / "tests" / "contract",
     )
 
     for root in guarded_roots:
@@ -276,8 +346,8 @@ def test_repo_does_not_reference_fact_category_attribute() -> None:
 
 def test_repo_does_not_reference_removed_single_leg_fact_attributes() -> None:
     guarded_roots = (
-        REPO_ROOT / "src" / "tallylot",
-        REPO_ROOT / "tests",
+        repo_root() / "src" / "tallylot",
+        repo_root() / "tests",
     )
     forbidden_attributes = {
         "asset_in",
@@ -300,7 +370,7 @@ def test_repo_does_not_reference_removed_single_leg_fact_attributes() -> None:
 
 
 def test_source_adapters_do_not_pass_string_classification_values() -> None:
-    adapters_root = REPO_ROOT / "src" / "tallylot" / "adapters" / "sources"
+    adapters_root = repo_root() / "src" / "tallylot" / "adapters" / "sources"
 
     for path in _python_files(adapters_root):
         for node in ast.walk(_module(path)):
@@ -326,14 +396,14 @@ def test_projection_hint_runtime_values_remain_machine_oriented() -> None:
 
 def test_balance_evidence_has_single_production_owner() -> None:
     occurrences = 0
-    for path in _python_files(REPO_ROOT / "src" / "tallylot"):
+    for path in _python_files(repo_root() / "src" / "tallylot"):
         text = path.read_text(encoding="utf-8")
         occurrences += text.count("class BalanceEvidence")
     assert occurrences == 1
 
 
 def test_transaction_classification_matrix_describes_runtime_projection_values() -> None:
-    matrix_text = (REPO_ROOT / "docs" / "concepts" / "transaction-classification.md").read_text(encoding="utf-8")
+    matrix_text = (repo_root() / "docs" / "concepts" / "transaction-classification.md").read_text(encoding="utf-8")
 
     assert "| `trade` | `trade` | `spot_trade` | `capital_exchange` | `asset_exchange` |" in matrix_text
     assert "| `deposit` | `deposit` | `asset_deposit` | `non_taxable_transfer_in` | `funding_inflow` |" in matrix_text

--- a/tests/contract/test_standards_guards.py
+++ b/tests/contract/test_standards_guards.py
@@ -77,13 +77,69 @@ def _assert_no_imports(root: Path, forbidden_modules: tuple[str, ...], *, produc
 
 
 def _uses_direct_repo_root_derivation(path: Path) -> bool:
+    def is_dunder_file_expr(node: ast.expr) -> bool:
+        return isinstance(node, ast.Name) and node.id == "__file__"
+
+    def is_path_dunder_file_expr(node: ast.expr) -> bool:
+        return (
+            isinstance(node, ast.Call)
+            and _is_named_call(node.func, "Path")
+            and len(node.args) == 1
+            and is_dunder_file_expr(node.args[0])
+        )
+
+    def is_resolve_call(node: ast.expr) -> bool:
+        return (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "resolve"
+            and is_path_dunder_file_expr(node.func.value)
+        )
+
+    def is_repo_root_derivation(node: ast.expr) -> bool:
+        current = node
+        if (
+            isinstance(current, ast.Subscript)
+            and isinstance(current.value, ast.Attribute)
+            and current.value.attr == "parents"
+        ):
+            return is_resolve_call(current.value.value)
+        while isinstance(current, ast.Attribute) and current.attr == "parent":
+            current = current.value
+        return is_resolve_call(current)
+
     module = _module(path)
     for node in ast.walk(module):
         if not isinstance(node, ast.Assign | ast.AnnAssign | ast.NamedExpr | ast.Call | ast.Attribute | ast.Subscript):
             continue
-        if "Path(__file__).resolve().parents[" in ast.unparse(node):
+        candidate: ast.expr | None = (
+            node.value if isinstance(node, ast.Assign | ast.AnnAssign | ast.NamedExpr) else node
+        )
+        if candidate is not None and is_repo_root_derivation(candidate):
             return True
     return False
+
+
+def test_repo_root_derivation_guard_catches_parent_and_parents_forms(tmp_path: Path) -> None:
+    parent_form = tmp_path / "parent_form.py"
+    parent_form.write_text(
+        "from pathlib import Path\nREPO = Path(__file__).resolve().parent.parent\n",
+        encoding="utf-8",
+    )
+    parents_form = tmp_path / "parents_form.py"
+    parents_form.write_text(
+        "from pathlib import Path\nREPO = Path(__file__).resolve().parents[1]\n",
+        encoding="utf-8",
+    )
+    allowed = tmp_path / "allowed.py"
+    allowed.write_text(
+        "from repo_support.paths import repo_root\nROOT = repo_root()\n",
+        encoding="utf-8",
+    )
+
+    assert _uses_direct_repo_root_derivation(parent_form) is True
+    assert _uses_direct_repo_root_derivation(parents_form) is True
+    assert _uses_direct_repo_root_derivation(allowed) is False
 
 
 def _defines_root_constants(path: Path) -> bool:

--- a/tests/support/adapter_packs.py
+++ b/tests/support/adapter_packs.py
@@ -2,18 +2,16 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from repo_support.paths import adapter_packs_root
 from tallylot.application.profiling import BuildProfileUseCase
 from tallylot.infrastructure.discovery import build_registry
 from tallylot.infrastructure.serialization import FilesystemArtifactStore
 from tallylot.ports.source_adapters import SourceAdapter
 from tallylot.ports.source_profiles import SourceProfile
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
-FIXTURE_ROOT = REPO_ROOT / "tests" / "fixtures" / "adapter_packs"
-
 
 def fixture_raw_dir(adapter: str, pack: str) -> Path:
-    return FIXTURE_ROOT / adapter / pack / "raw"
+    return adapter_packs_root() / adapter / pack / "raw"
 
 
 def profile_and_adapter(source: str, raw_dir: Path) -> tuple[SourceProfile, SourceAdapter]:

--- a/tests/unit/test_adapter_tooling.py
+++ b/tests/unit/test_adapter_tooling.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from repo_support import paths as repo_paths
 from tools.adapter_packs import load_adapter_packs, select_adapter_packs
-from tools.scaffold_adapter import AdapterScaffoldSpec, scaffold_adapter
+from tools.scaffold_adapter import AdapterScaffoldSpec, _build_argument_parser, scaffold_adapter
 
 
 def test_load_adapter_packs_discovers_structured_csv_pack() -> None:
@@ -23,6 +24,35 @@ def test_select_adapter_packs_rejects_unknown_id() -> None:
         assert "missing/pack" in str(exc)
     else:
         raise AssertionError("expected missing pack selection to fail")
+
+
+def test_load_adapter_packs_uses_active_repo_root_by_default(tmp_path: Path) -> None:
+    pack_root = tmp_path / "tests" / "fixtures" / "adapter_packs" / "example" / "basic"
+    (pack_root / "raw").mkdir(parents=True)
+    (pack_root / "expected").mkdir()
+    (pack_root / "pack.json").write_text(
+        '{"adapter":"example","source":"Example","expected_adapter":"example","capabilities":["normalize"]}\n',
+        encoding="utf-8",
+    )
+
+    with repo_paths.override_repo_root(tmp_path):
+        packs = load_adapter_packs()
+
+    assert len(packs) == 1
+    assert packs[0].id == "example/basic"
+
+
+def test_scaffold_parser_uses_active_repo_root_by_default(tmp_path: Path) -> None:
+    with repo_paths.override_repo_root(tmp_path):
+        args = _build_argument_parser().parse_args(
+            [
+                "source",
+                "platforms/example_exchange",
+                "Example Exchange",
+            ]
+        )
+
+    assert args.repo_root is None
 
 
 def test_scaffold_adapter_creates_package_layout(tmp_path: Path) -> None:

--- a/tests/unit/test_docs_maintenance.py
+++ b/tests/unit/test_docs_maintenance.py
@@ -1,21 +1,37 @@
 from __future__ import annotations
 
 import ast
+from collections.abc import Iterator
 from pathlib import Path
 from textwrap import dedent
 
 import pytest
 
+from repo_support import paths as repo_paths
 from tools import docs_maintenance
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
-ENTRYPOINT_PATHS = (
-    REPO_ROOT / "README.md",
-    REPO_ROOT / "AGENTS.md",
-    REPO_ROOT / "ROADMAP.md",
-    REPO_ROOT / "CHANGELOG.md",
-    *sorted((REPO_ROOT / ".claude" / "commands").glob("*.md")),
-)
+
+def repo_root() -> Path:
+    return repo_paths.repo_root()
+
+
+def entrypoint_paths() -> tuple[Path, ...]:
+    return (
+        repo_root() / "README.md",
+        repo_root() / "AGENTS.md",
+        repo_root() / "ROADMAP.md",
+        repo_root() / "CHANGELOG.md",
+        *sorted((repo_root() / ".claude" / "commands").glob("*.md")),
+    )
+
+
+@pytest.fixture(autouse=True)
+def reset_repo_root_state() -> Iterator[None]:
+    repo_paths.reset_repo_root()
+    try:
+        yield
+    finally:
+        repo_paths.reset_repo_root()
 
 
 def override_active_roots(
@@ -24,10 +40,12 @@ def override_active_roots(
     *,
     docs_root: Path | None = None,
 ) -> None:
+    del monkeypatch
     resolved_docs_root = docs_root or root / "docs"
-    monkeypatch.setattr(docs_maintenance.state, "REPO_ROOT", root)
-    monkeypatch.setattr(docs_maintenance.state, "DOCS_ROOT", resolved_docs_root)
-    monkeypatch.setattr(docs_maintenance.state, "AGENTS_ROOT", root / "agents")
+    expected_docs_root = root.resolve() / "docs"
+    if resolved_docs_root.resolve() != expected_docs_root:
+        raise AssertionError(f"docs root must resolve under the repo root: {resolved_docs_root}")
+    repo_paths.set_repo_root(root)
 
 
 def test_docs_maintenance_sync_check_passes() -> None:
@@ -35,7 +53,7 @@ def test_docs_maintenance_sync_check_passes() -> None:
 
 
 def test_parse_frontmatter_supports_optional_fields() -> None:
-    path = REPO_ROOT / "docs" / "reference" / "example.md"
+    path = repo_root() / "docs" / "reference" / "example.md"
     text = dedent(
         """\
         ---
@@ -66,7 +84,7 @@ def test_parse_frontmatter_supports_optional_fields() -> None:
 
 
 def test_parse_frontmatter_rejects_missing_related_target() -> None:
-    path = REPO_ROOT / "docs" / "reference" / "example.md"
+    path = repo_root() / "docs" / "reference" / "example.md"
     text = dedent(
         """\
         ---
@@ -91,7 +109,7 @@ def test_parse_frontmatter_rejects_missing_related_target() -> None:
 
 
 def test_parse_frontmatter_rejects_missing_related_anchor() -> None:
-    path = REPO_ROOT / "docs" / "reference" / "example.md"
+    path = repo_root() / "docs" / "reference" / "example.md"
     text = dedent(
         """\
         ---
@@ -116,7 +134,7 @@ def test_parse_frontmatter_rejects_missing_related_anchor() -> None:
 
 
 def test_parse_frontmatter_supports_nav_order() -> None:
-    path = REPO_ROOT / "docs" / "guides" / "example.md"
+    path = repo_root() / "docs" / "guides" / "example.md"
     text = dedent(
         """\
         ---
@@ -140,7 +158,7 @@ def test_parse_frontmatter_supports_nav_order() -> None:
 
 
 def test_parse_frontmatter_rejects_invalid_nav_order() -> None:
-    path = REPO_ROOT / "docs" / "guides" / "example.md"
+    path = repo_root() / "docs" / "guides" / "example.md"
     text = dedent(
         """\
         ---
@@ -164,7 +182,7 @@ def test_parse_frontmatter_rejects_invalid_nav_order() -> None:
 
 
 def test_parse_frontmatter_wraps_yaml_errors() -> None:
-    path = REPO_ROOT / "docs" / "guides" / "example.md"
+    path = repo_root() / "docs" / "guides" / "example.md"
     text = dedent(
         """\
         ---
@@ -184,8 +202,8 @@ def test_parse_frontmatter_wraps_yaml_errors() -> None:
 
 def test_docs_and_agents_pages_have_valid_frontmatter() -> None:
     paths = (
-        *sorted((REPO_ROOT / "docs").rglob("*.md")),
-        *sorted((REPO_ROOT / "agents").rglob("*.md")),
+        *sorted((repo_root() / "docs").rglob("*.md")),
+        *sorted((repo_root() / "agents").rglob("*.md")),
     )
     documents = docs_maintenance.validate_documents()
 
@@ -195,8 +213,8 @@ def test_docs_and_agents_pages_have_valid_frontmatter() -> None:
 def test_repo_markdown_paths_include_root_repo_docs() -> None:
     repo_paths = set(docs_maintenance.repo_markdown_paths())
 
-    assert REPO_ROOT / "ROADMAP.md" in repo_paths
-    assert REPO_ROOT / "CHANGELOG.md" in repo_paths
+    assert repo_root() / "ROADMAP.md" in repo_paths
+    assert repo_root() / "CHANGELOG.md" in repo_paths
 
 
 def test_root_consumers_use_state_getters_instead_of_root_constants() -> None:
@@ -206,7 +224,7 @@ def test_root_consumers_use_state_getters_instead_of_root_constants() -> None:
         "tools/docs_maintenance/links.py",
         "tools/docs_maintenance/metadata.py",
     ):
-        module_path = REPO_ROOT / relative
+        module_path = repo_root() / relative
         tree = ast.parse(module_path.read_text(encoding="utf-8"), filename=str(module_path))
         imported_names = {
             alias.name
@@ -265,11 +283,11 @@ def test_docs_maintenance_root_exports_follow_active_state_roots(
 
 
 def test_entrypoints_do_not_reference_retired_docs_paths() -> None:
-    for path in ENTRYPOINT_PATHS:
+    for path in entrypoint_paths():
         text = path.read_text(encoding="utf-8")
         for retired_reference in docs_maintenance.RETIRED_REFERENCES:
             assert retired_reference not in text, (
-                f"{path.relative_to(REPO_ROOT)} still references retired path {retired_reference}"
+                f"{path.relative_to(repo_root())} still references retired path {retired_reference}"
             )
 
 

--- a/tests/unit/test_docs_runtime_parity.py
+++ b/tests/unit/test_docs_runtime_parity.py
@@ -9,64 +9,86 @@ from typing import cast
 from typer.main import Typer
 from typer.models import CommandInfo
 
+from repo_support.paths import adapter_packs_root, agents_root, claude_commands_root, docs_root, repo_root
 from tallylot.infrastructure.workspace.layout import SEED_FILES
 from tallylot.interfaces.cli import app
 from tools.oracles.cli import app as oracle_app
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
-PRODUCTION_ROUTE_DOC_PATHS = [
-    REPO_ROOT / "README.md",
-    REPO_ROOT / "docs" / "guides" / "operator-quickstart.md",
-    REPO_ROOT / "docs" / "guides" / "source-intake.md",
-    REPO_ROOT / "docs" / "guides" / "normalize-screen-stage.md",
-    REPO_ROOT / "docs" / "reference" / "wallet-inventory-artifacts.md",
-    REPO_ROOT / "docs" / "workspace" / "analysis" / "inventory" / "README.md",
-    REPO_ROOT / ".claude" / "commands" / "source-intake.md",
-    REPO_ROOT / ".claude" / "commands" / "wallet-inventory.md",
-    REPO_ROOT / ".claude" / "commands" / "supporting-artifacts.md",
-]
-ORACLE_ROUTE_DOC_PATHS = [
-    REPO_ROOT / "docs" / "reference" / "baseline-validation-contract.md",
-    REPO_ROOT / "docs" / "reference" / "export-checklist.md",
-    REPO_ROOT / "docs" / "guides" / "operator-quickstart.md",
-    REPO_ROOT / "docs" / "guides" / "full-operator-workflow.md",
-    REPO_ROOT / "docs" / "guides" / "normalize-screen-stage.md",
-    REPO_ROOT / "docs" / "guides" / "verify-a-round.md",
-    REPO_ROOT / ".claude" / "commands" / "round-verification.md",
-    REPO_ROOT / ".claude" / "commands" / "source-diff.md",
-]
-ARCHITECTURE_DOC_PATHS = [
-    REPO_ROOT / "README.md",
-    REPO_ROOT / "ROADMAP.md",
-    REPO_ROOT / "docs" / "standards" / "engineering.md",
-    REPO_ROOT / "docs" / "concepts" / "reconciliation-tax-architecture.md",
-    REPO_ROOT / ".claude" / "commands" / "source-intake.md",
-]
-ENV_PREFIX_REQUIRED_DOC_PATHS = (
-    REPO_ROOT / "README.md",
-    REPO_ROOT / "docs" / "guides" / "operator-quickstart.md",
-    REPO_ROOT / "docs" / "guides" / "full-operator-workflow.md",
-    REPO_ROOT / "docs" / "guides" / "source-intake.md",
-    REPO_ROOT / "docs" / "guides" / "normalize-screen-stage.md",
-    REPO_ROOT / "docs" / "guides" / "verify-a-round.md",
-    REPO_ROOT / "docs" / "reference" / "baseline-validation-contract.md",
-    REPO_ROOT / "docs" / "reference" / "export-checklist.md",
-    REPO_ROOT / "docs" / "reference" / "wallet-inventory-artifacts.md",
-    REPO_ROOT / "docs" / "workspace" / "analysis" / "inventory" / "README.md",
-    REPO_ROOT / ".claude" / "commands" / "adapter-authoring.md",
-    REPO_ROOT / ".claude" / "commands" / "implementation-checkpoint.md",
-    REPO_ROOT / ".claude" / "commands" / "normalization-exceptions.md",
-    REPO_ROOT / ".claude" / "commands" / "reconciliation-tax-build.md",
-    REPO_ROOT / ".claude" / "commands" / "round-verification.md",
-    REPO_ROOT / ".claude" / "commands" / "source-diff.md",
-    REPO_ROOT / ".claude" / "commands" / "source-intake.md",
-    REPO_ROOT / ".claude" / "commands" / "supporting-artifacts.md",
-    REPO_ROOT / ".claude" / "commands" / "wallet-inventory.md",
-)
 PRODUCTION_COMMAND_ROUTE_PATTERN = re.compile(
     r'(?:UV_PROJECT_ENVIRONMENT="\$HOME/\.venvs/tallylot-py312" )?uv run tallylot '
     r"(?P<route>[a-z0-9_][a-z0-9_-]*(?: [a-z0-9_][a-z0-9_-]*){0,4})"
 )
+
+
+def production_route_doc_paths() -> list[Path]:
+    commands_root = claude_commands_root()
+    docs = docs_root()
+    return [
+        repo_root() / "README.md",
+        docs / "guides" / "operator-quickstart.md",
+        docs / "guides" / "source-intake.md",
+        docs / "guides" / "normalize-screen-stage.md",
+        docs / "reference" / "wallet-inventory-artifacts.md",
+        docs / "workspace" / "analysis" / "inventory" / "README.md",
+        commands_root / "source-intake.md",
+        commands_root / "wallet-inventory.md",
+        commands_root / "supporting-artifacts.md",
+    ]
+
+
+def oracle_route_doc_paths() -> list[Path]:
+    commands_root = claude_commands_root()
+    docs = docs_root()
+    return [
+        docs / "reference" / "baseline-validation-contract.md",
+        docs / "reference" / "export-checklist.md",
+        docs / "guides" / "operator-quickstart.md",
+        docs / "guides" / "full-operator-workflow.md",
+        docs / "guides" / "normalize-screen-stage.md",
+        docs / "guides" / "verify-a-round.md",
+        commands_root / "round-verification.md",
+        commands_root / "source-diff.md",
+    ]
+
+
+def architecture_doc_paths() -> list[Path]:
+    commands_root = claude_commands_root()
+    docs = docs_root()
+    return [
+        repo_root() / "README.md",
+        repo_root() / "ROADMAP.md",
+        docs / "standards" / "engineering.md",
+        docs / "concepts" / "reconciliation-tax-architecture.md",
+        commands_root / "source-intake.md",
+    ]
+
+
+def env_prefix_required_doc_paths() -> tuple[Path, ...]:
+    commands_root = claude_commands_root()
+    docs = docs_root()
+    return (
+        repo_root() / "README.md",
+        docs / "guides" / "operator-quickstart.md",
+        docs / "guides" / "full-operator-workflow.md",
+        docs / "guides" / "source-intake.md",
+        docs / "guides" / "normalize-screen-stage.md",
+        docs / "guides" / "verify-a-round.md",
+        docs / "reference" / "baseline-validation-contract.md",
+        docs / "reference" / "export-checklist.md",
+        docs / "reference" / "wallet-inventory-artifacts.md",
+        docs / "workspace" / "analysis" / "inventory" / "README.md",
+        commands_root / "adapter-authoring.md",
+        commands_root / "implementation-checkpoint.md",
+        commands_root / "normalization-exceptions.md",
+        commands_root / "reconciliation-tax-build.md",
+        commands_root / "round-verification.md",
+        commands_root / "source-diff.md",
+        commands_root / "source-intake.md",
+        commands_root / "supporting-artifacts.md",
+        commands_root / "wallet-inventory.md",
+    )
+
+
 ORACLE_COMMAND_ROUTE_PATTERN = re.compile(
     r'(?:UV_PROJECT_ENVIRONMENT="\$HOME/\.venvs/tallylot-py312" )?uv run python -m tools\.oracles\.cli '
     r"(?P<route>[a-z0-9_][a-z0-9_-]*(?: [a-z0-9_][a-z0-9_-]*){0,4})"
@@ -103,7 +125,7 @@ def _registered_routes(typer_app: Typer) -> set[str]:
 
 
 def test_documented_cli_routes_exist() -> None:
-    documented_routes = _documented_routes(PRODUCTION_ROUTE_DOC_PATHS, PRODUCTION_COMMAND_ROUTE_PATTERN)
+    documented_routes = _documented_routes(production_route_doc_paths(), PRODUCTION_COMMAND_ROUTE_PATTERN)
     registered_routes = _registered_routes(app)
 
     missing_routes = sorted(documented_routes - registered_routes)
@@ -112,7 +134,7 @@ def test_documented_cli_routes_exist() -> None:
 
 
 def test_documented_oracle_cli_routes_exist() -> None:
-    documented_routes = _documented_routes(ORACLE_ROUTE_DOC_PATHS, ORACLE_COMMAND_ROUTE_PATTERN)
+    documented_routes = _documented_routes(oracle_route_doc_paths(), ORACLE_COMMAND_ROUTE_PATTERN)
     registered_routes = _registered_routes(oracle_app)
 
     missing_routes = sorted(documented_routes - registered_routes)
@@ -134,7 +156,7 @@ def test_documented_claude_command_routes_exist() -> None:
     )
 
     for relative_path in command_paths:
-        assert (REPO_ROOT / relative_path).exists(), f"missing documented command route: {relative_path}"
+        assert (repo_root() / relative_path).exists(), f"missing documented command route: {relative_path}"
 
 
 def test_documented_claude_command_routes_are_not_ignored() -> None:
@@ -153,7 +175,7 @@ def test_documented_claude_command_routes_are_not_ignored() -> None:
     for relative_path in command_paths:
         result = subprocess.run(
             ("git", "check-ignore", "-q", relative_path),
-            cwd=REPO_ROOT,
+            cwd=repo_root(),
             capture_output=True,
             text=True,
             check=False,
@@ -162,7 +184,7 @@ def test_documented_claude_command_routes_are_not_ignored() -> None:
 
 
 def test_source_intake_route_mentions_current_typed_commands() -> None:
-    text = (REPO_ROOT / ".claude" / "commands" / "source-intake.md").read_text(encoding="utf-8")
+    text = (claude_commands_root() / "source-intake.md").read_text(encoding="utf-8")
 
     for command in (
         "source intake plan",
@@ -177,7 +199,7 @@ def test_source_intake_route_mentions_current_typed_commands() -> None:
 
 
 def test_round_verification_route_mentions_oracle_cli_commands() -> None:
-    text = (REPO_ROOT / ".claude" / "commands" / "round-verification.md").read_text(encoding="utf-8")
+    text = (claude_commands_root() / "round-verification.md").read_text(encoding="utf-8")
 
     scaffold_command = (
         'UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.oracles.cli round scaffold'
@@ -191,13 +213,13 @@ def test_round_verification_route_mentions_oracle_cli_commands() -> None:
 
 
 def test_supporting_route_mentions_checkpoint_pdf_balance_extraction_command() -> None:
-    text = (REPO_ROOT / ".claude" / "commands" / "supporting-artifacts.md").read_text(encoding="utf-8")
+    text = (claude_commands_root() / "supporting-artifacts.md").read_text(encoding="utf-8")
 
     assert "checkpoint extract-pdf-balances" in text
 
 
 def test_location_inventory_route_mentions_checkpoint_command() -> None:
-    text = (REPO_ROOT / ".claude" / "commands" / "wallet-inventory.md").read_text(encoding="utf-8")
+    text = (claude_commands_root() / "wallet-inventory.md").read_text(encoding="utf-8")
 
     assert "checkpoint rebuild-location-inventory" in text
 
@@ -216,14 +238,14 @@ def test_docs_do_not_reference_retired_service_or_model_buckets() -> None:
         "supporting extract-pdf-balances",
         "wallet inventory rebuild",
     )
-    for path in ARCHITECTURE_DOC_PATHS:
+    for path in architecture_doc_paths():
         text = path.read_text(encoding="utf-8").lower()
         for needle in forbidden:
             assert needle not in text, f"{path} still references retired surface {needle!r}"
 
 
 def test_docs_use_lowercase_filenames_except_readmes() -> None:
-    for path in sorted((REPO_ROOT / "docs").rglob("*")):
+    for path in sorted(docs_root().rglob("*")):
         if not path.is_file():
             continue
         if path.name == "README.md":
@@ -238,12 +260,12 @@ def test_repo_docs_do_not_reference_personal_workspace_roots() -> None:
         "~/Documents/",
     )
     paths = (
-        REPO_ROOT / "README.md",
-        REPO_ROOT / "AGENTS.md",
-        REPO_ROOT / "tallylot.toml",
-        *sorted((REPO_ROOT / "docs").rglob("*.md")),
-        *sorted((REPO_ROOT / "agents").rglob("*.md")),
-        *sorted((REPO_ROOT / ".claude").rglob("*.md")),
+        repo_root() / "README.md",
+        repo_root() / "AGENTS.md",
+        repo_root() / "tallylot.toml",
+        *sorted(docs_root().rglob("*.md")),
+        *sorted(agents_root().rglob("*.md")),
+        *sorted((repo_root() / ".claude").rglob("*.md")),
     )
 
     for path in paths:
@@ -253,12 +275,12 @@ def test_repo_docs_do_not_reference_personal_workspace_roots() -> None:
 
 
 def test_private_oracle_manifest_is_not_checked_in() -> None:
-    assert not (REPO_ROOT / "docs" / "reference" / "cointracking-full-export-manifest.csv").exists()
+    assert not (docs_root() / "reference" / "cointracking-full-export-manifest.csv").exists()
 
 
 def test_workspace_issue_log_seed_header_matches_template() -> None:
     template_header = (
-        (REPO_ROOT / "docs" / "workspace" / "analysis" / "issues" / "issue-log-template.csv")
+        (docs_root() / "workspace" / "analysis" / "issues" / "issue-log-template.csv")
         .read_text(encoding="utf-8")
         .splitlines()[0]
     )
@@ -271,7 +293,7 @@ def test_workspace_issue_log_seed_header_matches_template() -> None:
 
 def test_workspace_source_inventory_seed_header_matches_template() -> None:
     template_header = (
-        (REPO_ROOT / "docs" / "workspace" / "analysis" / "issues" / "source-inventory-template.csv")
+        (docs_root() / "workspace" / "analysis" / "issues" / "source-inventory-template.csv")
         .read_text(encoding="utf-8")
         .splitlines()[0]
     )
@@ -283,7 +305,7 @@ def test_workspace_source_inventory_seed_header_matches_template() -> None:
 
 
 def test_commit_standards_require_explicit_lint_amend_reverification() -> None:
-    text = (REPO_ROOT / "docs" / "standards" / "commits.md").read_text(encoding="utf-8")
+    text = (docs_root() / "standards" / "commits.md").read_text(encoding="utf-8")
 
     assert "Do not describe `mypy` or `pyright` as covering `pylint` findings." in text
     assert 'UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pylint <touched-file>' in text
@@ -293,8 +315,8 @@ def test_commit_standards_require_explicit_lint_amend_reverification() -> None:
 
 def test_implementation_anchor_references_use_explicit_doc_paths() -> None:
     paths = (
-        REPO_ROOT / "AGENTS.md",
-        REPO_ROOT / "docs" / "standards" / "implementation.md",
+        repo_root() / "AGENTS.md",
+        docs_root() / "standards" / "implementation.md",
     )
 
     for path in paths:
@@ -305,7 +327,7 @@ def test_implementation_anchor_references_use_explicit_doc_paths() -> None:
 def test_reference_docs_do_not_check_in_oracle_data_files() -> None:
     forbidden_suffixes = {".csv", ".json", ".zip", ".html", ".pdf"}
 
-    for path in sorted((REPO_ROOT / "docs" / "reference").rglob("*")):
+    for path in sorted((docs_root() / "reference").rglob("*")):
         if not path.is_file():
             continue
         assert path.suffix not in forbidden_suffixes, (
@@ -316,7 +338,7 @@ def test_reference_docs_do_not_check_in_oracle_data_files() -> None:
 def test_adapter_pack_goldens_do_not_embed_absolute_home_paths() -> None:
     forbidden = ("/home/user/", "CoinTracking.info/tallylot-2025")
 
-    for path in sorted((REPO_ROOT / "tests" / "fixtures" / "adapter_packs").rglob("*.json")):
+    for path in sorted(adapter_packs_root().rglob("*.json")):
         text = path.read_text(encoding="utf-8")
         for needle in forbidden:
             assert needle not in text, f"{path} still embeds absolute local path content"

--- a/tests/unit/test_quality_gates.py
+++ b/tests/unit/test_quality_gates.py
@@ -6,9 +6,8 @@ from pathlib import Path
 import pytest
 
 import tools.run_quality_gates
+from repo_support.paths import repo_root
 from tools.run_quality_gates import DEFAULT_TEST_COMMAND, FULL_TEST_COMMAND, _quality_gates
-
-REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def test_quality_gates_default_to_fast_commit_time_pytest() -> None:
@@ -61,7 +60,7 @@ def test_run_gate_exports_external_uv_project_environment(monkeypatch: pytest.Mo
 
 
 def test_pre_commit_config_excludes_pylint_hook() -> None:
-    config_text = (REPO_ROOT / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+    config_text = (repo_root() / ".pre-commit-config.yaml").read_text(encoding="utf-8")
 
     assert "id: pylint" not in config_text
     assert "name: pytest-fast" in config_text

--- a/tests/unit/test_repo_support_paths.py
+++ b/tests/unit/test_repo_support_paths.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from repo_support import paths as repo_paths
+
+
+def test_repo_support_paths_default_to_repo_checkout() -> None:
+    root = repo_paths.repo_root()
+
+    assert (root / "pyproject.toml").exists()
+    assert repo_paths.src_root() == root / "src"
+    assert repo_paths.tests_root() == root / "tests"
+    assert repo_paths.fixtures_root() == root / "tests" / "fixtures"
+    assert repo_paths.adapter_packs_root() == root / "tests" / "fixtures" / "adapter_packs"
+    assert repo_paths.docs_root() == root / "docs"
+    assert repo_paths.agents_root() == root / "agents"
+    assert repo_paths.claude_commands_root() == root / ".claude" / "commands"
+    assert repo_paths.vscode_settings_path() == root / ".vscode" / "settings.json"
+
+
+def test_override_repo_root_rebinds_derived_paths(tmp_path: Path) -> None:
+    with repo_paths.override_repo_root(tmp_path):
+        assert repo_paths.repo_root() == tmp_path.resolve()
+        assert repo_paths.adapter_packs_root() == tmp_path.resolve() / "tests" / "fixtures" / "adapter_packs"
+        assert repo_paths.relative_repo_path(tmp_path / "docs" / "README.md") == "docs/README.md"
+
+    assert repo_paths.repo_root() != tmp_path.resolve()
+
+
+def test_display_repo_path_falls_back_for_non_repo_paths(tmp_path: Path) -> None:
+    assert repo_paths.display_repo_path(tmp_path / "outside.txt") == str(tmp_path / "outside.txt")

--- a/tests/unit/test_repo_support_paths.py
+++ b/tests/unit/test_repo_support_paths.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import conftest as repo_conftest
 from repo_support import paths as repo_paths
 
 
@@ -30,3 +31,19 @@ def test_override_repo_root_rebinds_derived_paths(tmp_path: Path) -> None:
 
 def test_display_repo_path_falls_back_for_non_repo_paths(tmp_path: Path) -> None:
     assert repo_paths.display_repo_path(tmp_path / "outside.txt") == str(tmp_path / "outside.txt")
+
+
+def test_relative_repo_path_accepts_repo_relative_paths() -> None:
+    assert repo_paths.relative_repo_path(Path("docs/README.md")) == "docs/README.md"
+    assert repo_paths.display_repo_path(Path("docs/README.md")) == "docs/README.md"
+
+
+def test_conftest_adapter_collection_follows_active_repo_root(tmp_path: Path) -> None:
+    test_file = tmp_path / "src" / "tallylot" / "adapters" / "sources" / "platforms" / "demo" / "tests" / "test_demo.py"
+    test_file.parent.mkdir(parents=True)
+    test_file.write_text("def test_demo():\n    assert True\n", encoding="utf-8")
+
+    with repo_paths.override_repo_root(tmp_path):
+        assert repo_conftest.pytest_ignore_collect(test_file.parent) is False
+        assert repo_conftest.pytest_ignore_collect(test_file) is False
+        assert repo_conftest._marker_for_test_path(test_file) == "unit"

--- a/tests/unit/test_run_pylint.py
+++ b/tests/unit/test_run_pylint.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sys
 
+from repo_support.paths import repo_root
 from tools.run_pylint import TARGETS, PylintTarget
 
 
@@ -18,3 +19,9 @@ def test_pylint_targets_split_repo_code_from_tests() -> None:
     )
 
     assert expected_targets == TARGETS
+
+
+def test_test_pylint_rcfile_disables_protected_access() -> None:
+    config_text = (repo_root() / ".pylintrc-tests").read_text(encoding="utf-8")
+
+    assert "protected-access" in config_text

--- a/tests/unit/test_run_pylint.py
+++ b/tests/unit/test_run_pylint.py
@@ -13,7 +13,7 @@ def test_pylint_targets_split_repo_code_from_tests() -> None:
         ),
         PylintTarget(
             name="tests",
-            command=(sys.executable, "-m", "pylint", "--disable=protected-access", "tests"),
+            command=(sys.executable, "-m", "pylint", "--rcfile=.pylintrc-tests", "tests"),
         ),
     )
 

--- a/tests/unit/test_vscode_settings.py
+++ b/tests/unit/test_vscode_settings.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
+
+from repo_support.paths import vscode_settings_path
 
 
 def test_workspace_vscode_settings_pin_external_python_environment() -> None:
-    settings_path = Path(__file__).resolve().parents[2] / ".vscode" / "settings.json"
-    settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    settings = json.loads(vscode_settings_path().read_text(encoding="utf-8"))
 
     assert settings["python.defaultInterpreterPath"] == "${env:HOME}/.venvs/tallylot-py312/bin/python"
     assert settings["terminal.integrated.env.linux"]["UV_PROJECT_ENVIRONMENT"] == "${env:HOME}/.venvs/tallylot-py312"

--- a/tools/adapter_packs.py
+++ b/tools/adapter_packs.py
@@ -5,8 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_PACK_ROOT = REPO_ROOT / "tests" / "fixtures" / "adapter_packs"
+from repo_support.paths import adapter_packs_root
 
 
 @dataclass(frozen=True)
@@ -40,11 +39,12 @@ class AdapterPack:
 
 def load_adapter_packs(
     *,
-    pack_root: Path = DEFAULT_PACK_ROOT,
+    pack_root: Path | None = None,
     capability: str | None = None,
 ) -> tuple[AdapterPack, ...]:
+    resolved_pack_root = adapter_packs_root() if pack_root is None else pack_root.resolve()
     packs: list[AdapterPack] = []
-    for manifest in sorted(pack_root.glob("*/*/pack.json")):
+    for manifest in sorted(resolved_pack_root.glob("*/*/pack.json")):
         pack = _load_adapter_pack(manifest)
         if capability is not None and not pack.supports(capability):
             continue
@@ -54,7 +54,7 @@ def load_adapter_packs(
 
 def select_adapter_packs(
     *,
-    pack_root: Path = DEFAULT_PACK_ROOT,
+    pack_root: Path | None = None,
     selected_ids: tuple[str, ...] = (),
     capability: str | None = None,
 ) -> tuple[AdapterPack, ...]:

--- a/tools/docs_maintenance/__init__.py
+++ b/tools/docs_maintenance/__init__.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from . import state
@@ -36,9 +37,9 @@ def __getattr__(name: str) -> object:
 
 
 if TYPE_CHECKING:
-    REPO_ROOT = state.REPO_ROOT
-    DOCS_ROOT = state.DOCS_ROOT
-    AGENTS_ROOT = state.AGENTS_ROOT
+    REPO_ROOT: Path
+    DOCS_ROOT: Path
+    AGENTS_ROOT: Path
 
 
 __all__ = [

--- a/tools/docs_maintenance/state.py
+++ b/tools/docs_maintenance/state.py
@@ -2,29 +2,36 @@ from __future__ import annotations
 
 from pathlib import Path
 
-REPO_ROOT = Path(__file__).resolve().parents[2]
-DOCS_ROOT = REPO_ROOT / "docs"
-AGENTS_ROOT = REPO_ROOT / "agents"
+from repo_support.paths import (
+    agents_root as shared_agents_root,
+)
+from repo_support.paths import (
+    display_repo_path,
+    relative_repo_path,
+)
+from repo_support.paths import (
+    docs_root as shared_docs_root,
+)
+from repo_support.paths import (
+    repo_root as shared_repo_root,
+)
 
 
 def repo_root() -> Path:
-    return REPO_ROOT
+    return shared_repo_root()
 
 
 def docs_root() -> Path:
-    return DOCS_ROOT
+    return shared_docs_root()
 
 
 def agents_root() -> Path:
-    return AGENTS_ROOT
+    return shared_agents_root()
 
 
 def relative_path(path: Path) -> str:
-    return path.relative_to(repo_root()).as_posix()
+    return relative_repo_path(path)
 
 
 def display_path(path: Path) -> str:
-    try:
-        return relative_path(path)
-    except ValueError:
-        return str(path)
+    return display_repo_path(path)

--- a/tools/refresh_adapter_goldens.py
+++ b/tools/refresh_adapter_goldens.py
@@ -6,12 +6,13 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import cast
 
+from repo_support.paths import adapter_packs_root
 from tallylot.application.normalization import NormalizeRequest
 from tallylot.application.resource_refs import to_resource_ref
 from tallylot.infrastructure.composition import build_profile_use_case, normalize_source_use_case
 from tallylot.infrastructure.discovery.adapters import build_registry
 from tallylot.infrastructure.serialization import FilesystemArtifactStore
-from tools.adapter_packs import DEFAULT_PACK_ROOT, AdapterPack, select_adapter_packs
+from tools.adapter_packs import AdapterPack, select_adapter_packs
 
 EXPECTED_NORMALIZATION_ARTIFACTS = (
     "facts",
@@ -54,7 +55,7 @@ def _build_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--pack-root",
         type=Path,
-        default=DEFAULT_PACK_ROOT,
+        default=None,
         help="Root containing adapter pack fixtures.",
     )
     parser.add_argument(
@@ -135,8 +136,9 @@ def refresh_pack(pack: AdapterPack) -> tuple[Path, ...]:
 
 def main(argv: list[str] | None = None) -> int:
     args = _build_argument_parser().parse_args(argv)
+    pack_root = adapter_packs_root() if args.pack_root is None else args.pack_root.resolve()
     packs = select_adapter_packs(
-        pack_root=args.pack_root.resolve(),
+        pack_root=pack_root,
         selected_ids=tuple(args.packs),
         capability=args.capability,
     )

--- a/tools/run_pylint.py
+++ b/tools/run_pylint.py
@@ -19,7 +19,7 @@ TARGETS = (
     ),
     PylintTarget(
         name="tests",
-        command=(sys.executable, "-m", "pylint", "--disable=protected-access", "tests"),
+        command=(sys.executable, "-m", "pylint", "--rcfile=.pylintrc-tests", "tests"),
     ),
 )
 

--- a/tools/scaffold_adapter.py
+++ b/tools/scaffold_adapter.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from textwrap import dedent
 
-from tools.adapter_packs import REPO_ROOT
+from repo_support.paths import repo_root
 
 
 def _build_argument_parser() -> argparse.ArgumentParser:
@@ -24,7 +24,7 @@ def _build_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument("display_name")
     parser.add_argument("--description", default="")
     parser.add_argument("--version", default="0.1.0")
-    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    parser.add_argument("--repo-root", type=Path, default=None)
     parser.add_argument(
         "--force",
         action="store_true",
@@ -336,9 +336,10 @@ def _write_file(path: Path, content: str, *, force: bool) -> Path:
 
 def main(argv: list[str] | None = None) -> int:
     args = _build_argument_parser().parse_args(argv)
+    resolved_repo_root = repo_root() if args.repo_root is None else args.repo_root.resolve()
     created = scaffold_adapter(
         spec=AdapterScaffoldSpec(
-            repo_root=args.repo_root.resolve(),
+            repo_root=resolved_repo_root,
             kind=args.kind,
             module_name=args.module_name,
             display_name=args.display_name,
@@ -348,7 +349,7 @@ def main(argv: list[str] | None = None) -> int:
         force=args.force,
     )
     for path in created:
-        print(path.relative_to(args.repo_root.resolve()))
+        print(path.relative_to(resolved_repo_root))
     return 0
 
 

--- a/tools/scaffold_adapter.py
+++ b/tools/scaffold_adapter.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from textwrap import dedent
 
-from repo_support.paths import repo_root
+from repo_support.paths import repo_root as active_repo_root
 
 
 def _build_argument_parser() -> argparse.ArgumentParser:
@@ -336,7 +336,7 @@ def _write_file(path: Path, content: str, *, force: bool) -> Path:
 
 def main(argv: list[str] | None = None) -> int:
     args = _build_argument_parser().parse_args(argv)
-    resolved_repo_root = repo_root() if args.repo_root is None else args.repo_root.resolve()
+    resolved_repo_root = active_repo_root() if args.repo_root is None else args.repo_root.resolve()
     created = scaffold_adapter(
         spec=AdapterScaffoldSpec(
             repo_root=resolved_repo_root,


### PR DESCRIPTION
Why:
- repo-side tooling and tests were deriving the repo root in multiple
places, which made root overrides brittle and left several callers
caching stale paths at import time
- docs maintenance had already grown its own root-resolution center, so
the repo had competing seams for the same concern
- test-only pylint protected-access policy was still being handled
through scattered workarounds instead of one explicit contract

What:
- add `repo_support.paths` as the single repo-only root/path resolver
shared by tools and tests, with late-bound helpers and an explicit
scoped override seam
- migrate repo-side consumers to that resolver, including docs
maintenance, adapter-pack tooling, scaffold flows, VS Code settings
lookups, fixture helpers, and repo-side adapter tests
- remove cached repo-root defaults and other import-time path capture so
active root overrides apply consistently at runtime
- codify the `repo_support/` seam in standards and add contract guards
that block direct repo-root derivation, local root constants, production
imports from `repo_support` or `tools`, and generic sink modules
- centralize the test-side pylint protected-access policy in
`.pylintrc-tests` and lock that contract with tests instead of letting
more ad hoc workarounds spread

Checks:
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pytest
tests/unit/test_repo_support_paths.py tests/unit/test_adapter_tooling.py
tests/unit/test_quality_gates.py tests/unit/test_vscode_settings.py
tests/unit/test_docs_maintenance.py
tests/unit/test_docs_runtime_parity.py tests/unit/test_run_pylint.py
tests/contract/test_standards_guards.py
src/tallylot/adapters/sources/platforms/coinbase/tests/test_matching.py
-q --no-cov`
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m
tools.docs_maintenance sync --check`
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m
tools.run_quality_gates --full-tests`

Included checkpoints:
- `refactor(repo-support): centralize tooling root paths`
- `docs(repo-support): codify seam and add guards`
- `fix(repo-support): avoid scaffold resolver name clash`
- `fix(repo-support): remove cached repo-root consumers`
- `fix(testing): centralize test pylint protected-access policy`
- `test(testing): lock test pylint rcfile contract`
