### PR TITLE
docs: codify pull request merge policy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable-file MD041 MD032 -->
+<!-- Multi-checkpoint PRs must merge-commit. Single-checkpoint PRs must squash. -->
 
 Why:
 - explain the problem or constraint this PR resolves

--- a/docs/standards/commits.md
+++ b/docs/standards/commits.md
@@ -78,10 +78,15 @@ Checks:
 
 Standard footers are allowed, including `BREAKING CHANGE:`.
 
-## Pull Request And Squash Merge Standard
+## Pull Request Merge Strategy Standard
 
-`main` uses squash merges. Treat the pull request title and description as the
-canonical source for the commit that lands on `main`.
+`main` is a merge-commit branch by default. Preserve multi-checkpoint pull
+requests with merge commits so the reviewed checkpoint history remains visible
+in Git. Use squash merges only for the narrow single-checkpoint exception.
+
+Treat the pull request title and description as the canonical review record
+for every PR. For the single-checkpoint exception, that same metadata also
+becomes the generated squash commit that lands on `main`.
 
 Protected-branch rule:
 
@@ -95,7 +100,8 @@ Protected-branch rule:
 PR title rules:
 
 - use the same Conventional Commit subject format required for authored commits
-- keep the title history-ready on its own because the squash subject becomes
+- keep the title history-ready on its own because it remains the PR headline
+  and, for a single-checkpoint PR, the squash subject becomes
   `<pr title> (#<pr number>)`
 - do not use generic titles such as `update branch`, `cleanup`, or `misc fixes`
 
@@ -116,10 +122,19 @@ PR body rules:
 - for a one-commit PR, still list that single checkpoint under
   `Included checkpoints:`
 
-The GitHub-generated squash commit on `main` may retain the validated
-`Included checkpoints:` section from the PR body. Treat that as allowed for the
-generated mainline commit record, even though authored checkpoint commits
-should only use `Why:`, `What:`, and `Checks:` sections.
+Merge method rules:
+
+- if `Included checkpoints:` lists more than one commit, the PR must merge with
+  a merge commit
+- if `Included checkpoints:` lists exactly one commit, the PR must squash merge
+- do not squash multi-checkpoint PRs
+- do not create a merge commit for a single-checkpoint PR unless the user
+  explicitly requests a one-off repair in the current thread
+
+For a single-checkpoint PR, the GitHub-generated squash commit on `main` may
+retain the validated `Included checkpoints:` section from the PR body. Treat
+that as allowed for the generated mainline commit record, even though authored
+checkpoint commits should only use `Why:`, `What:`, and `Checks:` sections.
 
 Preferred PR body template:
 
@@ -161,6 +176,14 @@ Heuristics:
 Do not batch unrelated fixes together. Do not split one bounded change into a
 series of micro-commits with no practical review value.
 
+Before a checkpoint commit is pushed, fold a small, scoped follow-up patch into
+the owning checkpoint when that produces a cleaner review boundary. A
+non-pushed checkpoint commit may be amended for small cleanups and fixes that
+still belong to that same checkpoint. Use `git commit --amend`, `git rebase`,
+or fixup-based consolidation for that limited cleanup only, and update the
+amended commit message so `Why:`, `What:`, and `Checks:` remain accurate for
+the final commit content. Do not use repeated amend cycles to grow one broad
+commit that should be split into separate stable checkpoints.
 For multi-slice refactors, use designated checkpoint commits whenever the slice
 already leaves the tree coherent, linked, and narrow-check verified. A giant
 single-commit rewrite is only acceptable when the change cannot be reviewed or

--- a/docs/standards/implementation.md
+++ b/docs/standards/implementation.md
@@ -191,6 +191,12 @@ Expected behavior:
 - make a commit when a bounded slice is stable and verified
 - keep commits cohesive and reviewable
 - prefer one commit per coherent reshape slice, not one commit per file
+- before a checkpoint commit is pushed, amend or fix up a small, scoped
+  follow-up patch into the owning non-pushed checkpoint when that avoids a
+  low-value micro-commit, and update the amended commit message so its
+  `Why:`, `What:`, and `Checks:` sections still describe the final content
+- do not use repeated amend cycles to grow one broad checkpoint that should be
+  split into separate commits with clearer review and rollback boundaries
 - do not bundle unrelated fixes
 - do not wait for the user to remind you to commit once the task has reached a
   real checkpoint
@@ -198,7 +204,12 @@ Expected behavior:
   stable slice that already passes the narrow checks for that slice
 - when opening a PR, use a Conventional Commit title and the structured PR body
   defined in `docs/standards/commits.md` because that metadata
-  becomes the squash commit on `main`
+  stays attached to the PR record and becomes the squash commit on `main` for
+  the single-checkpoint exception
+- when the work uncovers follow-up or out-of-scope changes that do not belong
+  in the current PR, create the issue immediately so it does not get lost
+- do not defer issue creation for out-of-scope work until after merge, handoff,
+  or a later cleanup pass
 - before closing a non-trivial task, ensure the commit already exists rather
   than leaving commit creation as follow-up work
 - keep repo cleanup forward-only by default: do not use destructive rollback

--- a/tests/unit/test_commit_message_validator.py
+++ b/tests/unit/test_commit_message_validator.py
@@ -82,7 +82,7 @@ def test_squash_merge_commit_message_with_included_checkpoints_is_valid() -> Non
 refactor: source verification and routing (#11)
 
 Why:
-- keep the squash-merge record reviewable on main
+- keep the single-checkpoint squash record reviewable on main
 
 What:
 - preserve the validated pull request summary
@@ -239,7 +239,9 @@ Checks:
 def test_missing_structured_body_is_rejected() -> None:
     errors = _validate_commit_message_text("docs: route agents to narrow standards\n")
 
-    assert errors == ("commit message body is required with `Why:`, `What:`, `Checks:` sections",)
+    assert errors == (
+        "commit message body is required with `Why:`, `What:`, `Checks:` sections",
+    )
 
 
 def test_authored_commit_message_rejects_included_checkpoints_section() -> None:

--- a/tests/unit/test_docs_runtime_parity.py
+++ b/tests/unit/test_docs_runtime_parity.py
@@ -9,7 +9,13 @@ from typing import cast
 from typer.main import Typer
 from typer.models import CommandInfo
 
-from repo_support.paths import adapter_packs_root, agents_root, claude_commands_root, docs_root, repo_root
+from repo_support.paths import (
+    adapter_packs_root,
+    agents_root,
+    claude_commands_root,
+    docs_root,
+    repo_root,
+)
 from tallylot.infrastructure.workspace.layout import SEED_FILES
 from tallylot.interfaces.cli import app
 from tools.oracles.cli import app as oracle_app
@@ -125,7 +131,9 @@ def _registered_routes(typer_app: Typer) -> set[str]:
 
 
 def test_documented_cli_routes_exist() -> None:
-    documented_routes = _documented_routes(production_route_doc_paths(), PRODUCTION_COMMAND_ROUTE_PATTERN)
+    documented_routes = _documented_routes(
+        production_route_doc_paths(), PRODUCTION_COMMAND_ROUTE_PATTERN
+    )
     registered_routes = _registered_routes(app)
 
     missing_routes = sorted(documented_routes - registered_routes)
@@ -134,12 +142,16 @@ def test_documented_cli_routes_exist() -> None:
 
 
 def test_documented_oracle_cli_routes_exist() -> None:
-    documented_routes = _documented_routes(oracle_route_doc_paths(), ORACLE_COMMAND_ROUTE_PATTERN)
+    documented_routes = _documented_routes(
+        oracle_route_doc_paths(), ORACLE_COMMAND_ROUTE_PATTERN
+    )
     registered_routes = _registered_routes(oracle_app)
 
     missing_routes = sorted(documented_routes - registered_routes)
 
-    assert not missing_routes, f"documented oracle CLI routes do not exist: {missing_routes}"
+    assert not missing_routes, (
+        f"documented oracle CLI routes do not exist: {missing_routes}"
+    )
 
 
 def test_documented_claude_command_routes_exist() -> None:
@@ -156,7 +168,9 @@ def test_documented_claude_command_routes_exist() -> None:
     )
 
     for relative_path in command_paths:
-        assert (repo_root() / relative_path).exists(), f"missing documented command route: {relative_path}"
+        assert (repo_root() / relative_path).exists(), (
+            f"missing documented command route: {relative_path}"
+        )
 
 
 def test_documented_claude_command_routes_are_not_ignored() -> None:
@@ -199,21 +213,21 @@ def test_source_intake_route_mentions_current_typed_commands() -> None:
 
 
 def test_round_verification_route_mentions_oracle_cli_commands() -> None:
-    text = (claude_commands_root() / "round-verification.md").read_text(encoding="utf-8")
+    text = (claude_commands_root() / "round-verification.md").read_text(
+        encoding="utf-8"
+    )
 
-    scaffold_command = (
-        'UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.oracles.cli round scaffold'
-    )
-    compare_command = (
-        'UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.oracles.cli verification compare'
-    )
+    scaffold_command = 'UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.oracles.cli round scaffold'
+    compare_command = 'UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.oracles.cli verification compare'
 
     assert scaffold_command in text
     assert compare_command in text
 
 
 def test_supporting_route_mentions_checkpoint_pdf_balance_extraction_command() -> None:
-    text = (claude_commands_root() / "supporting-artifacts.md").read_text(encoding="utf-8")
+    text = (claude_commands_root() / "supporting-artifacts.md").read_text(
+        encoding="utf-8"
+    )
 
     assert "checkpoint extract-pdf-balances" in text
 
@@ -241,7 +255,9 @@ def test_docs_do_not_reference_retired_service_or_model_buckets() -> None:
     for path in architecture_doc_paths():
         text = path.read_text(encoding="utf-8").lower()
         for needle in forbidden:
-            assert needle not in text, f"{path} still references retired surface {needle!r}"
+            assert needle not in text, (
+                f"{path} still references retired surface {needle!r}"
+            )
 
 
 def test_docs_use_lowercase_filenames_except_readmes() -> None:
@@ -271,11 +287,15 @@ def test_repo_docs_do_not_reference_personal_workspace_roots() -> None:
     for path in paths:
         text = path.read_text(encoding="utf-8")
         for needle in forbidden:
-            assert needle not in text, f"{path} still references personal workspace path {needle}"
+            assert needle not in text, (
+                f"{path} still references personal workspace path {needle}"
+            )
 
 
 def test_private_oracle_manifest_is_not_checked_in() -> None:
-    assert not (docs_root() / "reference" / "cointracking-full-export-manifest.csv").exists()
+    assert not (
+        docs_root() / "reference" / "cointracking-full-export-manifest.csv"
+    ).exists()
 
 
 def test_workspace_issue_log_seed_header_matches_template() -> None:
@@ -285,7 +305,9 @@ def test_workspace_issue_log_seed_header_matches_template() -> None:
         .splitlines()[0]
     )
     seeded_header = next(
-        seed.content.strip() for seed in SEED_FILES if seed.relative_path == "analysis/issues/issue_log.csv"
+        seed.content.strip()
+        for seed in SEED_FILES
+        if seed.relative_path == "analysis/issues/issue_log.csv"
     )
 
     assert seeded_header == template_header
@@ -293,12 +315,20 @@ def test_workspace_issue_log_seed_header_matches_template() -> None:
 
 def test_workspace_source_inventory_seed_header_matches_template() -> None:
     template_header = (
-        (docs_root() / "workspace" / "analysis" / "issues" / "source-inventory-template.csv")
+        (
+            docs_root()
+            / "workspace"
+            / "analysis"
+            / "issues"
+            / "source-inventory-template.csv"
+        )
         .read_text(encoding="utf-8")
         .splitlines()[0]
     )
     seeded_header = next(
-        seed.content.strip() for seed in SEED_FILES if seed.relative_path == "analysis/issues/source_inventory.csv"
+        seed.content.strip()
+        for seed in SEED_FILES
+        if seed.relative_path == "analysis/issues/source_inventory.csv"
     )
 
     assert seeded_header == template_header
@@ -308,9 +338,33 @@ def test_commit_standards_require_explicit_lint_amend_reverification() -> None:
     text = (docs_root() / "standards" / "commits.md").read_text(encoding="utf-8")
 
     assert "Do not describe `mypy` or `pyright` as covering `pylint` findings." in text
-    assert 'UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pylint <touched-file>' in text
-    assert 'UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pytest -q --no-cov <touched-test-file>' in text
+    assert (
+        'UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pylint <touched-file>'
+        in text
+    )
+    assert (
+        'UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pytest -q --no-cov <touched-test-file>'
+        in text
+    )
     assert "git show HEAD:<path>" in text
+
+
+def test_commit_standards_document_hybrid_pr_merge_policy() -> None:
+    text = (docs_root() / "standards" / "commits.md").read_text(encoding="utf-8")
+    implementation_text = (docs_root() / "standards" / "implementation.md").read_text(
+        encoding="utf-8"
+    )
+    pr_template = (repo_root() / ".github" / "pull_request_template.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "`main` is a merge-commit branch by default." in text
+    assert "Use squash merges only for the narrow single-checkpoint exception." in text
+    assert "do not squash multi-checkpoint PRs" in text
+    assert "non-pushed checkpoint commit may be amended" in text
+    assert "single-checkpoint exception" in implementation_text
+    assert "create the issue immediately so it does not get lost" in implementation_text
+    assert "Single-checkpoint PRs must squash." in pr_template
 
 
 def test_implementation_anchor_references_use_explicit_doc_paths() -> None:
@@ -321,7 +375,9 @@ def test_implementation_anchor_references_use_explicit_doc_paths() -> None:
 
     for path in paths:
         text = path.read_text(encoding="utf-8")
-        assert "implementation plan" not in text.lower(), f"{path} still uses vague implementation-plan wording"
+        assert "implementation plan" not in text.lower(), (
+            f"{path} still uses vague implementation-plan wording"
+        )
 
 
 def test_reference_docs_do_not_check_in_oracle_data_files() -> None:
@@ -341,4 +397,6 @@ def test_adapter_pack_goldens_do_not_embed_absolute_home_paths() -> None:
     for path in sorted(adapter_packs_root().rglob("*.json")):
         text = path.read_text(encoding="utf-8")
         for needle in forbidden:
-            assert needle not in text, f"{path} still embeds absolute local path content"
+            assert needle not in text, (
+                f"{path} still embeds absolute local path content"
+            )

--- a/tests/unit/test_pr_metadata_validator.py
+++ b/tests/unit/test_pr_metadata_validator.py
@@ -2,7 +2,11 @@ from __future__ import annotations
 
 from pytest import MonkeyPatch
 
-from tools.validate_pr_metadata import _validate_pr_body, _validate_pr_checkpoints, _validate_pr_title
+from tools.validate_pr_metadata import (
+    _validate_pr_body,
+    _validate_pr_checkpoints,
+    _validate_pr_title,
+)
 
 
 def test_pr_title_with_conventional_commit_subject_is_valid() -> None:
@@ -24,10 +28,10 @@ def test_pr_title_without_conventional_commit_subject_is_rejected() -> None:
 def test_pr_body_with_required_sections_is_valid() -> None:
     body = """\
 Why:
-- keep mainline history concise
+- keep multi-checkpoint history visible on main
 
 What:
-- document and validate squash-merge metadata
+- document and validate pull request metadata
 
 Checks:
 - uv run python -m tools.run_quality_gates
@@ -46,10 +50,10 @@ def test_pr_body_tolerates_leading_html_comment() -> None:
 <!-- markdownlint-disable-file MD041 MD032 -->
 
 Why:
-- keep mainline history concise
+- keep multi-checkpoint history visible on main
 
 What:
-- document and validate squash-merge metadata
+- document and validate pull request metadata
 
 Checks:
 - uv run python -m tools.run_quality_gates
@@ -66,10 +70,10 @@ Included checkpoints:
 def test_pr_body_rejects_missing_section() -> None:
     body = """\
 Why:
-- keep mainline history concise
+- keep multi-checkpoint history visible on main
 
 What:
-- document and validate squash-merge metadata
+- document and validate pull request metadata
 
 Checks:
 - uv run python -m tools.run_quality_gates
@@ -83,10 +87,10 @@ Checks:
 def test_pr_body_rejects_non_bullet_content() -> None:
     body = """\
 Why:
-keep mainline history concise
+keep multi-checkpoint history visible on main
 
 What:
-- document and validate squash-merge metadata
+- document and validate pull request metadata
 
 Checks:
 - uv run python -m tools.run_quality_gates
@@ -97,16 +101,19 @@ Included checkpoints:
 
     errors = _validate_pr_body(body)
 
-    assert errors == ("`Why:` entries must use `- ` bullets", "`Why:` must contain at least one bullet")
+    assert errors == (
+        "`Why:` entries must use `- ` bullets",
+        "`Why:` must contain at least one bullet",
+    )
 
 
 def test_pr_checkpoints_match_commit_subjects(monkeypatch: MonkeyPatch) -> None:
     body = """\
 Why:
-- keep mainline history concise
+- keep multi-checkpoint history visible on main
 
 What:
-- document and validate squash-merge metadata
+- document and validate pull request metadata
 
 Checks:
 - uv run python -m tools.run_quality_gates
@@ -139,10 +146,10 @@ def test_pr_checkpoints_ignore_leading_html_comment(monkeypatch: MonkeyPatch) ->
 <!-- markdownlint-disable-file MD041 MD032 -->
 
 Why:
-- keep mainline history concise
+- keep multi-checkpoint history visible on main
 
 What:
-- document and validate squash-merge metadata
+- document and validate pull request metadata
 
 Checks:
 - uv run python -m tools.run_quality_gates
@@ -162,13 +169,15 @@ Included checkpoints:
     assert errors == ()
 
 
-def test_pr_checkpoints_reject_non_exact_commit_subjects(monkeypatch: MonkeyPatch) -> None:
+def test_pr_checkpoints_reject_non_exact_commit_subjects(
+    monkeypatch: MonkeyPatch,
+) -> None:
     body = """\
 Why:
-- keep mainline history concise
+- keep multi-checkpoint history visible on main
 
 What:
-- document and validate squash-merge metadata
+- document and validate pull request metadata
 
 Checks:
 - uv run python -m tools.run_quality_gates
@@ -185,16 +194,18 @@ Included checkpoints:
 
     errors = _validate_pr_checkpoints(body, base_sha="base", head_sha="head")
 
-    assert errors == ("`Included checkpoints:` entries must wrap commit subjects in backticks",)
+    assert errors == (
+        "`Included checkpoints:` entries must wrap commit subjects in backticks",
+    )
 
 
 def test_pr_checkpoints_reject_subject_mismatch(monkeypatch: MonkeyPatch) -> None:
     body = """\
 Why:
-- keep mainline history concise
+- keep multi-checkpoint history visible on main
 
 What:
-- document and validate squash-merge metadata
+- document and validate pull request metadata
 
 Checks:
 - uv run python -m tools.run_quality_gates
@@ -211,4 +222,6 @@ Included checkpoints:
 
     errors = _validate_pr_checkpoints(body, base_sha="base", head_sha="head")
 
-    assert errors == ("`Included checkpoints:` must exactly match the branch commit subjects in order",)
+    assert errors == (
+        "`Included checkpoints:` must exactly match the branch commit subjects in order",
+    )

--- a/tools/validate_pr_metadata.py
+++ b/tools/validate_pr_metadata.py
@@ -89,33 +89,49 @@ def _validate_pr_body(body: str) -> tuple[str, ...]:
     )
 
 
-def _validate_pr_checkpoints(body: str, *, base_sha: str, head_sha: str) -> tuple[str, ...]:
+def _validate_pr_checkpoints(
+    body: str, *, base_sha: str, head_sha: str
+) -> tuple[str, ...]:
     parsed_sections = _parse_required_sections(body)
     checkpoint_entries = parsed_sections["Included checkpoints"]
-    normalized_entries = tuple(_normalize_checkpoint_entry(entry) for entry in checkpoint_entries)
+    normalized_entries = tuple(
+        _normalize_checkpoint_entry(entry) for entry in checkpoint_entries
+    )
     actual_subjects = _load_commit_subjects(base_sha, head_sha)
 
     errors: list[str] = []
     for entry, normalized in zip(checkpoint_entries, normalized_entries, strict=False):
         if not entry.startswith("- `") or not entry.endswith("`"):
-            errors.append("`Included checkpoints:` entries must wrap commit subjects in backticks")
+            errors.append(
+                "`Included checkpoints:` entries must wrap commit subjects in backticks"
+            )
             break
 
         if validate_subject_line(normalized, allow_merge=False):
-            errors.append("`Included checkpoints:` entries must be exact Conventional Commit subjects")
+            errors.append(
+                "`Included checkpoints:` entries must be exact Conventional Commit subjects"
+            )
             break
 
     if normalized_entries != actual_subjects:
-        errors.append("`Included checkpoints:` must exactly match the branch commit subjects in order")
+        errors.append(
+            "`Included checkpoints:` must exactly match the branch commit subjects in order"
+        )
     return tuple(errors)
 
 
 def _build_argument_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Validate pull request title and body for squash merges.")
+    parser = argparse.ArgumentParser(
+        description="Validate pull request title and body for the repo merge strategy."
+    )
     parser.add_argument("--title", required=True, help="Pull request title.")
     parser.add_argument("--body", required=True, help="Pull request body.")
-    parser.add_argument("--base-sha", help="Base commit SHA for validating included checkpoints.")
-    parser.add_argument("--head-sha", help="Head commit SHA for validating included checkpoints.")
+    parser.add_argument(
+        "--base-sha", help="Base commit SHA for validating included checkpoints."
+    )
+    parser.add_argument(
+        "--head-sha", help="Head commit SHA for validating included checkpoints."
+    )
     return parser
 
 
@@ -124,7 +140,11 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     errors = [*_validate_pr_title(args.title), *_validate_pr_body(args.body)]
     if args.base_sha and args.head_sha:
-        errors.extend(_validate_pr_checkpoints(args.body, base_sha=args.base_sha, head_sha=args.head_sha))
+        errors.extend(
+            _validate_pr_checkpoints(
+                args.body, base_sha=args.base_sha, head_sha=args.head_sha
+            )
+        )
     if not errors:
         return 0
 


### PR DESCRIPTION
Why:
- align repo standards with the current merge-commit history model
- make the single-checkpoint squash exception explicit and narrow
- keep out-of-scope follow-up work from getting lost by requiring immediate issue creation

What:
- rewrite the PR merge strategy standard around merge commits by default
- clarify amend guidance for non-pushed checkpoint cleanups and one-off merge-commit exceptions
- update the PR template, validator wording, and parity tests to match the current repo policy

Checks:
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests

Included checkpoints:
- `docs: codify pull request merge policy`
