### PR TITLE
docs(history): anchor the public baseline sequence

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,7 @@ below when you need the detailed procedure for one stage of the workflow.
 - [Canadian Crypto Tax Guide](reference/canadian-crypto-tax-guide.md): Working CRA-aligned tax reference for the repo's Canadian crypto workflow.
 - [Tax Source Map](reference/tax-source-map.md): Targeted routing from repo tax questions to CRA-aligned reference sources.
 - [CoinTracking Oracle Artifacts](reference/cointracking-oracle-artifacts.md): Repo-safe reference for CoinTracking artifact families used only for development and validation.
+- [Repository History](reference/repository-history.md): Reference note for the public baseline sequence and where ordinary forward development begins.
 <!-- docs-maintenance:end reference -->
 
 ## Workspace Guidance

--- a/docs/reference/repository-history.md
+++ b/docs/reference/repository-history.md
@@ -1,0 +1,22 @@
+---
+title: "Repository History"
+summary: "Reference note for the public baseline sequence and where ordinary forward development begins."
+doc_type: reference
+audience: human
+owner: repo
+status: active
+---
+
+The direct root commit and pull requests `#1` through `#30` establish the
+current public baseline for TallyLot's typed runtime, docs, templates, and
+automation.
+
+That baseline sequence preserves multi-checkpoint branches as merge commits and
+single-checkpoint branches as squash commits, so the public code history is
+available directly in Git as well as on GitHub pull request pages.
+
+The direct root commit records why the earlier raw `tallylot-v0` export history
+is omitted from this public graph.
+
+This reference note lands in PR `#31`. Treat later pull requests as ordinary
+forward development on top of that baseline.


### PR DESCRIPTION
Why:
- the direct root commit and the first thirty pull requests now define the public baseline carried forward on main
- later work needs a stable handoff point for where ordinary forward development begins
- placing that note at the end of the replayed baseline keeps the baseline record aligned with the final merge-preserved history

What:
- add a repository history reference note that marks PR #31 as the baseline handoff point
- link that note from the docs index so the boundary is discoverable from the normal documentation entrypoint

Checks:
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests`

Included checkpoints:
- `docs(history): anchor the public baseline sequence`
