### PR TITLE
ci(guardrails): harden delivery guardrails and repo workflows

### DIFF
--- a/.agents/skills/adapter-authoring/SKILL.md
+++ b/.agents/skills/adapter-authoring/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: adapter-authoring
+description: >-
+  Start tallylot source or output adapter work with the repo's adapter
+  contract. Use when the task adds, repairs, or refactors adapter metadata,
+  translation logic, rendering, or adapter tests.
+---
+
+# Adapter Authoring
+
+Use this skill for adapter-focused work.
+
+## Workflow
+
+1. Read the adapter contract first:
+   - `docs/guides/write-an-adapter.md`
+   - `.claude/commands/adapter-authoring.md`
+   - `docs/standards/engineering.md`
+   - `docs/standards/implementation.md`
+2. Keep adapter metadata, implementation, and tests aligned in one slice.
+3. Keep normalization, rendering, and oracle-only behavior separated.
+4. Prefer the scaffold path for new adapters:
+   - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.scaffold_adapter ...`
+5. Add or update adapter tests beside the adapter package while implementing.
+6. Run the full quality gate before closing the adapter slice:
+   - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests`
+
+## Focus
+
+- explicit issues for ambiguity
+- provider-neutral runtime boundaries
+- no ad hoc adapter-local hacks

--- a/.agents/skills/adapter-authoring/agents/openai.yaml
+++ b/.agents/skills/adapter-authoring/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Adapter Authoring"
+  short_description: "Start tallylot adapter work with the repo's adapter contract and tooling."
+  default_prompt: "Use $adapter-authoring to load tallylot's adapter rules before changing source or output adapters."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/docs-authoring/SKILL.md
+++ b/.agents/skills/docs-authoring/SKILL.md
@@ -25,9 +25,11 @@ commits.
    `.claude/commands/`.
 3. Prefer updating an existing page over adding a new switchboard.
 4. Preserve frontmatter, generated markers, and doc type boundaries.
-5. Validate docs changes with:
+5. Keep tracked docs and control-plane text neutral, durable, and free of
+   scratch workflow bookkeeping.
+6. Validate docs changes with:
    - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.docs_maintenance sync --check`
-6. If the change also affects repo control-plane behavior, finish with the
+7. If the change also affects repo control-plane behavior, finish with the
    repo's broader quality gates before checkpointing.
 
 ## Focus

--- a/.agents/skills/docs-authoring/SKILL.md
+++ b/.agents/skills/docs-authoring/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: docs-authoring
+description: >-
+  Start tallylot docs, standards, and doc-like control-plane edits with the
+  repo's actual authoring path. Use when the task edits repo docs, standards,
+  README content, or docs-maintenance metadata.
+---
+
+# Docs Authoring
+
+Use this skill for repo documentation and standards work.
+
+Pair it with global `markdown` for syntax and low-churn Markdown editing and
+with `code-change-safety` when the change also touches automation or checkpoint
+commits.
+
+## Workflow
+
+1. Read the narrow authoring surface first:
+   - `AGENTS.md`
+   - `docs/README.md`
+   - `tools/docs_maintenance/cli.py`
+   - `tools/docs_maintenance/metadata.py`
+2. Keep human docs under `docs/` and agent-only routing under `AGENTS.md` or
+   `.claude/commands/`.
+3. Prefer updating an existing page over adding a new switchboard.
+4. Preserve frontmatter, generated markers, and doc type boundaries.
+5. Validate docs changes with:
+   - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.docs_maintenance sync --check`
+6. If the change also affects repo control-plane behavior, finish with the
+   repo's broader quality gates before checkpointing.
+
+## Focus
+
+- one primary doc type per file
+- neutral direct standards language
+- repo-native metadata, links, and generated sections

--- a/.agents/skills/docs-authoring/agents/openai.yaml
+++ b/.agents/skills/docs-authoring/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Docs Authoring"
+  short_description: "Start tallylot docs and standards edits with the repo-native authoring path."
+  default_prompt: "Use $docs-authoring to load the tallylot docs authoring path before editing repo docs."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/implementation-workflow/SKILL.md
+++ b/.agents/skills/implementation-workflow/SKILL.md
@@ -21,14 +21,18 @@ Pair it with global `code-change-safety` for cross-repo posture and with
    - `docs/standards/implementation.md`
    - `docs/standards/commits.md`
    - `.claude/commands/implementation-checkpoint.md`
-2. Confirm the owning layer, package, and final structure before editing.
-3. Add or update the tests that define the behavior.
+2. Confirm the owning layer, package, final structure, and forward-looking
+   architecture guidance before editing.
+3. Add or update only the tests that define meaningful behavior, contracts, or
+   regressions.
 4. Implement the change and refactor obvious shared seams while the seam is open.
 5. Use fresh editor diagnostics first when available, then targeted tests while
    iterating.
 6. Before closing substantial work, run:
    - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests`
-7. Create the verified checkpoint commit before considering the task done.
+7. After compaction or context loss, reload the same narrow standards before
+   more edits or commits.
+8. Create the verified checkpoint commit before considering the task done.
 
 ## Focus
 

--- a/.agents/skills/implementation-workflow/SKILL.md
+++ b/.agents/skills/implementation-workflow/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: implementation-workflow
+description: >-
+  Start ordinary tallylot code changes with the repo's narrow implementation
+  path. Use when the task is code design, implementation, refactoring, test
+  writing, or checkpointing inside this repo.
+---
+
+# Implementation Workflow
+
+Use this skill for the normal repo implementation path.
+
+Pair it with global `code-change-safety` for cross-repo posture and with
+`markdown` only when the task edits Markdown files.
+
+## Workflow
+
+1. Read only the narrow repo contracts first:
+   - `AGENTS.md`
+   - `docs/standards/engineering.md`
+   - `docs/standards/implementation.md`
+   - `docs/standards/commits.md`
+   - `.claude/commands/implementation-checkpoint.md`
+2. Confirm the owning layer, package, and final structure before editing.
+3. Add or update the tests that define the behavior.
+4. Implement the change and refactor obvious shared seams while the seam is open.
+5. Use fresh editor diagnostics first when available, then targeted tests while
+   iterating.
+6. Before closing substantial work, run:
+   - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests`
+7. Create the verified checkpoint commit before considering the task done.
+
+## Focus
+
+- keep strict typed layer boundaries
+- keep `Decimal` for monetary values
+- surface ambiguity as explicit issues
+- update `ROADMAP.md` with architecture or sequencing changes

--- a/.agents/skills/implementation-workflow/agents/openai.yaml
+++ b/.agents/skills/implementation-workflow/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Implementation Workflow"
+  short_description: "Start ordinary tallylot code changes with the narrow repo path."
+  default_prompt: "Use $implementation-workflow to load the narrow tallylot implementation path before coding."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/reconciliation-balance-operations/SKILL.md
+++ b/.agents/skills/reconciliation-balance-operations/SKILL.md
@@ -15,10 +15,12 @@ Use this skill for balance reconciliation workflow execution and diagnosis.
 
 1. Start with the runtime commands or the bundled script. Do not write ad hoc
    shell loops over source directories.
-2. Run coverage inspection first.
-3. Run balance checks second.
-4. Run reconciliation summary third.
-5. Use oracle commands only when the summary shows they are needed for
+2. Use `.claude/commands/reconciliation-balance-operations.md` when you need
+   the repo's matching command-route checklist.
+3. Run coverage inspection first.
+4. Run balance checks second.
+5. Run reconciliation summary third.
+6. Use oracle commands only when the summary shows they are needed for
    explanation or trust validation.
 
 ## Preferred Execution

--- a/.agents/skills/reconciliation-tax-build/SKILL.md
+++ b/.agents/skills/reconciliation-tax-build/SKILL.md
@@ -1,0 +1,38 @@
+---
+name: reconciliation-tax-build
+description: >-
+  Start tallylot's core reconciliation, checkpoint, accounting, and tax build
+  work with the repo's narrow architecture path. Use when the task changes fact
+  modeling, reconciliation rules, checkpoint assembly, journal logic, or tax
+  policy behavior.
+---
+
+# Reconciliation And Tax Build
+
+Use this skill for architecture-sensitive core workflow work.
+
+## Workflow
+
+1. Read the narrow architecture path first:
+   - `docs/concepts/reconciliation-tax-architecture.md`
+   - `docs/concepts/oracle-boundaries.md`
+   - `docs/concepts/transaction-classification.md`
+   - `docs/status/migration-sequence.md`
+   - `docs/standards/implementation.md`
+   - `.claude/commands/reconciliation-tax-build.md`
+2. Confirm whether the task changes facts, reconciliation, checkpoints,
+   accounting, tax policy, or oracle-only compatibility code.
+3. Keep provider-neutral facts at the center and keep CoinTracking-specific
+   behavior in compatibility or oracle surfaces.
+4. Add or update schema, invariant, reconciliation, or tax tests before
+   implementing behavior.
+5. Update `ROADMAP.md` in the same checkpoint when architecture or sequencing
+   decisions move.
+6. Finish with:
+   - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests`
+
+## Focus
+
+- build reconciliation before tax
+- keep `pydantic` at boundaries only
+- keep strict layer boundaries and `Decimal`-only financial handling

--- a/.agents/skills/reconciliation-tax-build/agents/openai.yaml
+++ b/.agents/skills/reconciliation-tax-build/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Reconciliation And Tax Build"
+  short_description: "Load tallylot's narrow architecture path for reconciliation, checkpoint, accounting, and tax work."
+  default_prompt: "Use $reconciliation-tax-build to load tallylot's architecture path for core reconciliation and tax work."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/round-verification-operations/SKILL.md
+++ b/.agents/skills/round-verification-operations/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: round-verification-operations
+description: >-
+  Run tallylot's round verification and oracle comparison path with the
+  documented repo workflow. Use when the task is scaffolding, exporting,
+  comparing, or closing a verification round.
+---
+
+# Round Verification Operations
+
+Use this skill for round verification workflow execution.
+
+## Workflow
+
+1. Read the verification route first:
+   - `docs/guides/verify-a-round.md`
+   - `docs/guides/full-operator-workflow.md`
+   - `.claude/commands/round-verification.md`
+2. Use the documented oracle CLI commands:
+   - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.oracles.cli round scaffold`
+   - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.oracles.cli verification compare`
+3. Review the round artifacts and comparison outputs before answering closeout
+   questions.
+4. Use `source diff` only when the verification path needs source-level repair
+   context.
+
+## Focus
+
+- keep oracle work dev-only
+- use explicit exported artifacts for review
+- do not treat oracle outputs as runtime state

--- a/.agents/skills/round-verification-operations/agents/openai.yaml
+++ b/.agents/skills/round-verification-operations/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Round Verification"
+  short_description: "Run tallylot's round verification and oracle comparison path."
+  default_prompt: "Use $round-verification-operations to run tallylot's documented round verification workflow."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/source-intake-operations/SKILL.md
+++ b/.agents/skills/source-intake-operations/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: source-intake-operations
+description: >-
+  Run tallylot's typed intake path without ad hoc shell choreography. Use when
+  the task is source intake planning, apply, manifesting, profiling,
+  normalization, or checkpoint inventory follow-through.
+---
+
+# Source Intake Operations
+
+Use this skill for source intake and normalization workflow execution.
+
+## Workflow
+
+1. Read the operator route first:
+   - `docs/guides/operator-quickstart.md`
+   - `docs/guides/source-intake.md`
+   - `.claude/commands/source-intake.md`
+2. Use the runtime CLI, not ad hoc loops:
+   - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run tallylot source intake plan`
+   - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run tallylot source intake apply`
+   - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run tallylot source manifest`
+   - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run tallylot source profile`
+   - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run tallylot source normalize`
+3. Review the emitted plan, profile, normalization, and issue artifacts before
+   moving to the next stage.
+4. Rebuild location inventory only when normalization produced wallet evidence.
+
+## Focus
+
+- plan before apply
+- inspect artifacts between stages
+- keep evidence outside the repo

--- a/.agents/skills/source-intake-operations/agents/openai.yaml
+++ b/.agents/skills/source-intake-operations/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Source Intake"
+  short_description: "Run tallylot's typed source intake path without ad hoc shell choreography."
+  default_prompt: "Use $source-intake-operations to run tallylot's typed intake and normalization route."
+
+policy:
+  allow_implicit_invocation: true

--- a/.claude/commands/implementation-checkpoint.md
+++ b/.claude/commands/implementation-checkpoint.md
@@ -39,6 +39,10 @@ Use this route before closing any non-trivial coding task.
    - do not rewrite a merged `main` commit if the original pull request must
      remain attached to the landing commit; open a new repair pull request
      instead
+   - for multi-checkpoint PR merges, use `<pr title> (#<pr number>)` as the
+     merge subject
+   - if a repair PR replaces an older PR, apply the repo's neutral
+     duplicate/superseded label before closing the repair loop
    - if the user explicitly requested a one-time protected-branch repair,
      verify the remote branch tip afterward and return to PR-only flow
 

--- a/.claude/commands/implementation-checkpoint.md
+++ b/.claude/commands/implementation-checkpoint.md
@@ -22,14 +22,17 @@ Use this route before closing any non-trivial coding task.
    - new decision logic
    - new parser or renderer contracts
    - fixed edge cases
-5. Run the appropriate verification path:
+   - meaningful regression prevention rather than trivial coverage
+5. Confirm tracked docs, templates, and control-plane text stayed neutral and
+   did not pick up scratch workflow bookkeeping.
+6. Run the appropriate verification path:
    - use fresh VS Code Problems diagnostics first when they are available and current
    - targeted tests while iterating
    - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests` before closing
      substantial work
    - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_ci_parity_checks` when the change touches CI,
      packaging, release, or other workflow surfaces
-6. If architecture, schema, or sequencing changed, update:
+7. If architecture, schema, or sequencing changed, update:
    - `ROADMAP.md`
    - `docs/concepts/reconciliation-tax-architecture.md`
    - any boundary, matrix, or migration docs affected
@@ -42,20 +45,26 @@ Use this route before closing any non-trivial coding task.
      - `tools/docs_maintenance/metadata.py`
      and confirm any new material belongs in human docs rather than agent-only
      routing and still follows the docs-maintenance scaffold and metadata rules
-7. Create the stable checkpoint commit when the slice is coherent and verified.
+8. After compaction or context loss, reload the narrow standards for the active
+   surface before more edits or commits:
+
+   - `docs/standards/implementation.md`
+   - `docs/standards/commits.md`
+   - `docs/standards/delivery-guardrails.md` when delivery work is active
+
+9. Create the stable checkpoint commit when the slice is coherent and verified.
    Do not close the task first and plan to commit afterward.
-8. Confirm branch handling stayed PR-only for protected branches:
-   - do not push directly to `main`
-   - do not use branch-protection bypass for ordinary delivery
-   - do not rewrite a merged `main` commit if the original pull request must
-     remain attached to the landing commit; open a new repair pull request
-     instead
-   - for multi-checkpoint PR merges, use `<pr title> (#<pr number>)` as the
-     merge subject
-   - if a repair PR replaces an older PR, apply the repo's neutral
-     duplicate/superseded label before closing the repair loop
-   - if the user explicitly requested a one-time protected-branch repair,
-     verify the remote branch tip afterward and return to PR-only flow
+
+10. Confirm branch handling stayed PR-only for protected branches: do not push
+    directly to `main`; do not use branch-protection bypass for ordinary
+    delivery; do not rewrite a merged `main` commit if the original pull
+    request must remain attached to the landing commit and use a new repair
+    pull request instead; for multi-checkpoint PR merges, use
+    `<pr title> (#<pr number>)` as the merge subject; if a repair PR replaces
+    an older PR, apply the repo's neutral duplicate/superseded label before
+    closing the repair loop; if the user explicitly requested a one-time
+    protected-branch repair, verify the remote branch tip afterward and return
+    to PR-only flow.
 
 If a needed structural fix is already obvious and bounded, include it in the
 same checkpoint instead of deferring it.

--- a/.claude/commands/implementation-checkpoint.md
+++ b/.claude/commands/implementation-checkpoint.md
@@ -36,6 +36,9 @@ Use this route before closing any non-trivial coding task.
 8. Confirm branch handling stayed PR-only for protected branches:
    - do not push directly to `main`
    - do not use branch-protection bypass for ordinary delivery
+   - do not rewrite a merged `main` commit if the original pull request must
+     remain attached to the landing commit; open a new repair pull request
+     instead
    - if the user explicitly requested a one-time protected-branch repair,
      verify the remote branch tip afterward and return to PR-only flow
 

--- a/.claude/commands/implementation-checkpoint.md
+++ b/.claude/commands/implementation-checkpoint.md
@@ -5,6 +5,8 @@ Use this route before closing any non-trivial coding task.
 1. Read:
    - `docs/standards/implementation.md`
    - `docs/standards/commits.md`
+   - use `code-change-safety` for repo changes and `markdown` for Markdown/docs
+     work when those skills are available
 2. Confirm the change still respects:
    - layer ownership
    - provider-neutral core design
@@ -31,6 +33,15 @@ Use this route before closing any non-trivial coding task.
    - `ROADMAP.md`
    - `docs/concepts/reconciliation-tax-architecture.md`
    - any boundary, matrix, or migration docs affected
+   - if standards, docs placement, doc authoring rules, or agent-default enforcement changed, reload:
+     - `AGENTS.md`
+     - `docs/README.md`
+     - `docs/status/current-state.md`
+     - `docs/reference/repository-history.md`
+     - `tools/docs_maintenance/cli.py`
+     - `tools/docs_maintenance/metadata.py`
+     and confirm any new material belongs in human docs rather than agent-only
+     routing and still follows the docs-maintenance scaffold and metadata rules
 7. Create the stable checkpoint commit when the slice is coherent and verified.
    Do not close the task first and plan to commit afterward.
 8. Confirm branch handling stayed PR-only for protected branches:

--- a/.claude/commands/pr-hardening-review.md
+++ b/.claude/commands/pr-hardening-review.md
@@ -6,10 +6,12 @@ Use this route for repeatable review passes on an active branch or draft PR.
    - `git status`
    - current diff and recent commits
    - current PR title, body, and changed files when PR work is active
+   - `AGENTS.md` so the repo's task-routing table is back in context
    - `docs/standards/delivery-guardrails.md`
    - `docs/standards/commits.md`
    - latest targeted verification results
-2. Review this fixed matrix:
+2. Red-team this fixed matrix and find up to 5 new unique findings for the
+   current pass:
    - design and ownership
    - correctness and behavior
    - complexity and over-engineering
@@ -18,12 +20,26 @@ Use this route for repeatable review passes on an active branch or draft PR.
    - documentation and control-plane alignment
    - delivery controls, PR metadata, and issue handling
    - compaction and context-loss recovery
-3. Re-check every prior fix surface first.
-4. Add one adjacent surface group per pass.
-5. Report up to 5 new evidence-backed findings.
-6. Stop early when fewer real findings exist. Do not invent findings to hit a
-   quota.
-7. Keep scratch notes untracked. Do not create tracked issue ledgers, review
+3. Re-check every prior fix surface first, then add one adjacent surface group
+   for the new pass.
+4. Repair every finding from that pass before starting the next pass.
+   - reload the narrow repo guidance for each repair surface using `AGENTS.md`,
+     its task-routing table, and the owning roadmap, architecture, migration,
+     or delivery docs surfaced by that route or by repo search hints
+   - add or tighten tests, docs, automation, and validation where the fix
+     belongs instead of leaving the repair in prose alone
+5. Verify the repaired slice and create bounded checkpoint commits during the
+   loop, following the repo's normal commit and checkpoint rules. Do not start
+   another red-team pass with uncommitted repaired findings unless the pass is
+   still in a very small in-progress slice.
+6. Continue steps 1 through 5 until a full pass yields no new meaningful
+   findings. When a pass finds fewer than 5 findings, report only those
+   findings. Do not invent findings to hit a quota.
+7. If the only remaining item is a very minor finishing touch, repair it and
+   finish once no other meaningful issues surface.
+8. Keep scratch notes untracked. Do not create tracked issue ledgers, review
    logs, or temporary bookkeeping files.
-8. Keep the PR draft until a full clean pass is complete. Mark ready for review
-   only as a separate later action.
+9. Keep the PR draft until a full clean loop has completed with no new
+   meaningful findings. For a final PR review, finish with a clean working tree
+   and reload the relevant delivery guidance or skills before updating the PR
+   state or marking it ready for review.

--- a/.claude/commands/pr-hardening-review.md
+++ b/.claude/commands/pr-hardening-review.md
@@ -1,0 +1,29 @@
+# PR Hardening Review
+
+Use this route for repeatable review passes on an active branch or draft PR.
+
+1. Reload only the narrow facts first:
+   - `git status`
+   - current diff and recent commits
+   - current PR title, body, and changed files when PR work is active
+   - `docs/standards/delivery-guardrails.md`
+   - `docs/standards/commits.md`
+   - latest targeted verification results
+2. Review this fixed matrix:
+   - design and ownership
+   - correctness and behavior
+   - complexity and over-engineering
+   - tests and regression value
+   - naming and public terminology
+   - documentation and control-plane alignment
+   - delivery controls, PR metadata, and issue handling
+   - compaction and context-loss recovery
+3. Re-check every prior fix surface first.
+4. Add one adjacent surface group per pass.
+5. Report up to 5 new evidence-backed findings.
+6. Stop early when fewer real findings exist. Do not invent findings to hit a
+   quota.
+7. Keep scratch notes untracked. Do not create tracked issue ledgers, review
+   logs, or temporary bookkeeping files.
+8. Keep the PR draft until a full clean pass is complete. Mark ready for review
+   only as a separate later action.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 # Control-plane ownership for delivery, standards, and agent-routing surfaces.
 
+.agents/skills/** @CrownOpsEng
 .github/workflows/** @CrownOpsEng
 .github/pull_request_template.md @CrownOpsEng
 .github/CODEOWNERS @CrownOpsEng
@@ -8,6 +9,8 @@ docs/standards/** @CrownOpsEng
 .claude/commands/** @CrownOpsEng
 tools/install_git_hooks.py @CrownOpsEng
 tools/pre_commit_hook.py @CrownOpsEng
+tools/audit_delivery_guardrails.py @CrownOpsEng
+tools/message_standards.py @CrownOpsEng
 tools/validate_commit_message.py @CrownOpsEng
 tools/validate_pr_metadata.py @CrownOpsEng
 tools/run_quality_gates.py @CrownOpsEng

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# Control-plane ownership for delivery, standards, and agent-routing surfaces.
+
+.github/workflows/** @CrownOpsEng
+.github/pull_request_template.md @CrownOpsEng
+.github/CODEOWNERS @CrownOpsEng
+AGENTS.md @CrownOpsEng
+docs/standards/** @CrownOpsEng
+.claude/commands/** @CrownOpsEng
+tools/install_git_hooks.py @CrownOpsEng
+tools/pre_commit_hook.py @CrownOpsEng
+tools/validate_commit_message.py @CrownOpsEng
+tools/validate_pr_metadata.py @CrownOpsEng
+tools/run_quality_gates.py @CrownOpsEng
+tools/run_ci_parity_checks.py @CrownOpsEng

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,7 @@ Checks:
 - list the verification you actually ran
 
 Included checkpoints:
-- list the branch commit subjects in chronological order
+- `list the branch commit subjects in chronological order`
 
 Follow-ups:
 - Refs #456: optional follow-up work that this PR does not close

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,9 @@
 <!-- markdownlint-disable-file MD041 MD032 -->
 <!-- Multi-checkpoint PRs must merge-commit. Single-checkpoint PRs must squash. -->
+<!-- Open PRs as draft first. Mark ready for review only after a clean hardening pass. -->
 
 Why:
+- Closes #123: describe one resolved problem when this PR closes an issue
 - explain the problem or constraint this PR resolves
 
 What:
@@ -12,3 +14,6 @@ Checks:
 
 Included checkpoints:
 - list the branch commit subjects in chronological order
+
+Follow-ups:
+- Refs #456: optional follow-up work that this PR does not close

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -51,5 +51,10 @@
   "python.analysis.diagnosticMode": "workspace",
   "ruff.importStrategy": "fromEnvironment",
   "mypy-type-checker.importStrategy": "fromEnvironment",
+  "pylint.path": [
+    "${interpreter}",
+    "-m",
+    "tools.vscode_pylint"
+  ],
   "pylint.importStrategy": "fromEnvironment"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,11 +29,13 @@ Do not pre-load every repo doc by default.
 | ---- | ---- |
 | Code placement, typing, modularization, naming | `docs/standards/engineering.md` |
 | Active implementation execution discipline | `docs/standards/implementation.md`, `docs/standards/commits.md` |
+| Repo standards, docs placement, doc authoring rules, or agent-default enforcement changes | `AGENTS.md`, `docs/README.md`, `docs/status/current-state.md`, `docs/reference/repository-history.md`, `docs/standards/implementation.md`, `docs/standards/commits.md`, `tools/docs_maintenance/cli.py`, `tools/docs_maintenance/metadata.py` |
+| Delivery guardrails, protected-branch behavior, or agent-assisted Git operations | `docs/standards/delivery-guardrails.md`, `docs/standards/commits.md` |
 | Planning sequence, delivery slices, or rollout checkpoints | `ROADMAP.md` |
 | Reconciliation, checkpoint, journal, or tax-engine implementation | `docs/concepts/reconciliation-tax-architecture.md` |
 | Platform-agnostic boundaries, classification mapping, or migration order | `docs/concepts/oracle-boundaries.md`, `docs/concepts/transaction-classification.md`, `docs/status/migration-sequence.md` |
 | Source or output adapter work | `docs/guides/write-an-adapter.md` |
-| Docs structure, generated index sections, or doc placement | `AGENTS.md`, `docs/README.md` |
+| Docs structure, generated index sections, doc placement, or doc authoring rules | `AGENTS.md`, `docs/README.md`, `tools/docs_maintenance/cli.py`, `tools/docs_maintenance/metadata.py` |
 | External workspace layout and seeded files | `docs/concepts/workspace-model.md`, `docs/workspace/README.md` |
 | Operational state or manual workflow | `docs/status/current-state.md`, `docs/guides/operator-quickstart.md`, `docs/guides/source-intake.md`, `docs/guides/normalize-screen-stage.md`, `docs/guides/verify-a-round.md`, `docs/guides/full-operator-workflow.md` |
 | Repo-specific baseline and verification context | `docs/status/current-state.md`, `docs/reference/repository-history.md` |
@@ -49,6 +51,9 @@ Do not pre-load every repo doc by default.
   `.claude/commands/`.
 - Agent-only repo routing and maintenance rules live in this file and
   `.claude/commands/`.
+- When editing repo docs or Markdown, use the `markdown` skill if available.
+- When editing repo standards, automation, or other control-plane files, use
+  the `code-change-safety` skill as the starting workflow if available.
 - Agent-only context must not live in `docs/` unless it is genuinely useful to
   humans.
 - Every new doc must have one primary type: concept, guide, reference,
@@ -181,3 +186,6 @@ Workspace resolution order:
 - When work affects architecture, schema, or execution sequencing, update
   `ROADMAP.md` and `docs/concepts/reconciliation-tax-architecture.md`
   together.
+- When work affects delivery policy, branch protection expectations, or
+  agent-default Git behavior, update `docs/standards/delivery-guardrails.md`
+  with the relevant repo standards.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,7 @@ Do not pre-load every repo doc by default.
 | Active implementation execution discipline | `docs/standards/implementation.md`, `docs/standards/commits.md` |
 | Repo standards, docs placement, doc authoring rules, or agent-default enforcement changes | `AGENTS.md`, `docs/README.md`, `docs/status/current-state.md`, `docs/reference/repository-history.md`, `docs/standards/implementation.md`, `docs/standards/commits.md`, `tools/docs_maintenance/cli.py`, `tools/docs_maintenance/metadata.py` |
 | Delivery guardrails, protected-branch behavior, or agent-assisted Git operations | `docs/standards/delivery-guardrails.md`, `docs/standards/commits.md`, `tools/audit_delivery_guardrails.py` |
+| PR hardening review or review-loop recovery | `docs/standards/delivery-guardrails.md`, `docs/standards/commits.md`, `.claude/commands/pr-hardening-review.md` |
 | Planning sequence, delivery slices, or rollout checkpoints | `ROADMAP.md` |
 | Reconciliation, checkpoint, journal, or tax-engine implementation | `docs/concepts/reconciliation-tax-architecture.md` |
 | Platform-agnostic boundaries, classification mapping, or migration order | `docs/concepts/oracle-boundaries.md`, `docs/concepts/transaction-classification.md`, `docs/status/migration-sequence.md` |
@@ -54,6 +55,9 @@ Do not pre-load every repo doc by default.
 - When editing repo docs or Markdown, use the `markdown` skill if available.
 - When editing repo standards, automation, or other control-plane files, use
   the `code-change-safety` skill as the starting workflow if available.
+- Keep tracked docs, templates, and control-plane text neutral and durable.
+- Do not store scratch review notes, hardening ledgers, or temporary process
+  bookkeeping in tracked files.
 - Agent-only context must not live in `docs/` unless it is genuinely useful to
   humans.
 - Every new doc must have one primary type: concept, guide, reference,
@@ -110,6 +114,10 @@ Do not pre-load every repo doc by default.
   - `Why:` states the problem, constraint, or risk being addressed
   - `What:` states the concrete repo behavior or structure changed
   - avoid rhetorical, promotional, or exaggerated wording in repo history
+- Add tests only when they protect meaningful behavior, contracts,
+  non-trivial decision logic, or fixed regressions.
+- Before shaping a non-trivial change, reload the narrow roadmap,
+  architecture, migration, or owning-boundary guidance for that surface.
 - Keep public-facing names simple and ergonomic. Prefer short neutral command
   and API names over long implementation labels, and only add qualifiers when
   a real ambiguity exists.
@@ -133,6 +141,11 @@ Do not pre-load every repo doc by default.
   duplicate/superseded label on the older PR before closing the repair loop.
 - Use a neutral replacement comment only when the repo has no suitable label
   or the user explicitly asks for explanatory prose.
+- Open pull requests as draft by default and keep them draft through the
+  hardening loop.
+- Mark a PR ready for review only as a separate action after a clean hardening
+  pass.
+- Never close a PR autonomously without explicit user instruction.
 - For multi-checkpoint PR merges, set the merge subject to
   `<pr title> (#<pr number>)` so the PR number remains visible in mainline
   history.
@@ -180,7 +193,7 @@ Workspace resolution order:
 - Keep domain models centered on frozen dataclasses, enums, and value objects.
 - Follow `docs/standards/implementation.md` during coding:
   - structure first
-  - tests alongside behavior
+  - tests alongside behavior, but only when they add real regression value
   - refactor obvious shared seams during the task
   - commit at stable checkpoints without waiting to be reminded
 - When work affects architecture, schema, or execution sequencing, update

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ Do not pre-load every repo doc by default.
 | Code placement, typing, modularization, naming | `docs/standards/engineering.md` |
 | Active implementation execution discipline | `docs/standards/implementation.md`, `docs/standards/commits.md` |
 | Repo standards, docs placement, doc authoring rules, or agent-default enforcement changes | `AGENTS.md`, `docs/README.md`, `docs/status/current-state.md`, `docs/reference/repository-history.md`, `docs/standards/implementation.md`, `docs/standards/commits.md`, `tools/docs_maintenance/cli.py`, `tools/docs_maintenance/metadata.py` |
-| Delivery guardrails, protected-branch behavior, or agent-assisted Git operations | `docs/standards/delivery-guardrails.md`, `docs/standards/commits.md` |
+| Delivery guardrails, protected-branch behavior, or agent-assisted Git operations | `docs/standards/delivery-guardrails.md`, `docs/standards/commits.md`, `tools/audit_delivery_guardrails.py` |
 | Planning sequence, delivery slices, or rollout checkpoints | `ROADMAP.md` |
 | Reconciliation, checkpoint, journal, or tax-engine implementation | `docs/concepts/reconciliation-tax-architecture.md` |
 | Platform-agnostic boundaries, classification mapping, or migration order | `docs/concepts/oracle-boundaries.md`, `docs/concepts/transaction-classification.md`, `docs/status/migration-sequence.md` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,6 +104,8 @@ Do not pre-load every repo doc by default.
 - Treat protected branches as PR-only landing surfaces:
   - do not push directly to `main`
   - do not bypass branch protection for ordinary delivery
+  - do not rewrite a merged `main` commit when preserving the original pull
+    request association matters; use a new pull request repair instead
   - do not force-push protected branches unless the user explicitly requests a
     one-time repair in the current thread after branch protection has been
     temporarily adjusted

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,13 @@ Do not pre-load every repo doc by default.
   - prefer small cohesive commits
   - avoid micro-commits with no rollback or review value
   - end the task on a clean, meaningful checkpoint commit
+- Keep commit, PR, and doc language neutral and direct:
+  - `Why:` states the problem, constraint, or risk being addressed
+  - `What:` states the concrete repo behavior or structure changed
+  - avoid rhetorical, promotional, or exaggerated wording in repo history
+- Keep public-facing names simple and ergonomic. Prefer short neutral command
+  and API names over long implementation labels, and only add qualifiers when
+  a real ambiguity exists.
 - Treat protected branches as PR-only landing surfaces:
   - do not push directly to `main`
   - do not bypass branch protection for ordinary delivery
@@ -117,6 +124,9 @@ Do not pre-load every repo doc by default.
     that cleanup in the current thread
   - prefer additive fixes, follow-up commits, or leaving cleanup for the user
     over destructive local undo
+- If a repair pull request supersedes an older pull request, leave a neutral
+  comment on the older PR that links to the replacement PR and states that the
+  old PR is superseded or duplicate history.
 - If a flat directory would exceed 2 same-prefix files for one capability,
   regroup that capability into a package in the same task.
 - If a feature already has a package, keep new helpers inside that package

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,8 +125,12 @@ Do not pre-load every repo doc by default.
   - prefer additive fixes, follow-up commits, or leaving cleanup for the user
     over destructive local undo
 - If a repair pull request supersedes an older pull request, leave a neutral
-  comment on the older PR that links to the replacement PR and states that the
-  old PR is superseded or duplicate history.
+  duplicate/superseded label on the older PR before closing the repair loop.
+- Use a neutral replacement comment only when the repo has no suitable label
+  or the user explicitly asks for explanatory prose.
+- For multi-checkpoint PR merges, set the merge subject to
+  `<pr title> (#<pr number>)` so the PR number remains visible in mainline
+  history.
 - If a flat directory would exceed 2 same-prefix files for one capability,
   regroup that capability into a package in the same task.
 - If a feature already has a package, keep new helpers inside that package

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -210,6 +210,8 @@ Scope:
 - keep provenance and reuse documentation clear
 - keep the docs set navigable by type and concern
 - keep public-facing scope descriptions aligned with the implemented runtime
+- keep delivery guardrails layered across platform settings, repo-native
+  validators, and agent defaults so repo policy does not depend on prose alone
 
 Exit criteria:
 
@@ -217,6 +219,9 @@ Exit criteria:
   assumptions
 - a new contributor or coding agent can find the correct roadmap, status,
   concept, guide, and workspace docs without broad context loading
+- the default-branch delivery path is enforced by platform and repo controls
+  strongly enough that a single agent mistake cannot silently bypass the
+  intended PR-only workflow
 
 ### 10. Post-Core Runtime Expansion
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -212,6 +212,9 @@ Scope:
 - keep public-facing scope descriptions aligned with the implemented runtime
 - keep delivery guardrails layered across platform settings, repo-native
   validators, and agent defaults so repo policy does not depend on prose alone
+- keep control-plane ownership routing and default-branch guardrail audits
+  explicit so local repo state and live GitHub protection drift are checked
+  together
 
 Exit criteria:
 
@@ -222,6 +225,8 @@ Exit criteria:
 - the default-branch delivery path is enforced by platform and repo controls
   strongly enough that a single agent mistake cannot silently bypass the
   intended PR-only workflow
+- the repo can audit local CODEOWNERS coverage and live GitHub delivery
+  settings together without broad context loading or one-off shell repair work
 
 ### 10. Post-Core Runtime Expansion
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -86,4 +86,5 @@ that follows the external workspace layout.
 - [Engineering Standards](standards/engineering.md): Code placement, typing, modularity, and naming rules for the typed application.
 - [Implementation Working Agreement](standards/implementation.md): Execution rules for shaping, verifying, refactoring, and checkpointing repo work.
 - [Commit Standards](standards/commits.md): Conventional Commit, checkpoint, and PR body rules for stable repo history.
+- [Delivery Guardrails](standards/delivery-guardrails.md): Control hierarchy, enforcement tiers, and exception handling for repo delivery and agent-assisted Git operations.
 <!-- docs-maintenance:end standards -->

--- a/docs/standards/commits.md
+++ b/docs/standards/commits.md
@@ -11,8 +11,8 @@ nav_order: 30
 Use Conventional Commits for all authored commits. Keep commit history small,
 cohesive, and checkpoint-oriented.
 
-Auto-generated merge commits are tolerated by the validator, but authored
-commits should use the Conventional Commit format.
+Use Conventional Commit subjects and the structured body sections for merge
+commits too. Do not rely on GitHub's default `Merge pull request ...` subject.
 
 ## Subject Format
 
@@ -93,6 +93,8 @@ Protected-branch rule:
 - land changes on `main` through pull requests only
 - do not push directly to `main`
 - do not use branch-protection bypass or force-push for normal delivery
+- do not rewrite a merged `main` commit when the original pull request must
+  remain attached to the landing commit; open a new pull request repair instead
 - if a protected-branch repair exception is explicitly requested, limit that
   exception to the exact repair action, verify the remote branch tip
   immediately afterward, and restore PR-only flow before continuing
@@ -130,6 +132,12 @@ Merge method rules:
 - do not squash multi-checkpoint PRs
 - do not create a merge commit for a single-checkpoint PR unless the user
   explicitly requests a one-off repair in the current thread
+- when merging a multi-checkpoint PR, override GitHub's default merge subject
+  with the PR's Conventional Commit title and keep the merge body review-ready
+  instead of landing `Merge pull request ...`
+- for a merge commit, use the PR title as the merge subject and keep the merge
+  body in the same `Why:`, `What:`, `Checks:`, `Included checkpoints:` format
+  as the PR body so the mainline commit record matches the reviewed PR record
 
 For a single-checkpoint PR, the GitHub-generated squash commit on `main` may
 retain the validated `Included checkpoints:` section from the PR body. Treat

--- a/docs/standards/commits.md
+++ b/docs/standards/commits.md
@@ -13,6 +13,8 @@ cohesive, and checkpoint-oriented.
 
 Use Conventional Commit subjects and the structured body sections for merge
 commits too. Do not rely on GitHub's default `Merge pull request ...` subject.
+Keep commit and pull request language neutral, direct, and specific. Do not use
+rhetorical, promotional, or exaggerated wording in repo history.
 
 ## Subject Format
 
@@ -58,6 +60,14 @@ Preferred body sections:
 - `Why:`
 - `What:`
 - `Checks:`
+
+Write `Why:` and `What:` directly:
+
+- `Why:` states the problem, constraint, or risk the change addresses
+- `What:` states the behavior, structure, or contract changed in this patch
+- do not use `Why:` to restate the implementation
+- do not use `What:` to repeat generic intent without naming the concrete
+  repo change
 
 Example:
 
@@ -114,6 +124,8 @@ PR body rules:
   - `What:`
   - `Checks:`
   - `Included checkpoints:`
+- an optional `Issues:` section may follow `Included checkpoints:` when the PR
+  closes or supersedes GitHub issues or pull requests
 - use flat hyphen bullets under every section
 - keep `Included checkpoints:` in chronological order using the exact
   checkpoint subjects from the branch
@@ -121,6 +133,9 @@ PR body rules:
   subject, because CI validates that the list matches the branch history
 - describe the engineering outcome and reviewable behavior, not branch
   choreography or replay mechanics
+- use `Issues:` for neutral closeout links such as `Closes #34` or
+  `Supersedes #39`; do not encode status updates in ad hoc prose elsewhere in
+  the PR body
 - for a one-commit PR, still list that single checkpoint under
   `Included checkpoints:`
 
@@ -138,6 +153,9 @@ Merge method rules:
 - for a merge commit, use the PR title as the merge subject and keep the merge
   body in the same `Why:`, `What:`, `Checks:`, `Included checkpoints:` format
   as the PR body so the mainline commit record matches the reviewed PR record
+- if a repair PR supersedes an older pull request, leave a neutral comment on
+  the older PR that links to the replacement PR and states that it is
+  superseded or duplicate history
 
 For a single-checkpoint PR, the GitHub-generated squash commit on `main` may
 retain the validated `Included checkpoints:` section from the PR body. Treat
@@ -148,10 +166,10 @@ Preferred PR body template:
 
 ```text
 Why:
-- explain the problem or constraint this PR resolves
+- state the problem or constraint this PR resolves
 
 What:
-- summarize the engineering changes that matter for review
+- state the engineering changes that matter for review
 
 Checks:
 - list the verification you actually ran
@@ -159,6 +177,9 @@ Checks:
 Included checkpoints:
 - `refactor(example): first checkpoint subject`
 - `fix(example): second checkpoint subject`
+
+Issues:
+- Closes #123
 ```
 
 ## Stable Checkpoint Commits

--- a/docs/standards/commits.md
+++ b/docs/standards/commits.md
@@ -148,14 +148,17 @@ Merge method rules:
 - do not create a merge commit for a single-checkpoint PR unless the user
   explicitly requests a one-off repair in the current thread
 - when merging a multi-checkpoint PR, override GitHub's default merge subject
-  with the PR's Conventional Commit title and keep the merge body review-ready
-  instead of landing `Merge pull request ...`
-- for a merge commit, use the PR title as the merge subject and keep the merge
-  body in the same `Why:`, `What:`, `Checks:`, `Included checkpoints:` format
-  as the PR body so the mainline commit record matches the reviewed PR record
-- if a repair PR supersedes an older pull request, leave a neutral comment on
-  the older PR that links to the replacement PR and states that it is
-  superseded or duplicate history
+  with a deterministic subject that keeps the PR number visible instead of
+  landing `Merge pull request ...`
+- for a merge commit, use `<pr title> (#<pr number>)` as the merge subject and
+  keep the merge body in the same `Why:`, `What:`, `Checks:`,
+  `Included checkpoints:` format as the PR body so the mainline commit record
+  matches the reviewed PR record
+- if a repair PR supersedes an older pull request, add the repo's neutral
+  duplicate/superseded label to the older PR as the primary marker before
+  closing the repair loop
+- use a neutral comment on the older PR only when the repo has no suitable
+  label or the user explicitly asks for explanatory prose
 
 For a single-checkpoint PR, the GitHub-generated squash commit on `main` may
 retain the validated `Included checkpoints:` section from the PR body. Treat

--- a/docs/standards/commits.md
+++ b/docs/standards/commits.md
@@ -124,18 +124,20 @@ PR body rules:
   - `What:`
   - `Checks:`
   - `Included checkpoints:`
-- an optional `Issues:` section may follow `Included checkpoints:` when the PR
-  closes or supersedes GitHub issues or pull requests
+- an optional `Follow-ups:` section may follow `Included checkpoints:`
 - use flat hyphen bullets under every section
+- when the PR closes issues, put the closing bullets first under `Why:` using
+  the exact shape `- Closes #123: <problem statement>`
 - keep `Included checkpoints:` in chronological order using the exact
   checkpoint subjects from the branch
 - wrap every `Included checkpoints:` entry in backticks using the exact commit
   subject, because CI validates that the list matches the branch history
 - describe the engineering outcome and reviewable behavior, not branch
   choreography or replay mechanics
-- use `Issues:` for neutral closeout links such as `Closes #34` or
-  `Supersedes #39`; do not encode status updates in ad hoc prose elsewhere in
-  the PR body
+- use `Follow-ups:` for non-closing references such as `- Refs #456` or
+  `- Refs #456: deferred cleanup`
+- keep authored commit messages on `Why:`, `What:`, and `Checks:` without
+  issue-closing keywords unless the user explicitly requests otherwise
 - for a one-commit PR, still list that single checkpoint under
   `Included checkpoints:`
 
@@ -161,14 +163,16 @@ Merge method rules:
   label or the user explicitly asks for explanatory prose
 
 For a single-checkpoint PR, the GitHub-generated squash commit on `main` may
-retain the validated `Included checkpoints:` section from the PR body. Treat
-that as allowed for the generated mainline commit record, even though authored
-checkpoint commits should only use `Why:`, `What:`, and `Checks:` sections.
+retain the validated `Included checkpoints:` and `Follow-ups:` sections from
+the PR body. Treat that as allowed for the generated mainline commit record,
+even though authored checkpoint commits should only use `Why:`, `What:`, and
+`Checks:` sections.
 
 Preferred PR body template:
 
 ```text
 Why:
+- Closes #123: state the resolved problem when this PR closes an issue
 - state the problem or constraint this PR resolves
 
 What:
@@ -181,8 +185,8 @@ Included checkpoints:
 - `refactor(example): first checkpoint subject`
 - `fix(example): second checkpoint subject`
 
-Issues:
-- Closes #123
+Follow-ups:
+- Refs #456
 ```
 
 ## Stable Checkpoint Commits

--- a/docs/standards/delivery-guardrails.md
+++ b/docs/standards/delivery-guardrails.md
@@ -22,6 +22,10 @@ structure, authoring rules, and baseline context from `AGENTS.md`,
 surface and follows the repo's documentation metadata rules.
 Use `code-change-safety` for the repo-guidance reload path and pair it with the
 `markdown` skill when the task edits Markdown or docs surfaces.
+When the task changes GitHub-side delivery controls, run
+`UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.audit_delivery_guardrails`
+before and after the change so the local CODEOWNERS state and the live remote
+branch protection state are audited together.
 
 ## Guardrail Priority
 
@@ -63,6 +67,14 @@ Prefer GitHub controls that reject bad actions before they land:
 - stale-review dismissal or last-push review requirements when the repo wants
   post-push re-approval
 - CODEOWNERS or equivalent reviewer routing for control-plane files
+
+If the repo currently has only one single review-capable collaborator, keep
+required approving reviews and required code owner reviews as explicit deferred
+platform gaps instead of pretending those review gates are enforced. Continue
+to enforce the controls that remain achievable in a single-maintainer repo:
+PR-only branch protection, strict required checks, blocked force pushes,
+conversation resolution, and CODEOWNERS ownership routing for future reviewer
+expansion.
 
 Control-plane files include:
 
@@ -134,6 +146,8 @@ Before calling delivery complete, verify and report:
 - whether the landing subject exactly matched the required format
 - whether older superseded PRs were labeled correctly
 - whether the final remote branch tip still matches the reviewed PR record
+- whether review requirements are truly enforced or explicitly deferred because
+  the repo currently has only one single review-capable collaborator
 
 ## Exception Handling
 

--- a/docs/standards/delivery-guardrails.md
+++ b/docs/standards/delivery-guardrails.md
@@ -81,6 +81,7 @@ expansion.
 
 Control-plane files include:
 
+- `.agents/skills/**`
 - `.github/workflows/**`
 - `.github/pull_request_template.md`
 - `.github/CODEOWNERS`
@@ -89,6 +90,8 @@ Control-plane files include:
 - `.claude/commands/**`
 - `tools/install_git_hooks.py`
 - `tools/pre_commit_hook.py`
+- `tools/audit_delivery_guardrails.py`
+- `tools/message_standards.py`
 - `tools/validate_commit_message.py`
 - `tools/validate_pr_metadata.py`
 - `tools/run_quality_gates.py`

--- a/docs/standards/delivery-guardrails.md
+++ b/docs/standards/delivery-guardrails.md
@@ -129,9 +129,20 @@ PR hardening review is a repeatable procedure, not an improvised pass. Each
 pass should:
 
 - re-check prior fix surfaces first
-- add one adjacent surface group
-- report up to 5 new evidence-backed findings
-- stop early when fewer real findings exist
+- red-team one adjacent surface group and look for up to 5 new unique
+  evidence-backed findings across the active review domains
+- repair every finding from that pass before starting the next pass
+- reload the narrow repo guidance needed for each repair surface before editing:
+  use `AGENTS.md`, its task-routing table, and the owning roadmap,
+  architecture, migration, or delivery docs surfaced by that route or by repo
+  search hints instead of forcing one oversized preload bundle for every pass
+- run the relevant verification for the repaired slice and create bounded
+  checkpoint commits during the loop using the repo's normal commit rules
+- when a pass finds fewer than 5 new findings, report only those findings and
+  keep the loop moving
+- stop only after a full pass yields no new meaningful findings; if the only
+  remaining item is a minor finishing touch, repair it and finish once no other
+  meaningful issues surface
 - keep scratch tracking ephemeral and untracked
 
 ### 4. Agent Defaults

--- a/docs/standards/delivery-guardrails.md
+++ b/docs/standards/delivery-guardrails.md
@@ -1,0 +1,159 @@
+---
+title: "Delivery Guardrails"
+summary: "Control hierarchy, enforcement tiers, and exception handling for repo delivery and agent-assisted Git operations."
+doc_type: standard
+audience: human
+owner: repo
+status: active
+nav_order: 40
+---
+
+Use this document when delivery safety, branch protection, PR landing, merge
+metadata, or agent-default Git behavior is part of the task.
+
+This standard exists to prevent a repeat of failures where policy was known in
+prose but not enforced strongly enough at the platform, repo, or agent layer.
+
+Before changing delivery or standards guidance, reload the repo's docs
+structure, authoring rules, and baseline context from `AGENTS.md`,
+`docs/README.md`, `docs/status/current-state.md`,
+`docs/reference/repository-history.md`, `tools/docs_maintenance/cli.py`, and
+`tools/docs_maintenance/metadata.py` so new material lands in the right repo
+surface and follows the repo's documentation metadata rules.
+Use `code-change-safety` for the repo-guidance reload path and pair it with the
+`markdown` skill when the task edits Markdown or docs surfaces.
+
+## Guardrail Priority
+
+Apply delivery controls in this order:
+
+1. platform-native enforcement
+2. repo-native policy as code
+3. repo standards and checklists
+4. agent default behavior
+5. one-time repair exceptions explicitly requested in the current thread
+
+Do not rely on lower layers to compensate for a missing higher-layer control
+when the higher-layer control is available.
+
+## Default Delivery Posture
+
+- protected branches are PR-only landing surfaces
+- direct pushes to `main` are forbidden except for an explicit one-time repair
+  requested in the current thread
+- a merged `main` commit must not be rewritten when the original PR record
+  needs to remain attached to the landing commit
+- multi-checkpoint PRs land with a merge commit using
+  `<pr title> (#<pr number>)`
+- single-checkpoint PRs land with squash merge
+- replaced PRs use the repo's neutral duplicate or superseded label as the
+  primary closeout marker
+- comments on replaced PRs are fallback-only, not the default
+
+## Enforcement Tiers
+
+### 1. Platform-Native Controls
+
+Prefer GitHub controls that reject bad actions before they land:
+
+- rulesets or branch protection that require pull requests
+- required status checks
+- required reviews
+- blocked force pushes on protected branches
+- stale-review dismissal or last-push review requirements when the repo wants
+  post-push re-approval
+- CODEOWNERS or equivalent reviewer routing for control-plane files
+
+Control-plane files include:
+
+- `.github/workflows/**`
+- `.github/pull_request_template.md`
+- `.github/CODEOWNERS`
+- `AGENTS.md`
+- `docs/standards/**`
+- `.claude/commands/**`
+- `tools/install_git_hooks.py`
+- `tools/pre_commit_hook.py`
+- `tools/validate_commit_message.py`
+- `tools/validate_pr_metadata.py`
+- `tools/run_quality_gates.py`
+- `tools/run_ci_parity_checks.py`
+
+If a repo policy depends on a platform-native control that is not enabled, call
+that out as a real enforcement gap rather than assuming documentation is
+enough.
+
+### 2. Repo-Native Policy As Code
+
+Encode the repo's delivery rules in versioned artifacts:
+
+- commit-message validators
+- PR-metadata validators
+- hook installers and hook guards
+- CI workflows
+- contract tests that pin the standards
+- templates that match the validators
+
+When a delivery failure repeats or has high repair cost, add or tighten a
+machine-checkable guard instead of only adding more prose.
+
+### 3. Repo Standards And Checklists
+
+Use standards docs and checkpoint routes to explain:
+
+- why the rule exists
+- what exact behavior is required
+- what exceptions are allowed
+- what evidence must be checked before delivery is called done
+
+Checklist text should describe the audit path, not serve as the only barrier.
+Standards work itself must verify whether a rule belongs in human docs, agent
+routing, or repo-native automation before adding a new document or route.
+
+### 4. Agent Defaults
+
+Global skills and agent defaults should be conservative when repo rules are
+missing:
+
+- assume PR-only delivery for the default branch
+- assume merged default-branch history should not be rewritten
+- assume force-push is exceptional, not routine
+- prefer neutral direct `Why:` and `What:` language
+- re-check merge method and subject immediately before landing
+- report unresolved policy gaps instead of silently improvising
+- use the relevant safety and authoring skills up front rather than relying on
+  mid-task memory
+
+## Required Delivery Audit
+
+Before calling delivery complete, verify and report:
+
+- which repo standards were reloaded immediately before the action
+- whether the branch shape matched the allowed merge method
+- which checks were required and whether they passed
+- whether the landing subject exactly matched the required format
+- whether older superseded PRs were labeled correctly
+- whether the final remote branch tip still matches the reviewed PR record
+
+## Exception Handling
+
+One-time repair exceptions must be:
+
+- explicitly requested in the current thread
+- limited to the exact repair step
+- verified immediately afterward
+- followed by a return to normal PR-only flow
+
+Do not turn a repair exception into a standing workflow.
+
+## Rollout Order
+
+When strengthening delivery guardrails, prefer this order:
+
+1. enable or tighten platform-native controls
+2. add repo-native validators and tests
+3. align templates and docs with the enforced behavior
+4. update global skill defaults so repos without local standards still start
+   from a safer baseline
+
+Do not stop at the documentation layer when a stronger control is available.

--- a/docs/standards/delivery-guardrails.md
+++ b/docs/standards/delivery-guardrails.md
@@ -43,6 +43,8 @@ when the higher-layer control is available.
 ## Default Delivery Posture
 
 - protected branches are PR-only landing surfaces
+- pull requests open as draft by default
+- a PR becomes ready for review only after a clean hardening pass
 - direct pushes to `main` are forbidden except for an explicit one-time repair
   requested in the current thread
 - a merged `main` commit must not be rewritten when the original PR record
@@ -53,6 +55,7 @@ when the higher-layer control is available.
 - replaced PRs use the repo's neutral duplicate or superseded label as the
   primary closeout marker
 - comments on replaced PRs are fallback-only, not the default
+- PRs are never closed autonomously without explicit user instruction
 
 ## Enforcement Tiers
 
@@ -122,12 +125,22 @@ Checklist text should describe the audit path, not serve as the only barrier.
 Standards work itself must verify whether a rule belongs in human docs, agent
 routing, or repo-native automation before adding a new document or route.
 
+PR hardening review is a repeatable procedure, not an improvised pass. Each
+pass should:
+
+- re-check prior fix surfaces first
+- add one adjacent surface group
+- report up to 5 new evidence-backed findings
+- stop early when fewer real findings exist
+- keep scratch tracking ephemeral and untracked
+
 ### 4. Agent Defaults
 
 Global skills and agent defaults should be conservative when repo rules are
 missing:
 
 - assume PR-only delivery for the default branch
+- assume PRs stay draft until the hardening loop is clean
 - assume merged default-branch history should not be rewritten
 - assume force-push is exceptional, not routine
 - prefer neutral direct `Why:` and `What:` language
@@ -141,6 +154,7 @@ missing:
 Before calling delivery complete, verify and report:
 
 - which repo standards were reloaded immediately before the action
+- whether the PR remained draft until the hardening procedure finished cleanly
 - whether the branch shape matched the allowed merge method
 - which checks were required and whether they passed
 - whether the landing subject exactly matched the required format
@@ -159,6 +173,17 @@ One-time repair exceptions must be:
 - followed by a return to normal PR-only flow
 
 Do not turn a repair exception into a standing workflow.
+
+## Compaction Recovery
+
+After compaction or context loss, recover from deterministic delivery facts
+instead of tracked scratch notes:
+
+1. current branch tip and `git status`
+2. current diff and recent commits
+3. current PR title, body, and changed files when PR work is active
+4. narrow delivery standards and the active hardening route
+5. latest targeted verification results
 
 ## Rollout Order
 

--- a/docs/standards/engineering.md
+++ b/docs/standards/engineering.md
@@ -157,6 +157,9 @@ Current application of this rule:
 ## Naming Rules
 
 - Name modules after the bounded responsibility they own.
+- Keep public names and commands simple, neutral, and ergonomic. Prefer short
+  names that match the user-visible operation over long implementation labels,
+  and only add qualifiers when a real naming collision or ambiguity exists.
 - Prefer specific names such as `csv_parser.py`, `balance_mapper.py`, or
   `issue_rules.py` over generic names.
 - Match package structure to the architecture first and the external provider

--- a/docs/standards/engineering.md
+++ b/docs/standards/engineering.md
@@ -160,6 +160,11 @@ Current application of this rule:
 - Keep public names and commands simple, neutral, and ergonomic. Prefer short
   names that match the user-visible operation over long implementation labels,
   and only add qualifiers when a real naming collision or ambiguity exists.
+- Follow the same naming posture for modules, functions, classes, and commands:
+  choose concise descriptive names over decorative jargon.
+- Reject verbose pattern-label suffixes such as `UseCase`, `Manager`, or
+  `Handler` unless they disambiguate a real collision in the surrounding
+  namespace.
 - Prefer specific names such as `csv_parser.py`, `balance_mapper.py`, or
   `issue_rules.py` over generic names.
 - Match package structure to the architecture first and the external provider

--- a/docs/standards/implementation.md
+++ b/docs/standards/implementation.md
@@ -45,6 +45,10 @@ Prefer the repo's built-in tooling before inventing local workflows:
 - mirror GitHub Actions locally when changing workflow, packaging, or release
   behavior with
   `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_ci_parity_checks`
+- audit local CODEOWNERS coverage and live GitHub branch-protection settings
+  together when changing delivery policy, branch protection, or CI guardrails
+  with
+  `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.audit_delivery_guardrails`
 - scaffold new adapters with
   `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.scaffold_adapter ...`
 - refresh generated pyright test-private execution environments with

--- a/docs/standards/implementation.md
+++ b/docs/standards/implementation.md
@@ -85,6 +85,8 @@ otherwise:
 
 - keep the architecture aligned with
   `docs/concepts/reconciliation-tax-architecture.md`
+- read the narrow forward-looking roadmap, architecture, migration, or owning
+  boundary guidance before shaping a non-trivial change
 - refactor when a clearer shared seam is already visible
 - extract shared components before copy-paste patterns harden
 - create or update tests alongside the implementation
@@ -106,6 +108,10 @@ For non-trivial implementation work, use this order:
 
 Do not start by patching call sites ad hoc and only later trying to discover
 the right structure.
+
+Before shaping a non-trivial fix, reload the narrow forward-looking guidance
+that owns the change surface. Prefer the intended end-state seam over a local
+temporary patch when the repo already documents the target ownership model.
 
 ## Refactor Expectations
 
@@ -172,6 +178,17 @@ Minimum expectation:
 - add contract tests for new external artifact parsing or rendering
 - add regression tests for fixed edge cases
 
+Meaningful tests only:
+
+- add tests for user-visible behavior, real contracts, non-trivial decision
+  logic, and fixed regressions
+- do not add trivial getter or setter tests, wording-only assertions, duplicate
+  coverage at multiple layers, or call-order tests unless that order is the
+  contract
+- when tests become repetitive, treat that as a signal that the production seam
+  may be wrong and refactor the seam instead of piling on more near-duplicate
+  tests
+
 Do not leave edge-case behavior implicit in implementation code without a test
 that pins it down.
 
@@ -232,6 +249,9 @@ Expected behavior:
 - keep repo cleanup forward-only by default: do not use destructive rollback
   commands such as `rm -rf`, `git restore`, `git reset`, or `git checkout --`
   unless the user explicitly requests that cleanup in the current thread
+- keep tracked docs, templates, and control-plane artifacts neutral and durable
+- keep scratch review notes, temporary hardening ledgers, and compaction aids
+  untracked; recover from deterministic repo facts instead
 
 When not to commit:
 
@@ -241,6 +261,22 @@ When not to commit:
 
 Do not collapse a broad but separable refactor into one giant commit unless
 the slice truly cannot be reviewed or validated incrementally.
+
+## Compaction Recovery
+
+Treat compaction or context loss as an ordinary operating condition.
+
+When context is lost before more edits, commits, or delivery steps:
+
+1. reload `git status` and the current branch tip
+2. inspect the current diff and recent commits
+3. inspect current PR metadata and changed files when PR work is active
+4. reread only the narrow repo standards and start-skill docs for the active
+   surface
+5. reload the latest targeted verification results
+
+Do not rely on tracked scratch notes, phase logs, or preserved review ledgers
+to recover task state.
 
 ## Quality Gates
 

--- a/docs/standards/implementation.md
+++ b/docs/standards/implementation.md
@@ -206,9 +206,15 @@ Expected behavior:
   defined in `docs/standards/commits.md` because that metadata
   stays attached to the PR record and becomes the squash commit on `main` for
   the single-checkpoint exception
+- keep PR, commit, and doc language neutral and direct: `Why:` should state the
+  problem or constraint, `What:` should state the concrete repo change, and
+  neither section should use rhetorical or promotional wording
 - before merging a PR or rewriting mainline history, verify whether the pull
   request record must stay attached to the landing commit; if yes, do not
   rewrite that merge commit after merge
+- if a repair PR replaces an older pull request, mark the old PR as
+  superseded/duplicate with a neutral comment that links to the replacement
+  PR before closing the repair loop
 - when the work uncovers follow-up or out-of-scope changes that do not belong
   in the current PR, create the issue immediately so it does not get lost
 - do not defer issue creation for out-of-scope work until after merge, handoff,

--- a/docs/standards/implementation.md
+++ b/docs/standards/implementation.md
@@ -212,9 +212,13 @@ Expected behavior:
 - before merging a PR or rewriting mainline history, verify whether the pull
   request record must stay attached to the landing commit; if yes, do not
   rewrite that merge commit after merge
-- if a repair PR replaces an older pull request, mark the old PR as
-  superseded/duplicate with a neutral comment that links to the replacement
-  PR before closing the repair loop
+- if a multi-checkpoint PR merges with a merge commit, use
+  `<pr title> (#<pr number>)` as the merge subject so the mainline log keeps
+  the PR number visible
+- if a repair PR replaces an older pull request, mark the old PR with the
+  repo's neutral duplicate/superseded label before closing the repair loop
+- add a neutral replacement comment only when the repo has no suitable label
+  or the user explicitly asks for explanatory prose
 - when the work uncovers follow-up or out-of-scope changes that do not belong
   in the current PR, create the issue immediately so it does not get lost
 - do not defer issue creation for out-of-scope work until after merge, handoff,

--- a/docs/standards/implementation.md
+++ b/docs/standards/implementation.md
@@ -206,6 +206,9 @@ Expected behavior:
   defined in `docs/standards/commits.md` because that metadata
   stays attached to the PR record and becomes the squash commit on `main` for
   the single-checkpoint exception
+- before merging a PR or rewriting mainline history, verify whether the pull
+  request record must stay attached to the landing commit; if yes, do not
+  rewrite that merge commit after merge
 - when the work uncovers follow-up or out-of-scope changes that do not belong
   in the current PR, create the issue immediately so it does not get lost
 - do not defer issue creation for out-of-scope work until after merge, handoff,

--- a/tests/contract/test_standards_guards.py
+++ b/tests/contract/test_standards_guards.py
@@ -314,6 +314,49 @@ def test_delivery_standards_pin_merge_subject_and_repair_label_rules() -> None:
     assert "duplicate/superseded label" in checkpoint_text
 
 
+def test_delivery_guardrails_doc_is_routed_and_layered() -> None:
+    guardrails_text = (repo_root() / "docs/standards/delivery-guardrails.md").read_text(
+        encoding="utf-8"
+    )
+    docs_index_text = (repo_root() / "docs/README.md").read_text(encoding="utf-8")
+    agents_text = (repo_root() / "AGENTS.md").read_text(encoding="utf-8")
+    roadmap_text = (repo_root() / "ROADMAP.md").read_text(encoding="utf-8")
+    checkpoint_text = (
+        repo_root() / ".claude/commands/implementation-checkpoint.md"
+    ).read_text(encoding="utf-8")
+
+    assert "platform-native enforcement" in guardrails_text
+    assert "repo-native policy as code" in guardrails_text
+    assert "agent default behavior" in guardrails_text
+    assert "<pr title> (#<pr number>)" in guardrails_text
+    assert "duplicate or superseded label" in guardrails_text
+    assert "docs/status/current-state.md" in guardrails_text
+    assert "tools/docs_maintenance/cli.py" in guardrails_text
+    assert "`markdown` skill" in guardrails_text
+    assert "human docs, agent" in guardrails_text
+    assert "standards/delivery-guardrails.md" in docs_index_text
+    assert (
+        "Repo standards, docs placement, doc authoring rules, or agent-default enforcement changes"
+        in agents_text
+    )
+    assert "use the `markdown` skill if available" in agents_text
+    assert (
+        "use\n  the `code-change-safety` skill as the starting workflow" in agents_text
+    )
+    assert "tools/docs_maintenance/metadata.py" in agents_text
+    assert "docs/reference/repository-history.md" in agents_text
+    assert "docs/standards/delivery-guardrails.md" in agents_text
+    assert "delivery guardrails layered across platform settings" in roadmap_text
+    assert (
+        "if standards, docs placement, doc authoring rules, or agent-default enforcement changed"
+        in checkpoint_text
+    )
+    assert (
+        "use `code-change-safety` for repo changes and `markdown` for Markdown/docs"
+        in checkpoint_text
+    )
+
+
 def test_src_does_not_accumulate_flat_same_prefix_clusters() -> None:
     source_root = repo_root() / "src" / "tallylot"
 

--- a/tests/contract/test_standards_guards.py
+++ b/tests/contract/test_standards_guards.py
@@ -330,6 +330,8 @@ def test_delivery_guardrails_doc_is_routed_and_layered() -> None:
     assert "agent default behavior" in guardrails_text
     assert "<pr title> (#<pr number>)" in guardrails_text
     assert "duplicate or superseded label" in guardrails_text
+    assert "tools.audit_delivery_guardrails" in guardrails_text
+    assert "single review-capable collaborator" in guardrails_text
     assert "docs/status/current-state.md" in guardrails_text
     assert "tools/docs_maintenance/cli.py" in guardrails_text
     assert "`markdown` skill" in guardrails_text
@@ -347,6 +349,9 @@ def test_delivery_guardrails_doc_is_routed_and_layered() -> None:
     assert "docs/reference/repository-history.md" in agents_text
     assert "docs/standards/delivery-guardrails.md" in agents_text
     assert "delivery guardrails layered across platform settings" in roadmap_text
+    assert "control-plane ownership routing" in roadmap_text
+    assert "audit local CODEOWNERS coverage and live GitHub delivery" in roadmap_text
+    assert "settings together without broad context loading" in roadmap_text
     assert (
         "if standards, docs placement, doc authoring rules, or agent-default enforcement changed"
         in checkpoint_text
@@ -355,6 +360,30 @@ def test_delivery_guardrails_doc_is_routed_and_layered() -> None:
         "use `code-change-safety` for repo changes and `markdown` for Markdown/docs"
         in checkpoint_text
     )
+
+
+def test_control_plane_codeowners_file_exists_and_covers_guardrail_paths() -> None:
+    codeowners_path = repo_root() / ".github" / "CODEOWNERS"
+    assert codeowners_path.exists(), ".github/CODEOWNERS is missing"
+
+    codeowners_text = codeowners_path.read_text(encoding="utf-8")
+    required_entries = (
+        ".github/workflows/**",
+        ".github/pull_request_template.md",
+        ".github/CODEOWNERS",
+        "AGENTS.md",
+        "docs/standards/**",
+        ".claude/commands/**",
+        "tools/install_git_hooks.py",
+        "tools/pre_commit_hook.py",
+        "tools/validate_commit_message.py",
+        "tools/validate_pr_metadata.py",
+        "tools/run_quality_gates.py",
+        "tools/run_ci_parity_checks.py",
+    )
+
+    for entry in required_entries:
+        assert entry in codeowners_text, f"CODEOWNERS is missing {entry}"
 
 
 def test_src_does_not_accumulate_flat_same_prefix_clusters() -> None:

--- a/tests/contract/test_standards_guards.py
+++ b/tests/contract/test_standards_guards.py
@@ -403,6 +403,7 @@ def test_control_plane_codeowners_file_exists_and_covers_guardrail_paths() -> No
 
     codeowners_text = codeowners_path.read_text(encoding="utf-8")
     required_entries = (
+        ".agents/skills/**",
         ".github/workflows/**",
         ".github/pull_request_template.md",
         ".github/CODEOWNERS",
@@ -411,6 +412,8 @@ def test_control_plane_codeowners_file_exists_and_covers_guardrail_paths() -> No
         ".claude/commands/**",
         "tools/install_git_hooks.py",
         "tools/pre_commit_hook.py",
+        "tools/audit_delivery_guardrails.py",
+        "tools/message_standards.py",
         "tools/validate_commit_message.py",
         "tools/validate_pr_metadata.py",
         "tools/run_quality_gates.py",

--- a/tests/contract/test_standards_guards.py
+++ b/tests/contract/test_standards_guards.py
@@ -308,6 +308,8 @@ def test_delivery_standards_pin_merge_subject_and_repair_label_rules() -> None:
     assert "<pr title> (#<pr number>)" in implementation_text
     assert "<pr title> (#<pr number>)" in agents_text
     assert "<pr title> (#<pr number>)" in checkpoint_text
+    assert "Follow-ups:" in commits_text
+    assert "- Closes #123:" in commits_text
     assert "duplicate/superseded label" in commits_text
     assert "duplicate/superseded label" in implementation_text
     assert "duplicate/superseded label" in agents_text
@@ -324,11 +326,17 @@ def test_delivery_guardrails_doc_is_routed_and_layered() -> None:
     checkpoint_text = (
         repo_root() / ".claude/commands/implementation-checkpoint.md"
     ).read_text(encoding="utf-8")
+    hardening_route_text = (
+        repo_root() / ".claude" / "commands" / "pr-hardening-review.md"
+    ).read_text(encoding="utf-8")
 
     assert "platform-native enforcement" in guardrails_text
     assert "repo-native policy as code" in guardrails_text
     assert "agent default behavior" in guardrails_text
     assert "<pr title> (#<pr number>)" in guardrails_text
+    assert "draft by default" in guardrails_text
+    assert "ready for review" in guardrails_text
+    assert "evidence-backed findings" in guardrails_text
     assert "duplicate or superseded label" in guardrails_text
     assert "tools.audit_delivery_guardrails" in guardrails_text
     assert "single review-capable collaborator" in guardrails_text
@@ -348,6 +356,7 @@ def test_delivery_guardrails_doc_is_routed_and_layered() -> None:
     assert "tools/docs_maintenance/metadata.py" in agents_text
     assert "docs/reference/repository-history.md" in agents_text
     assert "docs/standards/delivery-guardrails.md" in agents_text
+    assert ".claude/commands/pr-hardening-review.md" in agents_text
     assert "delivery guardrails layered across platform settings" in roadmap_text
     assert "control-plane ownership routing" in roadmap_text
     assert "audit local CODEOWNERS coverage and live GitHub delivery" in roadmap_text
@@ -360,6 +369,11 @@ def test_delivery_guardrails_doc_is_routed_and_layered() -> None:
         "use `code-change-safety` for repo changes and `markdown` for Markdown/docs"
         in checkpoint_text
     )
+    assert "scratch workflow bookkeeping" in checkpoint_text
+    assert (
+        "Keep the PR draft until a full clean pass is complete" in hardening_route_text
+    )
+    assert "Do not invent findings to hit a" in hardening_route_text
 
 
 def test_control_plane_codeowners_file_exists_and_covers_guardrail_paths() -> None:

--- a/tests/contract/test_standards_guards.py
+++ b/tests/contract/test_standards_guards.py
@@ -68,23 +68,29 @@ def _is_named_call(node: ast.expr, name: str) -> bool:
     return False
 
 
-def _assert_no_imports(root: Path, forbidden_modules: tuple[str, ...], *, production_only: bool = False) -> None:
-    python_files = _production_python_files(root) if production_only else _python_files(root)
+def _assert_no_imports(
+    root: Path, forbidden_modules: tuple[str, ...], *, production_only: bool = False
+) -> None:
+    python_files = (
+        _production_python_files(root) if production_only else _python_files(root)
+    )
 
     for path in python_files:
         module = _module(path)
         for node in ast.walk(module):
             if isinstance(node, ast.ImportFrom) and node.module is not None:
                 for forbidden in forbidden_modules:
-                    assert not (node.module == forbidden or node.module.startswith(f"{forbidden}.")), (
-                        f"{path} imports forbidden module {forbidden}"
-                    )
+                    assert not (
+                        node.module == forbidden
+                        or node.module.startswith(f"{forbidden}.")
+                    ), f"{path} imports forbidden module {forbidden}"
             if isinstance(node, ast.Import):
                 for alias in node.names:
                     for forbidden in forbidden_modules:
-                        assert not (alias.name == forbidden or alias.name.startswith(f"{forbidden}.")), (
-                            f"{path} imports forbidden module {forbidden}"
-                        )
+                        assert not (
+                            alias.name == forbidden
+                            or alias.name.startswith(f"{forbidden}.")
+                        ), f"{path} imports forbidden module {forbidden}"
 
 
 def _uses_direct_repo_root_derivation(path: Path) -> bool:
@@ -121,17 +127,29 @@ def _uses_direct_repo_root_derivation(path: Path) -> bool:
 
     module = _module(path)
     for node in ast.walk(module):
-        if not isinstance(node, ast.Assign | ast.AnnAssign | ast.NamedExpr | ast.Call | ast.Attribute | ast.Subscript):
+        if not isinstance(
+            node,
+            ast.Assign
+            | ast.AnnAssign
+            | ast.NamedExpr
+            | ast.Call
+            | ast.Attribute
+            | ast.Subscript,
+        ):
             continue
         candidate: ast.expr | None = (
-            node.value if isinstance(node, ast.Assign | ast.AnnAssign | ast.NamedExpr) else node
+            node.value
+            if isinstance(node, ast.Assign | ast.AnnAssign | ast.NamedExpr)
+            else node
         )
         if candidate is not None and is_repo_root_derivation(candidate):
             return True
     return False
 
 
-def test_repo_root_derivation_guard_catches_parent_and_parents_forms(tmp_path: Path) -> None:
+def test_repo_root_derivation_guard_catches_parent_and_parents_forms(
+    tmp_path: Path,
+) -> None:
     parent_form = tmp_path / "parent_form.py"
     parent_form.write_text(
         "from pathlib import Path\nREPO = Path(__file__).resolve().parent.parent\n",
@@ -158,10 +176,15 @@ def _defines_root_constants(path: Path) -> bool:
     module = _module(path)
     for node in module.body:
         if isinstance(node, ast.Assign) and any(
-            isinstance(target, ast.Name) and target.id in constant_names for target in node.targets
+            isinstance(target, ast.Name) and target.id in constant_names
+            for target in node.targets
         ):
             return True
-        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.target.id in constant_names:
+        if (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id in constant_names
+        ):
             return True
     return False
 
@@ -177,7 +200,9 @@ def test_repo_has_no_type_ignore_comments() -> None:
     for path in _all_repo_python_files():
         text = path.read_text(encoding="utf-8")
         for needle in forbidden:
-            assert needle not in text, f"{path} contains forbidden typing bypass {needle!r}"
+            assert needle not in text, (
+                f"{path} contains forbidden typing bypass {needle!r}"
+            )
 
 
 def test_protected_access_suppressions_only_live_in_test_pylint_config() -> None:
@@ -197,16 +222,24 @@ def test_repo_root_derivation_is_centralized_in_repo_support_paths() -> None:
     approved = repo_root() / "repo_support" / "paths.py"
 
     offenders = [
-        path for path in _repo_side_python_files() if path != approved and _uses_direct_repo_root_derivation(path)
+        path
+        for path in _repo_side_python_files()
+        if path != approved and _uses_direct_repo_root_derivation(path)
     ]
 
-    assert not offenders, f"repo-side python still derives repo root outside repo_support.paths: {offenders}"
+    assert not offenders, (
+        f"repo-side python still derives repo root outside repo_support.paths: {offenders}"
+    )
 
 
 def test_repo_side_python_does_not_define_repo_root_constants() -> None:
-    offenders = [path for path in _repo_side_python_files() if _defines_root_constants(path)]
+    offenders = [
+        path for path in _repo_side_python_files() if _defines_root_constants(path)
+    ]
 
-    assert not offenders, f"repo-side python still defines local root constants: {offenders}"
+    assert not offenders, (
+        f"repo-side python still defines local root constants: {offenders}"
+    )
 
 
 def test_production_code_does_not_import_repo_support_or_tools() -> None:
@@ -220,24 +253,65 @@ def test_repo_support_avoids_generic_sink_modules() -> None:
     support_root = repo_root() / "repo_support"
     if not support_root.exists():
         raise AssertionError("repo_support package is missing")
-    offenders = sorted(path.name for path in support_root.rglob("*.py") if path.name in forbidden)
+    offenders = sorted(
+        path.name for path in support_root.rglob("*.py") if path.name in forbidden
+    )
 
-    assert not offenders, f"repo_support contains forbidden generic sink modules: {offenders}"
+    assert not offenders, (
+        f"repo_support contains forbidden generic sink modules: {offenders}"
+    )
 
 
 def test_markdownlint_only_disables_md013() -> None:
-    config = json.loads((repo_root() / ".markdownlint.json").read_text(encoding="utf-8"))
+    config = json.loads(
+        (repo_root() / ".markdownlint.json").read_text(encoding="utf-8")
+    )
     assert config == {"default": True, "MD013": False}
 
 
 def test_module_size_policy_remains_aligned() -> None:
     pylint_text = (repo_root() / ".pylintrc").read_text(encoding="utf-8")
-    standards_text = (repo_root() / "docs/standards/engineering.md").read_text(encoding="utf-8")
+    standards_text = (repo_root() / "docs/standards/engineering.md").read_text(
+        encoding="utf-8"
+    )
 
     assert "max-module-lines = 450" in pylint_text
-    assert re.search(r"Refactor before extending beyond 300 lines", standards_text) is not None
-    assert re.search(r"Treat `300` lines as the official repo refactor limit", standards_text) is not None
-    assert re.search(r"Treat `450` lines as the hard-stop lint ceiling", standards_text) is not None
+    assert (
+        re.search(r"Refactor before extending beyond 300 lines", standards_text)
+        is not None
+    )
+    assert (
+        re.search(
+            r"Treat `300` lines as the official repo refactor limit", standards_text
+        )
+        is not None
+    )
+    assert (
+        re.search(r"Treat `450` lines as the hard-stop lint ceiling", standards_text)
+        is not None
+    )
+
+
+def test_delivery_standards_pin_merge_subject_and_repair_label_rules() -> None:
+    commits_text = (repo_root() / "docs/standards/commits.md").read_text(
+        encoding="utf-8"
+    )
+    implementation_text = (repo_root() / "docs/standards/implementation.md").read_text(
+        encoding="utf-8"
+    )
+    agents_text = (repo_root() / "AGENTS.md").read_text(encoding="utf-8")
+    checkpoint_text = (
+        repo_root() / ".claude/commands/implementation-checkpoint.md"
+    ).read_text(encoding="utf-8")
+
+    assert "<pr title> (#<pr number>)" in commits_text
+    assert "<pr title> (#<pr number>)" in implementation_text
+    assert "<pr title> (#<pr number>)" in agents_text
+    assert "<pr title> (#<pr number>)" in checkpoint_text
+    assert "duplicate/superseded label" in commits_text
+    assert "duplicate/superseded label" in implementation_text
+    assert "duplicate/superseded label" in agents_text
+    assert "duplicate/superseded label" in checkpoint_text
 
 
 def test_src_does_not_accumulate_flat_same_prefix_clusters() -> None:
@@ -252,8 +326,12 @@ def test_src_does_not_accumulate_flat_same_prefix_clusters() -> None:
             if len(parts) < 2:
                 continue
             prefix_groups["_".join(parts[:2])].append(path.name)
-        offenders = {prefix: names for prefix, names in prefix_groups.items() if len(names) > 2}
-        assert not offenders, f"{directory} has flat same-prefix clusters that should be packaged: {offenders}"
+        offenders = {
+            prefix: names for prefix, names in prefix_groups.items() if len(names) > 2
+        }
+        assert not offenders, (
+            f"{directory} has flat same-prefix clusters that should be packaged: {offenders}"
+        )
 
 
 def test_retired_bucket_directories_do_not_exist() -> None:
@@ -308,14 +386,18 @@ def test_future_capability_roots_remain_available_for_next_phase() -> None:
 
     for package in required_packages:
         assert package.is_dir(), f"missing future capability package root: {package}"
-        assert (package / "__init__.py").exists(), f"missing package marker for {package}"
+        assert (package / "__init__.py").exists(), (
+            f"missing package marker for {package}"
+        )
         importlib.import_module(".".join(package.relative_to(src_root.parent).parts))
     for module in required_modules:
         assert module.exists(), f"missing capability boundary module: {module}"
 
 
 def test_production_packaging_excludes_dev_only_oracle_tooling() -> None:
-    pyproject = tomllib.loads((repo_root() / "pyproject.toml").read_text(encoding="utf-8"))
+    pyproject = tomllib.loads(
+        (repo_root() / "pyproject.toml").read_text(encoding="utf-8")
+    )
 
     scripts = pyproject["project"]["scripts"]
     wheel_packages = pyproject["tool"]["hatch"]["build"]["targets"]["wheel"]["packages"]
@@ -327,7 +409,9 @@ def test_production_packaging_excludes_dev_only_oracle_tooling() -> None:
 
 def test_typecheck_configs_remain_strict() -> None:
     mypy_text = (repo_root() / "mypy.ini").read_text(encoding="utf-8")
-    pyright_config = json.loads((repo_root() / "pyrightconfig.json").read_text(encoding="utf-8"))
+    pyright_config = json.loads(
+        (repo_root() / "pyrightconfig.json").read_text(encoding="utf-8")
+    )
 
     assert "strict = true" in mypy_text
     assert "warn_unused_ignores = true" in mypy_text
@@ -343,7 +427,9 @@ def test_pyright_private_usage_config_matches_repo_test_trees() -> None:
         "tests",
         *(
             path.relative_to(repo_root()).as_posix()
-            for path in sorted((repo_root() / "src" / "tallylot" / "adapters").rglob("tests"))
+            for path in sorted(
+                (repo_root() / "src" / "tallylot" / "adapters").rglob("tests")
+            )
             if path.is_dir()
         ),
     }
@@ -358,7 +444,9 @@ def test_pyright_private_usage_config_matches_repo_test_trees() -> None:
 
 
 def test_pyright_root_config_extends_generated_test_config() -> None:
-    pyright_config = json.loads((repo_root() / "pyrightconfig.json").read_text(encoding="utf-8"))
+    pyright_config = json.loads(
+        (repo_root() / "pyrightconfig.json").read_text(encoding="utf-8")
+    )
 
     assert pyright_config.get("extends") == f"./{PYRIGHT_GENERATED_TEST_CONFIG_NAME}"
     assert "executionEnvironments" not in pyright_config
@@ -399,7 +487,9 @@ def test_ports_modules_do_not_import_implementation_layers() -> None:
     )
 
 
-def test_adapter_production_modules_do_not_import_application_or_infrastructure() -> None:
+def test_adapter_production_modules_do_not_import_application_or_infrastructure() -> (
+    None
+):
     adapters_root = repo_root() / "src" / "tallylot" / "adapters"
 
     _assert_no_imports(
@@ -449,7 +539,9 @@ def test_repo_does_not_reference_fact_category_attribute() -> None:
         for path in _python_files(root):
             for node in ast.walk(_module(path)):
                 if isinstance(node, ast.Attribute):
-                    assert node.attr != "category", f"{path} references removed fact category attribute"
+                    assert node.attr != "category", (
+                        f"{path} references removed fact category attribute"
+                    )
 
 
 def test_repo_does_not_reference_removed_single_leg_fact_attributes() -> None:
@@ -489,7 +581,9 @@ def test_source_adapters_do_not_pass_string_classification_values() -> None:
             for keyword in node.keywords:
                 if keyword.arg not in CLASSIFICATION_KEYWORDS:
                     continue
-                if isinstance(keyword.value, ast.Constant) and isinstance(keyword.value.value, str):
+                if isinstance(keyword.value, ast.Constant) and isinstance(
+                    keyword.value.value, str
+                ):
                     raise AssertionError(
                         f"{path} passes string classification value {keyword.arg}={keyword.value.value!r} "
                         "through shared draft helpers"
@@ -510,11 +604,21 @@ def test_balance_evidence_has_single_production_owner() -> None:
     assert occurrences == 1
 
 
-def test_transaction_classification_matrix_describes_runtime_projection_values() -> None:
-    matrix_text = (repo_root() / "docs" / "concepts" / "transaction-classification.md").read_text(encoding="utf-8")
+def test_transaction_classification_matrix_describes_runtime_projection_values() -> (
+    None
+):
+    matrix_text = (
+        repo_root() / "docs" / "concepts" / "transaction-classification.md"
+    ).read_text(encoding="utf-8")
 
-    assert "| `trade` | `trade` | `spot_trade` | `capital_exchange` | `asset_exchange` |" in matrix_text
-    assert "| `deposit` | `deposit` | `asset_deposit` | `non_taxable_transfer_in` | `funding_inflow` |" in matrix_text
+    assert (
+        "| `trade` | `trade` | `spot_trade` | `capital_exchange` | `asset_exchange` |"
+        in matrix_text
+    )
+    assert (
+        "| `deposit` | `deposit` | `asset_deposit` | `non_taxable_transfer_in` | `funding_inflow` |"
+        in matrix_text
+    )
     assert (
         "| `withdrawal` | `withdrawal` | `asset_withdrawal` | `non_taxable_transfer_out` | `funding_outflow` |"
         in matrix_text

--- a/tests/contract/test_standards_guards.py
+++ b/tests/contract/test_standards_guards.py
@@ -370,10 +370,31 @@ def test_delivery_guardrails_doc_is_routed_and_layered() -> None:
         in checkpoint_text
     )
     assert "scratch workflow bookkeeping" in checkpoint_text
+    assert "full clean loop has completed with no new" in hardening_route_text
+    assert "invent findings to hit a quota" in hardening_route_text
     assert (
-        "Keep the PR draft until a full clean pass is complete" in hardening_route_text
+        "stop only after a full pass yields no new meaningful findings"
+        in guardrails_text
     )
-    assert "Do not invent findings to hit a" in hardening_route_text
+    assert (
+        "Continue steps 1 through 5 until a full pass yields no new meaningful"
+        in hardening_route_text
+    )
+    assert (
+        "repair every finding from that pass before starting the next pass"
+        in guardrails_text
+    )
+    assert "AGENTS.md`, its task-routing table" in guardrails_text
+    assert "checkpoint commits during the loop" in guardrails_text
+    assert (
+        "Repair every finding from that pass before starting the next pass"
+        in hardening_route_text
+    )
+    assert "create bounded checkpoint commits during the" in hardening_route_text
+    assert (
+        "relevant delivery guidance or skills before updating the PR"
+        in hardening_route_text
+    )
 
 
 def test_control_plane_codeowners_file_exists_and_covers_guardrail_paths() -> None:

--- a/tests/unit/test_commit_message_validator.py
+++ b/tests/unit/test_commit_message_validator.py
@@ -87,6 +87,7 @@ def test_squash_merge_commit_message_with_included_checkpoints_is_valid() -> Non
 refactor: source verification and routing (#11)
 
 Why:
+- Closes #44: preserve the review record on main
 - keep the single-checkpoint squash record reviewable on main
 
 What:
@@ -98,6 +99,9 @@ Checks:
 Included checkpoints:
 - `fix(sources): harden live export parsing and verification`
 - `refactor(sources): harden on-chain ids and family routing`
+
+Follow-ups:
+- Refs #45: clean up old repair notes
 """
 
     errors = _validate_commit_message_text(message)
@@ -271,6 +275,27 @@ Included checkpoints:
     assert errors == (
         "unsupported structured label: Included checkpoints:",
         "unexpected trailing content: - `docs: route agents to narrow standards`",
+    )
+
+
+def test_authored_commit_message_rejects_issue_closing_keywords() -> None:
+    errors = _validate_commit_message_text(
+        """\
+docs: route agents to narrow standards
+
+Why:
+- Closes #44: keep routing guidance explicit
+
+What:
+- point agents to the narrowest applicable standards doc
+
+Checks:
+- uv run python -m tools.validate_commit_message .git/COMMIT_EDITMSG
+"""
+    )
+
+    assert errors == (
+        "authored commit messages must not use issue-closing keywords; use the PR `Why:` section instead",
     )
 
 

--- a/tests/unit/test_commit_message_validator.py
+++ b/tests/unit/test_commit_message_validator.py
@@ -71,10 +71,15 @@ BREAKING CHANGE: verification compare is now verification diff
     assert not errors
 
 
-def test_merge_commit_message_is_allowed() -> None:
+def test_merge_commit_message_requires_conventional_subject() -> None:
     errors = _validate_commit_message_text("Merge branch 'feature/refactor'\n")
 
-    assert not errors
+    assert errors == (
+        "subject must match `type(scope): imperative summary` or "
+        "`type: imperative summary` using one of: feat, fix, refactor, docs, "
+        "test, chore, build, ci, perf, revert",
+        "commit message body is required with `Why:`, `What:`, `Checks:` sections",
+    )
 
 
 def test_squash_merge_commit_message_with_included_checkpoints_is_valid() -> None:

--- a/tests/unit/test_delivery_guardrails_audit.py
+++ b/tests/unit/test_delivery_guardrails_audit.py
@@ -23,7 +23,7 @@ def _protected_branch_payload() -> dict[str, object]:
         },
         "enforce_admins": {"enabled": True},
         "allow_force_pushes": {"enabled": False},
-        "required_conversation_resolution": {"enabled": False},
+        "required_conversation_resolution": {"enabled": True},
     }
 
 
@@ -44,10 +44,7 @@ def test_evaluate_remote_guardrails_defers_review_requirements_for_single_mainta
 
     assert report.errors == ()
     assert any("one review-capable collaborator" in note for note in report.notes)
-    assert any(
-        "required conversation resolution is disabled" in warning
-        for warning in report.warnings
-    )
+    assert report.warnings == ()
 
 
 def test_evaluate_remote_guardrails_warns_when_multi_reviewer_repo_lacks_review_gates() -> (
@@ -78,6 +75,7 @@ def test_evaluate_remote_guardrails_errors_for_missing_core_branch_controls() ->
     }
     payload["enforce_admins"] = {"enabled": False}
     payload["allow_force_pushes"] = {"enabled": True}
+    payload["required_conversation_resolution"] = {"enabled": False}
 
     report = audit._evaluate_remote_guardrails(
         protection=payload,
@@ -93,14 +91,33 @@ def test_evaluate_remote_guardrails_errors_for_missing_core_branch_controls() ->
     assert any("missing required status checks" in error for error in report.errors)
     assert any("enforce admins" in error for error in report.errors)
     assert any("block force pushes" in error for error in report.errors)
+    assert any("conversation resolution" in error for error in report.errors)
     assert any(".github/CODEOWNERS" in error for error in report.errors)
 
 
 def test_missing_codeowners_entries_reports_missing_patterns() -> None:
     missing = audit._missing_codeowners_patterns(("AGENTS.md", "docs/standards/**"))
 
+    assert ".agents/skills/**" in missing
     assert ".github/workflows/**" in missing
+    assert "tools/message_standards.py" in missing
     assert "tools/run_ci_parity_checks.py" in missing
+
+
+def test_rulesets_only_repo_does_not_fail_branch_protection_audit() -> None:
+    report = audit._evaluate_remote_guardrails(
+        protection=None,
+        rulesets=[{"name": "protect-main"}],
+        collaborators=[{"login": "CrownOpsEng", "permissions": {"pull": True}}],
+        codeowners_patterns=audit.CONTROL_PLANE_CODEOWNER_PATTERNS,
+    )
+
+    assert report.errors == ()
+    assert any(
+        "rulesets are the active platform control" in warning
+        for warning in report.warnings
+    )
+    assert any("repository rulesets are configured" in note for note in report.notes)
 
 
 def test_gh_api_json_or_none_returns_none_for_404(monkeypatch: MonkeyPatch) -> None:

--- a/tests/unit/test_delivery_guardrails_audit.py
+++ b/tests/unit/test_delivery_guardrails_audit.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import subprocess
+
+from pytest import MonkeyPatch
+
+import tools.audit_delivery_guardrails as audit
+
+
+def _protected_branch_payload() -> dict[str, object]:
+    return {
+        "required_status_checks": {
+            "strict": True,
+            "contexts": ["commit-messages", "quality"],
+            "checks": [
+                {"context": "commit-messages"},
+                {"context": "quality"},
+            ],
+        },
+        "required_pull_request_reviews": {
+            "required_approving_review_count": 0,
+            "require_code_owner_reviews": False,
+        },
+        "enforce_admins": {"enabled": True},
+        "allow_force_pushes": {"enabled": False},
+        "required_conversation_resolution": {"enabled": False},
+    }
+
+
+def test_evaluate_remote_guardrails_defers_review_requirements_for_single_maintainer() -> (
+    None
+):
+    report = audit._evaluate_remote_guardrails(
+        protection=_protected_branch_payload(),
+        rulesets=[],
+        collaborators=[
+            {
+                "login": "CrownOpsEng",
+                "permissions": {"pull": True},
+            }
+        ],
+        codeowners_patterns=audit.CONTROL_PLANE_CODEOWNER_PATTERNS,
+    )
+
+    assert report.errors == ()
+    assert any("one review-capable collaborator" in note for note in report.notes)
+    assert any(
+        "required conversation resolution is disabled" in warning
+        for warning in report.warnings
+    )
+
+
+def test_evaluate_remote_guardrails_warns_when_multi_reviewer_repo_lacks_review_gates() -> (
+    None
+):
+    report = audit._evaluate_remote_guardrails(
+        protection=_protected_branch_payload(),
+        rulesets=[],
+        collaborators=[
+            {"login": "CrownOpsEng", "permissions": {"pull": True}},
+            {"login": "teammate", "permissions": {"pull": True}},
+        ],
+        codeowners_patterns=audit.CONTROL_PLANE_CODEOWNER_PATTERNS,
+    )
+
+    assert report.errors == ()
+    assert any(
+        "at least one approving review" in warning for warning in report.warnings
+    )
+    assert any("code owner reviews" in warning for warning in report.warnings)
+
+
+def test_evaluate_remote_guardrails_errors_for_missing_core_branch_controls() -> None:
+    payload = _protected_branch_payload()
+    payload["required_status_checks"] = {
+        "strict": False,
+        "contexts": ["commit-messages"],
+    }
+    payload["enforce_admins"] = {"enabled": False}
+    payload["allow_force_pushes"] = {"enabled": True}
+
+    report = audit._evaluate_remote_guardrails(
+        protection=payload,
+        rulesets=[],
+        collaborators=[
+            {"login": "CrownOpsEng", "permissions": {"pull": True}},
+            {"login": "teammate", "permissions": {"pull": True}},
+        ],
+        codeowners_patterns=(),
+    )
+
+    assert any("strict status checks" in error for error in report.errors)
+    assert any("missing required status checks" in error for error in report.errors)
+    assert any("enforce admins" in error for error in report.errors)
+    assert any("block force pushes" in error for error in report.errors)
+    assert any(".github/CODEOWNERS" in error for error in report.errors)
+
+
+def test_missing_codeowners_entries_reports_missing_patterns() -> None:
+    missing = audit._missing_codeowners_patterns(("AGENTS.md", "docs/standards/**"))
+
+    assert ".github/workflows/**" in missing
+    assert "tools/run_ci_parity_checks.py" in missing
+
+
+def test_gh_api_json_or_none_returns_none_for_404(monkeypatch: MonkeyPatch) -> None:
+    def fake_gh_json(*_args: str) -> object:
+        raise subprocess.CalledProcessError(
+            returncode=1,
+            cmd=("gh", "api", "repos/CrownOpsEng/tallylot/branches/main/protection"),
+            stderr="gh: HTTP 404: Not Found",
+        )
+
+    monkeypatch.setattr(audit, "_gh_json", fake_gh_json)
+
+    assert (
+        audit._gh_api_json_or_none(
+            "repos/CrownOpsEng/tallylot/branches/main/protection"
+        )
+        is None
+    )

--- a/tests/unit/test_pr_metadata_validator.py
+++ b/tests/unit/test_pr_metadata_validator.py
@@ -232,7 +232,7 @@ Included checkpoints:
         head_sha="1111111",
     )
 
-    assert errors == ()
+    assert not errors
 
 
 def test_pr_checkpoints_ignore_leading_html_comment(monkeypatch: MonkeyPatch) -> None:
@@ -260,7 +260,7 @@ Included checkpoints:
 
     errors = _validate_pr_checkpoints(body, base_sha="base", head_sha="head")
 
-    assert errors == ()
+    assert not errors
 
 
 def test_pr_checkpoints_reject_non_exact_commit_subjects(

--- a/tests/unit/test_pr_metadata_validator.py
+++ b/tests/unit/test_pr_metadata_validator.py
@@ -107,6 +107,29 @@ Included checkpoints:
     )
 
 
+def test_pr_body_accepts_optional_issues_section() -> None:
+    body = """\
+Why:
+- keep multi-checkpoint history visible on main
+
+What:
+- document and validate pull request metadata
+
+Checks:
+- uv run python -m tools.run_quality_gates
+
+Included checkpoints:
+- `docs: codify pull request standards`
+
+Issues:
+- Closes #34
+"""
+
+    errors = _validate_pr_body(body)
+
+    assert not errors
+
+
 def test_pr_checkpoints_match_commit_subjects(monkeypatch: MonkeyPatch) -> None:
     body = """\
 Why:

--- a/tests/unit/test_pr_metadata_validator.py
+++ b/tests/unit/test_pr_metadata_validator.py
@@ -28,6 +28,7 @@ def test_pr_title_without_conventional_commit_subject_is_rejected() -> None:
 def test_pr_body_with_required_sections_is_valid() -> None:
     body = """\
 Why:
+- Closes #34: preserve multi-checkpoint history on main
 - keep multi-checkpoint history visible on main
 
 What:
@@ -50,6 +51,7 @@ def test_pr_body_tolerates_leading_html_comment() -> None:
 <!-- markdownlint-disable-file MD041 MD032 -->
 
 Why:
+- Closes #34: preserve multi-checkpoint history on main
 - keep multi-checkpoint history visible on main
 
 What:
@@ -107,7 +109,7 @@ Included checkpoints:
     )
 
 
-def test_pr_body_accepts_optional_issues_section() -> None:
+def test_pr_body_accepts_optional_follow_ups_section() -> None:
     body = """\
 Why:
 - keep multi-checkpoint history visible on main
@@ -121,13 +123,82 @@ Checks:
 Included checkpoints:
 - `docs: codify pull request standards`
 
-Issues:
-- Closes #34
+Follow-ups:
+- Refs #34: tighten merge-repair automation
 """
 
     errors = _validate_pr_body(body)
 
     assert not errors
+
+
+def test_pr_body_rejects_malformed_why_closing_bullet() -> None:
+    body = """\
+Why:
+- Closes #34
+- keep multi-checkpoint history visible on main
+
+What:
+- document and validate pull request metadata
+
+Checks:
+- uv run python -m tools.run_quality_gates
+
+Included checkpoints:
+- `docs: codify pull request standards`
+"""
+
+    errors = _validate_pr_body(body)
+
+    assert errors == (
+        "`Why:` issue-closing bullets must match `- Closes #123: problem statement`",
+    )
+
+
+def test_pr_body_rejects_late_why_closing_bullet() -> None:
+    body = """\
+Why:
+- keep multi-checkpoint history visible on main
+- Closes #34: preserve multi-checkpoint history on main
+
+What:
+- document and validate pull request metadata
+
+Checks:
+- uv run python -m tools.run_quality_gates
+
+Included checkpoints:
+- `docs: codify pull request standards`
+"""
+
+    errors = _validate_pr_body(body)
+
+    assert errors == ("`Why:` issue-closing bullets must come before other bullets",)
+
+
+def test_pr_body_rejects_bad_follow_up_bullet() -> None:
+    body = """\
+Why:
+- keep multi-checkpoint history visible on main
+
+What:
+- document and validate pull request metadata
+
+Checks:
+- uv run python -m tools.run_quality_gates
+
+Included checkpoints:
+- `docs: codify pull request standards`
+
+Follow-ups:
+- follow up in #34
+"""
+
+    errors = _validate_pr_body(body)
+
+    assert errors == (
+        "`Follow-ups:` bullets must match `- Refs #123` or `- Refs #123: note`",
+    )
 
 
 def test_pr_checkpoints_match_commit_subjects(monkeypatch: MonkeyPatch) -> None:

--- a/tests/unit/test_quality_gates.py
+++ b/tests/unit/test_quality_gates.py
@@ -87,6 +87,18 @@ def test_pre_commit_config_keeps_hook_validations_without_ruff_duplication() -> 
     assert "id: ruff" not in config_text
 
 
+def test_pre_commit_config_keeps_single_pass_checkpoint_validations() -> None:
+    config_text = (repo_root() / ".pre-commit-config.yaml").read_text(encoding="utf-8")
+
+    assert config_text.count("id: markdownlint") == 1
+    assert config_text.count("id: commit-message") == 1
+    assert config_text.count("id: mypy") == 1
+    assert config_text.count("id: pyright") == 1
+    assert config_text.count("name: pytest-fast") == 1
+    assert "tools.run_quality_gates" not in config_text
+    assert "tools.run_ci_parity_checks" not in config_text
+
+
 def test_quality_gates_refresh_generated_pyright_config_before_running(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/unit/test_repo_agent_skills.py
+++ b/tests/unit/test_repo_agent_skills.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from repo_support.paths import repo_root
+
+
+@dataclass(frozen=True)
+class ExpectedSkill:
+    display_name: str
+    required_fragments: tuple[str, ...]
+
+
+EXPECTED_SKILLS = {
+    "adapter-authoring": ExpectedSkill(
+        display_name="Adapter Authoring",
+        required_fragments=(
+            "docs/guides/write-an-adapter.md",
+            ".claude/commands/adapter-authoring.md",
+            "tools.scaffold_adapter",
+        ),
+    ),
+    "docs-authoring": ExpectedSkill(
+        display_name="Docs Authoring",
+        required_fragments=(
+            "docs/README.md",
+            "tools/docs_maintenance/cli.py",
+            "tools/docs_maintenance/metadata.py",
+            "uv run python -m tools.docs_maintenance sync --check",
+        ),
+    ),
+    "implementation-workflow": ExpectedSkill(
+        display_name="Implementation Workflow",
+        required_fragments=(
+            "docs/standards/engineering.md",
+            "docs/standards/implementation.md",
+            "docs/standards/commits.md",
+            ".claude/commands/implementation-checkpoint.md",
+        ),
+    ),
+    "reconciliation-balance-operations": ExpectedSkill(
+        display_name="Reconciliation Balances",
+        required_fragments=(
+            ".claude/commands/reconciliation-balance-operations.md",
+            ".agents/skills/reconciliation-balance-operations/scripts/reconciliation_balance_operations.py",
+        ),
+    ),
+    "reconciliation-tax-build": ExpectedSkill(
+        display_name="Reconciliation And Tax Build",
+        required_fragments=(
+            "docs/concepts/reconciliation-tax-architecture.md",
+            "docs/concepts/oracle-boundaries.md",
+            "docs/concepts/transaction-classification.md",
+            "docs/status/migration-sequence.md",
+            ".claude/commands/reconciliation-tax-build.md",
+            "ROADMAP.md",
+        ),
+    ),
+    "round-verification-operations": ExpectedSkill(
+        display_name="Round Verification",
+        required_fragments=(
+            "docs/guides/verify-a-round.md",
+            ".claude/commands/round-verification.md",
+            "tools.oracles.cli round scaffold",
+            "tools.oracles.cli verification compare",
+        ),
+    ),
+    "source-intake-operations": ExpectedSkill(
+        display_name="Source Intake",
+        required_fragments=(
+            "docs/guides/operator-quickstart.md",
+            "docs/guides/source-intake.md",
+            ".claude/commands/source-intake.md",
+            "source intake plan",
+            "source intake apply",
+        ),
+    ),
+}
+
+
+def _skill_root(skill_name: str) -> Path:
+    return repo_root() / ".agents" / "skills" / skill_name
+
+
+def test_expected_repo_local_skills_exist() -> None:
+    skill_names = {
+        path.name
+        for path in (repo_root() / ".agents" / "skills").iterdir()
+        if path.is_dir()
+    }
+
+    for skill_name in EXPECTED_SKILLS:
+        assert skill_name in skill_names, f"missing repo-local skill {skill_name}"
+
+
+def test_repo_local_skill_metadata_and_bodies_are_lightweight() -> None:
+    for skill_name, expected in EXPECTED_SKILLS.items():
+        skill_root = _skill_root(skill_name)
+        skill_path = skill_root / "SKILL.md"
+        metadata_path = skill_root / "agents" / "openai.yaml"
+
+        assert skill_path.exists(), f"{skill_name} is missing SKILL.md"
+        assert metadata_path.exists(), f"{skill_name} is missing agents/openai.yaml"
+
+        skill_text = skill_path.read_text(encoding="utf-8")
+        skill_lines = skill_text.splitlines()
+        assert len(skill_lines) <= 120, (
+            f"{skill_name} is too large for progressive disclosure"
+        )
+        assert "## Workflow" in skill_text, (
+            f"{skill_name} is missing a workflow section"
+        )
+        for fragment in expected.required_fragments:
+            assert fragment in skill_text, f"{skill_name} is missing {fragment}"
+
+        metadata = yaml.safe_load(metadata_path.read_text(encoding="utf-8"))
+        assert metadata["interface"]["display_name"] == expected.display_name
+        assert f"${skill_name}" in metadata["interface"]["default_prompt"]
+        assert metadata["policy"]["allow_implicit_invocation"] is True

--- a/tests/unit/test_vscode_pylint.py
+++ b/tests/unit/test_vscode_pylint.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import sys
+
+from tools.vscode_pylint import _pylint_argv
+
+
+def test_test_files_use_test_pylint_rcfile() -> None:
+    argv = _pylint_argv(("tests/unit/test_quality_gates.py",))
+
+    assert argv == (
+        sys.executable,
+        "-m",
+        "pylint",
+        "--rcfile=.pylintrc-tests",
+        "tests/unit/test_quality_gates.py",
+    )
+
+
+def test_non_test_files_use_base_pylint_config() -> None:
+    argv = _pylint_argv(("tools/run_pylint.py",))
+
+    assert argv == (
+        sys.executable,
+        "-m",
+        "pylint",
+        "tools/run_pylint.py",
+    )
+
+
+def test_from_stdin_uses_test_pylint_rcfile_for_test_paths() -> None:
+    argv = _pylint_argv(
+        (
+            "--from-stdin",
+            "tests/unit/test_quality_gates.py",
+        )
+    )
+
+    assert argv == (
+        sys.executable,
+        "-m",
+        "pylint",
+        "--rcfile=.pylintrc-tests",
+        "--from-stdin",
+        "tests/unit/test_quality_gates.py",
+    )
+
+
+def test_existing_rcfile_is_preserved() -> None:
+    argv = _pylint_argv(
+        (
+            "--rcfile=.pylintrc-tests",
+            "tests/unit/test_quality_gates.py",
+        )
+    )
+
+    assert argv == (
+        sys.executable,
+        "-m",
+        "pylint",
+        "--rcfile=.pylintrc-tests",
+        "tests/unit/test_quality_gates.py",
+    )

--- a/tests/unit/test_vscode_settings.py
+++ b/tests/unit/test_vscode_settings.py
@@ -8,5 +8,16 @@ from repo_support.paths import vscode_settings_path
 def test_workspace_vscode_settings_pin_external_python_environment() -> None:
     settings = json.loads(vscode_settings_path().read_text(encoding="utf-8"))
 
-    assert settings["python.defaultInterpreterPath"] == "${env:HOME}/.venvs/tallylot-py312/bin/python"
-    assert settings["terminal.integrated.env.linux"]["UV_PROJECT_ENVIRONMENT"] == "${env:HOME}/.venvs/tallylot-py312"
+    assert (
+        settings["python.defaultInterpreterPath"]
+        == "${env:HOME}/.venvs/tallylot-py312/bin/python"
+    )
+    assert (
+        settings["terminal.integrated.env.linux"]["UV_PROJECT_ENVIRONMENT"]
+        == "${env:HOME}/.venvs/tallylot-py312"
+    )
+    assert settings["pylint.path"] == [
+        "${interpreter}",
+        "-m",
+        "tools.vscode_pylint",
+    ]

--- a/tools/audit_delivery_guardrails.py
+++ b/tools/audit_delivery_guardrails.py
@@ -12,6 +12,7 @@ from repo_support.paths import repo_root
 
 REQUIRED_STATUS_CHECKS = ("commit-messages", "quality")
 CONTROL_PLANE_CODEOWNER_PATTERNS = (
+    ".agents/skills/**",
     ".github/workflows/**",
     ".github/pull_request_template.md",
     ".github/CODEOWNERS",
@@ -20,6 +21,8 @@ CONTROL_PLANE_CODEOWNER_PATTERNS = (
     ".claude/commands/**",
     "tools/install_git_hooks.py",
     "tools/pre_commit_hook.py",
+    "tools/audit_delivery_guardrails.py",
+    "tools/message_standards.py",
     "tools/validate_commit_message.py",
     "tools/validate_pr_metadata.py",
     "tools/run_quality_gates.py",
@@ -249,6 +252,18 @@ def _evaluate_remote_guardrails(
     notes: list[str] = []
 
     if protection is None:
+        if rulesets:
+            warnings.append(
+                "default-branch protection endpoint is absent; repository rulesets "
+                "are the active platform control and branch-protection-specific "
+                "checks were skipped"
+            )
+            notes.append("repository rulesets are configured")
+            return GuardrailReport(
+                errors=tuple(errors),
+                warnings=tuple(warnings),
+                notes=tuple(notes),
+            )
         errors.append("default-branch protection is missing")
         return GuardrailReport(
             errors=tuple(errors),
@@ -264,7 +279,7 @@ def _evaluate_remote_guardrails(
         errors.append("branch protection must block force pushes")
 
     if not _bool_setting(protection, "required_conversation_resolution"):
-        warnings.append("required conversation resolution is disabled")
+        errors.append("branch protection must require conversation resolution")
 
     pr_reviews = cast(
         Mapping[str, object],

--- a/tools/audit_delivery_guardrails.py
+++ b/tools/audit_delivery_guardrails.py
@@ -1,0 +1,346 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, cast
+
+from repo_support.paths import repo_root
+
+REQUIRED_STATUS_CHECKS = ("commit-messages", "quality")
+CONTROL_PLANE_CODEOWNER_PATTERNS = (
+    ".github/workflows/**",
+    ".github/pull_request_template.md",
+    ".github/CODEOWNERS",
+    "AGENTS.md",
+    "docs/standards/**",
+    ".claude/commands/**",
+    "tools/install_git_hooks.py",
+    "tools/pre_commit_hook.py",
+    "tools/validate_commit_message.py",
+    "tools/validate_pr_metadata.py",
+    "tools/run_quality_gates.py",
+    "tools/run_ci_parity_checks.py",
+)
+
+
+@dataclass(frozen=True)
+class GuardrailReport:
+    errors: tuple[str, ...] = ()
+    warnings: tuple[str, ...] = ()
+    notes: tuple[str, ...] = ()
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Audit local and remote delivery guardrails for the current repository."
+    )
+    parser.add_argument("--repo", help="owner/name override for the GitHub repository")
+    parser.add_argument(
+        "--branch", help="branch to inspect; defaults to the GitHub default branch"
+    )
+    parser.add_argument(
+        "--codeowners-path",
+        type=Path,
+        default=repo_root() / ".github" / "CODEOWNERS",
+        help="Local CODEOWNERS file path to audit",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the audit report as JSON",
+    )
+    return parser.parse_args(argv)
+
+
+def _gh_json(*args: str) -> Any:
+    result = subprocess.run(
+        ("gh", *args),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def _gh_api_json_or_none(path: str) -> Any:
+    try:
+        return _gh_json("api", path)
+    except subprocess.CalledProcessError as error:
+        if "HTTP 404" in error.stderr:
+            return None
+        raise
+
+
+def _repo_identity(
+    repo_override: str | None, branch_override: str | None
+) -> tuple[str, str]:
+    if repo_override is not None and branch_override is not None:
+        return repo_override, branch_override
+
+    repo_view = cast(
+        Mapping[str, object],
+        _gh_json(
+            "repo",
+            "view",
+            "--json",
+            "nameWithOwner,defaultBranchRef",
+        ),
+    )
+    repo_name = repo_override or cast(str, repo_view["nameWithOwner"])
+    default_branch_ref = cast(Mapping[str, object], repo_view["defaultBranchRef"])
+    branch_name = branch_override or cast(str, default_branch_ref["name"])
+    return repo_name, branch_name
+
+
+def _codeowners_patterns(path: Path) -> tuple[str, ...]:
+    if not path.exists():
+        return ()
+
+    patterns: list[str] = []
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        patterns.append(line.split()[0])
+    return tuple(patterns)
+
+
+def _missing_codeowners_patterns(codeowners_patterns: Sequence[str]) -> tuple[str, ...]:
+    present = set(codeowners_patterns)
+    return tuple(
+        pattern
+        for pattern in CONTROL_PLANE_CODEOWNER_PATTERNS
+        if pattern not in present
+    )
+
+
+def _required_status_contexts(protection: Mapping[str, object]) -> set[str]:
+    required_status_checks = cast(
+        Mapping[str, object] | None,
+        protection.get("required_status_checks"),
+    )
+    if required_status_checks is None:
+        return set()
+
+    contexts = {
+        context
+        for context in cast(list[object], required_status_checks.get("contexts") or [])
+        if isinstance(context, str)
+    }
+    for raw_check in cast(list[object], required_status_checks.get("checks") or []):
+        if not isinstance(raw_check, Mapping):
+            continue
+        check = cast(Mapping[str, object], raw_check)
+        context = check.get("context")
+        if isinstance(context, str):
+            contexts.add(context)
+    return contexts
+
+
+def _collaborator_is_review_capable(collaborator: Mapping[str, object]) -> bool:
+    permissions_object = collaborator.get("permissions")
+    if not isinstance(permissions_object, Mapping):
+        return False
+    permissions = cast(Mapping[str, object], permissions_object)
+    return bool(permissions.get("pull"))
+
+
+def _has_multi_reviewer_surface(collaborators: Sequence[Mapping[str, object]]) -> bool:
+    review_capable = {
+        login
+        for collaborator in collaborators
+        if isinstance(login := collaborator.get("login"), str)
+        and _collaborator_is_review_capable(collaborator)
+    }
+    return len(review_capable) > 1
+
+
+def _evaluate_codeowners_guardrails(
+    codeowners_patterns: Sequence[str],
+) -> tuple[str, ...]:
+    missing_codeowners = _missing_codeowners_patterns(codeowners_patterns)
+    if not codeowners_patterns:
+        return ("local .github/CODEOWNERS is missing",)
+    if missing_codeowners:
+        return (
+            ".github/CODEOWNERS is missing control-plane entries: "
+            + ", ".join(missing_codeowners),
+        )
+    return ()
+
+
+def _evaluate_status_check_guardrails(
+    protection: Mapping[str, object],
+) -> tuple[str, ...]:
+    errors: list[str] = []
+    required_status_checks = cast(
+        Mapping[str, object] | None,
+        protection.get("required_status_checks"),
+    )
+    if not isinstance(required_status_checks, Mapping):
+        return ("branch protection must require strict status checks",)
+
+    if not bool(required_status_checks.get("strict")):
+        errors.append("branch protection must require strict status checks")
+
+    expected_status_checks: set[str] = set(REQUIRED_STATUS_CHECKS)
+    missing_status_checks = sorted(
+        expected_status_checks - _required_status_contexts(protection)
+    )
+    if missing_status_checks:
+        errors.append(
+            "branch protection is missing required status checks: "
+            + ", ".join(missing_status_checks)
+        )
+    return tuple(errors)
+
+
+def _bool_setting(protection: Mapping[str, object], setting_name: str) -> bool:
+    setting_object = protection.get(setting_name)
+    if not isinstance(setting_object, Mapping):
+        return False
+    setting = cast(Mapping[str, object], setting_object)
+    return bool(setting.get("enabled"))
+
+
+def _review_guardrail_messages(
+    collaborators: Sequence[Mapping[str, object]],
+    pr_reviews: Mapping[str, object],
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    warnings: list[str] = []
+    notes: list[str] = []
+    review_count = cast(int, pr_reviews.get("required_approving_review_count") or 0)
+    code_owner_reviews = bool(pr_reviews.get("require_code_owner_reviews"))
+
+    if _has_multi_reviewer_surface(collaborators):
+        if review_count < 1:
+            warnings.append(
+                "branch protection should require at least one approving review "
+                "when more than one review-capable collaborator exists"
+            )
+        if not code_owner_reviews:
+            warnings.append(
+                "branch protection should require code owner reviews when more "
+                "than one review-capable collaborator exists"
+            )
+        return tuple(warnings), ()
+
+    if review_count < 1 or not code_owner_reviews:
+        notes.append(
+            "required approving reviews and code owner reviews remain deferred "
+            "because the repo currently has only one review-capable collaborator"
+        )
+    return (), tuple(notes)
+
+
+def _evaluate_remote_guardrails(
+    *,
+    protection: Mapping[str, object] | None,
+    rulesets: Sequence[Mapping[str, object]],
+    collaborators: Sequence[Mapping[str, object]],
+    codeowners_patterns: Sequence[str],
+) -> GuardrailReport:
+    errors = list(_evaluate_codeowners_guardrails(codeowners_patterns))
+    warnings: list[str] = []
+    notes: list[str] = []
+
+    if protection is None:
+        errors.append("default-branch protection is missing")
+        return GuardrailReport(
+            errors=tuple(errors),
+            warnings=tuple(warnings),
+            notes=tuple(notes),
+        )
+
+    errors.extend(_evaluate_status_check_guardrails(protection))
+
+    if not _bool_setting(protection, "enforce_admins"):
+        errors.append("branch protection must enforce admins")
+    if _bool_setting(protection, "allow_force_pushes"):
+        errors.append("branch protection must block force pushes")
+
+    if not _bool_setting(protection, "required_conversation_resolution"):
+        warnings.append("required conversation resolution is disabled")
+
+    pr_reviews = cast(
+        Mapping[str, object],
+        protection.get("required_pull_request_reviews") or {},
+    )
+    review_warnings, review_notes = _review_guardrail_messages(
+        collaborators, pr_reviews
+    )
+    warnings.extend(review_warnings)
+    notes.extend(review_notes)
+
+    if rulesets:
+        notes.append("repository rulesets are configured")
+    else:
+        notes.append(
+            "classic branch protection is the active platform control; no "
+            "repository rulesets are configured"
+        )
+
+    return GuardrailReport(
+        errors=tuple(errors),
+        warnings=tuple(warnings),
+        notes=tuple(notes),
+    )
+
+
+def _print_report(report: GuardrailReport) -> None:
+    for label, items in (
+        ("ERROR", report.errors),
+        ("WARNING", report.warnings),
+        ("NOTE", report.notes),
+    ):
+        for item in items:
+            print(f"{label}: {item}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    repo_name, branch_name = _repo_identity(args.repo, args.branch)
+    codeowners_patterns = _codeowners_patterns(args.codeowners_path)
+
+    protection = cast(
+        Mapping[str, object] | None,
+        _gh_api_json_or_none(f"repos/{repo_name}/branches/{branch_name}/protection"),
+    )
+    rulesets = cast(
+        Sequence[Mapping[str, object]],
+        _gh_json("api", f"repos/{repo_name}/rulesets"),
+    )
+    collaborators = cast(
+        Sequence[Mapping[str, object]],
+        _gh_json("api", f"repos/{repo_name}/collaborators?per_page=100"),
+    )
+    report = _evaluate_remote_guardrails(
+        protection=protection,
+        rulesets=rulesets,
+        collaborators=collaborators,
+        codeowners_patterns=codeowners_patterns,
+    )
+
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "errors": report.errors,
+                    "warnings": report.warnings,
+                    "notes": report.notes,
+                },
+                indent=2,
+            )
+        )
+    else:
+        _print_report(report)
+
+    return 1 if report.errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/message_standards.py
+++ b/tools/message_standards.py
@@ -16,16 +16,14 @@ ALLOWED_TYPES = (
 )
 TYPE_PATTERN = "|".join(ALLOWED_TYPES)
 SCOPE_PATTERN = r"[a-z0-9]+(?:-[a-z0-9]+)*"
-SUBJECT_PATTERN = re.compile(rf"^(?:{TYPE_PATTERN})(?:\(({SCOPE_PATTERN})\))?: (?P<summary>.+)$")
-MERGE_SUBJECT_PATTERN = re.compile(r"^Merge (?:branch|pull request) ")
+SUBJECT_PATTERN = re.compile(
+    rf"^(?:{TYPE_PATTERN})(?:\(({SCOPE_PATTERN})\))?: (?P<summary>.+)$"
+)
 FOOTER_PATTERN = re.compile(r"^(?:BREAKING CHANGE|[A-Za-z][A-Za-z0-9-]*):(?: .+)?$")
 LABEL_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9 -]*:(?: .+)?$")
 
 
-def validate_subject_line(subject: str, *, allow_merge: bool = True) -> tuple[str, ...]:
-    if allow_merge and MERGE_SUBJECT_PATTERN.match(subject):
-        return ()
-
+def validate_subject_line(subject: str) -> tuple[str, ...]:
     errors: list[str] = []
     if len(subject) > 72:
         errors.append("subject must be 72 characters or fewer")
@@ -133,7 +131,9 @@ def validate_structured_sections(
         errors.append("insert a blank line between the subject and the body")
 
     for section in required_sections:
-        index, section_errors = _validate_required_section(lines, section=section, start_index=index)
+        index, section_errors = _validate_required_section(
+            lines, section=section, start_index=index
+        )
         errors.extend(section_errors)
 
     for section in optional_sections:
@@ -147,5 +147,7 @@ def validate_structured_sections(
         )
         errors.extend(section_errors)
 
-    errors.extend(_validate_trailing_lines(lines, start_index=index, allow_footers=allow_footers))
+    errors.extend(
+        _validate_trailing_lines(lines, start_index=index, allow_footers=allow_footers)
+    )
     return tuple(errors)

--- a/tools/validate_commit_message.py
+++ b/tools/validate_commit_message.py
@@ -14,6 +14,10 @@ from tools.message_standards import (
 )
 
 SQUASH_PR_SUBJECT_PATTERN = re.compile(r" \(\#\d+\)$")
+ISSUE_CLOSING_KEYWORD_PATTERN = re.compile(
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?) #\d+\b",
+    re.IGNORECASE,
+)
 
 
 @dataclass(frozen=True)
@@ -41,11 +45,12 @@ def _validate_commit_message_text(message: str) -> tuple[str, ...]:
         return ("commit message subject is required",)
 
     subject = lines[0]
+    is_generated_squash_commit = SQUASH_PR_SUBJECT_PATTERN.search(subject) is not None
     optional_sections = (
-        ("Included checkpoints",) if SQUASH_PR_SUBJECT_PATTERN.search(subject) else ()
+        ("Included checkpoints", "Follow-ups") if is_generated_squash_commit else ()
     )
 
-    return (
+    errors = [
         *validate_subject_line(subject),
         *validate_structured_sections(
             lines,
@@ -55,7 +60,15 @@ def _validate_commit_message_text(message: str) -> tuple[str, ...]:
             label="commit message",
             allow_footers=True,
         ),
-    )
+    ]
+    if not is_generated_squash_commit:
+        for line in lines[2:]:
+            if ISSUE_CLOSING_KEYWORD_PATTERN.search(line):
+                errors.append(
+                    "authored commit messages must not use issue-closing keywords; use the PR `Why:` section instead"
+                )
+                break
+    return tuple(errors)
 
 
 def _load_commit_message_file(path: Path) -> CommitMessage:

--- a/tools/validate_commit_message.py
+++ b/tools/validate_commit_message.py
@@ -9,7 +9,6 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from tools.message_standards import (
-    MERGE_SUBJECT_PATTERN,
     validate_structured_sections,
     validate_subject_line,
 )
@@ -42,9 +41,6 @@ def _validate_commit_message_text(message: str) -> tuple[str, ...]:
         return ("commit message subject is required",)
 
     subject = lines[0]
-    if MERGE_SUBJECT_PATTERN.match(subject):
-        return ()
-
     optional_sections = (
         ("Included checkpoints",) if SQUASH_PR_SUBJECT_PATTERN.search(subject) else ()
     )

--- a/tools/validate_pr_metadata.py
+++ b/tools/validate_pr_metadata.py
@@ -73,7 +73,7 @@ def _validate_pr_title(title: str) -> tuple[str, ...]:
     stripped = title.strip()
     if stripped == "":
         return ("PR title is required",)
-    return validate_subject_line(stripped, allow_merge=False)
+    return validate_subject_line(stripped)
 
 
 def _validate_pr_body(body: str) -> tuple[str, ...]:
@@ -107,7 +107,7 @@ def _validate_pr_checkpoints(
             )
             break
 
-        if validate_subject_line(normalized, allow_merge=False):
+        if validate_subject_line(normalized):
             errors.append(
                 "`Included checkpoints:` entries must be exact Conventional Commit subjects"
             )

--- a/tools/validate_pr_metadata.py
+++ b/tools/validate_pr_metadata.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
 import argparse
+import re
 import subprocess
 import sys
 from collections.abc import Sequence
 
 from tools.message_standards import validate_structured_sections, validate_subject_line
+
+FOLLOW_UP_PATTERN = re.compile(r"^- Refs #\d+(?:: .+\S)?$")
+CLOSING_BULLET_PATTERN = re.compile(r"^- Closes #\d+: .+\S$")
+CLOSING_KEYWORD_PREFIX = re.compile(
+    r"^- (?:Close[sd]?|Fix(?:e[sd])?|Resolve[sd]?) #\d+", re.IGNORECASE
+)
 
 
 def _normalize_body_lines(body: str) -> tuple[str, ...]:
@@ -33,8 +40,8 @@ def _normalize_body_lines(body: str) -> tuple[str, ...]:
     return tuple(lines)
 
 
-def _parse_required_sections(body: str) -> dict[str, tuple[str, ...]]:
-    sections = ("Why", "What", "Checks", "Included checkpoints")
+def _parse_sections(body: str) -> dict[str, tuple[str, ...]]:
+    sections = ("Why", "What", "Checks", "Included checkpoints", "Follow-ups")
     parsed: dict[str, list[str]] = {section: [] for section in sections}
     current_section: str | None = None
 
@@ -80,20 +87,47 @@ def _validate_pr_body(body: str) -> tuple[str, ...]:
     lines = _normalize_body_lines(body)
     if not lines:
         return ("PR body is required",)
-    return validate_structured_sections(
-        ("placeholder", "", *lines),
-        required_sections=("Why", "What", "Checks", "Included checkpoints"),
-        optional_sections=("Issues",),
-        require_body=True,
-        label="PR",
-        allow_footers=False,
+    errors = list(
+        validate_structured_sections(
+            ("placeholder", "", *lines),
+            required_sections=("Why", "What", "Checks", "Included checkpoints"),
+            optional_sections=("Follow-ups",),
+            require_body=True,
+            label="PR",
+            allow_footers=False,
+        )
     )
+    parsed_sections = _parse_sections(body)
+
+    saw_non_closing_why_bullet = False
+    for entry in parsed_sections["Why"]:
+        if CLOSING_BULLET_PATTERN.fullmatch(entry):
+            if saw_non_closing_why_bullet:
+                errors.append(
+                    "`Why:` issue-closing bullets must come before other bullets"
+                )
+            continue
+        if CLOSING_KEYWORD_PREFIX.match(entry):
+            errors.append(
+                "`Why:` issue-closing bullets must match `- Closes #123: problem statement`"
+            )
+        saw_non_closing_why_bullet = True
+
+    for entry in parsed_sections["Follow-ups"]:
+        if FOLLOW_UP_PATTERN.fullmatch(entry):
+            continue
+        errors.append(
+            "`Follow-ups:` bullets must match `- Refs #123` or `- Refs #123: note`"
+        )
+        break
+
+    return tuple(errors)
 
 
 def _validate_pr_checkpoints(
     body: str, *, base_sha: str, head_sha: str
 ) -> tuple[str, ...]:
-    parsed_sections = _parse_required_sections(body)
+    parsed_sections = _parse_sections(body)
     checkpoint_entries = parsed_sections["Included checkpoints"]
     normalized_entries = tuple(
         _normalize_checkpoint_entry(entry) for entry in checkpoint_entries

--- a/tools/validate_pr_metadata.py
+++ b/tools/validate_pr_metadata.py
@@ -83,6 +83,7 @@ def _validate_pr_body(body: str) -> tuple[str, ...]:
     return validate_structured_sections(
         ("placeholder", "", *lines),
         required_sections=("Why", "What", "Checks", "Included checkpoints"),
+        optional_sections=("Issues",),
         require_body=True,
         label="PR",
         allow_footers=False,

--- a/tools/vscode_pylint.py
+++ b/tools/vscode_pylint.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+_TEST_RCFILE = ".pylintrc-tests"
+
+
+def _path_from_argument(argument: str) -> Path | None:
+    if argument.startswith("-"):
+        return None
+    if argument.endswith(".py"):
+        return Path(argument)
+    return None
+
+
+def _target_path(arguments: Sequence[str]) -> Path | None:
+    for index, argument in enumerate(arguments):
+        if argument == "--from-stdin" and index + 1 < len(arguments):
+            return Path(arguments[index + 1])
+        candidate = _path_from_argument(argument)
+        if candidate is not None:
+            return candidate
+    return None
+
+
+def _uses_test_rcfile(arguments: Sequence[str]) -> bool:
+    return any(
+        argument == f"--rcfile={_TEST_RCFILE}"
+        or (
+            argument == "--rcfile"
+            and index + 1 < len(arguments)
+            and arguments[index + 1] == _TEST_RCFILE
+        )
+        for index, argument in enumerate(arguments)
+    )
+
+
+def _should_use_test_rcfile(arguments: Sequence[str]) -> bool:
+    target = _target_path(arguments)
+    return target is not None and "tests" in target.parts
+
+
+def _pylint_argv(arguments: Sequence[str]) -> tuple[str, ...]:
+    if _uses_test_rcfile(arguments) or not _should_use_test_rcfile(arguments):
+        return (sys.executable, "-m", "pylint", *arguments)
+    return (sys.executable, "-m", "pylint", f"--rcfile={_TEST_RCFILE}", *arguments)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = tuple(sys.argv[1:] if argv is None else argv)
+    result = subprocess.run(_pylint_argv(arguments), check=False)
+    return result.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Why:
- delivery guardrails, repo-local workflow starts, and the PR hardening route still drifted across standards, validators, ownership routing, and editor tooling
- the branch now carries the full repair-first hardening loop work, so the open PR record must be rewritten to match the reviewed branch history instead of the earlier draft snapshot

What:
- add delivery guardrail audit coverage, repo-local workflow skill starts, and a repair-first PR hardening loop that reloads owning repo guidance before each fix slice
- tighten commit and PR metadata validation, control-plane ownership coverage, and the PR template so standards, tooling, and review flow stay aligned
- route VS Code pylint for test files through the test rcfile and normalize the related PR metadata validator success assertions

Checks:
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pytest -q --no-cov tests/unit/test_commit_message_validator.py tests/unit/test_pr_metadata_validator.py tests/unit/test_delivery_guardrails_audit.py tests/unit/test_quality_gates.py tests/unit/test_repo_agent_skills.py tests/unit/test_vscode_pylint.py tests/unit/test_vscode_settings.py tests/contract/test_standards_guards.py`
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.docs_maintenance sync --check`
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests`

Included checkpoints:
- `ci(standards): require structured merge landing metadata`
- `ci(standards): support neutral issue closeout and naming rules`
- `ci(standards): pin merge suffix and repair label rules`
- `test(ci): pin single-pass checkpoint hooks`
- `docs(standards): add delivery guardrail hierarchy`
- `ci(guardrails): audit delivery controls and ownership`
- `feat(skills): add repo-local workflow starts`
- `ci(delivery): validate issue-linked PR metadata`
- `docs(standards): codify hardening and recovery rules`
- `fix(vscode): route pylint test files through test rcfile`
- `docs(standards): codify repair-first hardening loop`
- `ci(guardrails): close audit and ownership gaps`
