### PR TITLE
refactor(quality): widen module limits and scan repo_support

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -15,4 +15,4 @@ disable =
 
 [FORMAT]
 max-line-length = 120
-max-module-lines = 450
+max-module-lines = 500

--- a/.pylintrc-tests
+++ b/.pylintrc-tests
@@ -16,4 +16,4 @@ disable =
 
 [FORMAT]
 max-line-length = 120
-max-module-lines = 450
+max-module-lines = 500

--- a/docs/standards/engineering.md
+++ b/docs/standards/engineering.md
@@ -72,12 +72,14 @@ Repo-native support boundaries:
 
 Default to one responsibility per module.
 
-- Keep most modules under roughly 150 lines.
-- Start a split review once a module approaches 200 lines.
-- Refactor before extending beyond 300 lines unless the file is mostly
+- Keep most modules under roughly 200 lines.
+- Start a split review once a module approaches 300 lines.
+- Refactor before extending beyond 400 lines unless the file is mostly
   declarative models, typed schemas, or protocol definitions.
-- Treat `300` lines as the official repo refactor limit.
-- Treat `450` lines as the hard-stop lint ceiling (`150%` of the repo limit).
+- Treat `400` lines as the official repo refactor limit.
+- Enforced limit is `500` lines as the hard-stop lint ceiling.
+- Keep the repo standard tighter than the enforcement ceiling so refactor
+  expectations stay ahead of the hard-stop lint cap.
 - Refactor by bounded concept, not by arbitrary suffixes.
 - Do not add new dumping-ground modules such as `helpers.py`, `utils.py`,
   `misc.py`, or another catch-all `common.py`.

--- a/mypy.ini
+++ b/mypy.ini
@@ -11,7 +11,7 @@ no_implicit_optional = true
 extra_checks = true
 show_error_codes = true
 pretty = true
-files = src, tests, tools
+files = src, tests, tools, repo_support
 mypy_path = src, .
 
 [mypy-tests.*]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -4,6 +4,7 @@
     "src",
     "tests",
     "tools",
+    "repo_support",
     "conftest.py"
   ],
   "exclude": [

--- a/repo_support/paths.py
+++ b/repo_support/paths.py
@@ -30,6 +30,10 @@ def _reset_repo_root() -> None:
     _STATE["repo_root"] = _DEFAULT_REPO_ROOT
 
 
+def reset_repo_root() -> None:
+    _reset_repo_root()
+
+
 @contextmanager
 def override_repo_root(path: Path) -> Iterator[Path]:
     previous_root = repo_root()

--- a/tests/contract/test_standards_guards.py
+++ b/tests/contract/test_standards_guards.py
@@ -271,23 +271,35 @@ def test_markdownlint_only_disables_md013() -> None:
 
 def test_module_size_policy_remains_aligned() -> None:
     pylint_text = (repo_root() / ".pylintrc").read_text(encoding="utf-8")
+    test_pylint_text = (repo_root() / ".pylintrc-tests").read_text(encoding="utf-8")
     standards_text = (repo_root() / "docs/standards/engineering.md").read_text(
         encoding="utf-8"
     )
 
-    assert "max-module-lines = 450" in pylint_text
+    assert "max-module-lines = 500" in pylint_text
+    assert "max-module-lines = 500" in test_pylint_text
     assert (
-        re.search(r"Refactor before extending beyond 300 lines", standards_text)
+        re.search(r"Refactor before extending beyond 400 lines", standards_text)
         is not None
     )
     assert (
         re.search(
-            r"Treat `300` lines as the official repo refactor limit", standards_text
+            r"Treat `400` lines as the official repo refactor limit", standards_text
         )
         is not None
     )
     assert (
-        re.search(r"Treat `450` lines as the hard-stop lint ceiling", standards_text)
+        re.search(
+            r"Enforced limit is `500` lines as the hard-stop lint ceiling",
+            standards_text,
+        )
+        is not None
+    )
+    assert (
+        re.search(
+            r"Keep the repo standard tighter than the enforcement ceiling",
+            standards_text,
+        )
         is not None
     )
 
@@ -555,8 +567,10 @@ def test_typecheck_configs_remain_strict() -> None:
 
     assert "strict = true" in mypy_text
     assert "warn_unused_ignores = true" in mypy_text
+    assert "files = src, tests, tools, repo_support" in mypy_text
     assert pyright_config["typeCheckingMode"] == "strict"
     assert pyright_config["reportUnnecessaryTypeIgnoreComment"] is True
+    assert "repo_support" in pyright_config["include"]
 
 
 def test_pyright_private_usage_config_matches_repo_test_trees() -> None:

--- a/tests/unit/test_docs_maintenance.py
+++ b/tests/unit/test_docs_maintenance.py
@@ -27,11 +27,11 @@ def entrypoint_paths() -> tuple[Path, ...]:
 
 @pytest.fixture(autouse=True)
 def reset_repo_root_state() -> Iterator[None]:
-    repo_paths._reset_repo_root()
+    repo_paths.reset_repo_root()
     try:
         yield
     finally:
-        repo_paths._reset_repo_root()
+        repo_paths.reset_repo_root()
 
 
 def override_active_roots(
@@ -44,7 +44,9 @@ def override_active_roots(
     resolved_docs_root = docs_root or root / "docs"
     expected_docs_root = root.resolve() / "docs"
     if resolved_docs_root.resolve() != expected_docs_root:
-        raise AssertionError(f"docs root must resolve under the repo root: {resolved_docs_root}")
+        raise AssertionError(
+            f"docs root must resolve under the repo root: {resolved_docs_root}"
+        )
     repo_paths._set_repo_root(root)
 
 
@@ -104,7 +106,9 @@ def test_parse_frontmatter_rejects_missing_related_target() -> None:
 
     frontmatter = docs_maintenance.parse_frontmatter(text, path)
 
-    with pytest.raises(ValueError, match="uses missing related target docs/does-not-exist.md"):
+    with pytest.raises(
+        ValueError, match="uses missing related target docs/does-not-exist.md"
+    ):
         docs_maintenance.validate_frontmatter(path, frontmatter)
 
 
@@ -225,11 +229,15 @@ def test_root_consumers_use_state_getters_instead_of_root_constants() -> None:
         "tools/docs_maintenance/metadata.py",
     ):
         module_path = repo_root() / relative
-        tree = ast.parse(module_path.read_text(encoding="utf-8"), filename=str(module_path))
+        tree = ast.parse(
+            module_path.read_text(encoding="utf-8"), filename=str(module_path)
+        )
         imported_names = {
             alias.name
             for node in ast.walk(tree)
-            if isinstance(node, ast.ImportFrom) and node.level == 1 and node.module == "state"
+            if isinstance(node, ast.ImportFrom)
+            and node.level == 1
+            and node.module == "state"
             for alias in node.names
         }
         assert imported_names.isdisjoint(root_constant_names), relative
@@ -502,7 +510,9 @@ def test_sync_check_rejects_retired_markdown_link_targets(
 
     override_active_roots(monkeypatch, tmp_path, docs_root=docs_root)
 
-    with pytest.raises(ValueError, match="still references retired path docs/file-map.md"):
+    with pytest.raises(
+        ValueError, match="still references retired path docs/file-map.md"
+    ):
         docs_maintenance.cli._check_retired_references()
 
 
@@ -581,7 +591,9 @@ def test_sync_check_rejects_retired_related_targets(
 
     override_active_roots(monkeypatch, tmp_path, docs_root=docs_root)
 
-    with pytest.raises(ValueError, match="still references retired path docs/file-map.md"):
+    with pytest.raises(
+        ValueError, match="still references retired path docs/file-map.md"
+    ):
         docs_maintenance.cli._check_retired_references()
 
 
@@ -608,11 +620,15 @@ def test_validate_markdown_links_accepts_reference_style_links(tmp_path: Path) -
     docs_maintenance.validate_markdown_links([readme, guide])
 
 
-def test_validate_markdown_links_rejects_missing_relative_target(tmp_path: Path) -> None:
+def test_validate_markdown_links_rejects_missing_relative_target(
+    tmp_path: Path,
+) -> None:
     path = tmp_path / "README.md"
     path.write_text("# Repo\n\n[Missing](docs/does-not-exist.md)\n", encoding="utf-8")
 
-    with pytest.raises(ValueError, match="links to missing path docs/does-not-exist.md"):
+    with pytest.raises(
+        ValueError, match="links to missing path docs/does-not-exist.md"
+    ):
         docs_maintenance.validate_markdown_links([path])
 
 
@@ -621,13 +637,17 @@ def test_validate_markdown_links_rejects_missing_anchor(tmp_path: Path) -> None:
     guide.parent.mkdir(parents=True)
     guide.write_text("## Step One\n", encoding="utf-8")
     readme = tmp_path / "README.md"
-    readme.write_text("[Guide](docs/guides/sample.md#missing-anchor)\n", encoding="utf-8")
+    readme.write_text(
+        "[Guide](docs/guides/sample.md#missing-anchor)\n", encoding="utf-8"
+    )
 
     with pytest.raises(ValueError, match="links to missing anchor #missing-anchor"):
         docs_maintenance.validate_markdown_links([readme, guide])
 
 
-def test_validate_markdown_links_rejects_broken_reference_style_link(tmp_path: Path) -> None:
+def test_validate_markdown_links_rejects_broken_reference_style_link(
+    tmp_path: Path,
+) -> None:
     readme = tmp_path / "README.md"
     readme.write_text(
         dedent(
@@ -640,11 +660,15 @@ def test_validate_markdown_links_rejects_broken_reference_style_link(tmp_path: P
         encoding="utf-8",
     )
 
-    with pytest.raises(ValueError, match="links to missing path docs/guides/missing.md"):
+    with pytest.raises(
+        ValueError, match="links to missing path docs/guides/missing.md"
+    ):
         docs_maintenance.validate_markdown_links([readme])
 
 
-def test_validate_markdown_links_accepts_duplicate_github_style_heading_anchor(tmp_path: Path) -> None:
+def test_validate_markdown_links_accepts_duplicate_github_style_heading_anchor(
+    tmp_path: Path,
+) -> None:
     page = tmp_path / "README.md"
     page.write_text(
         dedent(
@@ -685,7 +709,9 @@ def test_scaffold_workspace_doc_infers_reference_and_both(
     assert exit_code == 0
 
     created = tmp_path / "docs" / "workspace" / "working" / "example.md"
-    frontmatter = docs_maintenance.parse_frontmatter(created.read_text(encoding="utf-8"), created)
+    frontmatter = docs_maintenance.parse_frontmatter(
+        created.read_text(encoding="utf-8"), created
+    )
 
     assert frontmatter["doc_type"] == "reference"
     assert frontmatter["audience"] == "both"
@@ -845,7 +871,9 @@ def test_scaffold_agents_doc_accepts_explicit_doc_type(
     assert exit_code == 0
 
     created = tmp_path / "agents" / "example-agent.md"
-    frontmatter = docs_maintenance.parse_frontmatter(created.read_text(encoding="utf-8"), created)
+    frontmatter = docs_maintenance.parse_frontmatter(
+        created.read_text(encoding="utf-8"), created
+    )
 
     assert frontmatter["doc_type"] == "standard"
     assert frontmatter["audience"] == "agent"
@@ -924,7 +952,9 @@ def test_scaffold_sync_managed_doc_accepts_nav_order(
     assert exit_code == 0
 
     created = tmp_path / "docs" / "guides" / "example-guide.md"
-    frontmatter = docs_maintenance.parse_frontmatter(created.read_text(encoding="utf-8"), created)
+    frontmatter = docs_maintenance.parse_frontmatter(
+        created.read_text(encoding="utf-8"), created
+    )
 
     assert frontmatter["nav_order"] == 70
 
@@ -1036,7 +1066,9 @@ def test_scaffold_sync_managed_doc_escapes_yaml_sensitive_fields(
     assert exit_code == 0
 
     created = tmp_path / "docs" / "guides" / "quoted-guide.md"
-    frontmatter = docs_maintenance.parse_frontmatter(created.read_text(encoding="utf-8"), created)
+    frontmatter = docs_maintenance.parse_frontmatter(
+        created.read_text(encoding="utf-8"), created
+    )
 
     assert frontmatter["title"] == 'Guide "Quoted"'
     assert frontmatter["summary"] == 'Summary with "quotes".'
@@ -1252,13 +1284,18 @@ def test_scaffold_rejects_duplicate_nav_order_and_rolls_back(
 
 def test_validate_uv_examples_rejects_bare_uv_examples(tmp_path: Path) -> None:
     page = tmp_path / "README.md"
-    page.write_text("Run `uv run python -m tools.docs_maintenance sync --check`.\n", encoding="utf-8")
+    page.write_text(
+        "Run `uv run python -m tools.docs_maintenance sync --check`.\n",
+        encoding="utf-8",
+    )
 
     with pytest.raises(ValueError, match="markdown surfaces contain bare uv examples"):
         docs_maintenance.validate_uv_examples([page])
 
 
-def test_fenced_tilde_code_blocks_are_ignored_for_uv_and_link_validation(tmp_path: Path) -> None:
+def test_fenced_tilde_code_blocks_are_ignored_for_uv_and_link_validation(
+    tmp_path: Path,
+) -> None:
     guide = tmp_path / "docs" / "guides" / "sample.md"
     guide.parent.mkdir(parents=True)
     guide.write_text("# Sample\n", encoding="utf-8")
@@ -1279,7 +1316,9 @@ def test_fenced_tilde_code_blocks_are_ignored_for_uv_and_link_validation(tmp_pat
     docs_maintenance.validate_markdown_links([page, guide])
 
 
-def test_blockquoted_fenced_code_blocks_are_ignored_for_uv_and_link_validation(tmp_path: Path) -> None:
+def test_blockquoted_fenced_code_blocks_are_ignored_for_uv_and_link_validation(
+    tmp_path: Path,
+) -> None:
     guide = tmp_path / "docs" / "guides" / "sample.md"
     guide.parent.mkdir(parents=True)
     guide.write_text("# Sample\n", encoding="utf-8")
@@ -1321,7 +1360,9 @@ def test_html_comments_are_ignored_for_uv_and_link_validation(tmp_path: Path) ->
     docs_maintenance.validate_markdown_links([page, guide])
 
 
-def test_indented_code_blocks_are_ignored_for_uv_and_link_validation(tmp_path: Path) -> None:
+def test_indented_code_blocks_are_ignored_for_uv_and_link_validation(
+    tmp_path: Path,
+) -> None:
     guide = tmp_path / "docs" / "guides" / "sample.md"
     guide.parent.mkdir(parents=True)
     guide.write_text("# Sample\n", encoding="utf-8")

--- a/tests/unit/test_run_pylint.py
+++ b/tests/unit/test_run_pylint.py
@@ -12,16 +12,17 @@ def test_pylint_targets_split_repo_code_from_tests() -> None:
     targets = _pylint_targets()
 
     assert targets[0] == _PylintTarget(
-            name="src-tools",
-            command=(
-                sys.executable,
-                "-m",
-                "pylint",
-                f"--ignore-paths={_ADAPTER_TEST_IGNORE_PATHS}",
-                "src",
-                "tools",
-                "conftest.py",
-            ),
+        name="repo-code",
+        command=(
+            sys.executable,
+            "-m",
+            "pylint",
+            f"--ignore-paths={_ADAPTER_TEST_IGNORE_PATHS}",
+            "src",
+            "tools",
+            "repo_support",
+            "conftest.py",
+        ),
     )
     assert targets[1].name == "tests"
     assert targets[1].command[:5] == (
@@ -34,7 +35,16 @@ def test_pylint_targets_split_repo_code_from_tests() -> None:
 
 
 def test_pylint_targets_include_colocated_adapter_tests(tmp_path: Path) -> None:
-    (tmp_path / "src" / "tallylot" / "adapters" / "sources" / "wallets" / "demo" / "tests").mkdir(
+    (
+        tmp_path
+        / "src"
+        / "tallylot"
+        / "adapters"
+        / "sources"
+        / "wallets"
+        / "demo"
+        / "tests"
+    ).mkdir(
         parents=True,
     )
 

--- a/tools/run_pylint.py
+++ b/tools/run_pylint.py
@@ -23,7 +23,7 @@ def _pylint_targets(*, root: Path | None = None) -> tuple[_PylintTarget, ...]:
     active_root = repo_root() if root is None else root.expanduser().resolve()
     return (
         _PylintTarget(
-            name="src-tools",
+            name="repo-code",
             command=(
                 sys.executable,
                 "-m",
@@ -31,6 +31,7 @@ def _pylint_targets(*, root: Path | None = None) -> tuple[_PylintTarget, ...]:
                 f"--ignore-paths={_ADAPTER_TEST_IGNORE_PATHS}",
                 "src",
                 "tools",
+                "repo_support",
                 "conftest.py",
             ),
         ),


### PR DESCRIPTION
Why:
- expand the module line thresholds now that the main architecture is in place
- bring repo_support under the repo's normal lint and type enforcement so hidden issues are caught
- keep the repo refactor standard tighter than the hard-stop lint ceiling

What:
- raise the pylint module line ceiling to 500 for repo code and tests
- update the engineering standard to use 200/300/400 guidance with a 500-line lint cap
- include repo_support in mypy, pyright, and repo-side pylint targets
- add a public repo_support reset helper and route tests through that public access point
- extend standards and tooling tests to guard the wider scan surface

Checks:
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run mypy repo_support
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pyright repo_support
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pylint repo_support
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests

Included checkpoints:
- `refactor(quality): widen module limits and scan repo_support`
