### PR TITLE
feat(intake): preserve stable source label mappings

### DIFF
--- a/.claude/commands/source-intake.md
+++ b/.claude/commands/source-intake.md
@@ -2,16 +2,17 @@
 
 Use this route for a full typed intake pass:
 
-1. `source intake plan` before touching the workspace to see routing, package, overlap, and review decisions
-2. review `intake_plan.csv`, `intake_issues.csv`, and `intake_summary.json`
-3. `source intake apply` only when the plan is acceptable
-4. `source manifest` for the settled capture path when you need a deterministic capture manifest
-5. `source profile`
-6. review `profile.json`, `profile_inventory.csv`, `timezone_issues.csv`
-7. `source normalize`
-8. review `facts.csv`, `exceptions.csv`, `normalization_reviews.csv`, and `normalization_summary.json`
-9. `checkpoint rebuild-location-inventory` when normalization emitted wallet evidence
-10. `output render file` when the round needs an external output artifact such as `cointracking_candidate.csv`
+1. update `analysis/issues/source_label_map.csv` first when the incoming capture should preserve a stable operator-managed source label across source-scoped raw or working paths
+2. `source intake plan` before touching the workspace to see routing, package, overlap, source-resolution, and review decisions
+3. review `intake_plan.csv`, `intake_issues.csv`, and `intake_summary.json`
+4. `source intake apply` only when the plan is acceptable
+5. `source manifest` for the settled capture path when you need a deterministic capture manifest
+6. `source profile`
+7. review `profile.json`, `profile_inventory.csv`, `timezone_issues.csv`
+8. `source normalize`
+9. review `facts.csv`, `exceptions.csv`, `normalization_reviews.csv`, and `normalization_summary.json`
+10. `checkpoint rebuild-location-inventory` when normalization emitted wallet evidence
+11. `output render file` when the round needs an external output artifact such as `cointracking_candidate.csv`
 
 Use `docs/guides/operator-quickstart.md` for the short operator route,
 `docs/guides/source-intake.md` for the detailed intake procedure, and

--- a/docs/concepts/workspace-model.md
+++ b/docs/concepts/workspace-model.md
@@ -42,6 +42,7 @@ The workspace is seeded by `workspace init` with these major areas:
 
 - `analysis/issues/issue_log.csv`
 - `analysis/issues/source_inventory.csv`
+- `analysis/issues/source_label_map.csv`
 - `analysis/inventory/location_inventory.csv`
 - `outputs/logs/round_log.csv`
 - `config/workspace.json`

--- a/docs/guides/source-intake.md
+++ b/docs/guides/source-intake.md
@@ -21,6 +21,11 @@ capture.
 
 ## Plan The Intake
 
+Before running intake for a known legacy or manually named source, update
+`analysis/issues/source_label_map.csv` when the automatic content-based route
+should yield to a stable operator-managed source label. The map applies to
+source-scoped destinations under both `evidence/raw/source/` and `working/`.
+
 Run:
 
 ```bash
@@ -35,6 +40,9 @@ Review:
 - `intake_plan.csv`
 - `intake_issues.csv`
 - `intake_summary.json`
+
+Confirm that `source_resolution_status`, `source_resolution_reason`, and the
+final `target_path` align with the intended stable source label before apply.
 
 ## Apply The Intake
 

--- a/docs/workspace/README.md
+++ b/docs/workspace/README.md
@@ -64,6 +64,8 @@ paths keep them too.
   issue log seed example
 - [`analysis/issues/source-inventory-template.csv`](analysis/issues/source-inventory-template.csv):
   source inventory seed example
+- [`analysis/issues/source-label-map-template.csv`](analysis/issues/source-label-map-template.csv):
+  stable source-label map seed example
 - [`analysis/reconciliation/reconciliation-template.csv`](analysis/reconciliation/reconciliation-template.csv):
   reconciliation seed example
 

--- a/docs/workspace/analysis/issues/README.md
+++ b/docs/workspace/analysis/issues/README.md
@@ -7,8 +7,8 @@ owner: repo
 status: active
 ---
 
-This folder holds the two live issue-tracking control files that must stay
-current during execution.
+This folder holds the live issue, inventory, and intake-control files that
+must stay current during execution.
 
 Related generated inventory artifacts now live beside them in
 `analysis/inventory/`, especially `location_inventory.csv` and
@@ -96,3 +96,27 @@ These values describe the current external import and verification workflow.
 - `excluded_dust_balance` → confirmed post-cutoff activity exists, but the source is excluded from the initial queue because its baseline balance is within the agreed dust threshold
 
 Keep the values consistent so AI and manual review can sort and filter reliably.
+
+## `source_label_map.csv`
+
+Use this file when intake should preserve a stable operator-managed source
+label instead of landing files under a generated or content-derived label.
+
+Each row maps an incoming path prefix to a source label that already exists in
+`source_inventory.csv`.
+
+Rules:
+
+- `incoming_path_prefix` is relative to the intake `--incoming-dir`
+- `.` applies to the entire incoming capture
+- keep prefixes durable and operator-meaningful rather than adapter-specific
+- use the file when raw source evidence or source-scoped working artifacts
+  should stay associated with an existing stable source label
+- do not use this file to invent new source labels implicitly; add the source
+  to `source_inventory.csv` first
+
+Intake plan and apply both read this file from the workspace root. When a valid
+map row matches, it overrides content-based source-folder generation. When a
+matching row is invalid or points at an unknown source, intake surfaces that as
+an explicit plan/apply issue and skips the affected rows instead of silently
+falling back.

--- a/docs/workspace/analysis/issues/source-label-map-template.csv
+++ b/docs/workspace/analysis/issues/source-label-map-template.csv
@@ -1,0 +1,2 @@
+incoming_path_prefix,source,notes
+.,Example Source,Use this file to preserve a stable operator-managed source label during intake.

--- a/docs/workspace/evidence/raw/source/README.md
+++ b/docs/workspace/evidence/raw/source/README.md
@@ -28,6 +28,10 @@ capture folder just to satisfy one adapter. Adapter resolution should come from
 file families and content signatures first, with source labels used only as
 low-confidence hints when content is insufficient.
 
+When a legacy intake pass should land under an existing stable source label,
+use `analysis/issues/source_label_map.csv` to preserve that association
+explicitly instead of relying on generated labels.
+
 Bundle-aware intake may create nested bundle paths inside a capture, for example:
 
 - `evidence/raw/source/<source>/<capture_id>/<bundle_id>/archive/...`

--- a/docs/workspace/working/README.md
+++ b/docs/workspace/working/README.md
@@ -25,3 +25,8 @@ Subfolders:
   or import round
 
 Nothing here is a raw source of truth.
+
+Some working paths remain source-scoped even though they are not raw evidence.
+When intake needs manual control over those source associations, use
+`analysis/issues/source_label_map.csv` so the derived artifacts land under the
+same stable operator-managed source label as the related raw capture.

--- a/docs/workspace/working/supporting_artifacts/README.md
+++ b/docs/workspace/working/supporting_artifacts/README.md
@@ -20,6 +20,11 @@ Examples:
 Files here are useful support material, but they are not raw system-of-record
 evidence.
 
+When intake places supporting artifacts under a source-scoped path, it uses the
+same stable source-label mapping rules as raw source intake. Update
+`analysis/issues/source_label_map.csv` when a legacy or manual intake pass must
+stay tied to an existing operator-managed source label.
+
 Use
 [`balance_submissions/README.md`](balance_submissions/README.md)
 for the scaffolded manual balance submission package layout and handoff rules.

--- a/src/tallylot/application/intake/__init__.py
+++ b/src/tallylot/application/intake/__init__.py
@@ -16,6 +16,7 @@ from .inventory import resolve_inventory_route
 from .packages import PackageRuleSummary, PlannedPackageItem, apply_package_rules
 from .plan_intake import PlanIntakeUseCase
 from .routing import route_intake_file
+from .source_labels import load_source_label_context, resolve_source_label
 
 __all__ = [
     "ApplyIntakeUseCase",
@@ -36,7 +37,9 @@ __all__ = [
     "apply_package_rules",
     "detect_capture_id",
     "inspect_intake_file",
+    "load_source_label_context",
     "resolve_inventory_route",
+    "resolve_source_label",
     "route_intake_file",
     "scanned_tree_files",
 ]

--- a/src/tallylot/application/intake/apply_intake.py
+++ b/src/tallylot/application/intake/apply_intake.py
@@ -21,7 +21,9 @@ from tallylot.ports.source_adapters import SourceAdapterRegistryPort
 
 
 class ApplyIntakeUseCase:
-    def __init__(self, registry: SourceAdapterRegistryPort, artifacts: ArtifactStorePort) -> None:
+    def __init__(
+        self, registry: SourceAdapterRegistryPort, artifacts: ArtifactStorePort
+    ) -> None:
         self._registry = registry
         self._artifacts = artifacts
 
@@ -31,8 +33,10 @@ class ApplyIntakeUseCase:
         report_dir = path_from_ref(request.report_output_ref)
         report_dir.mkdir(parents=True, exist_ok=True)
         copied_count = 0
-        with scanned_tree_files(incoming_dir, inspect_archives=request.inspect_archives) as scanned_tree:
-            planned_items = build_planned_items(
+        with scanned_tree_files(
+            incoming_dir, inspect_archives=request.inspect_archives
+        ) as scanned_tree:
+            batch = build_planned_items(
                 scanned_tree.files,
                 self._registry,
                 self._artifacts,
@@ -43,7 +47,9 @@ class ApplyIntakeUseCase:
                     inspect_archives=request.inspect_archives,
                 ),
             )
-            issue_rows = [
+            planned_items = list(batch.planned_items)
+            issue_rows = list(batch.issue_rows)
+            issue_rows.extend(
                 {
                     "relative_path": issue.relative_path,
                     "severity": issue.severity,
@@ -51,7 +57,7 @@ class ApplyIntakeUseCase:
                     "message": issue.message,
                 }
                 for issue in scanned_tree.issues
-            ]
+            )
             for item in planned_items:
                 if item.action not in {"copy", "extract_copy"}:
                     continue
@@ -59,7 +65,13 @@ class ApplyIntakeUseCase:
                 shutil.copy2(item.source_path, item.target_path)
                 copied_count += 1
             write_capture_manifests(self._artifacts, workspace_root, planned_items)
-        write_reports(self._artifacts, report_dir, planned_items, issue_rows, copied_count=copied_count)
+        write_reports(
+            self._artifacts,
+            report_dir,
+            planned_items,
+            issue_rows,
+            copied_count=copied_count,
+        )
         return IntakeApplyResponse(
             report_output_ref=request.report_output_ref,
             file_count=len(planned_items),

--- a/src/tallylot/application/intake/path_rules.py
+++ b/src/tallylot/application/intake/path_rules.py
@@ -13,7 +13,11 @@ def package_key(entry: ScannedFile) -> str:
     if entry.archive_source_path:
         return entry.archive_source_path
     relative_path = Path(entry.relative_path)
-    return str(relative_path.parent) if relative_path.parent != Path() else entry.relative_path
+    return (
+        str(relative_path.parent)
+        if relative_path.parent != Path()
+        else entry.relative_path
+    )
 
 
 def bundle_id(entry: ScannedFile, *, source_folder: str) -> str:
@@ -49,18 +53,35 @@ def source_raw_target_path(
     bundle_id_value: str,
     bundle_relative_path_value: str,
 ) -> Path:
-    capture_root = workspace_root / "evidence" / "raw" / "source" / source_folder / capture_id
+    capture_root = (
+        workspace_root / "evidence" / "raw" / "source" / source_folder / capture_id
+    )
     if bundle_id_value.endswith("-loose"):
         return capture_root / bundle_relative_path_value
     return capture_root / bundle_id_value / bundle_relative_path_value
 
 
-def override_target_source(target_path: Path, previous_source: str, new_source: str) -> Path:
+def override_target_source(
+    target_path: Path, previous_source: str, new_source: str
+) -> Path:
     if previous_source == new_source:
         return target_path
     parts = list(target_path.parts)
-    for index, part in enumerate(parts):
-        if part == previous_source:
-            parts[index] = new_source
-            break
+    source_index = _source_segment_index(parts)
+    if source_index is None or parts[source_index] != previous_source:
+        return target_path
+    parts[source_index] = new_source
     return Path(*parts)
+
+
+def _source_segment_index(parts: list[str]) -> int | None:
+    for index in range(len(parts) - 3):
+        if (
+            parts[index : index + 3] == ["evidence", "raw", "source"]
+            and len(parts) > index + 3
+        ):
+            return index + 3
+    for index in range(len(parts) - 2):
+        if parts[index] == "working" and len(parts) > index + 2:
+            return index + 2
+    return None

--- a/src/tallylot/application/intake/path_rules.py
+++ b/src/tallylot/application/intake/path_rules.py
@@ -67,21 +67,35 @@ def override_target_source(
     if previous_source == new_source:
         return target_path
     parts = list(target_path.parts)
-    source_index = _source_segment_index(parts)
-    if source_index is None or parts[source_index] != previous_source:
-        return target_path
-    parts[source_index] = new_source
-    return Path(*parts)
+    for source_index in _source_segment_indexes(parts, previous_source):
+        parts[source_index] = new_source
+        return Path(*parts)
+    return target_path
 
 
-def _source_segment_index(parts: list[str]) -> int | None:
-    for index in range(len(parts) - 3):
-        if (
-            parts[index : index + 3] == ["evidence", "raw", "source"]
-            and len(parts) > index + 3
-        ):
-            return index + 3
-    for index in range(len(parts) - 2):
-        if parts[index] == "working" and len(parts) > index + 2:
-            return index + 2
-    return None
+def is_source_scoped_target_path(
+    target_path: Path,
+    *,
+    workspace_root: Path,
+    source_folder: str,
+) -> bool:
+    try:
+        relative_path = target_path.relative_to(workspace_root)
+    except ValueError:
+        return False
+    return any(
+        True for _ in _source_segment_indexes(list(relative_path.parts), source_folder)
+    )
+
+
+def _source_segment_indexes(parts: list[str], source_folder: str) -> tuple[int, ...]:
+    indexes: list[int] = []
+    for index, part in enumerate(parts):
+        if part != source_folder:
+            continue
+        if index >= 3 and parts[index - 3 : index] == ["evidence", "raw", "source"]:
+            indexes.append(index)
+            continue
+        if index >= 2 and parts[index - 2] == "working":
+            indexes.append(index)
+    return tuple(indexes)

--- a/src/tallylot/application/intake/plan/__init__.py
+++ b/src/tallylot/application/intake/plan/__init__.py
@@ -1,11 +1,12 @@
 """Planning subpackage for intake workflows."""
 
 from .builder import build_planned_items
-from .models import PlannedItem
+from .models import PlannedItem, PlannedItemBatch
 from .reports import write_capture_manifests, write_reports
 
 __all__ = [
     "PlannedItem",
+    "PlannedItemBatch",
     "build_planned_items",
     "write_capture_manifests",
     "write_reports",

--- a/src/tallylot/application/intake/plan/builder.py
+++ b/src/tallylot/application/intake/plan/builder.py
@@ -3,13 +3,15 @@
 from __future__ import annotations
 
 from tallylot.application.intake.contracts import IntakePlanRequest
+from tallylot.application.intake.source_labels import load_source_label_context
+from tallylot.application.resource_refs import path_from_ref
 from tallylot.ports.artifacts import ArtifactStorePort
 from tallylot.ports.source_adapters import SourceAdapterRegistryPort
 
 from ..archive import ScannedFile
 from .entry import build_planned_item
 from .finalize import apply_package_rules_to_items
-from .models import PlannedItem
+from .models import PlannedItemBatch
 
 
 def build_planned_items(
@@ -17,8 +19,23 @@ def build_planned_items(
     registry: SourceAdapterRegistryPort,
     artifacts: ArtifactStorePort,
     request: IntakePlanRequest,
-) -> list[PlannedItem]:
+) -> PlannedItemBatch:
+    source_label_context = load_source_label_context(
+        artifacts, path_from_ref(request.workspace_root_ref)
+    )
     planned_items = [
-        build_planned_item(entry, registry=registry, artifacts=artifacts, request=request) for entry in files
+        build_planned_item(
+            entry,
+            registry=registry,
+            artifacts=artifacts,
+            request=request,
+            source_label_context=source_label_context,
+        )
+        for entry in files
     ]
-    return apply_package_rules_to_items(planned_items, request=request)
+    return PlannedItemBatch(
+        planned_items=tuple(
+            apply_package_rules_to_items(planned_items, request=request)
+        ),
+        issue_rows=tuple(issue.to_row() for issue in source_label_context.issues),
+    )

--- a/src/tallylot/application/intake/plan/entry.py
+++ b/src/tallylot/application/intake/plan/entry.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 from tallylot.application.intake.contracts import IntakePlanRequest
+from tallylot.application.intake.source_labels import (
+    SourceLabelContext,
+    resolve_source_label,
+)
 from tallylot.application.resource_refs import path_from_ref
 from tallylot.ports.artifacts import ArtifactStorePort
 from tallylot.ports.source_adapters import SourceAdapterRegistryPort
 
 from ..archive import ScannedFile
 from ..file_facts import inspect_intake_file
-from ..inventory import resolve_inventory_route
 from ..overlap import IntakeOverlapRequest, resolve_overlap_review
 from ..path_rules import (
     bundle_id,
@@ -29,6 +32,7 @@ def build_planned_item(
     registry: SourceAdapterRegistryPort,
     artifacts: ArtifactStorePort,
     request: IntakePlanRequest,
+    source_label_context: SourceLabelContext,
 ) -> PlannedItem:
     incoming_dir = path_from_ref(request.incoming_capture_ref)
     workspace_root = path_from_ref(request.workspace_root_ref)
@@ -41,19 +45,27 @@ def build_planned_item(
         workspace_root=workspace_root,
         facts=facts,
     )
-    bundle_id_value = bundle_id(entry, source_folder=route.source_folder)
-    bundle_relative_path_value = bundle_relative_path(entry)
-    inventory_route = resolve_inventory_route(
+    route_key = (
+        entry.relative_path
+        if not entry.archive_member_path
+        else f"{entry.archive_source_path}::{entry.archive_member_path}"
+    )
+    source_resolution = resolve_source_label(
         artifacts=artifacts,
         workspace_root=workspace_root,
-        source_folder=route.source_folder,
+        context=source_label_context,
+        route_key=route_key,
         facts=facts,
+        source_folder=route.source_folder,
+        target_path=route.target_path,
     )
+    bundle_id_value = bundle_id(entry, source_folder=source_resolution.source_folder)
+    bundle_relative_path_value = bundle_relative_path(entry)
     overlap_review = resolve_overlap_review(
         artifacts=artifacts,
         request=IntakeOverlapRequest(
             workspace_root=workspace_root,
-            source_folder=inventory_route.source_folder,
+            source_folder=source_resolution.source_folder,
             capture_id=route.capture_id,
             relative_path=relative_path,
             sha256=entry.sha256,
@@ -64,13 +76,15 @@ def build_planned_item(
     source_target_path = (
         source_raw_target_path(
             workspace_root,
-            source_folder=inventory_route.source_folder,
+            source_folder=source_resolution.source_folder,
             capture_id=route.capture_id,
             bundle_id_value=bundle_id_value,
             bundle_relative_path_value=bundle_relative_path_value,
         )
         if route.category == "source_raw"
-        else override_target_source(route.target_path, route.source_folder, inventory_route.source_folder)
+        else override_target_source(
+            route.target_path, route.source_folder, source_resolution.source_folder
+        )
     )
     return PlannedItem(
         source_path=entry.file_path,
@@ -79,11 +93,11 @@ def build_planned_item(
         archive_member_path=entry.archive_member_path,
         category=route.category,
         role=route.role,
-        source_folder=inventory_route.source_folder,
+        source_folder=source_resolution.source_folder,
         capture_id=route.capture_id,
         bundle_id=bundle_id_value,
         bundle_relative_path=bundle_relative_path_value,
-        action=route.action,
+        action="skip" if source_resolution.blocked else route.action,
         package_key=package_key(entry),
         package_status="primary",
         package_primary_bundle_id=bundle_id_value,
@@ -92,23 +106,31 @@ def build_planned_item(
         package_scope_status="",
         package_decision_reason="",
         package_row_status="package_keep",
-        placement_status="planned_copy" if route.action in {"copy", "extract_copy"} else "inspect_only",
+        placement_status=(
+            "mapping_blocked_skip"
+            if source_resolution.blocked
+            else "planned_copy"
+            if route.action in {"copy", "extract_copy"}
+            else "inspect_only"
+        ),
+        source_resolution_status=source_resolution.source_resolution_status,
+        source_resolution_reason=source_resolution.source_resolution_reason,
         review_required=merge_review_required(
             route.review_required,
-            inventory_route.review_required,
+            source_resolution.review_required,
             overlap_review.review_required,
         ),
         review_codes=merge_review_values(
             route.review_codes,
-            inventory_route.review_codes,
+            source_resolution.review_codes,
             overlap_review.review_codes,
         ),
         review_reason=merge_review_values(
             route.review_reason,
-            inventory_route.review_reason,
+            source_resolution.review_reason,
             overlap_review.review_reason,
         ),
-        inventory_match_status=inventory_route.inventory_match_status,
+        inventory_match_status=source_resolution.inventory_match_status,
         sha256=entry.sha256,
         scope_tokens=facts.scope_tokens,
         target_path=source_target_path,

--- a/src/tallylot/application/intake/plan/entry.py
+++ b/src/tallylot/application/intake/plan/entry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from tallylot.application.intake.contracts import IntakePlanRequest
 from tallylot.application.intake.source_labels import (
     SourceLabelContext,
+    SourceLabelResolutionRequest,
     resolve_source_label,
 )
 from tallylot.application.resource_refs import path_from_ref
@@ -52,12 +53,14 @@ def build_planned_item(
     )
     source_resolution = resolve_source_label(
         artifacts=artifacts,
-        workspace_root=workspace_root,
         context=source_label_context,
-        route_key=route_key,
-        facts=facts,
-        source_folder=route.source_folder,
-        target_path=route.target_path,
+        request=SourceLabelResolutionRequest(
+            workspace_root=workspace_root,
+            route_key=route_key,
+            facts=facts,
+            source_folder=route.source_folder,
+            target_path=route.target_path,
+        ),
     )
     bundle_id_value = bundle_id(entry, source_folder=source_resolution.source_folder)
     bundle_relative_path_value = bundle_relative_path(entry)

--- a/src/tallylot/application/intake/plan/finalize.py
+++ b/src/tallylot/application/intake/plan/finalize.py
@@ -8,7 +8,11 @@ from tallylot.application.resource_refs import path_from_ref
 from ..packages import PlannedPackageItem, apply_package_rules
 from ..path_rules import effective_bundle_id, source_raw_target_path
 from .models import PlannedItem
-from .reviews import planned_review_codes, planned_review_reason, planned_review_required
+from .reviews import (
+    planned_review_codes,
+    planned_review_reason,
+    planned_review_required,
+)
 
 
 def apply_package_rules_to_items(
@@ -58,16 +62,32 @@ def apply_package_rules_to_items(
             action=package_map[str(item.source_path)].action,
             package_key=item.package_key,
             package_status=package_map[str(item.source_path)].package_status,
-            package_primary_bundle_id=package_map[str(item.source_path)].package_primary_bundle_id,
-            package_related_bundles=package_map[str(item.source_path)].package_related_bundles,
-            package_cycle_status=package_map[str(item.source_path)].package_cycle_status,
-            package_scope_status=package_map[str(item.source_path)].package_scope_status,
-            package_decision_reason=package_map[str(item.source_path)].package_decision_reason,
+            package_primary_bundle_id=package_map[
+                str(item.source_path)
+            ].package_primary_bundle_id,
+            package_related_bundles=package_map[
+                str(item.source_path)
+            ].package_related_bundles,
+            package_cycle_status=package_map[
+                str(item.source_path)
+            ].package_cycle_status,
+            package_scope_status=package_map[
+                str(item.source_path)
+            ].package_scope_status,
+            package_decision_reason=package_map[
+                str(item.source_path)
+            ].package_decision_reason,
             package_row_status=package_map[str(item.source_path)].package_row_status,
             placement_status=package_map[str(item.source_path)].placement_status,
-            review_required=planned_review_required(item, package_map[str(item.source_path)]),
+            source_resolution_status=item.source_resolution_status,
+            source_resolution_reason=item.source_resolution_reason,
+            review_required=planned_review_required(
+                item, package_map[str(item.source_path)]
+            ),
             review_codes=planned_review_codes(item, package_map[str(item.source_path)]),
-            review_reason=planned_review_reason(item, package_map[str(item.source_path)]),
+            review_reason=planned_review_reason(
+                item, package_map[str(item.source_path)]
+            ),
             inventory_match_status=item.inventory_match_status,
             sha256=item.sha256,
             scope_tokens=item.scope_tokens,
@@ -76,7 +96,9 @@ def apply_package_rules_to_items(
                     workspace_root,
                     source_folder=item.source_folder,
                     capture_id=item.capture_id,
-                    bundle_id_value=effective_bundle_id(item, package_map[str(item.source_path)]),
+                    bundle_id_value=effective_bundle_id(
+                        item, package_map[str(item.source_path)]
+                    ),
                     bundle_relative_path_value=item.bundle_relative_path,
                 )
                 if item.category == "source_raw"

--- a/src/tallylot/application/intake/plan/models.py
+++ b/src/tallylot/application/intake/plan/models.py
@@ -26,6 +26,8 @@ PLAN_HEADER = (
     "package_decision_reason",
     "package_row_status",
     "placement_status",
+    "source_resolution_status",
+    "source_resolution_reason",
     "review_required",
     "review_codes",
     "review_reason",
@@ -57,6 +59,8 @@ class PlannedItem:
     package_decision_reason: str
     package_row_status: str
     placement_status: str
+    source_resolution_status: str
+    source_resolution_reason: str
     review_required: str
     review_codes: str
     review_reason: str
@@ -87,9 +91,17 @@ class PlannedItem:
             "package_decision_reason": self.package_decision_reason,
             "package_row_status": self.package_row_status,
             "placement_status": self.placement_status,
+            "source_resolution_status": self.source_resolution_status,
+            "source_resolution_reason": self.source_resolution_reason,
             "review_required": self.review_required,
             "review_codes": self.review_codes,
             "review_reason": self.review_reason,
             "inventory_match_status": self.inventory_match_status,
             "target_path": str(self.target_path),
         }
+
+
+@dataclass(frozen=True)
+class PlannedItemBatch:
+    planned_items: tuple[PlannedItem, ...]
+    issue_rows: tuple[dict[str, str], ...]

--- a/src/tallylot/application/intake/plan/reports.py
+++ b/src/tallylot/application/intake/plan/reports.py
@@ -29,7 +29,22 @@ def write_reports(
             "file_count": len(planned_items),
             "issue_count": len(issue_rows),
             "copied_count": copied_count,
-            "planned_copy_count": sum(1 for item in planned_items if item.action in {"copy", "extract_copy"}),
+            "planned_copy_count": sum(
+                1 for item in planned_items if item.action in {"copy", "extract_copy"}
+            ),
+            "explicit_map_count": sum(
+                1
+                for item in planned_items
+                if item.source_resolution_status == "explicit_map"
+            ),
+            "explicit_map_blocked_count": sum(
+                1
+                for item in planned_items
+                if item.source_resolution_status == "explicit_map_blocked"
+            ),
+            "source_label_map_issue_count": sum(
+                1 for row in issue_rows if row["kind"].startswith("source_label_map_")
+            ),
             "duplicate_packages": _package_count(planned_items, "duplicate_package"),
             "merge_primary_packages": _package_count(planned_items, "merge_primary"),
             "merged_packages": _package_count(planned_items, "merge_member"),
@@ -46,9 +61,20 @@ def write_capture_manifests(
 ) -> None:
     capture_rows: dict[Path, list[dict[str, str]]] = {}
     for item in planned_items:
-        if item.category != "source_raw" or item.placement_status.startswith("package_") or item.action == "skip":
+        if (
+            item.category != "source_raw"
+            or item.placement_status.startswith("package_")
+            or item.action == "skip"
+        ):
             continue
-        capture_root = workspace_root / "evidence" / "raw" / "source" / item.source_folder / item.capture_id
+        capture_root = (
+            workspace_root
+            / "evidence"
+            / "raw"
+            / "source"
+            / item.source_folder
+            / item.capture_id
+        )
         capture_rows.setdefault(capture_root, []).append(
             {
                 "filename": str(item.target_path.relative_to(capture_root)),
@@ -75,6 +101,9 @@ def _package_count(planned_items: list[PlannedItem], package_status: str) -> int
             (item.source_folder, item.capture_id, item.bundle_id)
             for item in planned_items
             if item.package_status == package_status
-            or (package_status == "duplicate_package" and item.package_status.startswith("duplicate_package"))
+            or (
+                package_status == "duplicate_package"
+                and item.package_status.startswith("duplicate_package")
+            )
         }
     )

--- a/src/tallylot/application/intake/plan_intake.py
+++ b/src/tallylot/application/intake/plan_intake.py
@@ -4,14 +4,16 @@ from __future__ import annotations
 
 from tallylot.application.intake.archive import scanned_tree_files
 from tallylot.application.intake.contracts import IntakePlanRequest, IntakePlanResponse
-from tallylot.application.intake.plan import PlannedItem, build_planned_items, write_reports
+from tallylot.application.intake.plan import build_planned_items, write_reports
 from tallylot.application.resource_refs import path_from_ref
 from tallylot.ports.artifacts import ArtifactStorePort
 from tallylot.ports.source_adapters import SourceAdapterRegistryPort
 
 
 class PlanIntakeUseCase:
-    def __init__(self, registry: SourceAdapterRegistryPort, artifacts: ArtifactStorePort) -> None:
+    def __init__(
+        self, registry: SourceAdapterRegistryPort, artifacts: ArtifactStorePort
+    ) -> None:
         self._registry = registry
         self._artifacts = artifacts
 
@@ -19,10 +21,15 @@ class PlanIntakeUseCase:
         incoming_dir = path_from_ref(request.incoming_capture_ref)
         report_dir = path_from_ref(request.report_output_ref)
         report_dir.mkdir(parents=True, exist_ok=True)
-        planned_items: list[PlannedItem] = []
         issue_rows: list[dict[str, str]] = []
-        with scanned_tree_files(incoming_dir, inspect_archives=request.inspect_archives) as scanned_tree:
-            planned_items.extend(build_planned_items(scanned_tree.files, self._registry, self._artifacts, request))
+        with scanned_tree_files(
+            incoming_dir, inspect_archives=request.inspect_archives
+        ) as scanned_tree:
+            batch = build_planned_items(
+                scanned_tree.files, self._registry, self._artifacts, request
+            )
+            planned_items = list(batch.planned_items)
+            issue_rows.extend(batch.issue_rows)
             issue_rows.extend(
                 {
                     "relative_path": issue.relative_path,
@@ -32,10 +39,14 @@ class PlanIntakeUseCase:
                 }
                 for issue in scanned_tree.issues
             )
-        write_reports(self._artifacts, report_dir, planned_items, issue_rows, copied_count=0)
+        write_reports(
+            self._artifacts, report_dir, planned_items, issue_rows, copied_count=0
+        )
         return IntakePlanResponse(
             report_output_ref=request.report_output_ref,
             file_count=len(planned_items),
             issue_count=len(issue_rows),
-            planned_copy_count=sum(1 for item in planned_items if item.action in {"copy", "extract_copy"}),
+            planned_copy_count=sum(
+                1 for item in planned_items if item.action in {"copy", "extract_copy"}
+            ),
         )

--- a/src/tallylot/application/intake/source_labels/__init__.py
+++ b/src/tallylot/application/intake/source_labels/__init__.py
@@ -5,6 +5,7 @@ from .models import (
     SourceLabelConfigIssue,
     SourceLabelContext,
     SourceLabelResolution,
+    SourceLabelResolutionRequest,
     SourceLabelRule,
 )
 from .resolution import resolve_source_label
@@ -13,6 +14,7 @@ __all__ = [
     "SourceLabelConfigIssue",
     "SourceLabelContext",
     "SourceLabelResolution",
+    "SourceLabelResolutionRequest",
     "SourceLabelRule",
     "load_source_label_context",
     "resolve_source_label",

--- a/src/tallylot/application/intake/source_labels/__init__.py
+++ b/src/tallylot/application/intake/source_labels/__init__.py
@@ -1,0 +1,19 @@
+"""Source-label resolution for intake planning."""
+
+from .loading import load_source_label_context
+from .models import (
+    SourceLabelConfigIssue,
+    SourceLabelContext,
+    SourceLabelResolution,
+    SourceLabelRule,
+)
+from .resolution import resolve_source_label
+
+__all__ = [
+    "SourceLabelConfigIssue",
+    "SourceLabelContext",
+    "SourceLabelResolution",
+    "SourceLabelRule",
+    "load_source_label_context",
+    "resolve_source_label",
+]

--- a/src/tallylot/application/intake/source_labels/loading.py
+++ b/src/tallylot/application/intake/source_labels/loading.py
@@ -1,0 +1,148 @@
+"""Workspace-backed loading for source-label map control data."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from tallylot.ports.artifacts import ArtifactStorePort
+
+from .models import SourceLabelConfigIssue, SourceLabelContext, SourceLabelRule
+
+_WINDOWS_ABSOLUTE_PREFIX = re.compile(r"^[A-Za-z]:/")
+
+
+def load_source_label_context(
+    artifacts: ArtifactStorePort,
+    workspace_root: Path,
+) -> SourceLabelContext:
+    rules: list[SourceLabelRule] = []
+    issues: list[SourceLabelConfigIssue] = []
+    inventory_sources = _inventory_sources(artifacts, workspace_root)
+    map_path = workspace_root / "analysis" / "issues" / "source_label_map.csv"
+    if not map_path.exists():
+        return SourceLabelContext(rules=(), issues=())
+    grouped_rows: dict[str, list[tuple[int, str]]] = {}
+    for row_number, row in enumerate(artifacts.read_rows(map_path), start=2):
+        prefix_value = (row.get("incoming_path_prefix") or "").strip()
+        source_value = (row.get("source") or "").strip()
+        normalized_prefix, error_message = _normalize_prefix(prefix_value)
+        if error_message:
+            issues.append(
+                SourceLabelConfigIssue(
+                    relative_path=f"analysis/issues/source_label_map.csv:{row_number}",
+                    severity="error",
+                    kind="source_label_map_invalid_prefix",
+                    message=error_message,
+                    review_code="source_map_invalid_prefix",
+                )
+            )
+            continue
+        if not source_value:
+            issues.append(
+                SourceLabelConfigIssue(
+                    relative_path=f"analysis/issues/source_label_map.csv:{row_number}",
+                    severity="error",
+                    kind="source_label_map_unknown_source",
+                    message="Source label map row must include a source value.",
+                    matching_prefix=normalized_prefix,
+                    review_code="source_map_unknown_source",
+                )
+            )
+            continue
+        if source_value not in inventory_sources:
+            issues.append(
+                SourceLabelConfigIssue(
+                    relative_path=f"analysis/issues/source_label_map.csv:{row_number}",
+                    severity="error",
+                    kind="source_label_map_unknown_source",
+                    message=(
+                        f"Mapped source {source_value} is not present in "
+                        "analysis/issues/source_inventory.csv."
+                    ),
+                    matching_prefix=normalized_prefix,
+                    review_code="source_map_unknown_source",
+                )
+            )
+            continue
+        grouped_rows.setdefault(normalized_prefix, []).append(
+            (row_number, source_value)
+        )
+    for prefix, rows in grouped_rows.items():
+        sources = sorted({source for _, source in rows})
+        if len(sources) > 1:
+            line_list = ", ".join(str(line) for line, _ in rows)
+            issues.append(
+                SourceLabelConfigIssue(
+                    relative_path="analysis/issues/source_label_map.csv",
+                    severity="error",
+                    kind="source_label_map_conflict",
+                    message=(
+                        f"Conflicting source label map rows for prefix {prefix} on lines "
+                        f"{line_list}: {', '.join(sources)}"
+                    ),
+                    matching_prefix=prefix,
+                    review_code="source_map_conflict",
+                )
+            )
+            continue
+        rules.append(SourceLabelRule(prefix=prefix, source=sources[0]))
+    rules.sort(key=lambda item: (len(item.prefix), item.prefix), reverse=True)
+    issues.sort(key=lambda item: (item.relative_path, item.kind, item.message))
+    return SourceLabelContext(rules=tuple(rules), issues=tuple(issues))
+
+
+def _inventory_sources(artifacts: ArtifactStorePort, workspace_root: Path) -> set[str]:
+    source_inventory_path = (
+        workspace_root / "analysis" / "issues" / "source_inventory.csv"
+    )
+    if not source_inventory_path.exists():
+        return set()
+    return {
+        source
+        for row in artifacts.read_rows(source_inventory_path)
+        if (source := (row.get("source") or "").strip())
+    }
+
+
+def _normalize_prefix(value: str) -> tuple[str, str]:
+    normalized = value.replace("\\", "/")
+    if not normalized:
+        return "", "Source label map row must include an incoming_path_prefix value."
+    if normalized == ".":
+        return ".", ""
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    if not normalized:
+        return ".", ""
+    if normalized.startswith("/") or _WINDOWS_ABSOLUTE_PREFIX.match(normalized):
+        return (
+            "",
+            f"Source label map prefix {value!r} must stay relative to the incoming capture root.",
+        )
+    left, separator, right = normalized.partition("::")
+    normalized_left, left_error = _normalize_part(left)
+    if left_error:
+        return "", left_error
+    if not separator:
+        return normalized_left, ""
+    normalized_right, right_error = _normalize_part(right)
+    if right_error:
+        return "", right_error
+    return f"{normalized_left}::{normalized_right}", ""
+
+
+def _normalize_part(value: str) -> tuple[str, str]:
+    segments: list[str] = []
+    for segment in value.split("/"):
+        if segment in {"", "."}:
+            continue
+        if segment == "..":
+            return "", "Source label map prefixes must not traverse upward with '..'."
+        segments.append(segment)
+    if segments:
+        return "/".join(segments), ""
+    return (
+        "",
+        "Source label map prefixes must identify a path inside the incoming capture.",
+    )

--- a/src/tallylot/application/intake/source_labels/loading.py
+++ b/src/tallylot/application/intake/source_labels/loading.py
@@ -113,23 +113,34 @@ def _normalize_prefix(value: str) -> tuple[str, str]:
         return ".", ""
     while normalized.startswith("./"):
         normalized = normalized[2:]
+    normalized, prefix_error = _normalize_prefix_root(normalized, value)
+    if prefix_error:
+        return "", prefix_error
+    left, separator, right = normalized.partition("::")
+    normalized_left, left_error = _normalize_part(left)
+    normalized_right = ""
+    right_error = ""
+    if separator:
+        normalized_right, right_error = _normalize_part(right)
+    if left_error or right_error:
+        return "", left_error or right_error
+    if not separator:
+        return normalized_left, ""
+    return f"{normalized_left}::{normalized_right}", ""
+
+
+def _normalize_prefix_root(
+    normalized: str,
+    original_value: str,
+) -> tuple[str, str]:
     if not normalized:
         return ".", ""
     if normalized.startswith("/") or _WINDOWS_ABSOLUTE_PREFIX.match(normalized):
         return (
             "",
-            f"Source label map prefix {value!r} must stay relative to the incoming capture root.",
+            f"Source label map prefix {original_value!r} must stay relative to the incoming capture root.",
         )
-    left, separator, right = normalized.partition("::")
-    normalized_left, left_error = _normalize_part(left)
-    if left_error:
-        return "", left_error
-    if not separator:
-        return normalized_left, ""
-    normalized_right, right_error = _normalize_part(right)
-    if right_error:
-        return "", right_error
-    return f"{normalized_left}::{normalized_right}", ""
+    return normalized, ""
 
 
 def _normalize_part(value: str) -> tuple[str, str]:

--- a/src/tallylot/application/intake/source_labels/models.py
+++ b/src/tallylot/application/intake/source_labels/models.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from pathlib import Path
+
+from tallylot.application.intake.file_facts import IntakeFileFacts
 
 
 @dataclass(frozen=True)
@@ -45,3 +48,12 @@ class SourceLabelResolution:
     review_codes: str = ""
     review_reason: str = ""
     blocked: bool = False
+
+
+@dataclass(frozen=True)
+class SourceLabelResolutionRequest:
+    workspace_root: Path
+    route_key: str
+    facts: IntakeFileFacts
+    source_folder: str
+    target_path: Path

--- a/src/tallylot/application/intake/source_labels/models.py
+++ b/src/tallylot/application/intake/source_labels/models.py
@@ -1,0 +1,47 @@
+"""Typed models for source-label resolution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SourceLabelRule:
+    prefix: str
+    source: str
+
+
+@dataclass(frozen=True)
+class SourceLabelConfigIssue:
+    relative_path: str
+    severity: str
+    kind: str
+    message: str
+    matching_prefix: str = ""
+    review_code: str = ""
+
+    def to_row(self) -> dict[str, str]:
+        return {
+            "relative_path": self.relative_path,
+            "severity": self.severity,
+            "kind": self.kind,
+            "message": self.message,
+        }
+
+
+@dataclass(frozen=True)
+class SourceLabelContext:
+    rules: tuple[SourceLabelRule, ...]
+    issues: tuple[SourceLabelConfigIssue, ...]
+
+
+@dataclass(frozen=True)
+class SourceLabelResolution:
+    source_folder: str
+    source_resolution_status: str
+    source_resolution_reason: str
+    inventory_match_status: str
+    review_required: str = "no"
+    review_codes: str = ""
+    review_reason: str = ""
+    blocked: bool = False

--- a/src/tallylot/application/intake/source_labels/resolution.py
+++ b/src/tallylot/application/intake/source_labels/resolution.py
@@ -2,16 +2,17 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
-from tallylot.application.intake.file_facts import IntakeFileFacts
-from tallylot.application.intake.inventory import resolve_inventory_route
+from tallylot.application.intake.inventory import (
+    InventoryRouteDecision,
+    resolve_inventory_route,
+)
 from tallylot.ports.artifacts import ArtifactStorePort
 
 from .models import (
     SourceLabelConfigIssue,
     SourceLabelContext,
     SourceLabelResolution,
+    SourceLabelResolutionRequest,
     SourceLabelRule,
 )
 
@@ -19,78 +20,105 @@ from .models import (
 def resolve_source_label(
     *,
     artifacts: ArtifactStorePort,
-    workspace_root: Path,
     context: SourceLabelContext,
-    route_key: str,
-    facts: IntakeFileFacts,
-    source_folder: str,
-    target_path: Path,
+    request: SourceLabelResolutionRequest,
 ) -> SourceLabelResolution:
-    if not _is_source_scoped_target_path(target_path, workspace_root):
-        return SourceLabelResolution(
-            source_folder=source_folder,
-            source_resolution_status="routed_source"
-            if source_folder != "unclassified"
-            else "routed_unclassified",
-            source_resolution_reason=(
-                f"Non-source-scoped destination keeps routed source {source_folder}."
-                if source_folder != "unclassified"
-                else "Non-source-scoped destination keeps routed unclassified source."
-            ),
-            inventory_match_status="unmatched",
-        )
-    explicit_issue = _matching_issue(context.issues, route_key)
-    explicit_rule = _matching_rule(context.rules, route_key)
+    if not _is_source_scoped_target_path(request):
+        return _non_source_scoped_resolution(request.source_folder)
+    explicit_issue = _matching_issue(context.issues, request.route_key)
+    explicit_rule = _matching_rule(context.rules, request.route_key)
     if explicit_issue is not None and (
         explicit_rule is None
         or len(explicit_issue.matching_prefix) >= len(explicit_rule.prefix)
     ):
-        return SourceLabelResolution(
-            source_folder=source_folder,
-            source_resolution_status="explicit_map_blocked",
-            source_resolution_reason=explicit_issue.message,
-            inventory_match_status="not_evaluated_explicit_map",
-            review_required="yes",
-            review_codes=explicit_issue.review_code,
-            review_reason=explicit_issue.message,
-            blocked=True,
-        )
+        return _blocked_resolution(request.source_folder, explicit_issue)
     if explicit_rule is not None:
-        return SourceLabelResolution(
-            source_folder=explicit_rule.source,
-            source_resolution_status="explicit_map",
-            source_resolution_reason=f"Explicit source map matched prefix {explicit_rule.prefix} -> {explicit_rule.source}",
-            inventory_match_status="not_evaluated_explicit_map",
-        )
+        return _explicit_rule_resolution(explicit_rule)
     inventory_route = resolve_inventory_route(
         artifacts=artifacts,
-        workspace_root=workspace_root,
-        source_folder=source_folder,
-        facts=facts,
+        workspace_root=request.workspace_root,
+        source_folder=request.source_folder,
+        facts=request.facts,
     )
-    if inventory_route.inventory_match_status == "inventory_source_match":
+    return _inventory_or_routed_resolution(request.source_folder, inventory_route)
+
+
+def _non_source_scoped_resolution(source_folder: str) -> SourceLabelResolution:
+    return SourceLabelResolution(
+        source_folder=source_folder,
+        source_resolution_status="routed_source"
+        if source_folder != "unclassified"
+        else "routed_unclassified",
+        source_resolution_reason=(
+            f"Non-source-scoped destination keeps routed source {source_folder}."
+            if source_folder != "unclassified"
+            else "Non-source-scoped destination keeps routed unclassified source."
+        ),
+        inventory_match_status="unmatched",
+    )
+
+
+def _blocked_resolution(
+    source_folder: str,
+    issue: SourceLabelConfigIssue,
+) -> SourceLabelResolution:
+    return SourceLabelResolution(
+        source_folder=source_folder,
+        source_resolution_status="explicit_map_blocked",
+        source_resolution_reason=issue.message,
+        inventory_match_status="not_evaluated_explicit_map",
+        review_required="yes",
+        review_codes=issue.review_code,
+        review_reason=issue.message,
+        blocked=True,
+    )
+
+
+def _explicit_rule_resolution(rule: SourceLabelRule) -> SourceLabelResolution:
+    return SourceLabelResolution(
+        source_folder=rule.source,
+        source_resolution_status="explicit_map",
+        source_resolution_reason=(
+            f"Explicit source map matched prefix {rule.prefix} -> {rule.source}"
+        ),
+        inventory_match_status="not_evaluated_explicit_map",
+    )
+
+
+def _inventory_or_routed_resolution(
+    source_folder: str,
+    inventory_route: InventoryRouteDecision,
+) -> SourceLabelResolution:
+    status = inventory_route.inventory_match_status
+    if status == "inventory_source_match":
         return SourceLabelResolution(
             source_folder=inventory_route.source_folder,
             source_resolution_status="inventory_source_match",
-            source_resolution_reason=f"Wallet evidence matched existing inventory source {inventory_route.source_folder}",
-            inventory_match_status=inventory_route.inventory_match_status,
+            source_resolution_reason=(
+                "Wallet evidence matched existing inventory source "
+                f"{inventory_route.source_folder}"
+            ),
+            inventory_match_status=status,
         )
-    if inventory_route.inventory_match_status == "inventory_source_ambiguous":
+    if status == "inventory_source_ambiguous":
         return SourceLabelResolution(
             source_folder=inventory_route.source_folder,
             source_resolution_status="inventory_source_ambiguous",
             source_resolution_reason=inventory_route.review_reason,
-            inventory_match_status=inventory_route.inventory_match_status,
+            inventory_match_status=status,
             review_required=inventory_route.review_required,
             review_codes=inventory_route.review_codes,
             review_reason=inventory_route.review_reason,
         )
-    if inventory_route.inventory_match_status == "generic_scope_routing":
+    if status == "generic_scope_routing":
         return SourceLabelResolution(
             source_folder=inventory_route.source_folder,
             source_resolution_status="generic_scope_routing",
-            source_resolution_reason=f"Generated source label {inventory_route.source_folder} from wallet scope evidence.",
-            inventory_match_status=inventory_route.inventory_match_status,
+            source_resolution_reason=(
+                f"Generated source label {inventory_route.source_folder} "
+                "from wallet scope evidence."
+            ),
+            inventory_match_status=status,
         )
     return SourceLabelResolution(
         source_folder=source_folder,
@@ -98,11 +126,12 @@ def resolve_source_label(
         if source_folder != "unclassified"
         else "routed_unclassified",
         source_resolution_reason=(
-            f"Fell back to routed source {source_folder} from adapter or file-signature matching."
+            "Fell back to routed source "
+            f"{source_folder} from adapter or file-signature matching."
             if source_folder != "unclassified"
             else "No explicit or inferred source match; using unclassified."
         ),
-        inventory_match_status=inventory_route.inventory_match_status,
+        inventory_match_status=status,
     )
 
 
@@ -118,7 +147,8 @@ def _matching_issue(
     if not matching_issues:
         return None
     matching_issues.sort(
-        key=lambda item: (len(item.matching_prefix), item.matching_prefix), reverse=True
+        key=lambda item: (len(item.matching_prefix), item.matching_prefix),
+        reverse=True,
     )
     return matching_issues[0]
 
@@ -144,9 +174,9 @@ def _prefix_matches(prefix: str, route_key: str) -> bool:
     return next_character in {"/", ":"}
 
 
-def _is_source_scoped_target_path(target_path: Path, workspace_root: Path) -> bool:
+def _is_source_scoped_target_path(request: SourceLabelResolutionRequest) -> bool:
     try:
-        relative_path = target_path.relative_to(workspace_root)
+        relative_path = request.target_path.relative_to(request.workspace_root)
     except ValueError:
         return False
     parts = relative_path.parts

--- a/src/tallylot/application/intake/source_labels/resolution.py
+++ b/src/tallylot/application/intake/source_labels/resolution.py
@@ -6,6 +6,7 @@ from tallylot.application.intake.inventory import (
     InventoryRouteDecision,
     resolve_inventory_route,
 )
+from tallylot.application.intake.path_rules import is_source_scoped_target_path
 from tallylot.ports.artifacts import ArtifactStorePort
 
 from .models import (
@@ -23,7 +24,11 @@ def resolve_source_label(
     context: SourceLabelContext,
     request: SourceLabelResolutionRequest,
 ) -> SourceLabelResolution:
-    if not _is_source_scoped_target_path(request):
+    if not is_source_scoped_target_path(
+        request.target_path,
+        workspace_root=request.workspace_root,
+        source_folder=request.source_folder,
+    ):
         return _non_source_scoped_resolution(request.source_folder)
     explicit_issue = _matching_issue(context.issues, request.route_key)
     explicit_rule = _matching_rule(context.rules, request.route_key)
@@ -172,14 +177,3 @@ def _prefix_matches(prefix: str, route_key: str) -> bool:
         return False
     next_character = route_key[len(prefix) : len(prefix) + 1]
     return next_character in {"/", ":"}
-
-
-def _is_source_scoped_target_path(request: SourceLabelResolutionRequest) -> bool:
-    try:
-        relative_path = request.target_path.relative_to(request.workspace_root)
-    except ValueError:
-        return False
-    parts = relative_path.parts
-    if len(parts) >= 4 and parts[:3] == ("evidence", "raw", "source"):
-        return True
-    return len(parts) >= 3 and parts[0] == "working"

--- a/src/tallylot/application/intake/source_labels/resolution.py
+++ b/src/tallylot/application/intake/source_labels/resolution.py
@@ -1,0 +1,155 @@
+"""Source-label resolution for intake plan rows."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from tallylot.application.intake.file_facts import IntakeFileFacts
+from tallylot.application.intake.inventory import resolve_inventory_route
+from tallylot.ports.artifacts import ArtifactStorePort
+
+from .models import (
+    SourceLabelConfigIssue,
+    SourceLabelContext,
+    SourceLabelResolution,
+    SourceLabelRule,
+)
+
+
+def resolve_source_label(
+    *,
+    artifacts: ArtifactStorePort,
+    workspace_root: Path,
+    context: SourceLabelContext,
+    route_key: str,
+    facts: IntakeFileFacts,
+    source_folder: str,
+    target_path: Path,
+) -> SourceLabelResolution:
+    if not _is_source_scoped_target_path(target_path, workspace_root):
+        return SourceLabelResolution(
+            source_folder=source_folder,
+            source_resolution_status="routed_source"
+            if source_folder != "unclassified"
+            else "routed_unclassified",
+            source_resolution_reason=(
+                f"Non-source-scoped destination keeps routed source {source_folder}."
+                if source_folder != "unclassified"
+                else "Non-source-scoped destination keeps routed unclassified source."
+            ),
+            inventory_match_status="unmatched",
+        )
+    explicit_issue = _matching_issue(context.issues, route_key)
+    explicit_rule = _matching_rule(context.rules, route_key)
+    if explicit_issue is not None and (
+        explicit_rule is None
+        or len(explicit_issue.matching_prefix) >= len(explicit_rule.prefix)
+    ):
+        return SourceLabelResolution(
+            source_folder=source_folder,
+            source_resolution_status="explicit_map_blocked",
+            source_resolution_reason=explicit_issue.message,
+            inventory_match_status="not_evaluated_explicit_map",
+            review_required="yes",
+            review_codes=explicit_issue.review_code,
+            review_reason=explicit_issue.message,
+            blocked=True,
+        )
+    if explicit_rule is not None:
+        return SourceLabelResolution(
+            source_folder=explicit_rule.source,
+            source_resolution_status="explicit_map",
+            source_resolution_reason=f"Explicit source map matched prefix {explicit_rule.prefix} -> {explicit_rule.source}",
+            inventory_match_status="not_evaluated_explicit_map",
+        )
+    inventory_route = resolve_inventory_route(
+        artifacts=artifacts,
+        workspace_root=workspace_root,
+        source_folder=source_folder,
+        facts=facts,
+    )
+    if inventory_route.inventory_match_status == "inventory_source_match":
+        return SourceLabelResolution(
+            source_folder=inventory_route.source_folder,
+            source_resolution_status="inventory_source_match",
+            source_resolution_reason=f"Wallet evidence matched existing inventory source {inventory_route.source_folder}",
+            inventory_match_status=inventory_route.inventory_match_status,
+        )
+    if inventory_route.inventory_match_status == "inventory_source_ambiguous":
+        return SourceLabelResolution(
+            source_folder=inventory_route.source_folder,
+            source_resolution_status="inventory_source_ambiguous",
+            source_resolution_reason=inventory_route.review_reason,
+            inventory_match_status=inventory_route.inventory_match_status,
+            review_required=inventory_route.review_required,
+            review_codes=inventory_route.review_codes,
+            review_reason=inventory_route.review_reason,
+        )
+    if inventory_route.inventory_match_status == "generic_scope_routing":
+        return SourceLabelResolution(
+            source_folder=inventory_route.source_folder,
+            source_resolution_status="generic_scope_routing",
+            source_resolution_reason=f"Generated source label {inventory_route.source_folder} from wallet scope evidence.",
+            inventory_match_status=inventory_route.inventory_match_status,
+        )
+    return SourceLabelResolution(
+        source_folder=source_folder,
+        source_resolution_status="routed_source"
+        if source_folder != "unclassified"
+        else "routed_unclassified",
+        source_resolution_reason=(
+            f"Fell back to routed source {source_folder} from adapter or file-signature matching."
+            if source_folder != "unclassified"
+            else "No explicit or inferred source match; using unclassified."
+        ),
+        inventory_match_status=inventory_route.inventory_match_status,
+    )
+
+
+def _matching_issue(
+    issues: tuple[SourceLabelConfigIssue, ...],
+    route_key: str,
+) -> SourceLabelConfigIssue | None:
+    matching_issues = [
+        issue
+        for issue in issues
+        if issue.matching_prefix and _prefix_matches(issue.matching_prefix, route_key)
+    ]
+    if not matching_issues:
+        return None
+    matching_issues.sort(
+        key=lambda item: (len(item.matching_prefix), item.matching_prefix), reverse=True
+    )
+    return matching_issues[0]
+
+
+def _matching_rule(
+    rules: tuple[SourceLabelRule, ...],
+    route_key: str,
+) -> SourceLabelRule | None:
+    for rule in rules:
+        if _prefix_matches(rule.prefix, route_key):
+            return rule
+    return None
+
+
+def _prefix_matches(prefix: str, route_key: str) -> bool:
+    if prefix == ".":
+        return True
+    if route_key == prefix:
+        return True
+    if not route_key.startswith(prefix):
+        return False
+    next_character = route_key[len(prefix) : len(prefix) + 1]
+    return next_character in {"/", ":"}
+
+
+def _is_source_scoped_target_path(target_path: Path, workspace_root: Path) -> bool:
+    try:
+        relative_path = target_path.relative_to(workspace_root)
+    except ValueError:
+        return False
+    parts = relative_path.parts
+    if len(parts) >= 4 and parts[:3] == ("evidence", "raw", "source"):
+        return True
+    return len(parts) >= 3 and parts[0] == "working"

--- a/src/tallylot/infrastructure/workspace/layout.py
+++ b/src/tallylot/infrastructure/workspace/layout.py
@@ -47,6 +47,10 @@ SEED_FILES = (
         ),
     ),
     SeedFile(
+        "analysis/issues/source_label_map.csv",
+        "incoming_path_prefix,source,notes\n",
+    ),
+    SeedFile(
         "analysis/inventory/location_inventory.csv",
         "location_id,source,location_kind,location_label,evidence_path,identifier_kind,identifier_value,notes\n",
     ),

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -29,6 +29,7 @@ def test_workspace_init_cli(tmp_path: Path) -> None:
 
     assert result.exit_code == 0
     assert (workspace_root / "analysis/issues/issue_log.csv").exists()
+    assert (workspace_root / "analysis/issues/source_label_map.csv").exists()
 
 
 def test_profile_normalize_and_render_cli(
@@ -193,6 +194,49 @@ def test_source_intake_plan_and_apply_cli(tmp_path: Path) -> None:
     assert payload["copied_count"] == 1
     assert (
         workspace_root / "evidence/raw/source/unclassified/incoming/transactions.csv"
+    ).exists()
+
+
+def test_source_intake_cli_uses_workspace_source_label_map(tmp_path: Path) -> None:
+    incoming_dir = tmp_path / "incoming"
+    incoming_dir.mkdir()
+    (incoming_dir / "transactions.csv").write_text("a,b\n1,2\n", encoding="utf-8")
+    workspace_root = tmp_path / "workspace"
+    FilesystemArtifactStore().write_rows(
+        workspace_root / "analysis" / "issues" / "source_inventory.csv",
+        ("source",),
+        ({"source": "manual-main"},),
+    )
+    FilesystemArtifactStore().write_rows(
+        workspace_root / "analysis" / "issues" / "source_label_map.csv",
+        ("incoming_path_prefix", "source", "notes"),
+        ({"incoming_path_prefix": ".", "source": "manual-main", "notes": ""},),
+    )
+    report_dir = tmp_path / "reports"
+
+    result = runner.invoke(
+        app,
+        [
+            "source",
+            "intake",
+            "apply",
+            "--incoming-dir",
+            str(incoming_dir),
+            "--workspace-root",
+            str(workspace_root),
+            "--report-dir",
+            str(report_dir),
+        ],
+    )
+
+    payload = json.loads(result.stdout)
+    plan_rows = FilesystemArtifactStore().read_rows(report_dir / "intake_plan.csv")
+
+    assert result.exit_code == 0
+    assert payload["copied_count"] == 1
+    assert plan_rows[0]["source_resolution_status"] == "explicit_map"
+    assert (
+        workspace_root / "evidence/raw/source/manual-main/incoming/transactions.csv"
     ).exists()
 
 

--- a/tests/unit/application/intake/plan/test_routing_workflow.py
+++ b/tests/unit/application/intake/plan/test_routing_workflow.py
@@ -9,7 +9,9 @@ from tallylot.infrastructure.discovery import build_registry
 from tallylot.infrastructure.serialization.filesystem import FilesystemArtifactStore
 
 
-def test_source_intake_service_plans_archive_members_without_copying_them(tmp_path: Path) -> None:
+def test_source_intake_service_plans_archive_members_without_copying_them(
+    tmp_path: Path,
+) -> None:
     incoming_dir = tmp_path / "incoming"
     incoming_dir.mkdir()
     archive_path = incoming_dir / "bundle.zip"
@@ -30,15 +32,27 @@ def test_source_intake_service_plans_archive_members_without_copying_them(tmp_pa
     plan_rows = FilesystemArtifactStore().read_rows(report_dir / "intake_plan.csv")
 
     assert response.file_count == 2
-    assert any(row["action"] == "copy" and row["path"].endswith("bundle.zip") for row in plan_rows)
-    assert any(row["action"] == "extract_copy" and row["archive_member_path"] == "inner.csv" for row in plan_rows)
+    assert any(
+        row["action"] == "copy" and row["path"].endswith("bundle.zip")
+        for row in plan_rows
+    )
+    assert any(
+        row["action"] == "extract_copy" and row["archive_member_path"] == "inner.csv"
+        for row in plan_rows
+    )
 
 
 def test_source_intake_service_routes_source_artifacts_to_source_aware_supporting_paths(
     tmp_path: Path,
 ) -> None:
     incoming_dir = tmp_path / "incoming"
-    image_path = incoming_dir / "2021" / "Binance" / "From Binance" / "trade Analysis - ADA-USDT - Binance.png"
+    image_path = (
+        incoming_dir
+        / "2021"
+        / "Binance"
+        / "From Binance"
+        / "trade Analysis - ADA-USDT - Binance.png"
+    )
     scratch_csv = incoming_dir / "2021" / "Binance" / "2021 Isolated" / "test.csv"
     image_path.parent.mkdir(parents=True, exist_ok=True)
     scratch_csv.parent.mkdir(parents=True, exist_ok=True)
@@ -57,13 +71,27 @@ def test_source_intake_service_routes_source_artifacts_to_source_aware_supportin
     )
 
     plan_rows = FilesystemArtifactStore().read_rows(report_dir / "intake_plan.csv")
-    by_name = {Path(row["path"]).name: row for row in plan_rows if not row["archive_member_path"]}
+    by_name = {
+        Path(row["path"]).name: row
+        for row in plan_rows
+        if not row["archive_member_path"]
+    }
 
-    assert by_name["trade Analysis - ADA-USDT - Binance.png"]["role"] == "working_derivative"
-    assert by_name["trade Analysis - ADA-USDT - Binance.png"]["source_folder"] == "binance"
-    assert "/working/supporting_artifacts/binance/" in by_name["trade Analysis - ADA-USDT - Binance.png"]["target_path"]
+    assert (
+        by_name["trade Analysis - ADA-USDT - Binance.png"]["role"]
+        == "working_derivative"
+    )
+    assert (
+        by_name["trade Analysis - ADA-USDT - Binance.png"]["source_folder"] == "binance"
+    )
+    assert (
+        "/working/supporting_artifacts/binance/"
+        in by_name["trade Analysis - ADA-USDT - Binance.png"]["target_path"]
+    )
     assert by_name["test.csv"]["role"] == "working_derivative"
-    assert "/working/supporting_artifacts/binance/" in by_name["test.csv"]["target_path"]
+    assert (
+        "/working/supporting_artifacts/binance/" in by_name["test.csv"]["target_path"]
+    )
 
 
 def test_source_intake_service_routes_cointracking_html_and_sidecar_to_portfolio_capture(
@@ -71,7 +99,12 @@ def test_source_intake_service_routes_cointracking_html_and_sidecar_to_portfolio
 ) -> None:
     incoming_dir = tmp_path / "incoming"
     html_path = incoming_dir / "tmp" / "CoinTracking · Tax Declaration Export.html"
-    sidecar_path = incoming_dir / "tmp" / "CoinTracking · Tax Declaration Export_files" / "style.min.css"
+    sidecar_path = (
+        incoming_dir
+        / "tmp"
+        / "CoinTracking · Tax Declaration Export_files"
+        / "style.min.css"
+    )
     sidecar_path.parent.mkdir(parents=True, exist_ok=True)
     html_path.write_text(
         """
@@ -98,8 +131,13 @@ def test_source_intake_service_routes_cointracking_html_and_sidecar_to_portfolio
     plan_rows = FilesystemArtifactStore().read_rows(report_dir / "intake_plan.csv")
     by_name = {Path(row["path"]).name: row for row in plan_rows}
 
-    assert by_name["CoinTracking · Tax Declaration Export.html"]["role"] == "portfolio_export"
-    assert by_name["CoinTracking · Tax Declaration Export.html"]["capture_id"] == "2022-04"
+    assert (
+        by_name["CoinTracking · Tax Declaration Export.html"]["role"]
+        == "portfolio_export"
+    )
+    assert (
+        by_name["CoinTracking · Tax Declaration Export.html"]["capture_id"] == "2022-04"
+    )
     assert (
         "/evidence/raw/portfolio/cointracking/2022-04/"
         in by_name["CoinTracking · Tax Declaration Export.html"]["target_path"]
@@ -108,9 +146,13 @@ def test_source_intake_service_routes_cointracking_html_and_sidecar_to_portfolio
     assert by_name["style.min.css"]["capture_id"] == "2022-04"
 
 
-def test_source_intake_service_routes_wallet_export_to_existing_inventory_source(tmp_path: Path) -> None:
+def test_source_intake_service_routes_wallet_export_to_existing_inventory_source(
+    tmp_path: Path,
+) -> None:
     workspace_root = tmp_path / "workspace"
-    source_inventory_path = workspace_root / "analysis" / "issues" / "source_inventory.csv"
+    source_inventory_path = (
+        workspace_root / "analysis" / "issues" / "source_inventory.csv"
+    )
     source_inventory_path.parent.mkdir(parents=True, exist_ok=True)
     FilesystemArtifactStore().write_rows(
         source_inventory_path,
@@ -131,7 +173,9 @@ def test_source_intake_service_routes_wallet_export_to_existing_inventory_source
             },
         ),
     )
-    location_evidence_path = workspace_root / "analysis" / "inventory" / "location_inventory_evidence.csv"
+    location_evidence_path = (
+        workspace_root / "analysis" / "inventory" / "location_inventory_evidence.csv"
+    )
     location_evidence_path.parent.mkdir(parents=True, exist_ok=True)
     FilesystemArtifactStore().write_rows(
         location_evidence_path,
@@ -201,3 +245,58 @@ def test_source_intake_service_routes_wallet_export_to_existing_inventory_source
     assert row["source_folder"] == "eth-gala1"
     assert row["inventory_match_status"] == "inventory_source_match"
     assert row["review_required"] == "no"
+
+
+def test_source_intake_service_uses_explicit_source_label_map_for_stable_source_labels(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    issues_dir = workspace_root / "analysis" / "issues"
+    issues_dir.mkdir(parents=True, exist_ok=True)
+    artifacts = FilesystemArtifactStore()
+    artifacts.write_rows(
+        issues_dir / "source_inventory.csv",
+        ("source",),
+        ({"source": "binance-main"},),
+    )
+    artifacts.write_rows(
+        issues_dir / "source_label_map.csv",
+        ("incoming_path_prefix", "source", "notes"),
+        (
+            {
+                "incoming_path_prefix": "2021/Binance",
+                "source": "binance-main",
+                "notes": "",
+            },
+        ),
+    )
+    incoming_dir = tmp_path / "incoming"
+    image_path = (
+        incoming_dir
+        / "2021"
+        / "Binance"
+        / "From Binance"
+        / "trade Analysis - ADA-USDT - Binance.png"
+    )
+    image_path.parent.mkdir(parents=True, exist_ok=True)
+    image_path.write_bytes(b"png")
+    report_dir = tmp_path / "reports"
+
+    PlanIntakeUseCase(build_registry(), artifacts).execute(
+        IntakePlanRequest(
+            incoming_capture_ref=to_resource_ref(incoming_dir),
+            workspace_root_ref=to_workspace_path(workspace_root),
+            report_output_ref=to_resource_ref(report_dir),
+        )
+    )
+
+    row = next(
+        item
+        for item in artifacts.read_rows(report_dir / "intake_plan.csv")
+        if item["archive_member_path"] == ""
+    )
+
+    assert row["source_folder"] == "binance-main"
+    assert row["source_resolution_status"] == "explicit_map"
+    assert row["inventory_match_status"] == "not_evaluated_explicit_map"
+    assert "/working/supporting_artifacts/binance-main/" in row["target_path"]

--- a/tests/unit/application/intake/source_labels/test_resolution.py
+++ b/tests/unit/application/intake/source_labels/test_resolution.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tallylot.application.intake.file_facts import IntakeFileFacts
+from tallylot.application.intake.path_rules import override_target_source
+from tallylot.application.intake.source_labels import (
+    load_source_label_context,
+    resolve_source_label,
+)
+from tallylot.infrastructure.serialization.filesystem import FilesystemArtifactStore
+
+
+def test_load_source_label_context_reads_rules_and_reports_conflicts(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    issues_dir = workspace_root / "analysis" / "issues"
+    issues_dir.mkdir(parents=True)
+    artifacts = FilesystemArtifactStore()
+    artifacts.write_rows(
+        issues_dir / "source_inventory.csv",
+        ("source",),
+        ({"source": "binance-main"}, {"source": "binance-alt"}),
+    )
+    artifacts.write_rows(
+        issues_dir / "source_label_map.csv",
+        ("incoming_path_prefix", "source", "notes"),
+        (
+            {"incoming_path_prefix": ".", "source": "binance-main", "notes": ""},
+            {"incoming_path_prefix": "capture", "source": "binance-main", "notes": ""},
+            {"incoming_path_prefix": "capture", "source": "binance-alt", "notes": ""},
+            {"incoming_path_prefix": "../bad", "source": "binance-main", "notes": ""},
+        ),
+    )
+
+    context = load_source_label_context(artifacts, workspace_root)
+
+    assert tuple(rule.prefix for rule in context.rules) == (".",)
+    assert {issue.kind for issue in context.issues} == {
+        "source_label_map_conflict",
+        "source_label_map_invalid_prefix",
+    }
+
+
+def test_resolve_source_label_prefers_explicit_map_for_source_scoped_working_paths(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    issues_dir = workspace_root / "analysis" / "issues"
+    issues_dir.mkdir(parents=True)
+    artifacts = FilesystemArtifactStore()
+    artifacts.write_rows(
+        issues_dir / "source_inventory.csv",
+        ("source",),
+        ({"source": "binance-main"},),
+    )
+    artifacts.write_rows(
+        issues_dir / "source_label_map.csv",
+        ("incoming_path_prefix", "source", "notes"),
+        (
+            {
+                "incoming_path_prefix": "2021/Binance",
+                "source": "binance-main",
+                "notes": "",
+            },
+        ),
+    )
+
+    decision = resolve_source_label(
+        artifacts=artifacts,
+        workspace_root=workspace_root,
+        context=load_source_label_context(artifacts, workspace_root),
+        route_key="2021/Binance/trade Analysis - ADA-USDT - Binance.png",
+        facts=IntakeFileFacts(),
+        source_folder="binance",
+        target_path=workspace_root
+        / "working"
+        / "supporting_artifacts"
+        / "binance"
+        / "incoming"
+        / "trade Analysis - ADA-USDT - Binance.png",
+    )
+
+    assert decision.source_folder == "binance-main"
+    assert decision.source_resolution_status == "explicit_map"
+    assert decision.inventory_match_status == "not_evaluated_explicit_map"
+
+
+def test_resolve_source_label_blocks_matching_unknown_source_mapping(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    issues_dir = workspace_root / "analysis" / "issues"
+    issues_dir.mkdir(parents=True)
+    artifacts = FilesystemArtifactStore()
+    artifacts.write_rows(
+        issues_dir / "source_inventory.csv",
+        ("source",),
+        ({"source": "binance-main"},),
+    )
+    artifacts.write_rows(
+        issues_dir / "source_label_map.csv",
+        ("incoming_path_prefix", "source", "notes"),
+        ({"incoming_path_prefix": ".", "source": "missing-source", "notes": ""},),
+    )
+
+    decision = resolve_source_label(
+        artifacts=artifacts,
+        workspace_root=workspace_root,
+        context=load_source_label_context(artifacts, workspace_root),
+        route_key="transactions.csv",
+        facts=IntakeFileFacts(),
+        source_folder="unclassified",
+        target_path=workspace_root
+        / "evidence"
+        / "raw"
+        / "source"
+        / "unclassified"
+        / "incoming"
+        / "transactions.csv",
+    )
+
+    assert decision.source_resolution_status == "explicit_map_blocked"
+    assert decision.review_codes == "source_map_unknown_source"
+    assert decision.blocked is True
+
+
+def test_override_target_source_updates_any_source_scoped_working_surface() -> None:
+    original = Path("/tmp/workspace/working/normalized/binance/incoming/facts.csv")
+
+    updated = override_target_source(original, "binance", "binance-main")
+
+    assert updated == Path(
+        "/tmp/workspace/working/normalized/binance-main/incoming/facts.csv"
+    )

--- a/tests/unit/application/intake/source_labels/test_resolution.py
+++ b/tests/unit/application/intake/source_labels/test_resolution.py
@@ -7,6 +7,7 @@ from tallylot.application.intake.path_rules import override_target_source
 from tallylot.application.intake.source_labels import (
     load_source_label_context,
     resolve_source_label,
+    SourceLabelResolutionRequest,
 )
 from tallylot.infrastructure.serialization.filesystem import FilesystemArtifactStore
 
@@ -69,17 +70,19 @@ def test_resolve_source_label_prefers_explicit_map_for_source_scoped_working_pat
 
     decision = resolve_source_label(
         artifacts=artifacts,
-        workspace_root=workspace_root,
         context=load_source_label_context(artifacts, workspace_root),
-        route_key="2021/Binance/trade Analysis - ADA-USDT - Binance.png",
-        facts=IntakeFileFacts(),
-        source_folder="binance",
-        target_path=workspace_root
-        / "working"
-        / "supporting_artifacts"
-        / "binance"
-        / "incoming"
-        / "trade Analysis - ADA-USDT - Binance.png",
+        request=SourceLabelResolutionRequest(
+            workspace_root=workspace_root,
+            route_key="2021/Binance/trade Analysis - ADA-USDT - Binance.png",
+            facts=IntakeFileFacts(),
+            source_folder="binance",
+            target_path=workspace_root
+            / "working"
+            / "supporting_artifacts"
+            / "binance"
+            / "incoming"
+            / "trade Analysis - ADA-USDT - Binance.png",
+        ),
     )
 
     assert decision.source_folder == "binance-main"
@@ -107,18 +110,20 @@ def test_resolve_source_label_blocks_matching_unknown_source_mapping(
 
     decision = resolve_source_label(
         artifacts=artifacts,
-        workspace_root=workspace_root,
         context=load_source_label_context(artifacts, workspace_root),
-        route_key="transactions.csv",
-        facts=IntakeFileFacts(),
-        source_folder="unclassified",
-        target_path=workspace_root
-        / "evidence"
-        / "raw"
-        / "source"
-        / "unclassified"
-        / "incoming"
-        / "transactions.csv",
+        request=SourceLabelResolutionRequest(
+            workspace_root=workspace_root,
+            route_key="transactions.csv",
+            facts=IntakeFileFacts(),
+            source_folder="unclassified",
+            target_path=workspace_root
+            / "evidence"
+            / "raw"
+            / "source"
+            / "unclassified"
+            / "incoming"
+            / "transactions.csv",
+        ),
     )
 
     assert decision.source_resolution_status == "explicit_map_blocked"

--- a/tests/unit/application/intake/source_labels/test_resolution.py
+++ b/tests/unit/application/intake/source_labels/test_resolution.py
@@ -139,3 +139,58 @@ def test_override_target_source_updates_any_source_scoped_working_surface() -> N
     assert updated == Path(
         "/tmp/workspace/working/normalized/binance-main/incoming/facts.csv"
     )
+
+
+def test_override_target_source_handles_ancestor_named_working() -> None:
+    original = Path(
+        "/tmp/working/sandboxes/workspace/working/supporting_artifacts/binance/incoming/facts.csv"
+    )
+
+    updated = override_target_source(original, "binance", "binance-main")
+
+    assert updated == Path(
+        "/tmp/working/sandboxes/workspace/working/supporting_artifacts/binance-main/incoming/facts.csv"
+    )
+
+
+def test_resolve_source_label_skips_non_source_scoped_working_paths(
+    tmp_path: Path,
+) -> None:
+    workspace_root = tmp_path / "workspace"
+    issues_dir = workspace_root / "analysis" / "issues"
+    issues_dir.mkdir(parents=True)
+    artifacts = FilesystemArtifactStore()
+    artifacts.write_rows(
+        issues_dir / "source_inventory.csv",
+        ("source",),
+        ({"source": "binance-main"},),
+    )
+    artifacts.write_rows(
+        issues_dir / "source_label_map.csv",
+        ("incoming_path_prefix", "source", "notes"),
+        ({"incoming_path_prefix": ".", "source": "binance-main", "notes": ""},),
+    )
+
+    decision = resolve_source_label(
+        artifacts=artifacts,
+        context=load_source_label_context(artifacts, workspace_root),
+        request=SourceLabelResolutionRequest(
+            workspace_root=workspace_root,
+            route_key="batch-001/manifest.csv",
+            facts=IntakeFileFacts(),
+            source_folder="binance",
+            target_path=workspace_root
+            / "working"
+            / "import_batches"
+            / "batch-001"
+            / "manifest.csv",
+        ),
+    )
+
+    assert decision.source_folder == "binance"
+    assert decision.source_resolution_status == "routed_source"
+    assert (
+        decision.source_resolution_reason
+        == "Non-source-scoped destination keeps routed source binance."
+    )
+    assert decision.inventory_match_status == "unmatched"

--- a/tests/unit/application/intake/test_apply_workflow.py
+++ b/tests/unit/application/intake/test_apply_workflow.py
@@ -10,7 +10,9 @@ from tallylot.infrastructure.discovery import build_registry
 from tallylot.infrastructure.serialization.filesystem import FilesystemArtifactStore
 
 
-def test_source_intake_service_applies_loose_files_into_workspace(tmp_path: Path) -> None:
+def test_source_intake_service_applies_loose_files_into_workspace(
+    tmp_path: Path,
+) -> None:
     incoming_dir = tmp_path / "incoming"
     incoming_dir.mkdir()
     source_file = incoming_dir / "transactions.csv"
@@ -27,15 +29,27 @@ def test_source_intake_service_applies_loose_files_into_workspace(tmp_path: Path
         )
     )
 
-    summary = json.loads((report_dir / "intake_summary.json").read_text(encoding="utf-8"))
-    target = workspace_root / "evidence" / "raw" / "source" / "unclassified" / "incoming" / "transactions.csv"
+    summary = json.loads(
+        (report_dir / "intake_summary.json").read_text(encoding="utf-8")
+    )
+    target = (
+        workspace_root
+        / "evidence"
+        / "raw"
+        / "source"
+        / "unclassified"
+        / "incoming"
+        / "transactions.csv"
+    )
 
     assert response.copied_count == 1
     assert target.exists()
     assert summary["copied_count"] == 1
 
 
-def test_source_intake_service_applies_archive_members_into_workspace(tmp_path: Path) -> None:
+def test_source_intake_service_applies_archive_members_into_workspace(
+    tmp_path: Path,
+) -> None:
     incoming_dir = tmp_path / "incoming"
     incoming_dir.mkdir()
     archive_path = incoming_dir / "bundle.zip"
@@ -81,19 +95,17 @@ def test_source_intake_service_applies_archive_members_into_workspace(tmp_path: 
     assert member_target.exists()
 
 
-def test_source_intake_service_merges_same_cycle_near_duplicate_packages_on_apply(tmp_path: Path) -> None:
+def test_source_intake_service_merges_same_cycle_near_duplicate_packages_on_apply(
+    tmp_path: Path,
+) -> None:
     incoming_dir = tmp_path / "incoming"
     older = incoming_dir / "2021" / "Binance" / "202203291730-export"
     newer = incoming_dir / "2021" / "Binance" / "202203291830-export"
     older.mkdir(parents=True)
     newer.mkdir(parents=True)
-    borrow_payload = (
-        "Pair,Coin,Date,Amount,Type,Status\nADA/USDT,USDT,2021-05-25 12:53:03,0.0345,Auto borrowing,CONFIRM\n"
-    )
+    borrow_payload = "Pair,Coin,Date,Amount,Type,Status\nADA/USDT,USDT,2021-05-25 12:53:03,0.0345,Auto borrowing,CONFIRM\n"
     interest_payload = "Pair,Coin,Amount,Time,Interest Type\nADA/USDT,USDT,0.1,2021-05-25 12:53:03,Hourly\n"
-    repay_payload = (
-        "Pair,Coin,Date,Amount,Type,Status\nADA/USDT,USDT,2021-05-25 13:53:03,0.0345,Auto repayment,CONFIRM\n"
-    )
+    repay_payload = "Pair,Coin,Date,Amount,Type,Status\nADA/USDT,USDT,2021-05-25 13:53:03,0.0345,Auto repayment,CONFIRM\n"
     (older / "borrow.csv").write_text(borrow_payload, encoding="utf-8")
     (older / "interest.csv").write_text(interest_payload, encoding="utf-8")
     (newer / "borrow.csv").write_text(borrow_payload, encoding="utf-8")
@@ -110,13 +122,25 @@ def test_source_intake_service_merges_same_cycle_near_duplicate_packages_on_appl
         )
     )
 
-    summary = json.loads((report_dir / "intake_summary.json").read_text(encoding="utf-8"))
+    summary = json.loads(
+        (report_dir / "intake_summary.json").read_text(encoding="utf-8")
+    )
     plan_rows = FilesystemArtifactStore().read_rows(report_dir / "intake_plan.csv")
     manifest_rows = FilesystemArtifactStore().read_rows(
-        workspace_root / "evidence" / "raw" / "source" / "binance" / "2021-05" / "manifest.csv"
+        workspace_root
+        / "evidence"
+        / "raw"
+        / "source"
+        / "binance"
+        / "2021-05"
+        / "manifest.csv"
     )
     filenames = {row["filename"] for row in manifest_rows}
-    superseded = next(row for row in plan_rows if row["relative_path"].endswith("202203291730-export/borrow.csv"))
+    superseded = next(
+        row
+        for row in plan_rows
+        if row["relative_path"].endswith("202203291730-export/borrow.csv")
+    )
 
     assert summary["merge_primary_packages"] == 1
     assert summary["merged_packages"] == 1
@@ -127,16 +151,14 @@ def test_source_intake_service_merges_same_cycle_near_duplicate_packages_on_appl
     assert superseded["package_row_status"] == "package_merge_into_primary"
 
 
-def test_source_intake_service_marks_mixed_cycle_bundle_for_review_but_places_files(tmp_path: Path) -> None:
+def test_source_intake_service_marks_mixed_cycle_bundle_for_review_but_places_files(
+    tmp_path: Path,
+) -> None:
     incoming_dir = tmp_path / "incoming"
     bundle_dir = incoming_dir / "2021" / "Binance" / "MixedCycle"
     bundle_dir.mkdir(parents=True)
-    first_payload = (
-        "Pair,Coin,Date,Amount,Type,Status\nADA/USDT,USDT,2021-05-25 12:53:03,0.0345,Auto borrowing,CONFIRM\n"
-    )
-    second_payload = (
-        "Pair,Coin,Date,Amount,Type,Status\nADA/USDT,USDT,2021-05-26 12:53:03,0.0345,Auto borrowing,CONFIRM\n"
-    )
+    first_payload = "Pair,Coin,Date,Amount,Type,Status\nADA/USDT,USDT,2021-05-25 12:53:03,0.0345,Auto borrowing,CONFIRM\n"
+    second_payload = "Pair,Coin,Date,Amount,Type,Status\nADA/USDT,USDT,2021-05-26 12:53:03,0.0345,Auto borrowing,CONFIRM\n"
     (bundle_dir / "202203291730-borrow.csv").write_text(first_payload, encoding="utf-8")
     (bundle_dir / "202203301730-repay.csv").write_text(second_payload, encoding="utf-8")
 
@@ -151,11 +173,19 @@ def test_source_intake_service_marks_mixed_cycle_bundle_for_review_but_places_fi
         )
     )
 
-    summary = json.loads((report_dir / "intake_summary.json").read_text(encoding="utf-8"))
+    summary = json.loads(
+        (report_dir / "intake_summary.json").read_text(encoding="utf-8")
+    )
     plan_rows = FilesystemArtifactStore().read_rows(report_dir / "intake_plan.csv")
     mixed_rows = [row for row in plan_rows if row["bundle_id"] == "mixedcycle"]
     manifest_rows = FilesystemArtifactStore().read_rows(
-        workspace_root / "evidence" / "raw" / "source" / "binance" / "2021-05" / "manifest.csv"
+        workspace_root
+        / "evidence"
+        / "raw"
+        / "source"
+        / "binance"
+        / "2021-05"
+        / "manifest.csv"
     )
 
     assert summary["mixed_cycle_packages"] == 1
@@ -163,3 +193,103 @@ def test_source_intake_service_marks_mixed_cycle_bundle_for_review_but_places_fi
     assert all(row["review_required"] == "yes" for row in mixed_rows)
     assert all("package_cycle_mixed" in row["review_codes"] for row in mixed_rows)
     assert len(manifest_rows) == 2
+
+
+def test_source_intake_service_applies_explicit_source_label_map(
+    tmp_path: Path,
+) -> None:
+    incoming_dir = tmp_path / "incoming"
+    incoming_dir.mkdir()
+    source_file = incoming_dir / "transactions.csv"
+    source_file.write_text("a,b\n1,2\n", encoding="utf-8")
+
+    workspace_root = tmp_path / "workspace"
+    issues_dir = workspace_root / "analysis" / "issues"
+    issues_dir.mkdir(parents=True, exist_ok=True)
+    artifacts = FilesystemArtifactStore()
+    artifacts.write_rows(
+        issues_dir / "source_inventory.csv",
+        ("source",),
+        ({"source": "manual-main"},),
+    )
+    artifacts.write_rows(
+        issues_dir / "source_label_map.csv",
+        ("incoming_path_prefix", "source", "notes"),
+        ({"incoming_path_prefix": ".", "source": "manual-main", "notes": ""},),
+    )
+    report_dir = tmp_path / "reports"
+
+    response = ApplyIntakeUseCase(build_registry(), artifacts).execute(
+        IntakeApplyRequest(
+            incoming_capture_ref=to_resource_ref(incoming_dir),
+            workspace_root_ref=to_workspace_path(workspace_root),
+            report_output_ref=to_resource_ref(report_dir),
+        )
+    )
+
+    plan_rows = artifacts.read_rows(report_dir / "intake_plan.csv")
+    summary = json.loads(
+        (report_dir / "intake_summary.json").read_text(encoding="utf-8")
+    )
+    target = (
+        workspace_root
+        / "evidence"
+        / "raw"
+        / "source"
+        / "manual-main"
+        / "incoming"
+        / "transactions.csv"
+    )
+
+    assert response.copied_count == 1
+    assert target.exists()
+    assert plan_rows[0]["source_resolution_status"] == "explicit_map"
+    assert summary["explicit_map_count"] == 1
+
+
+def test_source_intake_service_skips_rows_blocked_by_invalid_source_label_map(
+    tmp_path: Path,
+) -> None:
+    incoming_dir = tmp_path / "incoming"
+    incoming_dir.mkdir()
+    source_file = incoming_dir / "transactions.csv"
+    source_file.write_text("a,b\n1,2\n", encoding="utf-8")
+
+    workspace_root = tmp_path / "workspace"
+    issues_dir = workspace_root / "analysis" / "issues"
+    issues_dir.mkdir(parents=True, exist_ok=True)
+    artifacts = FilesystemArtifactStore()
+    artifacts.write_rows(
+        issues_dir / "source_inventory.csv",
+        ("source",),
+        ({"source": "manual-main"},),
+    )
+    artifacts.write_rows(
+        issues_dir / "source_label_map.csv",
+        ("incoming_path_prefix", "source", "notes"),
+        ({"incoming_path_prefix": ".", "source": "missing-source", "notes": ""},),
+    )
+    report_dir = tmp_path / "reports"
+
+    response = ApplyIntakeUseCase(build_registry(), artifacts).execute(
+        IntakeApplyRequest(
+            incoming_capture_ref=to_resource_ref(incoming_dir),
+            workspace_root_ref=to_workspace_path(workspace_root),
+            report_output_ref=to_resource_ref(report_dir),
+        )
+    )
+
+    plan_rows = artifacts.read_rows(report_dir / "intake_plan.csv")
+    issue_rows = artifacts.read_rows(report_dir / "intake_issues.csv")
+    summary = json.loads(
+        (report_dir / "intake_summary.json").read_text(encoding="utf-8")
+    )
+
+    assert response.copied_count == 0
+    assert plan_rows[0]["action"] == "skip"
+    assert plan_rows[0]["placement_status"] == "mapping_blocked_skip"
+    assert plan_rows[0]["source_resolution_status"] == "explicit_map_blocked"
+    assert plan_rows[0]["review_codes"] == "source_map_unknown_source"
+    assert summary["explicit_map_blocked_count"] == 1
+    assert summary["source_label_map_issue_count"] == 1
+    assert issue_rows[0]["kind"] == "source_label_map_unknown_source"

--- a/tests/unit/test_docs_runtime_parity.py
+++ b/tests/unit/test_docs_runtime_parity.py
@@ -221,6 +221,7 @@ def test_source_intake_route_mentions_current_typed_commands() -> None:
         "output render file",
     ):
         assert command in text
+    assert "source_label_map.csv" in text
 
 
 def test_round_verification_route_mentions_oracle_cli_commands() -> None:
@@ -419,6 +420,27 @@ def test_workspace_source_inventory_seed_header_matches_template() -> None:
         seed.content.strip()
         for seed in SEED_FILES
         if seed.relative_path == "analysis/issues/source_inventory.csv"
+    )
+
+    assert seeded_header == template_header
+
+
+def test_workspace_source_label_map_seed_header_matches_template() -> None:
+    template_header = (
+        (
+            docs_root()
+            / "workspace"
+            / "analysis"
+            / "issues"
+            / "source-label-map-template.csv"
+        )
+        .read_text(encoding="utf-8")
+        .splitlines()[0]
+    )
+    seeded_header = next(
+        seed.content.strip()
+        for seed in SEED_FILES
+        if seed.relative_path == "analysis/issues/source_label_map.csv"
     )
 
     assert seeded_header == template_header

--- a/tests/unit/test_workspace_repository.py
+++ b/tests/unit/test_workspace_repository.py
@@ -12,10 +12,12 @@ def test_workspace_repository_initializes_seed_files(tmp_path: Path) -> None:
 
     issue_log = tmp_path / "analysis/issues/issue_log.csv"
     source_inventory = tmp_path / "analysis/issues/source_inventory.csv"
+    source_label_map = tmp_path / "analysis/issues/source_label_map.csv"
 
     assert created_paths
     assert issue_log.exists()
     assert source_inventory.exists()
+    assert source_label_map.exists()
     assert (tmp_path / "outputs/logs/round_log.csv").exists()
     assert (tmp_path / "config/workspace.json").exists()
     assert issue_log.read_text(encoding="utf-8").splitlines()[0] == (
@@ -28,4 +30,7 @@ def test_workspace_repository_initializes_seed_files(tmp_path: Path) -> None:
         "source,activity_after_cutoff,first_post_cutoff_tx,export_window_start,"
         "export_window_end,import_order,status,capture_path,profile_status,adapter,"
         "normalization_status,exception_count,candidate_path,notes"
+    )
+    assert source_label_map.read_text(encoding="utf-8").splitlines()[0] == (
+        "incoming_path_prefix,source,notes"
     )


### PR DESCRIPTION
Why:
- Closes #50: legacy intake needs a durable operator-managed source label override instead of relying only on inferred source labels
- source-scoped working destinations need the same manual association control as raw source intake paths
- the resolver needed one more hardening pass so only structurally source-scoped working paths participate in source remapping

What:
- seed `analysis/issues/source_label_map.csv` and load explicit source label mappings during intake plan and apply
- retarget source-scoped raw and working destinations through the resolved stable source label and report blocked mapping issues explicitly in intake artifacts
- harden source-scoped working path detection and working-path source rewrites so non-source working paths and ancestor path names do not interfere
- document the workspace mapping workflow and keep the resolver internals green under the full lint and type gates

Checks:
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pytest -q --no-cov tests/unit/application/intake tests/unit/test_workspace_repository.py tests/e2e/test_cli.py`
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pytest -q --no-cov tests/unit/test_workspace_repository.py tests/unit/test_docs_runtime_parity.py tests/e2e/test_cli.py`
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests`

Included checkpoints:
- `feat(intake): resolve explicit source label mappings`
- `docs(intake): document stable source label mapping`
- `fix(intake): satisfy source label quality gates`
- `fix(intake): harden source-scoped working path detection`
