### PR TITLE
docs(issues): standardize issue forms and follow-up policy

### DIFF
--- a/.agents/skills/docs-authoring/SKILL.md
+++ b/.agents/skills/docs-authoring/SKILL.md
@@ -12,7 +12,8 @@ Use this skill for repo documentation and standards work.
 
 Pair it with global `markdown` for syntax and low-churn Markdown editing and
 with `code-change-safety` when the change also touches automation or checkpoint
-commits.
+commits. Invoke `issue-workflow` when the task adds issue templates, issue
+policy, or proactive follow-up issue handling.
 
 ## Workflow
 

--- a/.agents/skills/implementation-workflow/SKILL.md
+++ b/.agents/skills/implementation-workflow/SKILL.md
@@ -11,7 +11,9 @@ description: >-
 Use this skill for the normal repo implementation path.
 
 Pair it with global `code-change-safety` for cross-repo posture and with
-`markdown` only when the task edits Markdown files.
+`markdown` only when the task edits Markdown files. Invoke `issue-workflow`
+when implementation uncovers meaningful out-of-scope repo work that should be
+captured as a follow-up issue.
 
 ## Workflow
 

--- a/.agents/skills/issue-workflow/SKILL.md
+++ b/.agents/skills/issue-workflow/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: issue-workflow
+description: >-
+  Start issue-template work and proactive follow-up issue creation with the
+  repo's narrow issue policy and delivery path.
+---
+
+# Issue Workflow
+
+Use this skill for GitHub issue forms, issue-writing policy, and proactive
+follow-up issue creation.
+
+Pair it with global `markdown` for Markdown edits and with
+`code-change-safety` when the task also changes repo standards, templates, or
+automation.
+
+## Workflow
+
+1. Read the narrow issue path first:
+   - `AGENTS.md`
+   - `docs/standards/issues.md`
+   - `docs/standards/implementation.md`
+   - `docs/standards/delivery-guardrails.md`
+   - `docs/standards/commits.md`
+   - `.claude/commands/issue-workflow.md`
+2. Search existing open issues before creating a new one.
+3. Open issues only for repo-engineering work in this repository.
+4. Keep issue content privacy-safe:
+   - no personal information
+   - no secrets or raw evidence
+   - no local absolute paths
+5. Use the standard issue structure:
+   - `Summary`
+   - `Problem`
+   - `Evidence`
+   - `Desired Outcome`
+   - `Acceptance Criteria`
+6. When meaningful out-of-scope repo work appears, create the issue
+   immediately instead of leaving it in scratch notes.
+7. If a PR is active, link non-closing follow-up issues from `Follow-ups:`.
+
+## Focus
+
+- repo-engineering scope only
+- duplicate search before new issue creation
+- privacy-safe issue content
+- durable issue templates and policy

--- a/.agents/skills/issue-workflow/agents/openai.yaml
+++ b/.agents/skills/issue-workflow/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Issue Workflow"
+  short_description: "Start issue-template work and proactive follow-up issue creation."
+  default_prompt: "Use $issue-workflow to load the tallylot issue policy and follow-up issue path before opening or changing repo issues."
+
+policy:
+  allow_implicit_invocation: true

--- a/.claude/commands/implementation-checkpoint.md
+++ b/.claude/commands/implementation-checkpoint.md
@@ -25,14 +25,18 @@ Use this route before closing any non-trivial coding task.
    - meaningful regression prevention rather than trivial coverage
 5. Confirm tracked docs, templates, and control-plane text stayed neutral and
    did not pick up scratch workflow bookkeeping.
-6. Run the appropriate verification path:
+6. Confirm meaningful out-of-scope repo work is not stranded in notes:
+   - search for an existing issue first
+   - create the follow-up issue immediately when no suitable issue exists
+   - keep issue content privacy-safe and repo-scoped
+7. Run the appropriate verification path:
    - use fresh VS Code Problems diagnostics first when they are available and current
    - targeted tests while iterating
    - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests` before closing
      substantial work
    - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_ci_parity_checks` when the change touches CI,
      packaging, release, or other workflow surfaces
-7. If architecture, schema, or sequencing changed, update:
+8. If architecture, schema, or sequencing changed, update:
    - `ROADMAP.md`
    - `docs/concepts/reconciliation-tax-architecture.md`
    - any boundary, matrix, or migration docs affected
@@ -45,17 +49,17 @@ Use this route before closing any non-trivial coding task.
      - `tools/docs_maintenance/metadata.py`
      and confirm any new material belongs in human docs rather than agent-only
      routing and still follows the docs-maintenance scaffold and metadata rules
-8. After compaction or context loss, reload the narrow standards for the active
+9. After compaction or context loss, reload the narrow standards for the active
    surface before more edits or commits:
 
    - `docs/standards/implementation.md`
    - `docs/standards/commits.md`
    - `docs/standards/delivery-guardrails.md` when delivery work is active
 
-9. Create the stable checkpoint commit when the slice is coherent and verified.
+10. Create the stable checkpoint commit when the slice is coherent and verified.
    Do not close the task first and plan to commit afterward.
 
-10. Confirm branch handling stayed PR-only for protected branches: do not push
+11. Confirm branch handling stayed PR-only for protected branches: do not push
     directly to `main`; do not use branch-protection bypass for ordinary
     delivery; do not rewrite a merged `main` commit if the original pull
     request must remain attached to the landing commit and use a new repair

--- a/.claude/commands/issue-workflow.md
+++ b/.claude/commands/issue-workflow.md
@@ -1,0 +1,29 @@
+# Issue Workflow
+
+Use this route for GitHub issue forms, issue-writing policy, and proactive
+follow-up issue creation.
+
+1. Read:
+   - `AGENTS.md`
+   - `docs/standards/issues.md`
+   - `docs/standards/implementation.md`
+   - `docs/standards/delivery-guardrails.md`
+   - `docs/standards/commits.md`
+2. Search existing open issues before opening a new one.
+3. Open issues only for repo-engineering work in this repository.
+4. Keep issue content privacy-safe:
+   - no personal information
+   - no secrets or raw evidence
+   - no wallet or account identifiers
+   - no local absolute paths
+5. Use the standard issue structure:
+   - `Summary`
+   - `Problem`
+   - `Evidence`
+   - `Desired Outcome`
+   - `Acceptance Criteria`
+6. When meaningful out-of-scope repo work appears during implementation or PR
+   hardening, create the follow-up issue immediately instead of leaving it in
+   scratch notes or handoff prose.
+7. If a PR is already active, link non-closing follow-up issues from
+   `Follow-ups:` using `- Refs #123`.

--- a/.claude/commands/pr-hardening-review.md
+++ b/.claude/commands/pr-hardening-review.md
@@ -28,6 +28,8 @@ Use this route for repeatable review passes on an active branch or draft PR.
      or delivery docs surfaced by that route or by repo search hints
    - add or tighten tests, docs, automation, and validation where the fix
      belongs instead of leaving the repair in prose alone
+   - when a meaningful finding should stay out of the active PR, search for an
+     existing issue first and open or link the follow-up issue immediately
 5. Verify the repaired slice and create bounded checkpoint commits during the
    loop, following the repo's normal commit and checkpoint rules. Do not start
    another red-team pass with uncommitted repaired findings unless the pass is
@@ -42,4 +44,6 @@ Use this route for repeatable review passes on an active branch or draft PR.
 9. Keep the PR draft until a full clean loop has completed with no new
    meaningful findings. For a final PR review, finish with a clean working tree
    and reload the relevant delivery guidance or skills before updating the PR
-   state or marking it ready for review.
+   state or marking it ready for review. Ensure any remaining out-of-scope repo
+   findings are captured as linked follow-up issues rather than left in review
+   prose alone.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 # Control-plane ownership for delivery, standards, and agent-routing surfaces.
 
 .agents/skills/** @CrownOpsEng
+.github/ISSUE_TEMPLATE/** @CrownOpsEng
 .github/workflows/** @CrownOpsEng
 .github/pull_request_template.md @CrownOpsEng
 .github/CODEOWNERS @CrownOpsEng

--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -1,0 +1,122 @@
+name: Bug
+description: Report incorrect behavior, regressions, broken tooling, or failing policy enforcement.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this tracker only for repo-engineering work in this repository.
+
+        Do not include personal information, secrets, raw evidence, wallet or account identifiers, or local absolute paths. Use sanitized summaries and repo-relative paths only.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One concise sentence describing the bug.
+      placeholder: A short description of the incorrect behavior.
+    validations:
+      required: true
+  - type: dropdown
+    id: repo-area
+    attributes:
+      label: Repo Area
+      description: Choose the repo surface this issue belongs to.
+      options:
+        - runtime code
+        - tests
+        - docs/standards
+        - templates/control-plane
+        - automation/CI
+        - refactor/maintenance
+    validations:
+      required: true
+  - type: input
+    id: relevant-paths
+    attributes:
+      label: Relevant Paths
+      description: Optional repo-relative paths only.
+      placeholder: docs/standards/issues.md, tools/audit_delivery_guardrails.py
+    validations:
+      required: false
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Describe the concrete problem and why it matters.
+      placeholder: What is broken, incorrect, or unexpectedly failing?
+    validations:
+      required: true
+  - type: textarea
+    id: observed-behavior
+    attributes:
+      label: Observed Behavior
+      description: Describe what currently happens.
+      placeholder: Current behavior, output, or failing condition.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: Describe what should happen instead.
+      placeholder: Expected behavior or output.
+    validations:
+      required: true
+  - type: textarea
+    id: steps-to-reproduce
+    attributes:
+      label: Steps To Reproduce
+      description: Give a small deterministic reproduction when possible.
+      placeholder: |
+        1. Run ...
+        2. Open ...
+        3. Observe ...
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Include sanitized evidence only.
+      placeholder: Error messages, failing checks, or repo-relative references that support the issue.
+    validations:
+      required: true
+  - type: textarea
+    id: relevant-output
+    attributes:
+      label: Relevant Output
+      description: Optional sanitized output or logs.
+      render: shell
+    validations:
+      required: false
+  - type: textarea
+    id: desired-outcome
+    attributes:
+      label: Desired Outcome
+      description: Describe the fixed end state.
+      placeholder: What should be true after the bug is resolved?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: List the reviewable conditions that define completion.
+      placeholder: |
+        - The failing behavior is corrected.
+        - The relevant guard or test covers the regression.
+    validations:
+      required: true
+  - type: checkboxes
+    id: issue-scope
+    attributes:
+      label: Submission Checks
+      options:
+        - label: I searched for an existing issue before opening this one.
+          required: true
+        - label: This issue is repo-scoped engineering work in this repository.
+          required: true
+        - label: This issue contains no personal information, secrets, raw evidence, wallet or account identifiers, or local absolute paths.
+          required: true

--- a/.github/ISSUE_TEMPLATE/02-workflow-gap.yml
+++ b/.github/ISSUE_TEMPLATE/02-workflow-gap.yml
@@ -1,0 +1,103 @@
+name: Workflow gap
+description: Propose a repo-supported workflow improvement or missing supported path.
+title: "[Workflow]: "
+labels:
+  - enhancement
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this tracker only for repo-engineering work in this repository.
+
+        Do not include personal information, secrets, raw evidence, wallet or account identifiers, or local absolute paths. Use sanitized summaries and repo-relative paths only.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One concise sentence describing the workflow gap.
+      placeholder: A short description of the missing or awkward repo-supported path.
+    validations:
+      required: true
+  - type: dropdown
+    id: repo-area
+    attributes:
+      label: Repo Area
+      description: Choose the repo surface this issue belongs to.
+      options:
+        - runtime code
+        - tests
+        - docs/standards
+        - templates/control-plane
+        - automation/CI
+        - refactor/maintenance
+    validations:
+      required: true
+  - type: input
+    id: relevant-paths
+    attributes:
+      label: Relevant Paths
+      description: Optional repo-relative paths only.
+      placeholder: docs/guides/source-intake.md, src/tallylot/interfaces/cli/
+    validations:
+      required: false
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Describe the gap or friction clearly.
+      placeholder: What supported path is missing, awkward, or incomplete?
+    validations:
+      required: true
+  - type: textarea
+    id: current-workflow-gap
+    attributes:
+      label: Current Workflow Gap
+      description: Describe the current workflow and where it breaks down.
+      placeholder: What do contributors or agents have to invent or do manually today?
+    validations:
+      required: true
+  - type: textarea
+    id: why-existing-behavior-is-insufficient
+    attributes:
+      label: Why Existing Behavior Is Insufficient
+      description: Explain why the current behavior or guidance is not enough.
+      placeholder: Why can this not stay as-is?
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Include sanitized evidence only.
+      placeholder: Existing docs, missing routes, review friction, or repo-relative references that support the gap.
+    validations:
+      required: true
+  - type: textarea
+    id: desired-outcome
+    attributes:
+      label: Desired Outcome
+      description: Describe the intended supported path or improved workflow.
+      placeholder: What should the repo support after this is addressed?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: List the reviewable conditions that define completion.
+      placeholder: |
+        - The repo supports the missing path without ad hoc manual steps.
+        - The owning docs or control-plane surface are aligned.
+    validations:
+      required: true
+  - type: checkboxes
+    id: issue-scope
+    attributes:
+      label: Submission Checks
+      options:
+        - label: I searched for an existing issue before opening this one.
+          required: true
+        - label: This issue is repo-scoped engineering work in this repository.
+          required: true
+        - label: This issue contains no personal information, secrets, raw evidence, wallet or account identifiers, or local absolute paths.
+          required: true

--- a/.github/ISSUE_TEMPLATE/03-ops-follow-up.yml
+++ b/.github/ISSUE_TEMPLATE/03-ops-follow-up.yml
@@ -1,0 +1,106 @@
+name: Ops follow-up
+description: Capture repo-maintenance work that should stay out of the current PR.
+title: "[Ops]: "
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this tracker only for repo-engineering work in this repository.
+
+        Do not include personal information, secrets, raw evidence, wallet or account identifiers, or local absolute paths. Use sanitized summaries and repo-relative paths only.
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One concise sentence describing the follow-up.
+      placeholder: A short description of the repo-maintenance follow-up.
+    validations:
+      required: true
+  - type: dropdown
+    id: repo-area
+    attributes:
+      label: Repo Area
+      description: Choose the repo surface this issue belongs to.
+      options:
+        - runtime code
+        - tests
+        - docs/standards
+        - templates/control-plane
+        - automation/CI
+        - refactor/maintenance
+    validations:
+      required: true
+  - type: input
+    id: relevant-paths
+    attributes:
+      label: Relevant Paths
+      description: Optional repo-relative paths only.
+      placeholder: .github/workflows/ci.yml, .claude/commands/pr-hardening-review.md
+    validations:
+      required: false
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: Describe the concrete repo-maintenance problem.
+      placeholder: What follow-up needs to be tracked separately?
+    validations:
+      required: true
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: Include sanitized evidence only.
+      placeholder: Repo-relative references, review findings, or policy gaps that support the follow-up.
+    validations:
+      required: true
+  - type: textarea
+    id: why-this-must-stay-out-of-the-current-pr
+    attributes:
+      label: Why This Must Stay Out Of The Current PR
+      description: Explain why this should be tracked separately instead of being added to the active branch.
+      placeholder: Why would adding this to the current PR widen scope or reduce review quality?
+    validations:
+      required: true
+  - type: dropdown
+    id: preferred-owning-surface
+    attributes:
+      label: Preferred Owning Surface
+      description: Choose the primary repo surface that should own the follow-up.
+      options:
+        - docs/standards
+        - templates/control-plane
+        - automation/CI
+        - agent routing/skills
+        - runtime code/tests
+    validations:
+      required: true
+  - type: textarea
+    id: desired-outcome
+    attributes:
+      label: Desired Outcome
+      description: Describe the intended completed state.
+      placeholder: What should be true after the follow-up lands?
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance-criteria
+    attributes:
+      label: Acceptance Criteria
+      description: List the reviewable conditions that define completion.
+      placeholder: |
+        - The follow-up lands as a bounded repo-maintenance change.
+        - The owning docs, templates, or automation are aligned.
+    validations:
+      required: true
+  - type: checkboxes
+    id: issue-scope
+    attributes:
+      label: Submission Checks
+      options:
+        - label: I searched for an existing issue before opening this one.
+          required: true
+        - label: This issue is repo-scoped engineering work in this repository.
+          required: true
+        - label: This issue contains no personal information, secrets, raw evidence, wallet or account identifiers, or local absolute paths.
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Repo docs and workflow guidance
+    url: https://github.com/CrownOpsEng/tallylot/blob/main/docs/README.md
+    about: Use the docs homepage for implemented workflow guidance before opening a tracking issue.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ Do not pre-load every repo doc by default.
 | Code placement, typing, modularization, naming | `docs/standards/engineering.md` |
 | Active implementation execution discipline | `docs/standards/implementation.md`, `docs/standards/commits.md` |
 | Repo standards, docs placement, doc authoring rules, or agent-default enforcement changes | `AGENTS.md`, `docs/README.md`, `docs/status/current-state.md`, `docs/reference/repository-history.md`, `docs/standards/implementation.md`, `docs/standards/commits.md`, `tools/docs_maintenance/cli.py`, `tools/docs_maintenance/metadata.py` |
+| Issue templates, issue-writing policy, or proactive follow-up issue creation | `AGENTS.md`, `docs/standards/issues.md`, `docs/standards/implementation.md`, `docs/standards/delivery-guardrails.md`, `docs/standards/commits.md`, `.claude/commands/issue-workflow.md` |
 | Delivery guardrails, protected-branch behavior, or agent-assisted Git operations | `docs/standards/delivery-guardrails.md`, `docs/standards/commits.md`, `tools/audit_delivery_guardrails.py` |
 | PR hardening review or review-loop recovery | `docs/standards/delivery-guardrails.md`, `docs/standards/commits.md`, `.claude/commands/pr-hardening-review.md` |
 | Planning sequence, delivery slices, or rollout checkpoints | `ROADMAP.md` |
@@ -58,6 +59,10 @@ Do not pre-load every repo doc by default.
 - Keep tracked docs, templates, and control-plane text neutral and durable.
 - Do not store scratch review notes, hardening ledgers, or temporary process
   bookkeeping in tracked files.
+- Keep repository issues repo-scoped and privacy-safe:
+  - no personal information
+  - no secrets or raw evidence
+  - no local absolute paths
 - Agent-only context must not live in `docs/` unless it is genuinely useful to
   humans.
 - Every new doc must have one primary type: concept, guide, reference,

--- a/docs/README.md
+++ b/docs/README.md
@@ -87,5 +87,6 @@ that follows the external workspace layout.
 - [Engineering Standards](standards/engineering.md): Code placement, typing, modularity, and naming rules for the typed application.
 - [Implementation Working Agreement](standards/implementation.md): Execution rules for shaping, verifying, refactoring, and checkpointing repo work.
 - [Commit Standards](standards/commits.md): Conventional Commit, checkpoint, and PR body rules for stable repo history.
+- [Issue Standards](standards/issues.md): Issue scope, privacy rules, template usage, and proactive follow-up issue handling for repo work.
 - [Delivery Guardrails](standards/delivery-guardrails.md): Control hierarchy, enforcement tiers, and exception handling for repo delivery and agent-assisted Git operations.
 <!-- docs-maintenance:end standards -->

--- a/docs/standards/commits.md
+++ b/docs/standards/commits.md
@@ -136,6 +136,9 @@ PR body rules:
   choreography or replay mechanics
 - use `Follow-ups:` for non-closing references such as `- Refs #456` or
   `- Refs #456: deferred cleanup`
+- use `Follow-ups:` for proactively opened out-of-scope issues discovered
+  during implementation or PR hardening when that work should stay separate
+  from the active PR
 - keep authored commit messages on `Why:`, `What:`, and `Checks:` without
   issue-closing keywords unless the user explicitly requests otherwise
 - for a one-commit PR, still list that single checkpoint under

--- a/docs/standards/delivery-guardrails.md
+++ b/docs/standards/delivery-guardrails.md
@@ -82,6 +82,7 @@ expansion.
 Control-plane files include:
 
 - `.agents/skills/**`
+- `.github/ISSUE_TEMPLATE/**`
 - `.github/workflows/**`
 - `.github/pull_request_template.md`
 - `.github/CODEOWNERS`
@@ -107,6 +108,7 @@ Encode the repo's delivery rules in versioned artifacts:
 
 - commit-message validators
 - PR-metadata validators
+- issue forms and chooser config
 - hook installers and hook guards
 - CI workflows
 - contract tests that pin the standards
@@ -141,6 +143,8 @@ pass should:
   search hints instead of forcing one oversized preload bundle for every pass
 - run the relevant verification for the repaired slice and create bounded
   checkpoint commits during the loop using the repo's normal commit rules
+- when a meaningful finding is real but should not expand the active PR, search
+  existing issues first and open or link the follow-up issue before merge
 - when a pass finds fewer than 5 new findings, report only those findings and
   keep the loop moving
 - stop only after a full pass yields no new meaningful findings; if the only
@@ -171,6 +175,10 @@ Before calling delivery complete, verify and report:
 - whether the PR remained draft until the hardening procedure finished cleanly
 - whether the branch shape matched the allowed merge method
 - which checks were required and whether they passed
+- whether meaningful out-of-scope repo findings were captured as issues and
+  linked from the PR when they stayed out of scope
+- whether any linked follow-up issue content remained privacy-safe and
+  repo-scoped
 - whether the landing subject exactly matched the required format
 - whether older superseded PRs were labeled correctly
 - whether the final remote branch tip still matches the reviewed PR record

--- a/docs/standards/implementation.md
+++ b/docs/standards/implementation.md
@@ -241,7 +241,20 @@ Expected behavior:
 - add a neutral replacement comment only when the repo has no suitable label
   or the user explicitly asks for explanatory prose
 - when the work uncovers follow-up or out-of-scope changes that do not belong
-  in the current PR, create the issue immediately so it does not get lost
+  in the current PR, search existing open issues first and create the issue
+  immediately when no suitable issue already exists
+- open only repo-engineering follow-up issues in this repository:
+  - code
+  - tests
+  - docs and standards
+  - templates and other control-plane files
+  - automation and CI
+- keep follow-up issues privacy-safe:
+  - no personal information
+  - no secrets or raw evidence
+  - no wallet or account identifiers
+  - no local absolute paths
+- use the repo-standard issue structure from `docs/standards/issues.md`
 - do not defer issue creation for out-of-scope work until after merge, handoff,
   or a later cleanup pass
 - before closing a non-trivial task, ensure the commit already exists rather

--- a/docs/standards/issues.md
+++ b/docs/standards/issues.md
@@ -1,0 +1,108 @@
+---
+title: "Issue Standards"
+summary: "Issue scope, privacy rules, template usage, and proactive follow-up issue handling for repo work."
+doc_type: standard
+audience: human
+owner: repo
+status: active
+nav_order: 35
+---
+
+Use this document when opening issues, designing issue templates, or deciding
+whether newly discovered work should become a separate tracked issue.
+
+## Repo Issue Scope
+
+Use repository issues only for repo-engineering work in this repository:
+
+- code
+- tests
+- docs and standards
+- templates and other control-plane files
+- automation and CI
+- refactor and maintenance work
+
+Do not use repository issues for:
+
+- personal reminders or private task lists
+- external workspace-only chores
+- raw evidence handling outside the repo
+- vague backlog dumping with no concrete repo change
+
+## Required Issue Structure
+
+All repo issues should use the shared structure below, whether they come from
+the GitHub form chooser or from a maintainer-authored blank issue:
+
+- `Summary`
+- `Problem`
+- `Evidence`
+- `Desired Outcome`
+- `Acceptance Criteria`
+
+Keep issue text concrete, reviewable, and scoped to one repo change or one
+bounded follow-up theme.
+
+## Privacy And Durability Rules
+
+Issue content must stay safe to keep in the public repo history.
+
+Do not include:
+
+- personal information
+- secrets, tokens, or credentials
+- raw evidence copied from the external workspace
+- wallet or account identifiers
+- local absolute filesystem paths
+
+Use sanitized summaries, neutral descriptions, and repo-relative paths instead.
+
+## Template Selection
+
+Use the GitHub issue forms under `.github/ISSUE_TEMPLATE/` by default:
+
+- `Bug` for incorrect behavior, regressions, broken tooling, or failing policy
+  enforcement
+- `Workflow gap` for missing or awkward repo-supported paths that should become
+  a supported capability
+- `Ops follow-up` for tooling, standards, templates, guardrails, or other
+  repo-maintenance work that should stay out of the current PR
+
+Maintainers may still use a blank issue when needed, but the blank issue must
+follow the same repo scope, privacy, and structure rules.
+
+## Duplicate Handling
+
+Before opening a new issue:
+
+- search existing open issues first
+- reuse the existing issue when it already captures the same repo work
+- open a new issue only when the work is materially different or missing
+
+Avoid splitting one bounded follow-up into several near-duplicate issues.
+
+## Proactive Follow-up Issues
+
+When implementation or PR hardening uncovers meaningful out-of-scope
+repo-engineering work that should not land in the active PR:
+
+- search for an existing issue first
+- open a new issue immediately when no suitable issue exists
+- keep the issue privacy-safe and repo-scoped
+- use the standard issue structure instead of an ad hoc note
+
+Do not defer follow-up issue creation until after merge, handoff, or a later
+cleanup pass.
+
+## PR Linkage Rules
+
+Use pull request metadata to distinguish resolved issues from tracked follow-up
+work:
+
+- use `Why:` with `- Closes #123: ...` only when the PR actually resolves the
+  issue
+- use `Follow-ups:` with `- Refs #123` or `- Refs #123: ...` for non-closing
+  issues that remain separate from the current PR
+
+When a follow-up issue is opened during implementation or hardening, link it
+from the active PR before merge.

--- a/tests/contract/test_issue_templates.py
+++ b/tests/contract/test_issue_templates.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import cast
+
+import yaml
+
+from repo_support.paths import repo_root
+
+
+def _template_dir() -> Path:
+    return repo_root() / ".github" / "ISSUE_TEMPLATE"
+
+
+def _string_key_dict(value: Mapping[object, object]) -> dict[str, object]:
+    return {str(key): item for key, item in value.items() if isinstance(key, str)}
+
+
+def _load_yaml(path: Path) -> dict[str, object]:
+    loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(loaded, Mapping), f"{path} must contain a YAML mapping"
+    return _string_key_dict(cast(Mapping[object, object], loaded))
+
+
+def _body_items(form: dict[str, object], *, path: Path) -> list[dict[str, object]]:
+    body = form.get("body")
+    assert isinstance(body, list) and body, f"{path} body is missing"
+    typed_body = cast(list[object], body)
+
+    items: list[dict[str, object]] = []
+    for item in typed_body:
+        assert isinstance(item, Mapping), f"{path} body item must be a mapping"
+        items.append(_string_key_dict(cast(Mapping[object, object], item)))
+    return items
+
+
+def _attributes(item: dict[str, object]) -> dict[str, object]:
+    attributes = item.get("attributes")
+    assert isinstance(attributes, Mapping), "issue template item attributes are missing"
+    return _string_key_dict(cast(Mapping[object, object], attributes))
+
+
+def _template_files() -> tuple[Path, ...]:
+    return tuple(
+        sorted(
+            path for path in _template_dir().glob("*.yml") if path.name != "config.yml"
+        )
+    )
+
+
+def test_issue_template_config_disables_blank_issues_and_points_to_docs() -> None:
+    config = _load_yaml(_template_dir() / "config.yml")
+
+    assert config["blank_issues_enabled"] is False
+    contact_links = config.get("contact_links")
+    assert isinstance(contact_links, list) and contact_links, (
+        "contact_links are missing"
+    )
+    typed_contact_links = cast(list[object], contact_links)
+    contact = typed_contact_links[0]
+    assert isinstance(contact, Mapping)
+    url = cast(Mapping[object, object], contact).get("url")
+    assert isinstance(url, str)
+    assert "docs/README.md" in url
+
+
+def test_issue_template_filenames_define_stable_order() -> None:
+    assert [path.name for path in _template_files()] == [
+        "01-bug.yml",
+        "02-workflow-gap.yml",
+        "03-ops-follow-up.yml",
+    ]
+
+
+def test_issue_forms_share_required_sections_and_scope_checks() -> None:
+    required_labels = {
+        "Summary",
+        "Repo Area",
+        "Relevant Paths",
+        "Problem",
+        "Evidence",
+        "Desired Outcome",
+        "Acceptance Criteria",
+        "Submission Checks",
+    }
+
+    for path in _template_files():
+        form = _load_yaml(path)
+        assert "assignees" not in form
+        assert "projects" not in form
+        assert "type" not in form
+
+        body = _body_items(form, path=path)
+
+        markdown_notice = body[0]
+        assert markdown_notice.get("type") == "markdown"
+        notice_text = str(_attributes(markdown_notice).get("value", ""))
+        assert "repo-engineering work" in notice_text
+        assert "personal information" in notice_text
+        assert "repo-relative paths" in notice_text
+
+        labels = {_attributes(item).get("label") for item in body}
+        assert required_labels.issubset(labels), f"{path} is missing shared fields"
+
+        submission_checks = next(
+            item
+            for item in body
+            if _attributes(item).get("label") == "Submission Checks"
+        )
+        options = _attributes(submission_checks).get("options")
+        assert isinstance(options, list)
+        typed_options = cast(list[object], options)
+        assert len(typed_options) == 3
+
+        option_labels: list[str] = []
+        for option in typed_options:
+            assert isinstance(option, Mapping)
+            label = cast(Mapping[object, object], option).get("label")
+            assert isinstance(label, str)
+            option_labels.append(label)
+
+        assert any("searched for an existing issue" in label for label in option_labels)
+        assert any("repo-scoped engineering work" in label for label in option_labels)
+        assert any(
+            "contains no personal information" in label for label in option_labels
+        )
+
+
+def test_issue_forms_do_not_collect_personal_contact_details() -> None:
+    forbidden_needles = ("contact details", "email", "e-mail")
+
+    for path in _template_files():
+        _body_items(_load_yaml(path), path=path)
+        lowered = path.read_text(encoding="utf-8").lower()
+        for needle in forbidden_needles:
+            assert needle not in lowered, f"{path} should not request {needle}"
+
+
+def test_issue_forms_apply_expected_template_specific_defaults() -> None:
+    bug = _load_yaml(_template_dir() / "01-bug.yml")
+    workflow = _load_yaml(_template_dir() / "02-workflow-gap.yml")
+    ops = _load_yaml(_template_dir() / "03-ops-follow-up.yml")
+
+    assert bug["title"] == "[Bug]: "
+    assert bug["labels"] == ["bug"]
+    assert workflow["title"] == "[Workflow]: "
+    assert workflow["labels"] == ["enhancement"]
+    assert ops["title"] == "[Ops]: "
+    assert "labels" not in ops

--- a/tests/contract/test_standards_guards.py
+++ b/tests/contract/test_standards_guards.py
@@ -299,6 +299,7 @@ def test_delivery_standards_pin_merge_subject_and_repair_label_rules() -> None:
     implementation_text = (repo_root() / "docs/standards/implementation.md").read_text(
         encoding="utf-8"
     )
+    issues_text = (repo_root() / "docs/standards/issues.md").read_text(encoding="utf-8")
     agents_text = (repo_root() / "AGENTS.md").read_text(encoding="utf-8")
     pr_template_text = (repo_root() / ".github" / "pull_request_template.md").read_text(
         encoding="utf-8"
@@ -327,6 +328,8 @@ def test_delivery_standards_pin_merge_subject_and_repair_label_rules() -> None:
     assert "PR_BODY_OPTIONAL_SECTIONS" in pr_validator_text
     assert "GENERATED_SQUASH_COMMIT_OPTIONAL_SECTIONS" in commit_validator_text
     assert "- Closes #123:" in commits_text
+    assert "Follow-ups:" in issues_text
+    assert "`Follow-ups:` with `- Refs #123`" in issues_text
     assert "duplicate/superseded label" in commits_text
     assert "duplicate/superseded label" in implementation_text
     assert "duplicate/superseded label" in agents_text
@@ -357,19 +360,27 @@ def test_delivery_guardrails_doc_is_routed_and_layered() -> None:
     assert "duplicate or superseded label" in guardrails_text
     assert "tools.audit_delivery_guardrails" in guardrails_text
     assert "single review-capable collaborator" in guardrails_text
+    assert ".github/ISSUE_TEMPLATE/**" in guardrails_text
     assert "docs/status/current-state.md" in guardrails_text
     assert "tools/docs_maintenance/cli.py" in guardrails_text
     assert "`markdown` skill" in guardrails_text
     assert "human docs, agent" in guardrails_text
     assert "standards/delivery-guardrails.md" in docs_index_text
+    assert "standards/issues.md" in docs_index_text
     assert (
         "Repo standards, docs placement, doc authoring rules, or agent-default enforcement changes"
+        in agents_text
+    )
+    assert (
+        "Issue templates, issue-writing policy, or proactive follow-up issue creation"
         in agents_text
     )
     assert "use the `markdown` skill if available" in agents_text
     assert (
         "use\n  the `code-change-safety` skill as the starting workflow" in agents_text
     )
+    assert "docs/standards/issues.md" in agents_text
+    assert ".claude/commands/issue-workflow.md" in agents_text
     assert "tools/docs_maintenance/metadata.py" in agents_text
     assert "docs/reference/repository-history.md" in agents_text
     assert "docs/standards/delivery-guardrails.md" in agents_text
@@ -387,6 +398,7 @@ def test_delivery_guardrails_doc_is_routed_and_layered() -> None:
         in checkpoint_text
     )
     assert "scratch workflow bookkeeping" in checkpoint_text
+    assert "search for an existing issue first" in checkpoint_text
     assert "full clean loop has completed with no new" in hardening_route_text
     assert "invent findings to hit a quota" in hardening_route_text
     assert (
@@ -421,6 +433,7 @@ def test_control_plane_codeowners_file_exists_and_covers_guardrail_paths() -> No
     codeowners_text = codeowners_path.read_text(encoding="utf-8")
     required_entries = (
         ".agents/skills/**",
+        ".github/ISSUE_TEMPLATE/**",
         ".github/workflows/**",
         ".github/pull_request_template.md",
         ".github/CODEOWNERS",

--- a/tests/unit/test_delivery_guardrails_audit.py
+++ b/tests/unit/test_delivery_guardrails_audit.py
@@ -99,6 +99,7 @@ def test_missing_codeowners_entries_reports_missing_patterns() -> None:
     missing = audit._missing_codeowners_patterns(("AGENTS.md", "docs/standards/**"))
 
     assert ".agents/skills/**" in missing
+    assert ".github/ISSUE_TEMPLATE/**" in missing
     assert ".github/workflows/**" in missing
     assert "tools/message_standards.py" in missing
     assert "tools/run_ci_parity_checks.py" in missing

--- a/tests/unit/test_docs_runtime_parity.py
+++ b/tests/unit/test_docs_runtime_parity.py
@@ -170,6 +170,7 @@ def test_documented_claude_command_routes_exist() -> None:
         ".claude/commands/adapter-authoring.md",
         ".claude/commands/balance-submission-operations.md",
         ".claude/commands/implementation-checkpoint.md",
+        ".claude/commands/issue-workflow.md",
         ".claude/commands/reconciliation-balance-operations.md",
         ".claude/commands/reconciliation-tax-build.md",
     )
@@ -191,6 +192,7 @@ def test_documented_claude_command_routes_are_not_ignored() -> None:
         ".claude/commands/adapter-authoring.md",
         ".claude/commands/balance-submission-operations.md",
         ".claude/commands/implementation-checkpoint.md",
+        ".claude/commands/issue-workflow.md",
         ".claude/commands/reconciliation-balance-operations.md",
         ".claude/commands/reconciliation-tax-build.md",
     )
@@ -451,7 +453,8 @@ def test_commit_standards_document_hybrid_pr_merge_policy() -> None:
     assert "do not squash multi-checkpoint PRs" in text
     assert "non-pushed checkpoint commit may be amended" in text
     assert "single-checkpoint exception" in implementation_text
-    assert "create the issue immediately so it does not get lost" in implementation_text
+    assert "search existing open issues first" in implementation_text
+    assert "use the repo-standard issue structure" in implementation_text
     assert "Single-checkpoint PRs must squash." in pr_template
 
 

--- a/tests/unit/test_repo_agent_skills.py
+++ b/tests/unit/test_repo_agent_skills.py
@@ -41,6 +41,16 @@ EXPECTED_SKILLS = {
             ".claude/commands/implementation-checkpoint.md",
         ),
     ),
+    "issue-workflow": ExpectedSkill(
+        display_name="Issue Workflow",
+        required_fragments=(
+            "docs/standards/issues.md",
+            "docs/standards/delivery-guardrails.md",
+            ".claude/commands/issue-workflow.md",
+            "Summary",
+            "Acceptance Criteria",
+        ),
+    ),
     "balance-submission-operations": ExpectedSkill(
         display_name="Balance Submission",
         required_fragments=(

--- a/tools/audit_delivery_guardrails.py
+++ b/tools/audit_delivery_guardrails.py
@@ -13,6 +13,7 @@ from repo_support.paths import repo_root
 REQUIRED_STATUS_CHECKS = ("commit-messages", "quality")
 CONTROL_PLANE_CODEOWNER_PATTERNS = (
     ".agents/skills/**",
+    ".github/ISSUE_TEMPLATE/**",
     ".github/workflows/**",
     ".github/pull_request_template.md",
     ".github/CODEOWNERS",


### PR DESCRIPTION
Why:
- Closes #52: standardize repo issue forms and proactive follow-up issue creation
- standardize issue scope, privacy rules, and follow-up issue handling for repo-engineering work

What:
- add GitHub issue forms and chooser config for bug, workflow gap, and ops follow-up issues
- add the issue standards doc plus the repo-local issue workflow skill and command route
- extend guardrails, CODEOWNERS, AGENTS routing, and targeted tests for issue-template control-plane coverage

Checks:
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.docs_maintenance sync --check
- markdownlint AGENTS.md .agents/skills/docs-authoring/SKILL.md .agents/skills/implementation-workflow/SKILL.md .agents/skills/issue-workflow/SKILL.md .claude/commands/implementation-checkpoint.md .claude/commands/issue-workflow.md .claude/commands/pr-hardening-review.md docs/standards/commits.md docs/standards/delivery-guardrails.md docs/standards/implementation.md docs/standards/issues.md docs/README.md
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pytest -q --no-cov tests/unit/test_repo_agent_skills.py tests/unit/test_docs_runtime_parity.py tests/unit/test_delivery_guardrails_audit.py tests/contract/test_standards_guards.py tests/contract/test_issue_templates.py
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.audit_delivery_guardrails
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pyright tests/contract/test_issue_templates.py

Included checkpoints:
- `docs(issues): standardize issue forms and follow-up policy`
