### PR TITLE
fix(hooks): fail fast when commit-msg validation is unavailable

### DIFF
--- a/docs/standards/commits.md
+++ b/docs/standards/commits.md
@@ -169,6 +169,9 @@ UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.inst
 The installed `pre-commit` hook formats safe staged Python files with Ruff
 before running the remaining hooks once. It skips auto-restaging for partially
 staged Python files so unrelated unstaged hunks are not accidentally committed.
+It also refuses to run when the sibling `commit-msg` validator hook is missing
+or stale, so clone-local hook drift cannot silently bypass commit-message
+validation.
 
 Validate messages directly when needed:
 

--- a/tests/unit/test_pre_commit_hook.py
+++ b/tests/unit/test_pre_commit_hook.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import pytest
 
 import tools.install_git_hooks
+import tools.pre_commit_hook
 from tools.install_git_hooks import _COMMIT_MSG_HOOK_TEMPLATE, _HOOK_TEMPLATE
 from tools.pre_commit_hook import _format_candidates, _skip_value
 
@@ -33,6 +34,69 @@ def test_skip_value_appends_formatter_hooks_once() -> None:
     assert _skip_value("pytest,ruff") == "pytest,ruff,ruff-format"
 
 
+def test_pre_commit_wrapper_fails_when_commit_msg_hook_is_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    hooks_dir = tmp_path / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+
+    assert tools.pre_commit_hook.main([]) == 1
+
+    assert "repo commit-msg hook is not installed" in capsys.readouterr().err
+
+
+def test_pre_commit_wrapper_rejects_stale_commit_msg_hook(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    hooks_dir = tmp_path / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (hooks_dir / "commit-msg").write_text(
+        "#!/usr/bin/env bash\nexit 0\n", encoding="utf-8"
+    )
+    monkeypatch.chdir(tmp_path)
+
+    assert tools.pre_commit_hook.main([]) == 1
+
+    assert "repo commit-msg hook is stale or invalid" in capsys.readouterr().err
+
+
+def test_pre_commit_wrapper_runs_when_commit_msg_hook_is_installed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_git_paths(*args: str) -> tuple[str, ...]:
+        del args
+        return ()
+
+    def fake_format_and_stage(paths: tuple[str, ...]) -> int:
+        del paths
+        return 0
+
+    def fake_run_pre_commit(hook_args: list[str]) -> int:
+        del hook_args
+        return 0
+
+    hooks_dir = tmp_path / ".git" / "hooks"
+    hooks_dir.mkdir(parents=True)
+    (hooks_dir / "commit-msg").write_text(
+        "#!/usr/bin/env bash\npre_commit hook-impl --hook-type=commit-msg\n",
+        encoding="utf-8",
+    )
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(tools.pre_commit_hook, "_git_paths", fake_git_paths)
+    monkeypatch.setattr(
+        tools.pre_commit_hook, "_format_and_stage", fake_format_and_stage
+    )
+    monkeypatch.setattr(tools.pre_commit_hook, "_run_pre_commit", fake_run_pre_commit)
+
+    assert tools.pre_commit_hook.main([]) == 0
+
+
 def test_install_hook_template_execs_repo_pre_commit_wrapper() -> None:
     assert "-m tools.pre_commit_hook" in _HOOK_TEMPLATE
     assert 'REPO_ROOT="$(git rev-parse --show-toplevel)"' in _HOOK_TEMPLATE
@@ -55,7 +119,13 @@ def test_install_hooks_uses_pre_commit_overwrite_mode(
         env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
         assert check is True
-        commands.append((tuple(command), cwd, None if env is None else env.get("UV_PROJECT_ENVIRONMENT")))
+        commands.append(
+            (
+                tuple(command),
+                cwd,
+                None if env is None else env.get("UV_PROJECT_ENVIRONMENT"),
+            )
+        )
         return subprocess.CompletedProcess(command, 0)
 
     hook_path = tmp_path / ".git" / "hooks" / "pre-commit"
@@ -66,7 +136,9 @@ def test_install_hooks_uses_pre_commit_overwrite_mode(
 
     environment_root = tmp_path / "external-env"
     (environment_root / "bin").mkdir(parents=True)
-    monkeypatch.setattr("tools.install_git_hooks.sys.executable", str(environment_root / "bin/python3"))
+    monkeypatch.setattr(
+        "tools.install_git_hooks.sys.executable", str(environment_root / "bin/python3")
+    )
     monkeypatch.setattr("tools.install_git_hooks.sys.prefix", str(environment_root))
     monkeypatch.setattr("tools.install_git_hooks.sys.base_prefix", "/usr")
     monkeypatch.setattr(subprocess, "run", fake_run)
@@ -74,7 +146,11 @@ def test_install_hooks_uses_pre_commit_overwrite_mode(
     tools.install_git_hooks._install_hooks(tmp_path)
 
     assert commands == [
-        (("git", "config", "--local", "commit.template", ".gitmessage.txt"), tmp_path, None),
+        (
+            ("git", "config", "--local", "commit.template", ".gitmessage.txt"),
+            tmp_path,
+            None,
+        ),
         (
             (
                 "uv",
@@ -116,6 +192,7 @@ def test_install_hooks_falls_back_to_default_external_environment(
         cwd: Path,
         env: dict[str, str] | None = None,
     ) -> subprocess.CompletedProcess[str]:
+        del check, cwd, env
         return subprocess.CompletedProcess(command, 0)
 
     monkeypatch.setattr("tools.install_git_hooks.sys.executable", "/usr/bin/python3")
@@ -126,5 +203,10 @@ def test_install_hooks_falls_back_to_default_external_environment(
     tools.install_git_hooks._install_hooks(tmp_path)
 
     expected_environment = Path.home() / ".venvs" / "tallylot-py312"
-    assert f"PROJECT_ENVIRONMENT={expected_environment}" in hook_path.read_text(encoding="utf-8")
-    assert f"PROJECT_ENVIRONMENT={expected_environment}" in commit_msg_hook_path.read_text(encoding="utf-8")
+    assert f"PROJECT_ENVIRONMENT={expected_environment}" in hook_path.read_text(
+        encoding="utf-8"
+    )
+    assert (
+        f"PROJECT_ENVIRONMENT={expected_environment}"
+        in commit_msg_hook_path.read_text(encoding="utf-8")
+    )

--- a/tools/pre_commit_hook.py
+++ b/tools/pre_commit_hook.py
@@ -6,6 +6,11 @@ import sys
 from pathlib import Path
 
 PYTHON_SUFFIXES = {".py", ".pyi"}
+_COMMIT_MSG_HOOK_PATH = Path(".git/hooks/commit-msg")
+_COMMIT_MSG_HOOK_NEEDLES = (
+    "--hook-type=commit-msg",
+    "pre_commit",
+)
 
 
 def _git_paths(*args: str) -> tuple[str, ...]:
@@ -26,7 +31,9 @@ def _format_candidates(
 ) -> tuple[str, ...]:
     partially_staged = set(initially_staged) & set(initially_unstaged)
     candidates = [
-        path for path in initially_staged if Path(path).suffix in PYTHON_SUFFIXES and path not in partially_staged
+        path
+        for path in initially_staged
+        if Path(path).suffix in PYTHON_SUFFIXES and path not in partially_staged
     ]
     return tuple(candidates)
 
@@ -61,6 +68,29 @@ def _run_pre_commit(hook_args: list[str]) -> int:
     return _run_command(command, env=env)
 
 
+def _require_commit_message_hook() -> int:
+    if not _COMMIT_MSG_HOOK_PATH.is_file():
+        print(
+            "repo commit-msg hook is not installed; run "
+            '`UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" '
+            "uv run python -m tools.install_git_hooks`",
+            file=sys.stderr,
+        )
+        return 1
+
+    hook_text = _COMMIT_MSG_HOOK_PATH.read_text(encoding="utf-8")
+    if all(needle in hook_text for needle in _COMMIT_MSG_HOOK_NEEDLES):
+        return 0
+
+    print(
+        "repo commit-msg hook is stale or invalid; run "
+        '`UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" '
+        "uv run python -m tools.install_git_hooks`",
+        file=sys.stderr,
+    )
+    return 1
+
+
 def _format_and_stage(paths: tuple[str, ...]) -> int:
     if not paths:
         return 0
@@ -78,7 +108,12 @@ def _format_and_stage(paths: tuple[str, ...]) -> int:
 
 def main(argv: list[str] | None = None) -> int:
     hook_args = list(sys.argv[1:] if argv is None else argv)
-    initially_staged = _git_paths("diff", "--cached", "--name-only", "--diff-filter=ACMR")
+    hook_status = _require_commit_message_hook()
+    if hook_status != 0:
+        return hook_status
+    initially_staged = _git_paths(
+        "diff", "--cached", "--name-only", "--diff-filter=ACMR"
+    )
     initially_unstaged = _git_paths("diff", "--name-only", "--diff-filter=ACMR")
     format_status = _format_and_stage(
         _format_candidates(


### PR DESCRIPTION
Why:
- prevent local clone hook drift from silently bypassing commit-message validation and surfacing only as CI failures

What:
- make the repo pre-commit wrapper fail fast when the sibling commit-msg hook is missing or stale
- add unit coverage for missing, stale, and valid commit-msg hook states
- document the fail-fast behavior in commit standards

Checks:
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests

Included checkpoints:
- `fix(hooks): fail fast when commit-msg validation is unavailable`
