### PR TITLE
fix(tools): sync editable env during hook bootstrap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,7 +67,10 @@ Do not pre-load every repo doc by default.
   override it with ad hoc repo-local envs.
 - For all `uv` commands in this repo, use:
   - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv ...`
-- Bootstrap each clone before doing stable work:
+- Bootstrap each clone before doing stable work. This refreshes the shared
+  external project environment for the current checkout and installs repo git
+  hooks, which clears stale editable package paths after repo relocation or
+  history rebuilds:
   - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.install_git_hooks`
 - Do not consider work ready until `markdownlint`, `ruff`, `mypy`, `pyright`,
   `pylint`, and `pytest` pass.

--- a/docs/standards/implementation.md
+++ b/docs/standards/implementation.md
@@ -32,8 +32,12 @@ Prefer the repo's built-in tooling before inventing local workflows:
 - inspect a fresh VS Code Problems snapshot first when the `vscode-problems`
   skill or MCP server is available, then fall back to CLI checks when the
   snapshot is stale, missing, or incomplete
-- bootstrap hooks in each clone with
+- bootstrap each clone with
   `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.install_git_hooks`
+  so the shared external environment is synced to the current checkout before
+  hook installation; rerun that command if
+  `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run tallylot ...`
+  resolves a stale editable checkout after repo relocation or history rebuilds
 - run broad verification with
   `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates`
 - run full verification before closing substantial work with

--- a/tests/unit/test_pre_commit_hook.py
+++ b/tests/unit/test_pre_commit_hook.py
@@ -152,6 +152,11 @@ def test_install_hooks_uses_pre_commit_overwrite_mode(
             None,
         ),
         (
+            ("uv", "sync", "--frozen"),
+            tmp_path,
+            str(Path.home() / ".venvs" / "tallylot-py312"),
+        ),
+        (
             (
                 "uv",
                 "run",

--- a/tools/install_git_hooks.py
+++ b/tools/install_git_hooks.py
@@ -85,6 +85,12 @@ def _install_hooks(repo_root: Path) -> None:
         cwd=repo_root,
     )
     subprocess.run(
+        ["uv", "sync", "--frozen"],
+        check=True,
+        cwd=repo_root,
+        env=repo_uv_environment(),
+    )
+    subprocess.run(
         [
             "uv",
             "run",
@@ -109,13 +115,17 @@ def _install_hooks(repo_root: Path) -> None:
         _HOOK_TEMPLATE.format(**hook_format_args),
         encoding="utf-8",
     )
-    hook_path.chmod(hook_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    hook_path.chmod(
+        hook_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    )
     commit_msg_hook_path = repo_root / ".git/hooks/commit-msg"
     commit_msg_hook_path.write_text(
         _COMMIT_MSG_HOOK_TEMPLATE.format(**hook_format_args),
         encoding="utf-8",
     )
-    commit_msg_hook_path.chmod(commit_msg_hook_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    commit_msg_hook_path.chmod(
+        commit_msg_hook_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
+    )
 
 
 def main() -> int:


### PR DESCRIPTION
Why:
- keep shared uv environments aligned with the current checkout after repo relocation or history rebuilds
- prevent CLI smoke checks from importing stale editable package paths

What:
- run a frozen uv sync before installing repo git hooks
- document that the clone bootstrap command refreshes the shared external environment
- cover the new bootstrap command sequence in hook-install tests

Checks:
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pytest -q --no-cov tests/unit/test_pre_commit_hook.py`
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run ruff check tools/install_git_hooks.py tests/unit/test_pre_commit_hook.py`
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.docs_maintenance sync --check`
- `markdownlint AGENTS.md docs/standards/implementation.md`

Included checkpoints:
- `fix(tools): sync editable env during hook bootstrap`
