### PR TITLE
ci: deduplicate hook and parity checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,26 +78,5 @@ jobs:
         run: python -m pip install uv
       - name: Sync dependencies
         run: uv sync --python 3.12 --frozen
-      - name: Markdownlint
-        run: uv run pre-commit run markdownlint --all-files
-      - name: Actionlint
-        run: uv run actionlint -color
-      - name: Ruff
-        run: uv run ruff check .
-      - name: Mypy
-        run: uv run mypy
-      - name: Pyright
-        run: uv run pyright
-      - name: Pylint
-        run: uv run python -m tools.run_pylint
-      - name: Pytest
-        run: uv run pytest
-      - name: Build distributions
-        run: uv build
-      - name: Verify built wheel entry point
-        run: |
-          set -eu
-          rm -rf /tmp/tallylot-wheel-test
-          python3.12 -m venv /tmp/tallylot-wheel-test
-          /tmp/tallylot-wheel-test/bin/pip install dist/*.whl
-          /tmp/tallylot-wheel-test/bin/tallylot --help >/dev/null
+      - name: Run CI parity checks
+        run: uv run python -m tools.run_ci_parity_checks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,4 @@
 repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.2
-    hooks:
-      - id: ruff
-        args: [--fix]
-      - id: ruff-format
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.45.0
     hooks:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,10 +92,11 @@ Do not pre-load every repo doc by default.
 - Do not run `tools.run_quality_gates --full-tests` immediately before
   `tools.run_ci_parity_checks`; the parity runner already includes the full
   quality gate pass.
-- The commit-time `pytest` hook is intentionally fast:
-  - `unit and not slow`
-  - no coverage
-  - run full `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pytest` before closing substantial work
+- Keep commit-time hooks narrow:
+  - safe staged Ruff autofixes
+  - commit-message validation
+  - markdownlint, mypy, pyright, and the fast pytest slice
+  - do not turn the hook path into a second full-suite verification pass
 - Treat commits as stable checkpoints by default:
   - prefer small cohesive commits
   - avoid micro-commits with no rollback or review value

--- a/docs/standards/commits.md
+++ b/docs/standards/commits.md
@@ -198,12 +198,12 @@ work:
 UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.install_git_hooks
 ```
 
-The installed `pre-commit` hook formats safe staged Python files with Ruff
-before running the remaining hooks once. It skips auto-restaging for partially
-staged Python files so unrelated unstaged hunks are not accidentally committed.
-It also refuses to run when the sibling `commit-msg` validator hook is missing
-or stale, so clone-local hook drift cannot silently bypass commit-message
-validation.
+The installed `pre-commit` hook is intentionally narrow. It formats safe
+staged Python files with Ruff before commit creation and skips auto-restaging
+for partially staged Python files so unrelated unstaged hunks are not
+accidentally committed. It also refuses to run when the sibling `commit-msg`
+validator hook is missing or stale, so clone-local hook drift cannot silently
+bypass commit-message validation.
 
 Validate messages directly when needed:
 
@@ -212,31 +212,28 @@ UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.vali
 UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.validate_commit_message --rev-range HEAD~3..HEAD
 ```
 
-## Commit-Time Test Policy
+## Commit-Time Verification Policy
 
-The `pre-commit` `pytest` hook is intentionally scoped to fast unit coverage:
+Commit-time hooks should enforce the bounded local safety checks we expect on
+every checkpoint commit without rerunning the full repo-wide verification
+matrix. Keep the hook path limited to safe staged Ruff autofixes plus the
+commit-time checks that protect every commit:
 
-```bash
-UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pytest -m "unit and not slow" --no-cov -q
-```
+- `markdownlint`
+- `mypy`
+- `pyright`
+- `pytest -m "unit and not slow" --no-cov -q`
+- commit-message validation
 
-That hook is meant to protect local commits without paying the cost of
-coverage, contract tests, or end-to-end CLI flows on every commit. Full
-verification still means running:
+Full verification still means running:
 
 ```bash
 UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests
 ```
 
 Do not also run `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pre-commit run --all-files` in addition to the
-parallel quality-gate runner unless you are validating the hooks themselves.
-
-Re-benchmark suite segments before broadening or shrinking the fast test slice:
-
-```bash
-UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.benchmark_tests
-UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.benchmark_tests --parallel
-```
+shared quality-gate or CI-parity runners unless you are validating hook
+behavior itself.
 
 For explicit local verification outside the hook path, the repo also ships a
 parallel quality-gate runner:
@@ -271,9 +268,10 @@ UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_
   --pr-body-file /tmp/pr-body.md
 ```
 
-`pylint` remains part of the parallel quality-gate runner, but it is not part
-of the `pre-commit` hook path because it is materially slower than the other
-commit-time checks.
+`pylint`, full-repo `ruff`, and the full `pytest` suite belong to the shared
+quality and CI-parity runners rather than the commit-time hook path. The fast
+hook checks should stay narrower than the full parity matrix so the same broad
+suite is not rerun twice inside one explicit verification pass.
 
 Do not describe `mypy` or `pyright` as covering `pylint` findings. Type checks
 and lint checks catch different failure classes and must be reported

--- a/docs/standards/implementation.md
+++ b/docs/standards/implementation.md
@@ -246,12 +246,11 @@ is:
 - do not run `tools.run_quality_gates --full-tests` again immediately before
   `tools.run_ci_parity_checks`; the parity runner already includes it
 
-If you are changing commit-time or suite-selection policy, benchmark first
-instead of guessing:
-
-- use `tools.benchmark_tests`
-- preserve the fast commit-time slice unless a measured change justifies
-  expanding it
+If you are changing commit-time or suite-selection policy, keep the hook path
+limited to bounded checkpoint checks and use the shared quality or parity
+runners as the single broad verification source. Benchmark with
+`tools.benchmark_tests` when you are proposing a different test slice, and do
+not expand the hook path into a second full-suite verification pass.
 
 ## Migration Discipline
 

--- a/tests/unit/test_ci_parity_checks.py
+++ b/tests/unit/test_ci_parity_checks.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from pytest import MonkeyPatch
 
 import tools.run_ci_parity_checks as ci_parity
+from repo_support.paths import repo_root
 
 
 def test_commit_message_range_uses_merge_base(monkeypatch: MonkeyPatch) -> None:
@@ -22,7 +23,9 @@ def test_commit_message_range_uses_merge_base(monkeypatch: MonkeyPatch) -> None:
     assert ci_parity._commit_message_range() == "abc123..def456"
 
 
-def test_commit_message_range_falls_back_to_head_commit(monkeypatch: MonkeyPatch) -> None:
+def test_commit_message_range_falls_back_to_head_commit(
+    monkeypatch: MonkeyPatch,
+) -> None:
     def fake_git_stdout(*args: str) -> str:
         if args == ("symbolic-ref", "--short", "refs/remotes/origin/HEAD"):
             return "origin/main"
@@ -37,7 +40,9 @@ def test_commit_message_range_falls_back_to_head_commit(monkeypatch: MonkeyPatch
     assert ci_parity._commit_message_range() == "HEAD^!"
 
 
-def test_ci_parity_stops_when_commit_message_step_fails(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+def test_ci_parity_stops_when_commit_message_step_fails(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(ci_parity, "_commit_message_range", lambda: "base..head")
 
@@ -58,7 +63,9 @@ def test_ci_parity_requires_full_pr_metadata_input(tmp_path: Path) -> None:
     assert ci_parity.main(["--pr-body-file", str(pr_body)]) == 2
 
 
-def test_ci_parity_runs_quality_build_and_verify(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+def test_ci_parity_runs_quality_build_and_verify(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
     monkeypatch.chdir(tmp_path)
     dist_dir = tmp_path / "dist"
     dist_dir.mkdir()
@@ -85,7 +92,9 @@ def test_ci_parity_runs_quality_build_and_verify(monkeypatch: MonkeyPatch, tmp_p
     assert steps_seen == ["quality", "build"]
 
 
-def test_ci_parity_can_include_commit_messages(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+def test_ci_parity_can_include_commit_messages(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(ci_parity, "_commit_message_range", lambda: "base..head")
     dist_dir = tmp_path / "dist"
@@ -113,7 +122,9 @@ def test_ci_parity_can_include_commit_messages(monkeypatch: MonkeyPatch, tmp_pat
     assert steps_seen == ["commit-messages", "quality", "build"]
 
 
-def test_ci_parity_can_include_pr_metadata(monkeypatch: MonkeyPatch, tmp_path: Path) -> None:
+def test_ci_parity_can_include_pr_metadata(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
     monkeypatch.chdir(tmp_path)
     monkeypatch.setattr(ci_parity, "_pr_validation_shas", lambda: ("base", "head"))
     pr_body = tmp_path / "pr.md"
@@ -148,8 +159,24 @@ def test_ci_parity_can_include_pr_metadata(monkeypatch: MonkeyPatch, tmp_path: P
     monkeypatch.setattr(ci_parity, "_run_step", fake_run_step)
     monkeypatch.setattr(ci_parity, "_verify_built_wheel", fake_verify_built_wheel)
 
-    assert ci_parity.main(["--pr-title", "ci: tighten parity", "--pr-body-file", str(pr_body)]) == 0
+    assert (
+        ci_parity.main(
+            ["--pr-title", "ci: tighten parity", "--pr-body-file", str(pr_body)]
+        )
+        == 0
+    )
     assert [step.name for step in steps_seen] == ["pr-metadata", "quality", "build"]
     assert steps_seen[0].command[4] == "tools.validate_pr_metadata"
     assert "--base-sha" in steps_seen[0].command
     assert "--head-sha" in steps_seen[0].command
+
+
+def test_ci_workflow_uses_parity_runner_for_quality_job() -> None:
+    workflow_text = (repo_root() / ".github/workflows/ci.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "uv run python -m tools.run_ci_parity_checks" in workflow_text
+    assert "run: uv run mypy" not in workflow_text
+    assert "run: uv run pyright" not in workflow_text
+    assert "run: uv run pytest" not in workflow_text

--- a/tests/unit/test_pre_commit_hook.py
+++ b/tests/unit/test_pre_commit_hook.py
@@ -8,7 +8,7 @@ import pytest
 import tools.install_git_hooks
 import tools.pre_commit_hook
 from tools.install_git_hooks import _COMMIT_MSG_HOOK_TEMPLATE, _HOOK_TEMPLATE
-from tools.pre_commit_hook import _format_candidates, _skip_value
+from tools.pre_commit_hook import _format_candidates
 
 
 def test_format_candidates_selects_only_safe_staged_python_files() -> None:
@@ -27,11 +27,6 @@ def test_format_candidates_skips_partially_staged_python_files() -> None:
     )
 
     assert candidates == ("src/other.py",)
-
-
-def test_skip_value_appends_formatter_hooks_once() -> None:
-    assert _skip_value(None) == "ruff,ruff-format"
-    assert _skip_value("pytest,ruff") == "pytest,ruff,ruff-format"
 
 
 def test_pre_commit_wrapper_fails_when_commit_msg_hook_is_missing(
@@ -69,16 +64,19 @@ def test_pre_commit_wrapper_runs_when_commit_msg_hook_is_installed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    format_calls: list[tuple[str, ...]] = []
+    pre_commit_calls: list[str] = []
+
     def fake_git_paths(*args: str) -> tuple[str, ...]:
         del args
         return ()
 
     def fake_format_and_stage(paths: tuple[str, ...]) -> int:
-        del paths
+        format_calls.append(paths)
         return 0
 
-    def fake_run_pre_commit(hook_args: list[str]) -> int:
-        del hook_args
+    def fake_run_pre_commit() -> int:
+        pre_commit_calls.append("run")
         return 0
 
     hooks_dir = tmp_path / ".git" / "hooks"
@@ -95,6 +93,8 @@ def test_pre_commit_wrapper_runs_when_commit_msg_hook_is_installed(
     monkeypatch.setattr(tools.pre_commit_hook, "_run_pre_commit", fake_run_pre_commit)
 
     assert tools.pre_commit_hook.main([]) == 0
+    assert format_calls == [()]
+    assert pre_commit_calls == ["run"]
 
 
 def test_install_hook_template_execs_repo_pre_commit_wrapper() -> None:
@@ -105,7 +105,7 @@ def test_install_hook_template_execs_repo_pre_commit_wrapper() -> None:
     assert 'REPO_ROOT="$(git rev-parse --show-toplevel)"' in _COMMIT_MSG_HOOK_TEMPLATE
 
 
-def test_install_hooks_uses_pre_commit_overwrite_mode(
+def test_install_hooks_syncs_environment_before_writing_repo_hooks(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -153,21 +153,6 @@ def test_install_hooks_uses_pre_commit_overwrite_mode(
         ),
         (
             ("uv", "sync", "--frozen"),
-            tmp_path,
-            str(Path.home() / ".venvs" / "tallylot-py312"),
-        ),
-        (
-            (
-                "uv",
-                "run",
-                "pre-commit",
-                "install",
-                "--overwrite",
-                "--hook-type",
-                "pre-commit",
-                "--hook-type",
-                "commit-msg",
-            ),
             tmp_path,
             str(Path.home() / ".venvs" / "tallylot-py312"),
         ),

--- a/tests/unit/test_quality_gates.py
+++ b/tests/unit/test_quality_gates.py
@@ -27,7 +27,14 @@ def test_quality_gates_default_to_fast_commit_time_pytest() -> None:
         "pylint",
         "pytest",
     ]
-    assert gates[0].command == ("uv", "run", "pre-commit", "run", "markdownlint", "--all-files")
+    assert gates[0].command == (
+        "uv",
+        "run",
+        "pre-commit",
+        "run",
+        "markdownlint",
+        "--all-files",
+    )
     assert gates[1].command == ("uv", "run", "actionlint", "-color")
     assert gates[4].command == ("uv", "run", "pyright")
     assert gates[5].command == ("uv", "run", "python", "-m", "tools.run_pylint")
@@ -40,7 +47,9 @@ def test_quality_gates_can_switch_to_full_pytest() -> None:
     assert gates[-1].command == _FULL_TEST_COMMAND
 
 
-def test_run_gate_exports_external_uv_project_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_run_gate_exports_external_uv_project_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     captured_environment: dict[str, str] = {}
 
     def fake_run(
@@ -62,14 +71,20 @@ def test_run_gate_exports_external_uv_project_environment(monkeypatch: pytest.Mo
     gate = _quality_gates(full_tests=False)[0]
     tools.run_quality_gates._run_gate(gate)
 
-    assert captured_environment["UV_PROJECT_ENVIRONMENT"] == str(Path.home() / ".venvs" / "tallylot-py312")
+    assert captured_environment["UV_PROJECT_ENVIRONMENT"] == str(
+        Path.home() / ".venvs" / "tallylot-py312"
+    )
 
 
-def test_pre_commit_config_excludes_pylint_hook() -> None:
+def test_pre_commit_config_keeps_hook_validations_without_ruff_duplication() -> None:
     config_text = (repo_root() / ".pre-commit-config.yaml").read_text(encoding="utf-8")
 
-    assert "id: pylint" not in config_text
+    assert "id: markdownlint" in config_text
+    assert "id: commit-message" in config_text
+    assert "id: mypy" in config_text
+    assert "id: pyright" in config_text
     assert "name: pytest-fast" in config_text
+    assert "id: ruff" not in config_text
 
 
 def test_quality_gates_refresh_generated_pyright_config_before_running(
@@ -88,7 +103,11 @@ def test_quality_gates_refresh_generated_pyright_config_before_running(
     def fake_run_gate(
         gate: QualityGate,
     ) -> tuple[QualityGate, subprocess.CompletedProcess[str], float]:
-        return gate, subprocess.CompletedProcess(gate.command, 0, stdout="", stderr=""), 0.0
+        return (
+            gate,
+            subprocess.CompletedProcess(gate.command, 0, stdout="", stderr=""),
+            0.0,
+        )
 
     monkeypatch.setattr(
         tools.run_quality_gates,

--- a/tools/install_git_hooks.py
+++ b/tools/install_git_hooks.py
@@ -90,22 +90,6 @@ def _install_hooks(repo_root: Path) -> None:
         cwd=repo_root,
         env=repo_uv_environment(),
     )
-    subprocess.run(
-        [
-            "uv",
-            "run",
-            "pre-commit",
-            "install",
-            "--overwrite",
-            "--hook-type",
-            "pre-commit",
-            "--hook-type",
-            "commit-msg",
-        ],
-        check=True,
-        cwd=repo_root,
-        env=repo_uv_environment(),
-    )
     hook_format_args = {
         "project_environment": shlex.quote(_hook_project_environment()),
         "python": shlex.quote(sys.executable),

--- a/tools/pre_commit_hook.py
+++ b/tools/pre_commit_hook.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import os
-import subprocess
 import sys
+import subprocess
 from pathlib import Path
 
 PYTHON_SUFFIXES = {".py", ".pyi"}
@@ -38,21 +38,12 @@ def _format_candidates(
     return tuple(candidates)
 
 
-def _skip_value(existing: str | None) -> str:
-    entries = [entry for entry in (existing or "").split(",") if entry]
-    for hook_id in ("ruff", "ruff-format"):
-        if hook_id not in entries:
-            entries.append(hook_id)
-    return ",".join(entries)
-
-
 def _run_command(command: list[str], *, env: dict[str, str] | None = None) -> int:
     return subprocess.run(command, check=False, env=env).returncode
 
 
-def _run_pre_commit(hook_args: list[str]) -> int:
+def _run_pre_commit() -> int:
     env = os.environ.copy()
-    env["SKIP"] = _skip_value(env.get("SKIP"))
     command = [
         sys.executable,
         "-m",
@@ -63,7 +54,6 @@ def _run_pre_commit(hook_args: list[str]) -> int:
         "--hook-dir",
         str(Path(".git/hooks").resolve()),
         "--",
-        *hook_args,
     ]
     return _run_command(command, env=env)
 
@@ -94,7 +84,7 @@ def _require_commit_message_hook() -> int:
 def _format_and_stage(paths: tuple[str, ...]) -> int:
     if not paths:
         return 0
-    print("running staged ruff autofixes before pre-commit", file=sys.stderr)
+    print("running staged ruff autofixes before commit", file=sys.stderr)
     for command in (
         [sys.executable, "-m", "ruff", "check", "--fix", *paths],
         [sys.executable, "-m", "ruff", "format", *paths],
@@ -107,7 +97,7 @@ def _format_and_stage(paths: tuple[str, ...]) -> int:
 
 
 def main(argv: list[str] | None = None) -> int:
-    hook_args = list(sys.argv[1:] if argv is None else argv)
+    del argv
     hook_status = _require_commit_message_hook()
     if hook_status != 0:
         return hook_status
@@ -123,7 +113,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     if format_status != 0:
         return format_status
-    return _run_pre_commit(hook_args)
+    return _run_pre_commit()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Why:
- closes #34 by deduplicating the shared lint and test execution paths without weakening the checkpoint guardrails that catch bad local commits
- keep the full CI quality and build flow defined in one place so the full suite does not drift or rerun as a separate fast-plus-full path

What:
- preserve commit-time markdownlint, mypy, pyright, and fast pytest validation while keeping staged Ruff autofixes in the custom pre-commit wrapper
- stop bootstrap from reinstalling generated pre-commit hook wrappers we do not use directly
- route the GitHub Actions quality job through tools.run_ci_parity_checks and align the repo standards plus regression tests with that shared path

Checks:
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pytest tests/unit/test_pre_commit_hook.py tests/unit/test_quality_gates.py tests/unit/test_ci_parity_checks.py -q --no-cov
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_ci_parity_checks
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.install_git_hooks

Included checkpoints:
- `ci: deduplicate hook and parity checks`
