### PR TITLE
refactor(guardrails): pin follow-ups metadata support

### DIFF
--- a/docs/standards/commits.md
+++ b/docs/standards/commits.md
@@ -124,7 +124,7 @@ PR body rules:
   - `What:`
   - `Checks:`
   - `Included checkpoints:`
-- an optional `Follow-ups:` section may follow `Included checkpoints:`
+- an optional `Follow-ups:` section is allowed after `Included checkpoints:`
 - use flat hyphen bullets under every section
 - when the PR closes issues, put the closing bullets first under `Why:` using
   the exact shape `- Closes #123: <problem statement>`

--- a/tests/contract/test_standards_guards.py
+++ b/tests/contract/test_standards_guards.py
@@ -300,6 +300,18 @@ def test_delivery_standards_pin_merge_subject_and_repair_label_rules() -> None:
         encoding="utf-8"
     )
     agents_text = (repo_root() / "AGENTS.md").read_text(encoding="utf-8")
+    pr_template_text = (repo_root() / ".github" / "pull_request_template.md").read_text(
+        encoding="utf-8"
+    )
+    message_standards_text = (repo_root() / "tools/message_standards.py").read_text(
+        encoding="utf-8"
+    )
+    pr_validator_text = (repo_root() / "tools/validate_pr_metadata.py").read_text(
+        encoding="utf-8"
+    )
+    commit_validator_text = (
+        repo_root() / "tools/validate_commit_message.py"
+    ).read_text(encoding="utf-8")
     checkpoint_text = (
         repo_root() / ".claude/commands/implementation-checkpoint.md"
     ).read_text(encoding="utf-8")
@@ -309,6 +321,11 @@ def test_delivery_standards_pin_merge_subject_and_repair_label_rules() -> None:
     assert "<pr title> (#<pr number>)" in agents_text
     assert "<pr title> (#<pr number>)" in checkpoint_text
     assert "Follow-ups:" in commits_text
+    assert "optional `Follow-ups:` section is allowed" in commits_text
+    assert "Follow-ups:" in pr_template_text
+    assert 'PR_BODY_OPTIONAL_SECTIONS = ("Follow-ups",)' in message_standards_text
+    assert "PR_BODY_OPTIONAL_SECTIONS" in pr_validator_text
+    assert "GENERATED_SQUASH_COMMIT_OPTIONAL_SECTIONS" in commit_validator_text
     assert "- Closes #123:" in commits_text
     assert "duplicate/superseded label" in commits_text
     assert "duplicate/superseded label" in implementation_text

--- a/tools/message_standards.py
+++ b/tools/message_standards.py
@@ -16,6 +16,18 @@ ALLOWED_TYPES = (
 )
 TYPE_PATTERN = "|".join(ALLOWED_TYPES)
 SCOPE_PATTERN = r"[a-z0-9]+(?:-[a-z0-9]+)*"
+AUTHORED_COMMIT_REQUIRED_SECTIONS = ("Why", "What", "Checks")
+PR_BODY_REQUIRED_SECTIONS = (
+    "Why",
+    "What",
+    "Checks",
+    "Included checkpoints",
+)
+PR_BODY_OPTIONAL_SECTIONS = ("Follow-ups",)
+GENERATED_SQUASH_COMMIT_OPTIONAL_SECTIONS = (
+    "Included checkpoints",
+    *PR_BODY_OPTIONAL_SECTIONS,
+)
 SUBJECT_PATTERN = re.compile(
     rf"^(?:{TYPE_PATTERN})(?:\(({SCOPE_PATTERN})\))?: (?P<summary>.+)$"
 )

--- a/tools/validate_commit_message.py
+++ b/tools/validate_commit_message.py
@@ -9,6 +9,8 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from tools.message_standards import (
+    AUTHORED_COMMIT_REQUIRED_SECTIONS,
+    GENERATED_SQUASH_COMMIT_OPTIONAL_SECTIONS,
     validate_structured_sections,
     validate_subject_line,
 )
@@ -47,14 +49,14 @@ def _validate_commit_message_text(message: str) -> tuple[str, ...]:
     subject = lines[0]
     is_generated_squash_commit = SQUASH_PR_SUBJECT_PATTERN.search(subject) is not None
     optional_sections = (
-        ("Included checkpoints", "Follow-ups") if is_generated_squash_commit else ()
+        GENERATED_SQUASH_COMMIT_OPTIONAL_SECTIONS if is_generated_squash_commit else ()
     )
 
     errors = [
         *validate_subject_line(subject),
         *validate_structured_sections(
             lines,
-            required_sections=("Why", "What", "Checks"),
+            required_sections=AUTHORED_COMMIT_REQUIRED_SECTIONS,
             optional_sections=optional_sections,
             require_body=True,
             label="commit message",

--- a/tools/validate_pr_metadata.py
+++ b/tools/validate_pr_metadata.py
@@ -6,7 +6,12 @@ import subprocess
 import sys
 from collections.abc import Sequence
 
-from tools.message_standards import validate_structured_sections, validate_subject_line
+from tools.message_standards import (
+    PR_BODY_OPTIONAL_SECTIONS,
+    PR_BODY_REQUIRED_SECTIONS,
+    validate_structured_sections,
+    validate_subject_line,
+)
 
 FOLLOW_UP_PATTERN = re.compile(r"^- Refs #\d+(?:: .+\S)?$")
 CLOSING_BULLET_PATTERN = re.compile(r"^- Closes #\d+: .+\S$")
@@ -41,7 +46,7 @@ def _normalize_body_lines(body: str) -> tuple[str, ...]:
 
 
 def _parse_sections(body: str) -> dict[str, tuple[str, ...]]:
-    sections = ("Why", "What", "Checks", "Included checkpoints", "Follow-ups")
+    sections = (*PR_BODY_REQUIRED_SECTIONS, *PR_BODY_OPTIONAL_SECTIONS)
     parsed: dict[str, list[str]] = {section: [] for section in sections}
     current_section: str | None = None
 
@@ -90,8 +95,8 @@ def _validate_pr_body(body: str) -> tuple[str, ...]:
     errors = list(
         validate_structured_sections(
             ("placeholder", "", *lines),
-            required_sections=("Why", "What", "Checks", "Included checkpoints"),
-            optional_sections=("Follow-ups",),
+            required_sections=PR_BODY_REQUIRED_SECTIONS,
+            optional_sections=PR_BODY_OPTIONAL_SECTIONS,
             require_body=True,
             label="PR",
             allow_footers=False,


### PR DESCRIPTION
Why:
- Closes #47: keep the optional PR `Follow-ups:` section explicit and regression-resistant across standards, templates, and validators
- centralizing the shared section metadata prevents the same allowance from drifting across control-plane code paths

What:
- state in the commit standard that `Follow-ups:` is allowed after `Included checkpoints:`
- reuse shared section constants in the PR and squash-commit validators and pin the template and validator alignment with a contract guard

Checks:
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pre-commit run markdownlint --files docs/standards/commits.md .github/pull_request_template.md
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run ruff check tools/message_standards.py tools/validate_commit_message.py tools/validate_pr_metadata.py tests/contract/test_standards_guards.py
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pytest tests/unit/test_commit_message_validator.py tests/unit/test_pr_metadata_validator.py tests/contract/test_standards_guards.py -q --no-cov

Included checkpoints:
- `refactor(guardrails): pin follow-ups metadata support`