### PR TITLE
ci(actions): upgrade workflow actions for node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install uv
@@ -70,8 +70,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Install uv


### PR DESCRIPTION
Why:
- GitHub Actions is warning that `actions/checkout@v4` and
`actions/setup-python@v5` still run on the deprecated Node 20 runtime
- Node 24 becomes the default JavaScript action runtime on June 2, 2026
and Node 20 is removed later in 2026
- issue #24 tracks removing this warning before it turns into a breaking
CI problem

What:
- upgrade `actions/checkout` from v4 to v6 in `.github/workflows/ci.yml`
- upgrade `actions/setup-python` from v5 to v6 in
`.github/workflows/ci.yml`
- leave the workflow shape unchanged apart from the runtime-safe action
versions

Checks:
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m
tools.run_ci_parity_checks`

Included checkpoints:
- `ci(actions): upgrade workflow actions for node 24`
