### PR TITLE
fix(ci): tolerate rewritten push ranges

### DIFF
--- a/tests/unit/test_commit_message_validator.py
+++ b/tests/unit/test_commit_message_validator.py
@@ -1,6 +1,14 @@
 from __future__ import annotations
 
-from tools.validate_commit_message import _validate_commit_message_text
+import subprocess
+
+from pytest import MonkeyPatch
+
+from tools.validate_commit_message import (
+    _fallback_rev_range,
+    _load_commit_messages_from_range,
+    _validate_commit_message_text,
+)
 
 
 def test_commit_message_without_scope_is_valid() -> None:
@@ -257,3 +265,61 @@ Included checkpoints:
         "unsupported structured label: Included checkpoints:",
         "unexpected trailing content: - `docs: route agents to narrow standards`",
     )
+
+
+def test_fallback_rev_range_uses_head_commit_only() -> None:
+    assert _fallback_rev_range("deadbeef..cafebabe") == "cafebabe^!"
+
+
+def test_fallback_rev_range_rejects_non_range_input() -> None:
+    assert _fallback_rev_range("HEAD^!") is None
+
+
+def test_load_commit_messages_from_range_falls_back_for_rewritten_history(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    calls: list[tuple[str, ...]] = []
+
+    def fake_run(
+        command: list[str],
+        *,
+        check: bool,
+        capture_output: bool,
+        text: bool,
+    ) -> subprocess.CompletedProcess[str]:
+        del check, capture_output, text
+        command_tuple = tuple(command)
+        calls.append(command_tuple)
+        if command_tuple == ("git", "rev-list", "--reverse", "before..after"):
+            raise subprocess.CalledProcessError(
+                returncode=128,
+                cmd=command,
+                stderr="fatal: Invalid revision range before..after",
+            )
+        if command_tuple == ("git", "rev-list", "--reverse", "after^!"):
+            return subprocess.CompletedProcess(command, 0, stdout="after\n", stderr="")
+        if command_tuple == ("git", "show", "--quiet", "--format=%B", "after"):
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=(
+                    "docs: codify pull request merge policy (#35)\n\n"
+                    "Why:\n- keep history clean\n\n"
+                    "What:\n- rewrite the commit record\n\n"
+                    "Checks:\n- uv run pytest\n\n"
+                    "Included checkpoints:\n"
+                    "- `docs: codify pull request merge policy`\n"
+                ),
+                stderr="",
+            )
+        raise AssertionError(f"unexpected command: {command_tuple}")
+
+    monkeypatch.setattr("tools.validate_commit_message.subprocess.run", fake_run)
+
+    messages = _load_commit_messages_from_range("before..after")
+
+    assert [message.label for message in messages] == ["commit after"]
+    assert calls[:2] == [
+        ("git", "rev-list", "--reverse", "before..after"),
+        ("git", "rev-list", "--reverse", "after^!"),
+    ]

--- a/tools/validate_commit_message.py
+++ b/tools/validate_commit_message.py
@@ -8,7 +8,11 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
-from tools.message_standards import MERGE_SUBJECT_PATTERN, validate_structured_sections, validate_subject_line
+from tools.message_standards import (
+    MERGE_SUBJECT_PATTERN,
+    validate_structured_sections,
+    validate_subject_line,
+)
 
 SQUASH_PR_SUBJECT_PATTERN = re.compile(r" \(\#\d+\)$")
 
@@ -41,7 +45,9 @@ def _validate_commit_message_text(message: str) -> tuple[str, ...]:
     if MERGE_SUBJECT_PATTERN.match(subject):
         return ()
 
-    optional_sections = ("Included checkpoints",) if SQUASH_PR_SUBJECT_PATTERN.search(subject) else ()
+    optional_sections = (
+        ("Included checkpoints",) if SQUASH_PR_SUBJECT_PATTERN.search(subject) else ()
+    )
 
     return (
         *validate_subject_line(subject),
@@ -60,13 +66,33 @@ def _load_commit_message_file(path: Path) -> CommitMessage:
     return CommitMessage(label=str(path), text=path.read_text(encoding="utf-8"))
 
 
+def _fallback_rev_range(rev_range: str) -> str | None:
+    if ".." not in rev_range:
+        return None
+    _, head_ref = rev_range.split("..", 1)
+    if head_ref == "":
+        return None
+    return f"{head_ref}^!"
+
+
 def _load_commit_messages_from_range(rev_range: str) -> tuple[CommitMessage, ...]:
-    revision_result = subprocess.run(
-        ["git", "rev-list", "--reverse", rev_range],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    try:
+        revision_result = subprocess.run(
+            ["git", "rev-list", "--reverse", rev_range],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except subprocess.CalledProcessError:
+        fallback_range = _fallback_rev_range(rev_range)
+        if fallback_range is None:
+            raise
+        revision_result = subprocess.run(
+            ["git", "rev-list", "--reverse", fallback_range],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
     commit_ids = tuple(line for line in revision_result.stdout.splitlines() if line)
     messages: list[CommitMessage] = []
     for commit_id in commit_ids:
@@ -76,14 +102,25 @@ def _load_commit_messages_from_range(rev_range: str) -> tuple[CommitMessage, ...
             capture_output=True,
             text=True,
         )
-        messages.append(CommitMessage(label=f"commit {commit_id[:7]}", text=message_result.stdout))
+        messages.append(
+            CommitMessage(label=f"commit {commit_id[:7]}", text=message_result.stdout)
+        )
     return tuple(messages)
 
 
 def _build_argument_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Validate commit messages for this repo.")
-    parser.add_argument("message_files", metavar="MESSAGE_FILE", nargs="*", help="Path to commit message file.")
-    parser.add_argument("--rev-range", dest="rev_range", help="Git revision range to validate.")
+    parser = argparse.ArgumentParser(
+        description="Validate commit messages for this repo."
+    )
+    parser.add_argument(
+        "message_files",
+        metavar="MESSAGE_FILE",
+        nargs="*",
+        help="Path to commit message file.",
+    )
+    parser.add_argument(
+        "--rev-range", dest="rev_range", help="Git revision range to validate."
+    )
     return parser
 
 
@@ -101,7 +138,9 @@ def main(argv: Sequence[str] | None = None) -> int:
     messages: list[CommitMessage] = []
     if args.rev_range is not None:
         messages.extend(_load_commit_messages_from_range(args.rev_range))
-    messages.extend(_load_commit_message_file(Path(path)) for path in args.message_files)
+    messages.extend(
+        _load_commit_message_file(Path(path)) for path in args.message_files
+    )
 
     has_errors = False
     for message in messages:


### PR DESCRIPTION
Why:
- keep push CI from crashing after a narrow protected-branch history repair
- validate the pushed commit message even when the previous remote tip is no longer an ancestor

What:
- fall back from an invalid two-dot revision range to the pushed head commit only
- add regression coverage for rewritten-history push ranges in the commit-message validator tests

Checks:
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pytest tests/unit/test_commit_message_validator.py -q --no-cov
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests

Included checkpoints:
- `fix(ci): tolerate rewritten push ranges`
