### PR TITLE
docs(standards): forbid protected-branch bypass

### DIFF
--- a/.claude/commands/implementation-checkpoint.md
+++ b/.claude/commands/implementation-checkpoint.md
@@ -33,6 +33,11 @@ Use this route before closing any non-trivial coding task.
    - any boundary, matrix, or migration docs affected
 7. Create the stable checkpoint commit when the slice is coherent and verified.
    Do not close the task first and plan to commit afterward.
+8. Confirm branch handling stayed PR-only for protected branches:
+   - do not push directly to `main`
+   - do not use branch-protection bypass for ordinary delivery
+   - if the user explicitly requested a one-time protected-branch repair,
+     verify the remote branch tip afterward and return to PR-only flow
 
 If a needed structural fix is already obvious and bounded, include it in the
 same checkpoint instead of deferring it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,14 @@ Do not pre-load every repo doc by default.
   - prefer small cohesive commits
   - avoid micro-commits with no rollback or review value
   - end the task on a clean, meaningful checkpoint commit
+- Treat protected branches as PR-only landing surfaces:
+  - do not push directly to `main`
+  - do not bypass branch protection for ordinary delivery
+  - do not force-push protected branches unless the user explicitly requests a
+    one-time repair in the current thread after branch protection has been
+    temporarily adjusted
+  - after any explicit one-time repair, verify the remote branch tip and return
+    to PR-only delivery before continuing
 - Treat repo cleanup as forward-only by default:
   - do not run `rm -rf`, `git restore`, `git reset`, `git checkout --`, or
     other destructive rollback commands unless the user explicitly asks for

--- a/docs/standards/commits.md
+++ b/docs/standards/commits.md
@@ -83,6 +83,15 @@ Standard footers are allowed, including `BREAKING CHANGE:`.
 `main` uses squash merges. Treat the pull request title and description as the
 canonical source for the commit that lands on `main`.
 
+Protected-branch rule:
+
+- land changes on `main` through pull requests only
+- do not push directly to `main`
+- do not use branch-protection bypass or force-push for normal delivery
+- if a protected-branch repair exception is explicitly requested, limit that
+  exception to the exact repair action, verify the remote branch tip
+  immediately afterward, and restore PR-only flow before continuing
+
 PR title rules:
 
 - use the same Conventional Commit subject format required for authored commits


### PR DESCRIPTION
Why:
- document the repository's protected-branch policy and prevent direct-push or bypass mistakes on main

What:
- add PR-only protected-branch rules to AGENTS.md
- document the same rule and repair exception in docs/standards/commits.md
- add a protected-branch verification step to the implementation checkpoint route

Checks:
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.docs_maintenance sync --check
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests

Included checkpoints:
- `docs(standards): forbid protected-branch bypass`
