### PR TITLE
docs(agent-routing): sync docs index and planning entrypoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ Do not pre-load every repo doc by default.
 | ---- | ---- |
 | Code placement, typing, modularization, naming | `docs/standards/engineering.md` |
 | Active implementation execution discipline | `docs/standards/implementation.md`, `docs/standards/commits.md` |
+| Planning sequence, delivery slices, or rollout checkpoints | `ROADMAP.md` |
 | Reconciliation, checkpoint, journal, or tax-engine implementation | `docs/concepts/reconciliation-tax-architecture.md` |
 | Platform-agnostic boundaries, classification mapping, or migration order | `docs/concepts/oracle-boundaries.md`, `docs/concepts/transaction-classification.md`, `docs/status/migration-sequence.md` |
 | Source or output adapter work | `docs/guides/write-an-adapter.md` |


### PR DESCRIPTION
Why:
- fix stale generated documentation navigation and expose the planning doc from the agent routing table

What:
- add a narrow planning-doc lookup row to AGENTS.md
- refresh the generated repository-history summary in docs/README.md

Checks:
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.docs_maintenance sync --check
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates

Included checkpoints:
- `docs(agent-routing): sync docs index and planning entrypoint`
