### PR TITLE
feat(pr-review): harden repo-native review lanes

### DIFF
--- a/.agents/skills/docs-authoring/SKILL.md
+++ b/.agents/skills/docs-authoring/SKILL.md
@@ -10,16 +10,19 @@ description: >-
 
 Use this skill for repo documentation and standards work.
 
-Pair it with global `markdown` for syntax and low-churn Markdown editing and
-with `code-change-safety` when the change also touches automation or checkpoint
-commits. Invoke `issue-workflow` when the task adds issue templates, issue
-policy, or proactive follow-up issue handling.
+Pair it with `markdown` for syntax and low-churn Markdown editing. Invoke
+`issue-workflow` when the task adds issue templates, issue policy, or
+proactive follow-up issue handling.
 
 ## Workflow
 
 1. Read the narrow authoring surface first:
    - `AGENTS.md`
    - `docs/README.md`
+   - `docs/status/current-state.md`
+   - `docs/reference/repository-history.md`
+   - `docs/standards/implementation.md`
+   - `docs/standards/commits.md`
    - `tools/docs_maintenance/cli.py`
    - `tools/docs_maintenance/metadata.py`
 2. Keep human docs under `docs/` and agent-only routing under `AGENTS.md` or

--- a/.agents/skills/implementation-workflow/SKILL.md
+++ b/.agents/skills/implementation-workflow/SKILL.md
@@ -10,10 +10,9 @@ description: >-
 
 Use this skill for the normal repo implementation path.
 
-Pair it with global `code-change-safety` for cross-repo posture and with
-`markdown` only when the task edits Markdown files. Invoke `issue-workflow`
-when implementation uncovers meaningful out-of-scope repo work that should be
-captured as a follow-up issue.
+Pair it with `markdown` only when the task edits Markdown files. Invoke
+`issue-workflow` when implementation uncovers meaningful out-of-scope repo
+work that should be captured as a follow-up issue.
 
 ## Workflow
 
@@ -35,6 +34,9 @@ captured as a follow-up issue.
 7. After compaction or context loss, reload the same narrow standards before
    more edits or commits.
 8. Create the verified checkpoint commit before considering the task done.
+   Use the shell-safe commit/PR authoring path from
+   `docs/standards/commits.md` whenever the structured metadata includes
+   backticks, quotes, or other shell-sensitive text.
 
 ## Focus
 

--- a/.agents/skills/issue-workflow/SKILL.md
+++ b/.agents/skills/issue-workflow/SKILL.md
@@ -10,9 +10,8 @@ description: >-
 Use this skill for GitHub issue forms, issue-writing policy, and proactive
 follow-up issue creation.
 
-Pair it with global `markdown` for Markdown edits and with
-`code-change-safety` when the task also changes repo standards, templates, or
-automation.
+Pair it with `markdown` for Markdown edits and reload `docs-authoring` when
+the same task also changes repo standards, templates, or automation.
 
 ## Workflow
 
@@ -37,7 +36,10 @@ automation.
    - `Acceptance Criteria`
 6. When meaningful out-of-scope repo work appears, create the issue
    immediately instead of leaving it in scratch notes.
-7. If a PR is active, link non-closing follow-up issues from `Follow-ups:`.
+7. If a PR is active, link non-closing follow-up issues from `Follow-ups:` and
+   use the shell-safe PR-body guidance in `docs/standards/commits.md` when the
+   structured metadata contains backticks, quotes, or other shell-sensitive
+   text.
 
 ## Focus
 

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: pr-review
+description: >-
+  Start tallylot's repo-native PR review loop with the local standards, route,
+  and change-sensitive review checks. Use when the task is PR review,
+  hardening, or review-loop recovery on an active branch or draft PR.
+---
+
+# PR Review
+
+Use this skill for repeatable review passes on an active branch or draft PR.
+
+## Workflow
+
+1. Read the narrow PR review surface first:
+   - `docs/standards/delivery-guardrails.md`
+   - `docs/standards/implementation.md`
+   - `docs/standards/commits.md`
+   - `.claude/commands/pr-review.md`
+2. Start from deterministic branch and PR facts rather than scratch notes.
+3. Use
+   `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.audit_pr_review`
+   to identify the applicable surface groups, review domains, and required
+   verification before calling a pass clean.
+4. Repair findings in bounded slices, rerun the required checks for the
+   repaired slice, and keep the PR draft until a full applicable-surface pass
+   yields no new meaningful findings.
+5. Use `issue-workflow`, `docs-authoring`, or `implementation-workflow` when
+   the repair surface moves into those repo-local workflows.
+
+## Focus
+
+- cover every applicable changed surface group
+- keep findings evidence-backed
+- use the strongest broad verification family without skipping declared
+  surface-specific checks

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -21,12 +21,15 @@ Use this skill for repeatable review passes on an active branch or draft PR.
 3. Use
    `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.audit_pr_review`
    to identify the applicable surface groups, review domains, and required
-   verification before calling a pass clean.
+   verification before choosing the next issue-finding pass.
 4. Repair findings in bounded slices, rerun the required checks for the
    repaired slice, and keep the PR draft until a full applicable-surface pass
    yields no new meaningful findings.
-   Do not treat green `tools.run_pr_review_checks` output as a clean pass by
-   itself; it is only verification evidence for the current red-team pass.
+   Do not describe an upcoming pass as clean, final, or publish-ready; every
+   pass is issue-finding with open outcome.
+   Do not treat green `tools.run_pr_review_checks` output as a no-findings
+   decision by itself; it is only verification evidence for the current
+   red-team pass.
 5. Use `issue-workflow`, `docs-authoring`, or `implementation-workflow` when
    the repair surface moves into those repo-local workflows.
 

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -25,6 +25,8 @@ Use this skill for repeatable review passes on an active branch or draft PR.
 4. Repair findings in bounded slices, rerun the required checks for the
    repaired slice, and keep the PR draft until a full applicable-surface pass
    yields no new meaningful findings.
+   Do not treat green `tools.run_pr_review_checks` output as a clean pass by
+   itself; it is only verification evidence for the current red-team pass.
 5. Use `issue-workflow`, `docs-authoring`, or `implementation-workflow` when
    the repair surface moves into those repo-local workflows.
 

--- a/.agents/skills/pr-review/agents/openai.yaml
+++ b/.agents/skills/pr-review/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "PR Review"
+  short_description: "Start tallylot's repo-native PR review loop before hardening an active branch or draft PR."
+  default_prompt: "Use $pr-review to load tallylot's repo-native PR review route before reviewing or hardening an active PR."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/pr-review/agents/openai.yaml
+++ b/.agents/skills/pr-review/agents/openai.yaml
@@ -1,7 +1,7 @@
 interface:
   display_name: "PR Review"
-  short_description: "Start tallylot's repo-native PR review loop before hardening an active branch or draft PR."
-  default_prompt: "Use $pr-review to load tallylot's repo-native PR review route before reviewing or hardening an active PR."
+  short_description: "Start tallylot's repo-native issue-finding PR review loop before hardening an active branch or draft PR."
+  default_prompt: "Use $pr-review to load tallylot's repo-native issue-finding PR review route before reviewing or hardening an active PR."
 
 policy:
   allow_implicit_invocation: true

--- a/.claude/commands/implementation-checkpoint.md
+++ b/.claude/commands/implementation-checkpoint.md
@@ -5,8 +5,9 @@ Use this route before closing any non-trivial coding task.
 1. Read:
    - `docs/standards/implementation.md`
    - `docs/standards/commits.md`
-   - use `code-change-safety` for repo changes and `markdown` for Markdown/docs
-     work when those skills are available
+   - use `markdown` for Markdown/docs work when that skill is available
+   - use the shell-safe commit and PR authoring rules in
+     `docs/standards/commits.md` when structured metadata is involved
 2. Confirm the change still respects:
    - layer ownership
    - provider-neutral core design

--- a/.claude/commands/implementation-checkpoint.md
+++ b/.claude/commands/implementation-checkpoint.md
@@ -58,7 +58,9 @@ Use this route before closing any non-trivial coding task.
    - `docs/standards/delivery-guardrails.md` when delivery work is active
 
 10. Create the stable checkpoint commit when the slice is coherent and verified.
-   Do not close the task first and plan to commit afterward.
+   If the task contains more than one separable reviewable slice, split it into
+   multiple bounded checkpoint commits before closeout. Do not close the task
+   first and plan to commit afterward.
 
 11. Confirm branch handling stayed PR-only for protected branches: do not push
     directly to `main`; do not use branch-protection bypass for ordinary

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -14,8 +14,8 @@ Use this route for repeatable review passes on an active branch or draft PR.
 2. Use
    `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.audit_pr_review`
    to identify the current diff's applicable surface groups, review domains,
-   required verification family, and any unmapped paths before claiming a
-   clean pass.
+   required verification family, any supplemental blocking lanes, and any
+   unmapped paths before claiming a clean pass.
 3. Re-check every prior fix surface first, then inspect the next applicable
    changed surface group that has not yet completed a clean pass.
 4. Repair every finding from that pass before starting the next pass.
@@ -28,7 +28,8 @@ Use this route for repeatable review passes on an active branch or draft PR.
      existing issue first and open or link the follow-up issue immediately
 5. Rerun the required review checks for the repaired slice with
    `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_pr_review_checks`
-   or the narrower required slice, then create a bounded checkpoint commit
+   or the narrower required slice, including any blocking stress or packaging
+   lane required for the current diff, then create a bounded checkpoint commit
    before starting the next pass. Do not start another red-team pass with
    uncommitted repaired findings unless the pass is still in a very small
    in-progress slice.

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -15,9 +15,11 @@ Use this route for repeatable review passes on an active branch or draft PR.
    `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.audit_pr_review`
    to identify the current diff's applicable surface groups, review domains,
    required verification family, any supplemental blocking lanes, and any
-   unmapped paths before claiming a clean pass.
+   unmapped paths before deciding the current pass found no new meaningful
+   findings.
 3. Re-check every prior fix surface first, then inspect the next applicable
-   changed surface group that has not yet completed a clean pass.
+   changed surface group that has not yet been re-checked in the current full
+   loop.
 4. Repair every finding from that pass before starting the next pass.
    - reload the narrow repo guidance for each repair surface using `AGENTS.md`,
      its task-routing table, and the owning roadmap, architecture, migration,
@@ -33,19 +35,22 @@ Use this route for repeatable review passes on an active branch or draft PR.
    before starting the next pass. Do not start another red-team pass with
    uncommitted repaired findings unless the pass is still in a very small
    in-progress slice.
-   Do not treat a green `tools.run_pr_review_checks` result as a clean pass by
-   itself; it is only the verification evidence for the current red-team pass.
+   Do not describe an upcoming pass as clean, final, or publish-ready; every
+   pass is issue-finding with open outcome.
+   Do not treat a green `tools.run_pr_review_checks` result as a no-findings
+   decision by itself; it is only the verification evidence for the current
+   red-team pass.
 6. Continue steps 1 through 5 until every applicable changed surface group has
-   completed a clean pass and a full applicable-surface loop yields no new
-   meaningful findings. When a pass finds fewer than 5 findings, report only
-   those findings. Do not invent findings to hit a quota.
+   been revisited and a full applicable-surface loop yields no new meaningful
+   findings. When a pass finds fewer than 5 findings, report only those
+   findings. Do not invent findings to hit a quota.
 7. If the only remaining item is a very minor finishing touch, repair it and
    finish once no other meaningful issues surface.
 8. Keep scratch notes untracked. Do not create tracked issue ledgers, review
    logs, or temporary bookkeeping files.
-9. Keep the PR draft until a full clean loop has completed with no new
-   meaningful findings. For a final PR review, finish with a clean working tree
-   and reload the relevant delivery guidance or skills before updating the PR
-   state or marking it ready for review. Ensure any remaining out-of-scope repo
+9. Keep the PR draft until the full applicable-surface issue-finding loop
+   yields no new meaningful findings. Before updating the PR state or marking
+   it ready for review, finish with a clean working tree and reload the
+   relevant delivery guidance or skills. Ensure any remaining out-of-scope repo
    findings are captured as linked follow-up issues rather than left in review
    prose alone.

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -1,4 +1,4 @@
-# PR Hardening Review
+# PR Review
 
 Use this route for repeatable review passes on an active branch or draft PR.
 
@@ -8,20 +8,16 @@ Use this route for repeatable review passes on an active branch or draft PR.
    - current PR title, body, and changed files when PR work is active
    - `AGENTS.md` so the repo's task-routing table is back in context
    - `docs/standards/delivery-guardrails.md`
+   - `docs/standards/implementation.md`
    - `docs/standards/commits.md`
    - latest targeted verification results
-2. Red-team this fixed matrix and find up to 5 new unique findings for the
-   current pass:
-   - design and ownership
-   - correctness and behavior
-   - complexity and over-engineering
-   - tests and regression value
-   - naming and public terminology
-   - documentation and control-plane alignment
-   - delivery controls, PR metadata, and issue handling
-   - compaction and context-loss recovery
-3. Re-check every prior fix surface first, then add one adjacent surface group
-   for the new pass.
+2. Use
+   `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.audit_pr_review`
+   to identify the current diff's applicable surface groups, review domains,
+   required verification family, and any unmapped paths before claiming a
+   clean pass.
+3. Re-check every prior fix surface first, then inspect the next applicable
+   changed surface group that has not yet completed a clean pass.
 4. Repair every finding from that pass before starting the next pass.
    - reload the narrow repo guidance for each repair surface using `AGENTS.md`,
      its task-routing table, and the owning roadmap, architecture, migration,
@@ -30,13 +26,16 @@ Use this route for repeatable review passes on an active branch or draft PR.
      belongs instead of leaving the repair in prose alone
    - when a meaningful finding should stay out of the active PR, search for an
      existing issue first and open or link the follow-up issue immediately
-5. Verify the repaired slice and create bounded checkpoint commits during the
-   loop, following the repo's normal commit and checkpoint rules. Do not start
-   another red-team pass with uncommitted repaired findings unless the pass is
-   still in a very small in-progress slice.
-6. Continue steps 1 through 5 until a full pass yields no new meaningful
-   findings. When a pass finds fewer than 5 findings, report only those
-   findings. Do not invent findings to hit a quota.
+5. Rerun the required review checks for the repaired slice with
+   `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_pr_review_checks`
+   or the narrower required slice, then create a bounded checkpoint commit
+   before starting the next pass. Do not start another red-team pass with
+   uncommitted repaired findings unless the pass is still in a very small
+   in-progress slice.
+6. Continue steps 1 through 5 until every applicable changed surface group has
+   completed a clean pass and a full applicable-surface loop yields no new
+   meaningful findings. When a pass finds fewer than 5 findings, report only
+   those findings. Do not invent findings to hit a quota.
 7. If the only remaining item is a very minor finishing touch, repair it and
    finish once no other meaningful issues surface.
 8. Keep scratch notes untracked. Do not create tracked issue ledgers, review

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -33,6 +33,8 @@ Use this route for repeatable review passes on an active branch or draft PR.
    before starting the next pass. Do not start another red-team pass with
    uncommitted repaired findings unless the pass is still in a very small
    in-progress slice.
+   Do not treat a green `tools.run_pr_review_checks` result as a clean pass by
+   itself; it is only the verification evidence for the current red-team pass.
 6. Continue steps 1 through 5 until every applicable changed surface group has
    completed a clean pass and a full applicable-surface loop yields no new
    meaningful findings. When a pass finds fewer than 5 findings, report only

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,7 +11,9 @@ docs/standards/** @CrownOpsEng
 tools/install_git_hooks.py @CrownOpsEng
 tools/pre_commit_hook.py @CrownOpsEng
 tools/audit_delivery_guardrails.py @CrownOpsEng
+tools/audit_pr_review.py @CrownOpsEng
 tools/message_standards.py @CrownOpsEng
+tools/run_pr_review_checks.py @CrownOpsEng
 tools/validate_commit_message.py @CrownOpsEng
 tools/validate_pr_metadata.py @CrownOpsEng
 tools/run_quality_gates.py @CrownOpsEng

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,7 @@
 # Control-plane ownership for delivery, standards, and agent-routing surfaces.
 
 .agents/skills/** @CrownOpsEng
+.github/actions/** @CrownOpsEng
 .github/ISSUE_TEMPLATE/** @CrownOpsEng
 .github/workflows/** @CrownOpsEng
 .github/pull_request_template.md @CrownOpsEng
@@ -12,6 +13,7 @@ tools/install_git_hooks.py @CrownOpsEng
 tools/pre_commit_hook.py @CrownOpsEng
 tools/audit_delivery_guardrails.py @CrownOpsEng
 tools/audit_pr_review.py @CrownOpsEng
+tools/benchmark_quality_gates.py @CrownOpsEng
 tools/message_standards.py @CrownOpsEng
 tools/run_pr_review_checks.py @CrownOpsEng
 tools/validate_commit_message.py @CrownOpsEng

--- a/.github/ISSUE_TEMPLATE/03-ops-follow-up.yml
+++ b/.github/ISSUE_TEMPLATE/03-ops-follow-up.yml
@@ -35,7 +35,7 @@ body:
     attributes:
       label: Relevant Paths
       description: Optional repo-relative paths only.
-      placeholder: .github/workflows/ci.yml, .claude/commands/pr-hardening-review.md
+      placeholder: .github/workflows/ci.yml, .claude/commands/pr-review.md
     validations:
       required: false
   - type: textarea

--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -1,0 +1,21 @@
+name: Setup Python and uv
+description: Setup Python 3.12, restore the uv cache, and sync repo dependencies.
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-python@v6
+      with:
+        python-version: "3.12"
+    - uses: actions/cache@v4
+      with:
+        path: ~/.cache/uv
+        key: uv-${{ runner.os }}-py312-${{ hashFiles('uv.lock') }}
+        restore-keys: |
+          uv-${{ runner.os }}-py312-
+    - name: Install uv
+      shell: bash
+      run: python -m pip install uv
+    - name: Sync dependencies
+      shell: bash
+      run: uv sync --python 3.12 --frozen

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,14 +3,18 @@
 <!-- Open PRs as draft first. Mark ready for review only after a clean hardening pass. -->
 
 Why:
-- Closes #123: describe one resolved problem when this PR closes an issue
 - explain the problem or constraint this PR resolves
+- add any review context that helps explain the change
 
 What:
 - summarize the engineering changes that matter for review
 
 Checks:
 - list the verification you actually ran
+
+<!-- Required: use `- Closes #123: ...`, `- Refs #123[: ...]`, or `- None: ...`. -->
+Issue linkage:
+- Closes #123: describe the resolved issue, reference the related issue, or explain why no existing issue applies
 
 Included checkpoints:
 - `list the branch commit subjects in chronological order`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,69 +4,16 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
-      - edited
-      - ready_for_review
 
 permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ci-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  commit-messages:
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-      - name: Install uv
-        run: python -m pip install uv
-      - name: Sync dependencies
-        run: uv sync --python 3.12 --frozen
-      - name: Validate commit messages
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          BEFORE_SHA: ${{ github.event.before }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          CURRENT_SHA: ${{ github.sha }}
-        run: |
-          set -eu
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            RANGE="$BASE_SHA..$HEAD_SHA"
-          elif [ "$BEFORE_SHA" = "0000000000000000000000000000000000000000" ]; then
-            RANGE="$CURRENT_SHA^!"
-          else
-            RANGE="$BEFORE_SHA..$CURRENT_SHA"
-          fi
-          uv run python -m tools.validate_commit_message --rev-range "$RANGE"
-      - name: Validate PR metadata
-        if: github.event_name == 'pull_request'
-        env:
-          PR_TITLE: ${{ github.event.pull_request.title }}
-          PR_BODY: ${{ github.event.pull_request.body }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          uv run python -m tools.validate_pr_metadata \
-            --title "$PR_TITLE" \
-            --body "$PR_BODY" \
-            --base-sha "$BASE_SHA" \
-            --head-sha "$HEAD_SHA"
-
   quality:
-    needs: commit-messages
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,17 +13,47 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  quality:
+  lint-format:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-python-uv
+      - name: Lint formatting and workflow surfaces
+        run: uv run python -m tools.run_ci_parity_checks --step lint-format
+
+  types:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-python-uv
+      - name: Run type checks
+        run: uv run python -m tools.run_ci_parity_checks --step types
+
+  pylint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-python-uv
+      - name: Run pylint
+        run: uv run python -m tools.run_ci_parity_checks --step pylint
+
+  tests:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-      - name: Install uv
-        run: python -m pip install uv
-      - name: Sync dependencies
-        run: uv sync --python 3.12 --frozen
-      - name: Run CI parity checks
-        run: uv run python -m tools.run_ci_parity_checks
+      - uses: ./.github/actions/setup-python-uv
+      - name: Run full tests
+        run: uv run python -m tools.run_ci_parity_checks --step tests
+
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-python-uv
+      - name: Build and verify wheel
+        run: uv run python -m tools.run_ci_parity_checks --step build --step verify-wheel

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -24,13 +24,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-      - name: Install uv
-        run: python -m pip install uv
-      - name: Sync dependencies
-        run: uv sync --python 3.12 --frozen
+      - uses: ./.github/actions/setup-python-uv
       - name: Validate commit messages
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
@@ -57,13 +51,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-      - name: Install uv
-        run: python -m pip install uv
-      - name: Sync dependencies
-        run: uv sync --python 3.12 --frozen
+      - uses: ./.github/actions/setup-python-uv
+      - name: Audit PR review plan
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: uv run python -m tools.audit_pr_review --base-sha "$BASE_SHA" --head-sha "$HEAD_SHA"
       - name: Run PR review checks
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,71 @@
+name: pr-review
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+      - ready_for_review
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-review-${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  commit-messages:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install uv
+        run: python -m pip install uv
+      - name: Sync dependencies
+        run: uv sync --python 3.12 --frozen
+      - name: Validate commit messages
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: uv run python -m tools.validate_commit_message --rev-range "$BASE_SHA..$HEAD_SHA"
+      - name: Validate PR metadata
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          uv run python -m tools.validate_pr_metadata \
+            --title "$PR_TITLE" \
+            --body "$PR_BODY" \
+            --base-sha "$BASE_SHA" \
+            --head-sha "$HEAD_SHA"
+
+  pr-review:
+    needs: commit-messages
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Install uv
+        run: python -m pip install uv
+      - name: Sync dependencies
+        run: uv sync --python 3.12 --frozen
+      - name: Run PR review checks
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: uv run python -m tools.run_pr_review_checks --base-sha "$BASE_SHA" --head-sha "$HEAD_SHA"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,6 @@ repos:
         pass_filenames: false
       - id: pytest
         name: pytest-fast
-        entry: uv run pytest -m "unit and not slow" --no-cov -q
+        entry: uv run python -m tools.run_fast_pytest
         language: system
         pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,10 @@ Do not pre-load every repo doc by default.
   - do not turn the hook path into a second full-suite verification pass
 - Treat commits as stable checkpoints by default:
   - prefer small cohesive commits
+  - keep every authored commit bounded to one reviewable slice
   - avoid micro-commits with no rollback or review value
+  - split large but separable work into multiple bounded checkpoint commits
+    instead of one umbrella commit
   - end the task on a clean, meaningful checkpoint commit
 - Keep commit, PR, and doc language neutral and direct:
   - `Why:` states the problem, constraint, or risk being addressed

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,7 +55,8 @@ Do not pre-load every repo doc by default.
   `.claude/commands/`.
 - When editing repo docs or Markdown, use the `markdown` skill if available.
 - When editing repo standards, automation, or other control-plane files, use
-  the `code-change-safety` skill as the starting workflow if available.
+  the repo-local workflow for the active surface and reload the narrow repo
+  guidance listed in this file before editing.
 - Keep tracked docs, templates, and control-plane text neutral and durable.
 - Do not store scratch review notes, hardening ledgers, or temporary process
   bookkeeping in tracked files.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,10 @@ Do not pre-load every repo doc by default.
   - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates`
   - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests`
   - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_ci_parity_checks`
+- Benchmark quality-gate scheduling or test-slice changes before changing the
+  default verification path:
+  - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.benchmark_quality_gates`
+  - `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.benchmark_tests`
 - Do not run `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pre-commit run --all-files` in addition to the parallel quality-gate runner unless you are debugging hook behavior itself.
 - Use `tools.run_quality_gates --full-tests` as the normal final local
   verification command.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Do not pre-load every repo doc by default.
 | Repo standards, docs placement, doc authoring rules, or agent-default enforcement changes | `AGENTS.md`, `docs/README.md`, `docs/status/current-state.md`, `docs/reference/repository-history.md`, `docs/standards/implementation.md`, `docs/standards/commits.md`, `tools/docs_maintenance/cli.py`, `tools/docs_maintenance/metadata.py` |
 | Issue templates, issue-writing policy, or proactive follow-up issue creation | `AGENTS.md`, `docs/standards/issues.md`, `docs/standards/implementation.md`, `docs/standards/delivery-guardrails.md`, `docs/standards/commits.md`, `.claude/commands/issue-workflow.md` |
 | Delivery guardrails, protected-branch behavior, or agent-assisted Git operations | `docs/standards/delivery-guardrails.md`, `docs/standards/commits.md`, `tools/audit_delivery_guardrails.py` |
-| PR hardening review or review-loop recovery | `docs/standards/delivery-guardrails.md`, `docs/standards/commits.md`, `.claude/commands/pr-hardening-review.md` |
+| PR review or review-loop recovery | `docs/standards/delivery-guardrails.md`, `docs/standards/implementation.md`, `docs/standards/commits.md`, `.claude/commands/pr-review.md` |
 | Planning sequence, delivery slices, or rollout checkpoints | `ROADMAP.md` |
 | Reconciliation, checkpoint, journal, or tax-engine implementation | `docs/concepts/reconciliation-tax-architecture.md` |
 | Platform-agnostic boundaries, classification mapping, or migration order | `docs/concepts/oracle-boundaries.md`, `docs/concepts/transaction-classification.md`, `docs/status/migration-sequence.md` |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -238,6 +238,9 @@ Scope:
 - keep control-plane ownership routing and default-branch guardrail audits
   explicit so local repo state and live GitHub protection drift are checked
   together
+- keep repo-native PR review routing, change-sensitive PR-only review checks,
+  and explicit changed-surface coverage aligned so review loops do not stop
+  early after only inspecting a narrow subset of the touched surfaces
 
 Exit criteria:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -241,6 +241,8 @@ Scope:
 - keep repo-native PR review routing, change-sensitive PR-only review checks,
   and explicit changed-surface coverage aligned so review loops do not stop
   early after only inspecting a narrow subset of the touched surfaces
+- keep quality-gate scheduling benchmark-backed and push CI split into explicit
+  lint, type, pylint, test, and build jobs instead of one opaque parity shell
 
 Exit criteria:
 

--- a/conftest.py
+++ b/conftest.py
@@ -65,6 +65,8 @@ def pytest_collection_modifyitems(items: list[Item]) -> None:
         marker = _marker_for_test_path(item.path)
         if marker is not None:
             item.add_marker(marker)
+        if _coverage_is_disabled(item):
+            _drop_no_cover_marker(item)
 
 
 def pytest_ignore_collect(collection_path: Path) -> bool:
@@ -85,3 +87,11 @@ def _marker_for_test_path(path: Path) -> str | None:
     if any(path.is_relative_to(test_dir) for test_dir in _adapter_test_dirs()):
         return "unit"
     return None
+
+
+def _coverage_is_disabled(item: Item) -> bool:
+    return bool(getattr(item.config.option, "no_cov", False))
+
+
+def _drop_no_cover_marker(item: Item) -> None:
+    item.own_markers = [mark for mark in item.own_markers if mark.name != "no_cover"]

--- a/docs/standards/commits.md
+++ b/docs/standards/commits.md
@@ -123,11 +123,17 @@ PR body rules:
   - `Why:`
   - `What:`
   - `Checks:`
+  - `Issue linkage:`
   - `Included checkpoints:`
 - an optional `Follow-ups:` section is allowed after `Included checkpoints:`
 - use flat hyphen bullets under every section
-- when the PR closes issues, put the closing bullets first under `Why:` using
-  the exact shape `- Closes #123: <problem statement>`
+- `Issue linkage:` is required for every PR
+- use `Issue linkage:` with `- Closes #123: <problem statement>` when the PR
+  resolves an existing issue
+- use `Issue linkage:` with `- Refs #123` or `- Refs #123: <note>` when the
+  PR links to tracked work without closing it
+- use `Issue linkage:` with `- None: <reason>` only when no existing issue
+  applies after search
 - keep `Included checkpoints:` in chronological order using the exact
   checkpoint subjects from the branch
 - wrap every `Included checkpoints:` entry in backticks using the exact commit
@@ -175,7 +181,6 @@ Preferred PR body template:
 
 ```text
 Why:
-- Closes #123: state the resolved problem when this PR closes an issue
 - state the problem or constraint this PR resolves
 
 What:
@@ -183,6 +188,9 @@ What:
 
 Checks:
 - list the verification you actually ran
+
+Issue linkage:
+- Closes #123: state the resolved issue, link non-closing tracked work, or explain why no issue applies
 
 Included checkpoints:
 - `refactor(example): first checkpoint subject`

--- a/docs/standards/commits.md
+++ b/docs/standards/commits.md
@@ -259,6 +259,10 @@ UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.vali
 UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.validate_commit_message --rev-range HEAD~3..HEAD
 ```
 
+When structured commit messages or PR bodies include backticks, quotes, or
+other shell-sensitive text, use file/stdin authoring forms rather than inline
+`-m` or `--body` arguments so the metadata stays literal.
+
 ## Commit-Time Verification Policy
 
 Commit-time hooks should enforce the bounded local safety checks we expect on

--- a/docs/standards/commits.md
+++ b/docs/standards/commits.md
@@ -9,7 +9,9 @@ nav_order: 30
 ---
 
 Use Conventional Commits for all authored commits. Keep commit history small,
-cohesive, and checkpoint-oriented.
+cohesive, and checkpoint-oriented. Every authored commit must stay bounded to
+one reviewable slice. When a task spans more than one separable slice, land it
+as multiple bounded checkpoint commits instead of one umbrella commit.
 
 Use Conventional Commit subjects and the structured body sections for merge
 commits too. Do not rely on GitHub's default `Merge pull request ...` subject.
@@ -48,8 +50,11 @@ Subject rules:
 - lowercase type
 - optional lowercase kebab-case scope
 - non-empty imperative summary
+- summary names a concrete repo surface or behavior
 - maximum 72 characters for the full subject line
 - no trailing period
+- do not use generic summaries such as `cleanup`, `misc fixes`, or
+  `update branch`
 
 ## Body Template
 
@@ -207,6 +212,7 @@ working agreement, not optional guidance to ignore once a change is stable.
 
 A stable checkpoint means:
 
+- the commit covers one bounded reviewable slice
 - the change slice is coherent and reviewable
 - the tree is internally consistent
 - relevant checks have passed
@@ -219,6 +225,10 @@ Heuristics:
 - larger risky refactor: split only where rollback or review value is real
 - broad but separable docs or repo-structure refactor: checkpoint each stable
   slice instead of batching everything into one umbrella commit
+
+For large scopes, the default end state is still bounded commits. Do not wait
+until the end of the branch and then collapse several reviewable slices into
+one authored commit just because the broader task was related.
 
 Do not batch unrelated fixes together. Do not split one bounded change into a
 series of micro-commits with no practical review value.

--- a/docs/standards/delivery-guardrails.md
+++ b/docs/standards/delivery-guardrails.md
@@ -20,8 +20,8 @@ structure, authoring rules, and baseline context from `AGENTS.md`,
 `docs/reference/repository-history.md`, `tools/docs_maintenance/cli.py`, and
 `tools/docs_maintenance/metadata.py` so new material lands in the right repo
 surface and follows the repo's documentation metadata rules.
-Use `code-change-safety` for the repo-guidance reload path and pair it with the
-`markdown` skill when the task edits Markdown or docs surfaces.
+Use the repo-local workflow for the active surface on that reload path and pair
+it with the `markdown` skill when the task edits Markdown or docs surfaces.
 When the task changes GitHub-side delivery controls, run
 `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.audit_delivery_guardrails`
 before and after the change so the local CODEOWNERS state and the live remote

--- a/docs/standards/delivery-guardrails.md
+++ b/docs/standards/delivery-guardrails.md
@@ -82,6 +82,7 @@ expansion.
 Control-plane files include:
 
 - `.agents/skills/**`
+- `.github/actions/**`
 - `.github/ISSUE_TEMPLATE/**`
 - `.github/workflows/**`
 - `.github/pull_request_template.md`
@@ -93,6 +94,7 @@ Control-plane files include:
 - `tools/pre_commit_hook.py`
 - `tools/audit_delivery_guardrails.py`
 - `tools/audit_pr_review.py`
+- `tools/benchmark_quality_gates.py`
 - `tools/message_standards.py`
 - `tools/run_pr_review_checks.py`
 - `tools/validate_commit_message.py`
@@ -154,8 +156,8 @@ the changed surface groups in the current PR diff:
     and over-engineering, tests and regression value, naming and public
     terminology, documentation and control-plane alignment
 - `ci_or_release`
-  - paths: `.github/workflows/**` and the repo's parity-sensitive delivery
-    tooling and config surfaces
+  - paths: `.github/actions/**`, `.github/workflows/**`, and the repo's
+    parity-sensitive delivery tooling and config surfaces
   - review domains: workflow correctness, delivery enforcement, metadata parity
 
 When more than one surface group is present:
@@ -218,8 +220,9 @@ push-to-mainline CI.
   PR metadata on pull requests only
 - the `pr-review` PR status runs `tools.run_pr_review_checks` against the PR
   diff and applies the repo's change-sensitive review verification matrix
-- push/mainline CI keeps the shared quality and parity path for landed changes,
-  but it does not replace the PR-only review audit
+- push/mainline CI keeps the shared quality and parity path for landed changes
+  through explicit lint, type, pylint, test, and build jobs rather than one
+  opaque umbrella status, but it does not replace the PR-only review audit
 - `pr-review` is not a local commit-hook requirement
 
 ## Required Delivery Audit

--- a/docs/standards/delivery-guardrails.md
+++ b/docs/standards/delivery-guardrails.md
@@ -44,7 +44,8 @@ when the higher-layer control is available.
 
 - protected branches are PR-only landing surfaces
 - pull requests open as draft by default
-- a PR becomes ready for review only after a clean hardening pass
+- a PR becomes ready for review only after the full issue-finding hardening
+  loop yields no new meaningful findings
 - direct pushes to `main` are forbidden except for an explicit one-time repair
   requested in the current thread
 - a merged `main` commit must not be rewritten when the original PR record
@@ -179,11 +180,13 @@ Each PR review pass should:
 
 - re-check prior fix surfaces first
 - use `tools.audit_pr_review` to confirm the applicable surface groups, review
-  domains, required verification family, and any unmapped paths before calling
-  the pass clean
+  domains, required verification family, and any unmapped paths before deciding
+  the current pass found no new meaningful findings
 - treat passing `tools.run_pr_review_checks` or broader verification as review
   evidence only; a green runner never replaces the mandatory red-team repair
-  loop or the clean-pass decision
+  loop or decides the pass outcome
+- describe each upcoming pass as issue-finding with open outcome; do not
+  pre-label the next pass as clean, final, or publish-ready
 - red-team one adjacent applicable surface group and look for up to 5 new
   unique evidence-backed findings for the current pass
 - repair every finding from that pass before starting the next pass
@@ -197,10 +200,10 @@ Each PR review pass should:
   existing issues first and open or link the follow-up issue before merge
 - when a pass finds fewer than 5 new findings, report only those findings and
   keep the loop moving
-- stop only after every applicable changed surface group has completed a clean
-  pass and a full applicable-surface loop yields no new meaningful findings; if
-  the only remaining item is a minor finishing touch, repair it and finish once
-  no other meaningful issues surface
+- stop only after every applicable changed surface group has been revisited and
+  a full applicable-surface loop yields no new meaningful findings; if the only
+  remaining item is a minor finishing touch, repair it and finish once no other
+  meaningful issues surface
 - keep scratch tracking ephemeral and untracked
 
 ### 4. Agent Defaults
@@ -213,6 +216,8 @@ missing:
 - assume merged default-branch history should not be rewritten
 - assume force-push is exceptional, not routine
 - prefer neutral direct `Why:` and `What:` language
+- frame each upcoming review pass as issue-finding with open outcome rather
+  than as a pre-labeled clean or final pass
 - re-check merge method and subject immediately before landing
 - report unresolved policy gaps instead of silently improvising
 - use the relevant safety and authoring skills up front rather than relying on

--- a/docs/standards/delivery-guardrails.md
+++ b/docs/standards/delivery-guardrails.md
@@ -92,7 +92,9 @@ Control-plane files include:
 - `tools/install_git_hooks.py`
 - `tools/pre_commit_hook.py`
 - `tools/audit_delivery_guardrails.py`
+- `tools/audit_pr_review.py`
 - `tools/message_standards.py`
+- `tools/run_pr_review_checks.py`
 - `tools/validate_commit_message.py`
 - `tools/validate_pr_metadata.py`
 - `tools/run_quality_gates.py`
@@ -130,26 +132,66 @@ Checklist text should describe the audit path, not serve as the only barrier.
 Standards work itself must verify whether a rule belongs in human docs, agent
 routing, or repo-native automation before adding a new document or route.
 
-PR hardening review is a repeatable procedure, not an improvised pass. Each
-pass should:
+PR review is a repeatable procedure, not an improvised pass. Review starts from
+the changed surface groups in the current PR diff:
+
+- `human_docs`
+  - paths: `README.md`, `CHANGELOG.md`, and `docs/**` except
+    `docs/standards/**`
+  - review domains: factual accuracy, metadata and link integrity, audience
+    and type placement
+- `control_plane_text`
+  - paths: `AGENTS.md`, `ROADMAP.md`, `.agents/skills/**`,
+    `.claude/commands/**`, `docs/standards/**`,
+    `.github/pull_request_template.md`, `.github/ISSUE_TEMPLATE/**`,
+    `.github/CODEOWNERS`
+  - review domains: policy correctness, route-skill-standard alignment,
+    delivery behavior, compaction and context-loss recovery, issue and privacy
+    handling
+- `repo_code_or_tooling`
+  - paths: `src/**`, Python under `tools/**`, `repo_support/**`, `tests/**`
+  - review domains: design and ownership, correctness and behavior, complexity
+    and over-engineering, tests and regression value, naming and public
+    terminology, documentation and control-plane alignment
+- `ci_or_release`
+  - paths: `.github/workflows/**` and the repo's parity-sensitive delivery
+    tooling and config surfaces
+  - review domains: workflow correctness, delivery enforcement, metadata parity
+
+When more than one surface group is present:
+
+- review domains are the union across every applicable surface group
+- the strongest broad verification family wins:
+  - `docs-maintenance`
+  - `control-plane-targeted`
+  - `quality-gates-full`
+  - `ci-parity`
+- surface-specific targeted checks still apply when the touched path declares
+  them, even when a stronger broad runner is also required
+
+Each PR review pass should:
 
 - re-check prior fix surfaces first
-- red-team one adjacent surface group and look for up to 5 new unique
-  evidence-backed findings across the active review domains
+- use `tools.audit_pr_review` to confirm the applicable surface groups, review
+  domains, required verification family, and any unmapped paths before calling
+  the pass clean
+- red-team one adjacent applicable surface group and look for up to 5 new
+  unique evidence-backed findings for the current pass
 - repair every finding from that pass before starting the next pass
 - reload the narrow repo guidance needed for each repair surface before editing:
   use `AGENTS.md`, its task-routing table, and the owning roadmap,
   architecture, migration, or delivery docs surfaced by that route or by repo
   search hints instead of forcing one oversized preload bundle for every pass
-- run the relevant verification for the repaired slice and create bounded
+- run the required review checks for the repaired slice and create bounded
   checkpoint commits during the loop using the repo's normal commit rules
 - when a meaningful finding is real but should not expand the active PR, search
   existing issues first and open or link the follow-up issue before merge
 - when a pass finds fewer than 5 new findings, report only those findings and
   keep the loop moving
-- stop only after a full pass yields no new meaningful findings; if the only
-  remaining item is a minor finishing touch, repair it and finish once no other
-  meaningful issues surface
+- stop only after every applicable changed surface group has completed a clean
+  pass and a full applicable-surface loop yields no new meaningful findings; if
+  the only remaining item is a minor finishing touch, repair it and finish once
+  no other meaningful issues surface
 - keep scratch tracking ephemeral and untracked
 
 ### 4. Agent Defaults
@@ -167,11 +209,25 @@ missing:
 - use the relevant safety and authoring skills up front rather than relying on
   mid-task memory
 
+## PR-Only CI Enforcement
+
+Pull request review enforcement stays separate from local commit hooks and
+push-to-mainline CI.
+
+- the `commit-messages` PR status validates the branch commit-message range and
+  PR metadata on pull requests only
+- the `pr-review` PR status runs `tools.run_pr_review_checks` against the PR
+  diff and applies the repo's change-sensitive review verification matrix
+- push/mainline CI keeps the shared quality and parity path for landed changes,
+  but it does not replace the PR-only review audit
+- `pr-review` is not a local commit-hook requirement
+
 ## Required Delivery Audit
 
 Before calling delivery complete, verify and report:
 
 - which repo standards were reloaded immediately before the action
+- which applicable changed surface groups were reviewed
 - whether the PR remained draft until the hardening procedure finished cleanly
 - whether the branch shape matched the allowed merge method
 - which checks were required and whether they passed
@@ -184,6 +240,8 @@ Before calling delivery complete, verify and report:
 - whether the final remote branch tip still matches the reviewed PR record
 - whether review requirements are truly enforced or explicitly deferred because
   the repo currently has only one single review-capable collaborator
+- whether PR-only CI enforcement required both `commit-messages` and
+  `pr-review` for mergeable pull requests
 
 ## Exception Handling
 

--- a/docs/standards/delivery-guardrails.md
+++ b/docs/standards/delivery-guardrails.md
@@ -64,7 +64,7 @@ when the higher-layer control is available.
 Prefer GitHub controls that reject bad actions before they land:
 
 - rulesets or branch protection that require pull requests
-- required status checks
+- required status checks pinned to their owning app, not only named by context
 - required reviews
 - blocked force pushes on protected branches
 - stale-review dismissal or last-push review requirements when the repo wants
@@ -227,6 +227,8 @@ push-to-mainline CI.
   PR metadata on pull requests only
 - the `pr-review` PR status runs `tools.run_pr_review_checks` against the PR
   diff and applies the repo's change-sensitive review verification matrix
+- required PR-only statuses must stay pinned to the GitHub Actions app through
+  branch-protection check app IDs, not only by status context name
 - push/mainline CI keeps the shared quality and parity path for landed changes
   through explicit lint, type, pylint, test, and build jobs rather than one
   opaque umbrella status, but it does not replace the PR-only review audit
@@ -252,6 +254,8 @@ Before calling delivery complete, verify and report:
   the repo currently has only one single review-capable collaborator
 - whether PR-only CI enforcement required both `commit-messages` and
   `pr-review` for mergeable pull requests
+- whether required PR-only statuses were pinned to the owning GitHub Actions
+  app instead of relying on unpinned status-context names alone
 
 ## Exception Handling
 

--- a/docs/standards/delivery-guardrails.md
+++ b/docs/standards/delivery-guardrails.md
@@ -151,7 +151,8 @@ the changed surface groups in the current PR diff:
     delivery behavior, compaction and context-loss recovery, issue and privacy
     handling
 - `repo_code_or_tooling`
-  - paths: `src/**`, Python under `tools/**`, `repo_support/**`, `tests/**`
+  - paths: `src/**`, Python under `tools/**`, `repo_support/**`, `tests/**`,
+    and repo-root test support such as `conftest.py`
   - review domains: design and ownership, correctness and behavior, complexity
     and over-engineering, tests and regression value, naming and public
     terminology, documentation and control-plane alignment
@@ -168,6 +169,9 @@ When more than one surface group is present:
   - `control-plane-targeted`
   - `quality-gates-full`
   - `ci-parity`
+- when `ci-parity` wins for a mixed repo-code and CI diff, do not also run a
+  duplicate `quality-gates-full` pass; `ci-parity` already includes the full
+  quality, build, and wheel parity path
 - surface-specific targeted checks still apply when the touched path declares
   them, even when a stronger broad runner is also required
 
@@ -177,6 +181,9 @@ Each PR review pass should:
 - use `tools.audit_pr_review` to confirm the applicable surface groups, review
   domains, required verification family, and any unmapped paths before calling
   the pass clean
+- treat passing `tools.run_pr_review_checks` or broader verification as review
+  evidence only; a green runner never replaces the mandatory red-team repair
+  loop or the clean-pass decision
 - red-team one adjacent applicable surface group and look for up to 5 new
   unique evidence-backed findings for the current pass
 - repair every finding from that pass before starting the next pass

--- a/docs/standards/implementation.md
+++ b/docs/standards/implementation.md
@@ -42,6 +42,9 @@ Prefer the repo's built-in tooling before inventing local workflows:
   `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates`
 - run full verification before closing substantial work with
   `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests`
+  The repo keeps the fast gate on the benchmark-backed phased schedule and the
+  full gate on the benchmark-backed all-at-once schedule; do not change those
+  defaults without rerunning the benchmark tools.
 - mirror GitHub Actions locally when changing workflow, packaging, or release
   behavior with
   `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_ci_parity_checks`
@@ -65,6 +68,8 @@ Prefer the repo's built-in tooling before inventing local workflows:
   `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.refresh_adapter_goldens ...`
 - benchmark test-slice changes with
   `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.benchmark_tests`
+- benchmark quality-gate scheduling changes with
+  `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.benchmark_quality_gates`
 
 Do not replace these with ad hoc shell habits when the repo already has a
 supported path.
@@ -336,8 +341,9 @@ touched control-plane paths.
 If you are changing commit-time or suite-selection policy, keep the hook path
 limited to bounded checkpoint checks and use the shared quality or parity
 runners as the single broad verification source. Benchmark with
-`tools.benchmark_tests` when you are proposing a different test slice, and do
-not expand the hook path into a second full-suite verification pass.
+`tools.benchmark_tests` and `tools.benchmark_quality_gates` when you are
+proposing a different test slice or quality-gate schedule, and do not expand
+the hook path into a second full-suite verification pass.
 
 ## Migration Discipline
 

--- a/docs/standards/implementation.md
+++ b/docs/standards/implementation.md
@@ -42,9 +42,10 @@ Prefer the repo's built-in tooling before inventing local workflows:
   `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates`
 - run full verification before closing substantial work with
   `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests`
-  The repo keeps the fast gate on the benchmark-backed phased schedule and the
-  full gate on the benchmark-backed all-at-once schedule; do not change those
-  defaults without rerunning the benchmark tools.
+  The repo keeps the fast gate on the phased schedule, the fast pytest slice
+  on 4 workers by default, and the full gate on serial full-suite coverage.
+  Override the fast worker count only through
+  `TALLYLOT_FAST_PYTEST_WORKERS`; use `0` to force serial.
 - mirror GitHub Actions locally when changing workflow, packaging, or release
   behavior with
   `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_ci_parity_checks`
@@ -56,6 +57,10 @@ Prefer the repo's built-in tooling before inventing local workflows:
   `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.audit_pr_review`
   and run the required review checks for the current diff with
   `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_pr_review_checks`
+- run the blocking flake and order-sensitivity lane with
+  `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_test_stress_checks`
+- report coverage hotspots from a recent full-suite run with
+  `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.report_coverage_hotspots`
 - scaffold new adapters with
   `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.scaffold_adapter ...`
 - refresh generated pyright test-private execution environments with
@@ -73,6 +78,19 @@ Prefer the repo's built-in tooling before inventing local workflows:
 
 Do not replace these with ad hoc shell habits when the repo already has a
 supported path.
+
+## Benchmark Rules
+
+Use the repo benchmark tools only for explicit default-selection decisions.
+
+- benchmark one suite or quality-gate comparison set at a time
+- warm caches before measured runs
+- use warmup runs plus repeated measured iterations, then compare medians
+  instead of one-off timings
+- benchmark both local hardware and GitHub runner classes before calling a
+  default benchmark-backed in docs, tests, or review rationale
+- keep `-n auto` as a benchmark or debug candidate only; do not promote it to
+  a repo default without fresh local and GitHub runner evidence
 
 `pyrightconfig.tests.json` is generated repo policy for test-private execution
 environments. Do not hand-maintain adapter `executionEnvironments` in
@@ -331,18 +349,29 @@ is:
   parity matters
 - do not run `tools.run_quality_gates --full-tests` again immediately before
   `tools.run_ci_parity_checks`; the parity runner already includes it
+- use `tools.run_fast_pytest` or the hook-owned pre-commit path for the fast
+  checkpoint loop; do not duplicate the fast pytest CLI contract in new
+  wrappers or config entries
 
 For PR review and repair loops, choose verification by changed surface:
 
 - `human_docs`: run `tools.docs_maintenance sync --check`
 - `control_plane_text`: run docs maintenance plus the targeted policy tests
   declared by `tools.run_pr_review_checks`
-- `repo_code_or_tooling`: run `tools.run_quality_gates --full-tests`
-- `ci_or_release`: run `tools.run_ci_parity_checks`
+- `repo_code_or_tooling`: run `tools.run_quality_gates --full-tests`, then the
+  blocking stress lane, and let PR routing add pre-merge packaging validation
+  for packaging-sensitive repo-code diffs
+- `ci_or_release`: run `tools.run_ci_parity_checks`; the PR route also keeps
+  the blocking stress lane on for these diffs
+
+Coverage hotspot reports are informative review output only. Use them to pick
+the next hardening target after a full-suite run; do not treat them as a
+replacement for correctness tests or the existing repo-wide coverage gate.
 
 When more than one surface group is present, the strongest broad verification
 family wins, but any declared surface-specific targeted checks still apply for
-touched control-plane paths.
+touched control-plane paths. Coverage hotspots stay informative even when the
+rest of the PR review route is blocking.
 
 If you are changing commit-time or suite-selection policy, keep the hook path
 limited to bounded checkpoint checks and use the shared quality or parity
@@ -368,6 +397,9 @@ Split the work into a smaller compatible slice.
 Keep workflow integrity rules explicit while the repo continues migrating.
 
 - filesystem scans that enumerate user evidence must be deterministic
+- xdist-sensitive parametrization and collection inputs must preserve
+  deterministic ordering; do not feed unordered collections into parametrized
+  tests that need reproducible parallel collection
 - tree-walking services should use the shared scan path with explicit output
   exclusions rather than ad hoc `rglob()` behavior
 - archive inspection, archive safety limits, and archive-member issue reporting

--- a/docs/standards/implementation.md
+++ b/docs/standards/implementation.md
@@ -197,6 +197,12 @@ Meaningful tests only:
 - when tests become repetitive, treat that as a signal that the production seam
   may be wrong and refactor the seam instead of piling on more near-duplicate
   tests
+- for repo-side agent scripts and internal workflow entry points, cover
+  behavior in-process when a callable seam exists and reserve subprocess tests
+  for the real launch boundary
+- avoid duplicate in-process and subprocess tests that prove the same workflow
+  behavior; once behavior is covered in-process, thin launch-boundary tests may
+  use `@pytest.mark.no_cover`
 
 Do not leave edge-case behavior implicit in implementation code without a test
 that pins it down.

--- a/docs/standards/implementation.md
+++ b/docs/standards/implementation.md
@@ -363,6 +363,10 @@ For PR review and repair loops, choose verification by changed surface:
   for packaging-sensitive repo-code diffs
 - `ci_or_release`: run `tools.run_ci_parity_checks`; the PR route also keeps
   the blocking stress lane on for these diffs
+- mixed `repo_code_or_tooling` plus `ci_or_release`: let `ci-parity` win as
+  the broad runner because it already includes the full quality, build, and
+  wheel parity path; keep the surface-specific targeted checks and the stress
+  lane, but do not duplicate `tools.run_quality_gates --full-tests`
 
 Coverage hotspot reports are informative review output only. Use them to pick
 the next hardening target after a full-suite run; do not treat them as a

--- a/docs/standards/implementation.md
+++ b/docs/standards/implementation.md
@@ -216,12 +216,16 @@ Expected behavior:
 - make a commit when a bounded slice is stable and verified
 - keep commits cohesive and reviewable
 - prefer one commit per coherent reshape slice, not one commit per file
+- keep each authored commit bounded to one reviewable concern with a clear
+  rollback boundary
 - before a checkpoint commit is pushed, amend or fix up a small, scoped
   follow-up patch into the owning non-pushed checkpoint when that avoids a
   low-value micro-commit, and update the amended commit message so its
   `Why:`, `What:`, and `Checks:` sections still describe the final content
 - do not use repeated amend cycles to grow one broad checkpoint that should be
   split into separate commits with clearer review and rollback boundaries
+- for large but separable scopes, create multiple bounded checkpoint commits
+  before closeout instead of ending on one umbrella authored commit
 - do not bundle unrelated fixes
 - do not wait for the user to remind you to commit once the task has reached a
   real checkpoint
@@ -275,6 +279,7 @@ When not to commit:
 - the worktree is inconsistent
 - the tests for the slice are failing
 - the checkpoint would be hard to review or roll back
+- the current diff still contains multiple separable reviewable slices
 
 Do not collapse a broad but separable refactor into one giant commit unless
 the slice truly cannot be reviewed or validated incrementally.

--- a/docs/standards/implementation.md
+++ b/docs/standards/implementation.md
@@ -49,6 +49,10 @@ Prefer the repo's built-in tooling before inventing local workflows:
   together when changing delivery policy, branch protection, or CI guardrails
   with
   `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.audit_delivery_guardrails`
+- audit PR review surface coverage with
+  `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.audit_pr_review`
+  and run the required review checks for the current diff with
+  `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_pr_review_checks`
 - scaffold new adapters with
   `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.scaffold_adapter ...`
 - refresh generated pyright test-private execution environments with
@@ -311,6 +315,18 @@ is:
   parity matters
 - do not run `tools.run_quality_gates --full-tests` again immediately before
   `tools.run_ci_parity_checks`; the parity runner already includes it
+
+For PR review and repair loops, choose verification by changed surface:
+
+- `human_docs`: run `tools.docs_maintenance sync --check`
+- `control_plane_text`: run docs maintenance plus the targeted policy tests
+  declared by `tools.run_pr_review_checks`
+- `repo_code_or_tooling`: run `tools.run_quality_gates --full-tests`
+- `ci_or_release`: run `tools.run_ci_parity_checks`
+
+When more than one surface group is present, the strongest broad verification
+family wins, but any declared surface-specific targeted checks still apply for
+touched control-plane paths.
 
 If you are changing commit-time or suite-selection policy, keep the hook path
 limited to bounded checkpoint checks and use the shared quality or parity

--- a/docs/standards/issues.md
+++ b/docs/standards/issues.md
@@ -99,10 +99,14 @@ cleanup pass.
 Use pull request metadata to distinguish resolved issues from tracked follow-up
 work:
 
-- use `Why:` with `- Closes #123: ...` only when the PR actually resolves the
-  issue
-- use `Follow-ups:` with `- Refs #123` or `- Refs #123: ...` for non-closing
-  issues that remain separate from the current PR
+- every PR must include an `Issue linkage:` section that makes the issue
+  decision explicit before merge
+- use `Issue linkage:` with `- Closes #123: ...` only when the PR actually
+  resolves the issue
+- use `Issue linkage:` with `- Refs #123` or `- Refs #123: ...` for
+  non-closing tracked work that remains separate from the current PR
+- use `Issue linkage:` with `- None: ...` only when no existing issue applies
+  after search and the reason is stated directly in the PR body
 
 When a follow-up issue is opened during implementation or hardening, link it
 from the active PR before merge.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ markers = [
     "unit: fast unit-level coverage.",
     "e2e: end-to-end CLI and service coverage.",
     "contract: adapter and output contract coverage.",
+    "no_cover: launch-boundary tests excluded from coverage once behavior is covered in-process.",
     "slow: comparatively expensive tests kept out of commit-time pytest hooks.",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dev = [
     "pyright>=1.1.399,<2.0.0",
     "pytest>=8.3.5,<9.0.0",
     "pytest-cov>=6.0.0,<7.0.0",
+    "pytest-randomly>=3.16.0,<4.0.0",
     "pytest-xdist>=3.6.1,<4.0.0",
     "reportlab>=4.4.0,<5.0.0",
     "ruff>=0.11.2,<0.12.0",

--- a/repo_support/pr_review.py
+++ b/repo_support/pr_review.py
@@ -3,7 +3,15 @@ from __future__ import annotations
 import subprocess
 from collections.abc import Sequence
 from dataclasses import dataclass
-from pathlib import PurePosixPath
+
+from repo_support.pr_review_paths import (
+    is_control_plane_text,
+    is_human_docs,
+    is_packaging_sensitive_path,
+    is_production_code_path,
+    path_surface_groups,
+    path_targeted_check_names,
+)
 
 SURFACE_GROUP_ORDER = (
     "human_docs",
@@ -51,37 +59,6 @@ SURFACE_VERIFICATION_LEVEL = {
     "repo_code_or_tooling": "quality-gates-full",
     "ci_or_release": "ci-parity",
 }
-CONTROL_PLANE_EXACT_PATHS = (
-    "AGENTS.md",
-    "ROADMAP.md",
-    ".github/pull_request_template.md",
-    ".github/CODEOWNERS",
-)
-CONTROL_PLANE_PREFIXES = (
-    ".agents/skills/",
-    ".claude/commands/",
-    "docs/standards/",
-    ".github/ISSUE_TEMPLATE/",
-)
-CI_OR_RELEASE_EXACT_PATHS = (
-    ".pre-commit-config.yaml",
-    ".pylintrc-tests",
-    "pyproject.toml",
-    "pyrightconfig.json",
-    "pyrightconfig.tests.json",
-    "uv.lock",
-    "tools/audit_delivery_guardrails.py",
-    "tools/audit_pr_review.py",
-    "tools/install_git_hooks.py",
-    "tools/message_standards.py",
-    "tools/pre_commit_hook.py",
-    "tools/run_ci_parity_checks.py",
-    "tools/run_pr_review_checks.py",
-    "tools/run_quality_gates.py",
-    "tools/validate_commit_message.py",
-    "tools/validate_pr_metadata.py",
-)
-CI_OR_RELEASE_PREFIXES = (".github/actions/", ".github/workflows/")
 
 
 @dataclass(frozen=True)
@@ -98,6 +75,11 @@ class PrReviewPlan:
     review_domains: tuple[str, ...]
     targeted_checks: tuple[TargetedCheck, ...]
     verification_level: str
+    requires_full_quality_gates: bool
+    requires_ci_parity: bool
+    requires_pre_merge_packaging_verification: bool
+    requires_test_stress_checks: bool
+    requires_coverage_hotspot_report: bool
     unmapped_paths: tuple[str, ...]
 
 
@@ -172,6 +154,17 @@ TARGETED_CHECKS_BY_NAME = {
             "tests/unit/test_commit_message_validator.py",
         ),
     ),
+    "pre-commit-hook-tooling": TargetedCheck(
+        name="pre-commit-hook-tooling",
+        command=(
+            "uv",
+            "run",
+            "pytest",
+            "--no-cov",
+            "-q",
+            "tests/unit/test_pre_commit_hook.py",
+        ),
+    ),
     "quality-gates-tooling": TargetedCheck(
         name="quality-gates-tooling",
         command=(
@@ -216,6 +209,28 @@ TARGETED_CHECKS_BY_NAME = {
             "tests/unit/test_run_pr_review_checks.py",
         ),
     ),
+    "test-stress-checks": TargetedCheck(
+        name="test-stress-checks",
+        command=(
+            "uv",
+            "run",
+            "pytest",
+            "--no-cov",
+            "-q",
+            "tests/unit/test_run_test_stress_checks.py",
+        ),
+    ),
+    "coverage-hotspots": TargetedCheck(
+        name="coverage-hotspots",
+        command=(
+            "uv",
+            "run",
+            "pytest",
+            "--no-cov",
+            "-q",
+            "tests/unit/test_report_coverage_hotspots.py",
+        ),
+    ),
 }
 
 
@@ -258,108 +273,23 @@ def changed_paths(
     return tuple(line for line in result.stdout.splitlines() if line)
 
 
-def _is_human_docs(path: str) -> bool:
-    return path in {"README.md", "CHANGELOG.md"} or (
-        path.startswith("docs/") and not path.startswith("docs/standards/")
-    )
-
-
-def _is_control_plane_text(path: str) -> bool:
-    return path in CONTROL_PLANE_EXACT_PATHS or path.startswith(CONTROL_PLANE_PREFIXES)
-
-
-def _is_repo_code_or_tooling(path: str) -> bool:
-    return (
-        path.startswith(("src/", "tests/", "repo_support/"))
-        or path.startswith("tools/")
-        and path.endswith(".py")
-    )
-
-
-def _is_ci_or_release(path: str) -> bool:
-    return path in CI_OR_RELEASE_EXACT_PATHS or path.startswith(CI_OR_RELEASE_PREFIXES)
-
-
-def _path_surface_groups(path: str) -> tuple[str, ...]:
-    groups: list[str] = []
-    if _is_human_docs(path):
-        groups.append("human_docs")
-    if _is_control_plane_text(path):
-        groups.append("control_plane_text")
-    if _is_repo_code_or_tooling(path):
-        groups.append("repo_code_or_tooling")
-    if _is_ci_or_release(path):
-        groups.append("ci_or_release")
-    return tuple(groups)
-
-
-def _path_targeted_check_names(path: str) -> tuple[str, ...]:
-    check_names: list[str] = []
-    pure_path = PurePosixPath(path)
-    if path.startswith(".agents/skills/"):
-        check_names.append("repo-agent-skills")
-    if (
-        path == "AGENTS.md"
-        or path == "ROADMAP.md"
-        or path.startswith("docs/standards/")
-        or path.startswith(".claude/commands/")
-    ):
-        check_names.append("standards-guards")
-    if path.startswith(".claude/commands/"):
-        check_names.append("docs-runtime-parity")
-    if (
-        path.startswith(".github/workflows/")
-        or path == ".github/CODEOWNERS"
-        or path == "docs/standards/delivery-guardrails.md"
-        or path == "tools/audit_delivery_guardrails.py"
-    ):
-        check_names.append("delivery-guardrails-audit")
-    if path in {
-        ".github/pull_request_template.md",
-        "docs/standards/commits.md",
-        "docs/standards/issues.md",
-        "tools/message_standards.py",
-        "tools/validate_pr_metadata.py",
-    }:
-        check_names.append("pr-metadata-validator")
-    if path in {
-        "docs/standards/commits.md",
-        "tools/message_standards.py",
-        "tools/validate_commit_message.py",
-    }:
-        check_names.append("commit-message-validator")
-    if path == "tools/run_quality_gates.py":
-        check_names.append("quality-gates-tooling")
-    if path.startswith(".github/actions/") or path in {
-        ".github/workflows/ci.yml",
-        "tools/run_ci_parity_checks.py",
-    }:
-        check_names.append("ci-parity-tooling")
-    if path in {"repo_support/pr_review.py", "tools/audit_pr_review.py"}:
-        check_names.append("audit-pr-review")
-    if path in {
-        "repo_support/pr_review.py",
-        "tools/run_pr_review_checks.py",
-        ".github/workflows/pr-review.yml",
-    }:
-        check_names.append("run-pr-review-checks")
-    if pure_path.parts[:2] == ("tools", "docs_maintenance"):
-        check_names.append("standards-guards")
-    return tuple(check_names)
-
-
 def classify_changed_paths(paths: Sequence[str]) -> PrReviewPlan:
     grouped_paths: dict[str, list[str]] = {name: [] for name in SURFACE_GROUP_ORDER}
     review_domains: list[str] = []
     targeted_checks: list[TargetedCheck] = []
     verification_level = "none"
+    requires_full_quality_gates = False
+    requires_ci_parity = False
+    requires_test_stress_checks = False
+    requires_coverage_hotspot_report = False
+    has_packaging_sensitive_repo_code = False
     unmapped_paths: list[str] = []
 
-    if any(_is_human_docs(path) or _is_control_plane_text(path) for path in paths):
+    if any(is_human_docs(path) or is_control_plane_text(path) for path in paths):
         targeted_checks.append(DOCS_MAINTENANCE_CHECK)
 
     for path in paths:
-        groups = _path_surface_groups(path)
+        groups = path_surface_groups(path)
         if not groups:
             unmapped_paths.append(path)
             continue
@@ -373,7 +303,17 @@ def classify_changed_paths(paths: Sequence[str]) -> PrReviewPlan:
             for domain in SURFACE_REVIEW_DOMAINS[group]:
                 if domain not in review_domains:
                     review_domains.append(domain)
-        for check_name in _path_targeted_check_names(path):
+        if "repo_code_or_tooling" in groups:
+            requires_full_quality_gates = True
+            requires_test_stress_checks = True
+        if "ci_or_release" in groups:
+            requires_ci_parity = True
+            requires_test_stress_checks = True
+        if is_production_code_path(path):
+            requires_coverage_hotspot_report = True
+        if "repo_code_or_tooling" in groups and is_packaging_sensitive_path(path):
+            has_packaging_sensitive_repo_code = True
+        for check_name in path_targeted_check_names(path):
             check = TARGETED_CHECKS_BY_NAME[check_name]
             if check not in targeted_checks:
                 targeted_checks.append(check)
@@ -391,5 +331,14 @@ def classify_changed_paths(paths: Sequence[str]) -> PrReviewPlan:
         review_domains=tuple(review_domains),
         targeted_checks=tuple(targeted_checks),
         verification_level=verification_level,
+        requires_full_quality_gates=requires_full_quality_gates,
+        requires_ci_parity=requires_ci_parity,
+        requires_pre_merge_packaging_verification=(
+            requires_full_quality_gates
+            and not requires_ci_parity
+            and has_packaging_sensitive_repo_code
+        ),
+        requires_test_stress_checks=requires_test_stress_checks,
+        requires_coverage_hotspot_report=requires_coverage_hotspot_report,
         unmapped_paths=tuple(unmapped_paths),
     )

--- a/repo_support/pr_review.py
+++ b/repo_support/pr_review.py
@@ -81,7 +81,7 @@ CI_OR_RELEASE_EXACT_PATHS = (
     "tools/validate_commit_message.py",
     "tools/validate_pr_metadata.py",
 )
-CI_OR_RELEASE_PREFIXES = (".github/workflows/",)
+CI_OR_RELEASE_PREFIXES = (".github/actions/", ".github/workflows/")
 
 
 @dataclass(frozen=True)
@@ -330,7 +330,10 @@ def _path_targeted_check_names(path: str) -> tuple[str, ...]:
         check_names.append("commit-message-validator")
     if path == "tools/run_quality_gates.py":
         check_names.append("quality-gates-tooling")
-    if path in {".github/workflows/ci.yml", "tools/run_ci_parity_checks.py"}:
+    if path.startswith(".github/actions/") or path in {
+        ".github/workflows/ci.yml",
+        "tools/run_ci_parity_checks.py",
+    }:
         check_names.append("ci-parity-tooling")
     if path in {"repo_support/pr_review.py", "tools/audit_pr_review.py"}:
         check_names.append("audit-pr-review")

--- a/repo_support/pr_review.py
+++ b/repo_support/pr_review.py
@@ -1,0 +1,392 @@
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+
+SURFACE_GROUP_ORDER = (
+    "human_docs",
+    "control_plane_text",
+    "repo_code_or_tooling",
+    "ci_or_release",
+)
+VERIFICATION_LEVEL_ORDER = {
+    "none": 0,
+    "docs-maintenance": 1,
+    "control-plane-targeted": 2,
+    "quality-gates-full": 3,
+    "ci-parity": 4,
+}
+SURFACE_REVIEW_DOMAINS = {
+    "human_docs": (
+        "factual accuracy",
+        "metadata and link integrity",
+        "audience and type placement",
+    ),
+    "control_plane_text": (
+        "policy correctness",
+        "route-skill-standard alignment",
+        "delivery behavior",
+        "compaction and context-loss recovery",
+        "issue and privacy handling",
+    ),
+    "repo_code_or_tooling": (
+        "design and ownership",
+        "correctness and behavior",
+        "complexity and over-engineering",
+        "tests and regression value",
+        "naming and public terminology",
+        "documentation and control-plane alignment",
+    ),
+    "ci_or_release": (
+        "workflow correctness",
+        "delivery enforcement",
+        "metadata parity",
+    ),
+}
+SURFACE_VERIFICATION_LEVEL = {
+    "human_docs": "docs-maintenance",
+    "control_plane_text": "control-plane-targeted",
+    "repo_code_or_tooling": "quality-gates-full",
+    "ci_or_release": "ci-parity",
+}
+CONTROL_PLANE_EXACT_PATHS = (
+    "AGENTS.md",
+    "ROADMAP.md",
+    ".github/pull_request_template.md",
+    ".github/CODEOWNERS",
+)
+CONTROL_PLANE_PREFIXES = (
+    ".agents/skills/",
+    ".claude/commands/",
+    "docs/standards/",
+    ".github/ISSUE_TEMPLATE/",
+)
+CI_OR_RELEASE_EXACT_PATHS = (
+    ".pre-commit-config.yaml",
+    ".pylintrc-tests",
+    "pyproject.toml",
+    "pyrightconfig.json",
+    "pyrightconfig.tests.json",
+    "uv.lock",
+    "tools/audit_delivery_guardrails.py",
+    "tools/audit_pr_review.py",
+    "tools/install_git_hooks.py",
+    "tools/message_standards.py",
+    "tools/pre_commit_hook.py",
+    "tools/run_ci_parity_checks.py",
+    "tools/run_pr_review_checks.py",
+    "tools/run_quality_gates.py",
+    "tools/validate_commit_message.py",
+    "tools/validate_pr_metadata.py",
+)
+CI_OR_RELEASE_PREFIXES = (".github/workflows/",)
+
+
+@dataclass(frozen=True)
+class TargetedCheck:
+    name: str
+    command: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PrReviewPlan:
+    changed_paths: tuple[str, ...]
+    grouped_paths: tuple[tuple[str, tuple[str, ...]], ...]
+    surface_groups: tuple[str, ...]
+    review_domains: tuple[str, ...]
+    targeted_checks: tuple[TargetedCheck, ...]
+    verification_level: str
+    unmapped_paths: tuple[str, ...]
+
+
+DOCS_MAINTENANCE_CHECK = TargetedCheck(
+    name="docs-maintenance",
+    command=("uv", "run", "python", "-m", "tools.docs_maintenance", "sync", "--check"),
+)
+TARGETED_CHECKS_BY_NAME = {
+    "repo-agent-skills": TargetedCheck(
+        name="repo-agent-skills",
+        command=(
+            "uv",
+            "run",
+            "pytest",
+            "--no-cov",
+            "-q",
+            "tests/unit/test_repo_agent_skills.py",
+        ),
+    ),
+    "standards-guards": TargetedCheck(
+        name="standards-guards",
+        command=(
+            "uv",
+            "run",
+            "pytest",
+            "--no-cov",
+            "-q",
+            "tests/contract/test_standards_guards.py",
+        ),
+    ),
+    "docs-runtime-parity": TargetedCheck(
+        name="docs-runtime-parity",
+        command=(
+            "uv",
+            "run",
+            "pytest",
+            "--no-cov",
+            "-q",
+            "tests/unit/test_docs_runtime_parity.py",
+        ),
+    ),
+    "delivery-guardrails-audit": TargetedCheck(
+        name="delivery-guardrails-audit",
+        command=(
+            "uv",
+            "run",
+            "pytest",
+            "--no-cov",
+            "-q",
+            "tests/unit/test_delivery_guardrails_audit.py",
+        ),
+    ),
+    "pr-metadata-validator": TargetedCheck(
+        name="pr-metadata-validator",
+        command=(
+            "uv",
+            "run",
+            "pytest",
+            "--no-cov",
+            "-q",
+            "tests/unit/test_pr_metadata_validator.py",
+        ),
+    ),
+    "commit-message-validator": TargetedCheck(
+        name="commit-message-validator",
+        command=(
+            "uv",
+            "run",
+            "pytest",
+            "--no-cov",
+            "-q",
+            "tests/unit/test_commit_message_validator.py",
+        ),
+    ),
+    "quality-gates-tooling": TargetedCheck(
+        name="quality-gates-tooling",
+        command=(
+            "uv",
+            "run",
+            "pytest",
+            "--no-cov",
+            "-q",
+            "tests/unit/test_quality_gates.py",
+        ),
+    ),
+    "ci-parity-tooling": TargetedCheck(
+        name="ci-parity-tooling",
+        command=(
+            "uv",
+            "run",
+            "pytest",
+            "--no-cov",
+            "-q",
+            "tests/unit/test_ci_parity_checks.py",
+        ),
+    ),
+    "audit-pr-review": TargetedCheck(
+        name="audit-pr-review",
+        command=(
+            "uv",
+            "run",
+            "pytest",
+            "--no-cov",
+            "-q",
+            "tests/unit/test_audit_pr_review.py",
+        ),
+    ),
+    "run-pr-review-checks": TargetedCheck(
+        name="run-pr-review-checks",
+        command=(
+            "uv",
+            "run",
+            "pytest",
+            "--no-cov",
+            "-q",
+            "tests/unit/test_run_pr_review_checks.py",
+        ),
+    ),
+}
+
+
+def _git_stdout(*args: str) -> str:
+    result = subprocess.run(
+        ("git", *args),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _default_branch_ref() -> str:
+    try:
+        return _git_stdout("symbolic-ref", "--short", "refs/remotes/origin/HEAD")
+    except subprocess.CalledProcessError:
+        return "origin/main"
+
+
+def changed_paths(
+    base_sha: str | None = None, head_sha: str | None = None
+) -> tuple[str, ...]:
+    head = head_sha or "HEAD"
+    if base_sha is not None:
+        base = base_sha
+    else:
+        default_branch = _default_branch_ref()
+        try:
+            base = _git_stdout("merge-base", head, default_branch)
+        except subprocess.CalledProcessError:
+            base = f"{head}^"
+
+    result = subprocess.run(
+        ("git", "diff", "--name-only", "--diff-filter=ACMR", base, head),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return tuple(line for line in result.stdout.splitlines() if line)
+
+
+def _is_human_docs(path: str) -> bool:
+    return path in {"README.md", "CHANGELOG.md"} or (
+        path.startswith("docs/") and not path.startswith("docs/standards/")
+    )
+
+
+def _is_control_plane_text(path: str) -> bool:
+    return path in CONTROL_PLANE_EXACT_PATHS or path.startswith(CONTROL_PLANE_PREFIXES)
+
+
+def _is_repo_code_or_tooling(path: str) -> bool:
+    return (
+        path.startswith(("src/", "tests/", "repo_support/"))
+        or path.startswith("tools/")
+        and path.endswith(".py")
+    )
+
+
+def _is_ci_or_release(path: str) -> bool:
+    return path in CI_OR_RELEASE_EXACT_PATHS or path.startswith(CI_OR_RELEASE_PREFIXES)
+
+
+def _path_surface_groups(path: str) -> tuple[str, ...]:
+    groups: list[str] = []
+    if _is_human_docs(path):
+        groups.append("human_docs")
+    if _is_control_plane_text(path):
+        groups.append("control_plane_text")
+    if _is_repo_code_or_tooling(path):
+        groups.append("repo_code_or_tooling")
+    if _is_ci_or_release(path):
+        groups.append("ci_or_release")
+    return tuple(groups)
+
+
+def _path_targeted_check_names(path: str) -> tuple[str, ...]:
+    check_names: list[str] = []
+    pure_path = PurePosixPath(path)
+    if path.startswith(".agents/skills/"):
+        check_names.append("repo-agent-skills")
+    if (
+        path == "AGENTS.md"
+        or path == "ROADMAP.md"
+        or path.startswith("docs/standards/")
+        or path.startswith(".claude/commands/")
+    ):
+        check_names.append("standards-guards")
+    if path.startswith(".claude/commands/"):
+        check_names.append("docs-runtime-parity")
+    if (
+        path.startswith(".github/workflows/")
+        or path == ".github/CODEOWNERS"
+        or path == "docs/standards/delivery-guardrails.md"
+        or path == "tools/audit_delivery_guardrails.py"
+    ):
+        check_names.append("delivery-guardrails-audit")
+    if path in {
+        ".github/pull_request_template.md",
+        "docs/standards/commits.md",
+        "docs/standards/issues.md",
+        "tools/message_standards.py",
+        "tools/validate_pr_metadata.py",
+    }:
+        check_names.append("pr-metadata-validator")
+    if path in {
+        "docs/standards/commits.md",
+        "tools/message_standards.py",
+        "tools/validate_commit_message.py",
+    }:
+        check_names.append("commit-message-validator")
+    if path == "tools/run_quality_gates.py":
+        check_names.append("quality-gates-tooling")
+    if path in {".github/workflows/ci.yml", "tools/run_ci_parity_checks.py"}:
+        check_names.append("ci-parity-tooling")
+    if path in {"repo_support/pr_review.py", "tools/audit_pr_review.py"}:
+        check_names.append("audit-pr-review")
+    if path in {
+        "repo_support/pr_review.py",
+        "tools/run_pr_review_checks.py",
+        ".github/workflows/pr-review.yml",
+    }:
+        check_names.append("run-pr-review-checks")
+    if pure_path.parts[:2] == ("tools", "docs_maintenance"):
+        check_names.append("standards-guards")
+    return tuple(check_names)
+
+
+def classify_changed_paths(paths: Sequence[str]) -> PrReviewPlan:
+    grouped_paths: dict[str, list[str]] = {name: [] for name in SURFACE_GROUP_ORDER}
+    review_domains: list[str] = []
+    targeted_checks: list[TargetedCheck] = []
+    verification_level = "none"
+    unmapped_paths: list[str] = []
+
+    if any(_is_human_docs(path) or _is_control_plane_text(path) for path in paths):
+        targeted_checks.append(DOCS_MAINTENANCE_CHECK)
+
+    for path in paths:
+        groups = _path_surface_groups(path)
+        if not groups:
+            unmapped_paths.append(path)
+            continue
+        for group in groups:
+            grouped_paths[group].append(path)
+            verification_level = max(
+                verification_level,
+                SURFACE_VERIFICATION_LEVEL[group],
+                key=lambda level: VERIFICATION_LEVEL_ORDER[level],
+            )
+            for domain in SURFACE_REVIEW_DOMAINS[group]:
+                if domain not in review_domains:
+                    review_domains.append(domain)
+        for check_name in _path_targeted_check_names(path):
+            check = TARGETED_CHECKS_BY_NAME[check_name]
+            if check not in targeted_checks:
+                targeted_checks.append(check)
+
+    grouped = tuple(
+        (group, tuple(paths_for_group))
+        for group, paths_for_group in grouped_paths.items()
+        if paths_for_group
+    )
+    surface_groups = tuple(group for group, _ in grouped)
+    return PrReviewPlan(
+        changed_paths=tuple(paths),
+        grouped_paths=grouped,
+        surface_groups=surface_groups,
+        review_domains=tuple(review_domains),
+        targeted_checks=tuple(targeted_checks),
+        verification_level=verification_level,
+        unmapped_paths=tuple(unmapped_paths),
+    )

--- a/repo_support/pr_review_paths.py
+++ b/repo_support/pr_review_paths.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from pathlib import PurePosixPath
+
+CONTROL_PLANE_EXACT_PATHS = (
+    "AGENTS.md",
+    "ROADMAP.md",
+    ".github/pull_request_template.md",
+    ".github/CODEOWNERS",
+)
+CONTROL_PLANE_PREFIXES = (
+    ".agents/skills/",
+    ".claude/commands/",
+    "docs/standards/",
+    ".github/ISSUE_TEMPLATE/",
+)
+CI_OR_RELEASE_EXACT_PATHS = (
+    ".pre-commit-config.yaml",
+    ".pylintrc-tests",
+    "pyproject.toml",
+    "pyrightconfig.json",
+    "pyrightconfig.tests.json",
+    "uv.lock",
+    "tools/audit_delivery_guardrails.py",
+    "tools/audit_pr_review.py",
+    "tools/install_git_hooks.py",
+    "tools/message_standards.py",
+    "tools/pre_commit_hook.py",
+    "tools/run_ci_parity_checks.py",
+    "tools/run_pr_review_checks.py",
+    "tools/run_quality_gates.py",
+    "tools/validate_commit_message.py",
+    "tools/validate_pr_metadata.py",
+)
+CI_OR_RELEASE_PREFIXES = (".github/actions/", ".github/workflows/")
+PACKAGING_SENSITIVE_EXACT_PATHS = (
+    "pyproject.toml",
+    "uv.lock",
+    "tools/run_ci_parity_checks.py",
+)
+PACKAGING_SENSITIVE_PREFIXES = (
+    ".github/actions/",
+    ".github/workflows/",
+    "src/tallylot/interfaces/cli/",
+)
+
+
+def is_human_docs(path: str) -> bool:
+    return path in {"README.md", "CHANGELOG.md"} or (
+        path.startswith("docs/") and not path.startswith("docs/standards/")
+    )
+
+
+def is_control_plane_text(path: str) -> bool:
+    return path in CONTROL_PLANE_EXACT_PATHS or path.startswith(CONTROL_PLANE_PREFIXES)
+
+
+def is_repo_code_or_tooling(path: str) -> bool:
+    return (
+        path.startswith(("src/", "tests/", "repo_support/"))
+        or path.startswith("tools/")
+        and path.endswith(".py")
+    )
+
+
+def is_ci_or_release(path: str) -> bool:
+    return path in CI_OR_RELEASE_EXACT_PATHS or path.startswith(CI_OR_RELEASE_PREFIXES)
+
+
+def is_packaging_sensitive_path(path: str) -> bool:
+    return path in PACKAGING_SENSITIVE_EXACT_PATHS or path.startswith(
+        PACKAGING_SENSITIVE_PREFIXES
+    )
+
+
+def is_production_code_path(path: str) -> bool:
+    return path.startswith("src/tallylot/")
+
+
+def path_surface_groups(path: str) -> tuple[str, ...]:
+    groups: list[str] = []
+    if is_human_docs(path):
+        groups.append("human_docs")
+    if is_control_plane_text(path):
+        groups.append("control_plane_text")
+    if is_repo_code_or_tooling(path):
+        groups.append("repo_code_or_tooling")
+    if is_ci_or_release(path):
+        groups.append("ci_or_release")
+    return tuple(groups)
+
+
+def path_targeted_check_names(path: str) -> tuple[str, ...]:
+    check_names: list[str] = []
+    pure_path = PurePosixPath(path)
+    if path.startswith(".agents/skills/"):
+        check_names.append("repo-agent-skills")
+
+    condition_checks = (
+        (
+            path == "AGENTS.md"
+            or path == "ROADMAP.md"
+            or path.startswith("docs/standards/")
+            or path.startswith(".claude/commands/"),
+            ("standards-guards",),
+        ),
+        (
+            path.startswith(".claude/commands/"),
+            ("docs-runtime-parity",),
+        ),
+        (
+            path.startswith(".github/workflows/")
+            or path == ".github/CODEOWNERS"
+            or path == "docs/standards/delivery-guardrails.md"
+            or path == "tools/audit_delivery_guardrails.py",
+            ("delivery-guardrails-audit",),
+        ),
+        (
+            path
+            in {
+                ".github/pull_request_template.md",
+                "docs/standards/commits.md",
+                "docs/standards/issues.md",
+                "tools/message_standards.py",
+                "tools/validate_pr_metadata.py",
+            },
+            ("pr-metadata-validator",),
+        ),
+        (
+            path
+            in {
+                "docs/standards/commits.md",
+                "tools/message_standards.py",
+                "tools/validate_commit_message.py",
+            },
+            ("commit-message-validator",),
+        ),
+        (
+            path
+            in {
+                "tools/run_quality_gates.py",
+                "repo_support/quality_gates.py",
+                "repo_support/pytest_commands.py",
+            },
+            ("quality-gates-tooling",),
+        ),
+        (
+            path
+            in {
+                ".pre-commit-config.yaml",
+                "repo_support/pytest_commands.py",
+                "tools/pre_commit_hook.py",
+                "tools/run_fast_pytest.py",
+            },
+            ("pre-commit-hook-tooling",),
+        ),
+        (
+            path.startswith(".github/actions/")
+            or path in {".github/workflows/ci.yml", "tools/run_ci_parity_checks.py"},
+            ("ci-parity-tooling",),
+        ),
+        (
+            path
+            in {
+                "repo_support/pr_review.py",
+                "repo_support/pr_review_paths.py",
+                "tools/audit_pr_review.py",
+            },
+            ("audit-pr-review",),
+        ),
+        (
+            path
+            in {
+                "repo_support/pr_review.py",
+                "repo_support/pr_review_paths.py",
+                "tools/run_pr_review_checks.py",
+                ".github/workflows/pr-review.yml",
+            },
+            ("run-pr-review-checks",),
+        ),
+        (path == "tools/run_test_stress_checks.py", ("test-stress-checks",)),
+        (path == "tools/report_coverage_hotspots.py", ("coverage-hotspots",)),
+    )
+    for condition, names in condition_checks:
+        if condition:
+            check_names.extend(names)
+    if pure_path.parts[:2] == ("tools", "docs_maintenance"):
+        check_names.append("standards-guards")
+    return tuple(check_names)

--- a/repo_support/pr_review_paths.py
+++ b/repo_support/pr_review_paths.py
@@ -14,6 +14,7 @@ CONTROL_PLANE_PREFIXES = (
     "docs/standards/",
     ".github/ISSUE_TEMPLATE/",
 )
+REPO_CODE_OR_TOOLING_EXACT_PATHS = ("conftest.py",)
 CI_OR_RELEASE_EXACT_PATHS = (
     ".pre-commit-config.yaml",
     ".pylintrc-tests",
@@ -57,7 +58,8 @@ def is_control_plane_text(path: str) -> bool:
 
 def is_repo_code_or_tooling(path: str) -> bool:
     return (
-        path.startswith(("src/", "tests/", "repo_support/"))
+        path in REPO_CODE_OR_TOOLING_EXACT_PATHS
+        or path.startswith(("src/", "tests/", "repo_support/"))
         or path.startswith("tools/")
         and path.endswith(".py")
     )

--- a/repo_support/pytest_commands.py
+++ b/repo_support/pytest_commands.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import os
+
+DEFAULT_FAST_PYTEST_WORKERS = 4
+FAST_PYTEST_WORKERS_ENV = "TALLYLOT_FAST_PYTEST_WORKERS"
+FAST_PYTEST_MARKER_EXPRESSION = "unit and not slow"
+
+
+def resolve_fast_pytest_workers(workers: int | None = None) -> int:
+    if workers is not None:
+        resolved_workers = workers
+    else:
+        raw_workers = os.environ.get(FAST_PYTEST_WORKERS_ENV)
+        resolved_workers = (
+            DEFAULT_FAST_PYTEST_WORKERS if raw_workers is None else int(raw_workers)
+        )
+    if resolved_workers < 0:
+        raise ValueError("fast pytest worker count must be zero or greater")
+    return resolved_workers
+
+
+def build_fast_pytest_command(*, workers: int | None = None) -> tuple[str, ...]:
+    resolved_workers = resolve_fast_pytest_workers(workers)
+    command = ["uv", "run", "pytest"]
+    if resolved_workers > 0:
+        command.extend(("-n", str(resolved_workers)))
+    command.extend(("-m", FAST_PYTEST_MARKER_EXPRESSION, "--no-cov", "-q"))
+    return tuple(command)

--- a/repo_support/quality_gates.py
+++ b/repo_support/quality_gates.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+
+from repo_support.paths import repo_root
+
+QUALITY_GATE_ORDER = (
+    "markdownlint",
+    "actionlint",
+    "ruff",
+    "mypy",
+    "pyright",
+    "pylint",
+    "pytest",
+)
+QUALITY_SCHEDULES = ("auto", "all-at-once", "phased")
+FAST_PYTEST_WORKERS = 4
+
+
+@dataclass(frozen=True)
+class QualityGate:
+    name: str
+    command: tuple[str, ...]
+    coverage_gate: bool = False
+
+
+@dataclass(frozen=True)
+class QualityPhase:
+    name: str
+    gate_names: tuple[str, ...]
+
+
+def available_quality_gates(*, full_tests: bool) -> dict[str, QualityGate]:
+    pytest_command = (
+        ("uv", "run", "pytest")
+        if full_tests
+        else (
+            "uv",
+            "run",
+            "pytest",
+            "-n",
+            str(FAST_PYTEST_WORKERS),
+            "-m",
+            "unit and not slow",
+            "--no-cov",
+            "-q",
+        )
+    )
+    return {
+        "markdownlint": QualityGate(
+            name="markdownlint",
+            command=("uv", "run", "pre-commit", "run", "markdownlint", "--all-files"),
+        ),
+        "actionlint": QualityGate(
+            name="actionlint",
+            command=("uv", "run", "actionlint", "-color"),
+        ),
+        "ruff": QualityGate(name="ruff", command=("uv", "run", "ruff", "check", ".")),
+        "mypy": QualityGate(name="mypy", command=("uv", "run", "mypy")),
+        "pyright": QualityGate(name="pyright", command=("uv", "run", "pyright")),
+        "pylint": QualityGate(
+            name="pylint",
+            command=("uv", "run", "python", "-m", "tools.run_pylint"),
+        ),
+        "pytest": QualityGate(
+            name="pytest",
+            command=pytest_command,
+            coverage_gate=full_tests,
+        ),
+    }
+
+
+def quality_phase_plan(
+    *,
+    full_tests: bool,
+    schedule: str,
+    selected_gate_names: Iterable[str] | None = None,
+) -> tuple[QualityPhase, ...]:
+    if schedule not in QUALITY_SCHEDULES:
+        raise ValueError(f"unsupported quality schedule: {schedule}")
+
+    resolved_schedule = schedule
+    if schedule == "auto":
+        resolved_schedule = "all-at-once" if full_tests else "phased"
+
+    phases: tuple[QualityPhase, ...]
+    if resolved_schedule == "all-at-once":
+        phases = (QualityPhase(name="all-at-once", gate_names=QUALITY_GATE_ORDER),)
+    else:
+        phases = (
+            QualityPhase(
+                name="quick-static",
+                gate_names=("markdownlint", "actionlint", "ruff", "mypy"),
+            ),
+            QualityPhase(
+                name="heavy-static",
+                gate_names=("pyright", "pylint"),
+            ),
+            QualityPhase(name="tests", gate_names=("pytest",)),
+        )
+
+    selected = None
+    if selected_gate_names is not None:
+        selected = set(selected_gate_names)
+
+    filtered_phases: list[QualityPhase] = []
+    for phase in phases:
+        gate_names = tuple(
+            gate_name
+            for gate_name in phase.gate_names
+            if selected is None or gate_name in selected
+        )
+        if gate_names:
+            filtered_phases.append(QualityPhase(name=phase.name, gate_names=gate_names))
+    return tuple(filtered_phases)
+
+
+def apply_gate_environment(
+    existing: Mapping[str, str],
+    *,
+    coverage_gate: bool,
+) -> dict[str, str]:
+    environment = dict(existing)
+    if not coverage_gate:
+        return environment
+
+    coverage_config = str(repo_root() / "pyproject.toml")
+    existing_addopts = environment.get("PYTEST_ADDOPTS", "").strip()
+    coverage_addopt = f"--cov-config={coverage_config}"
+    if coverage_addopt not in existing_addopts.split():
+        environment["PYTEST_ADDOPTS"] = f"{existing_addopts} {coverage_addopt}".strip()
+    environment["COVERAGE_PROCESS_START"] = coverage_config
+    environment["COVERAGE_RCFILE"] = coverage_config
+    return environment

--- a/repo_support/quality_gates.py
+++ b/repo_support/quality_gates.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from repo_support.paths import repo_root
+from repo_support.pytest_commands import build_fast_pytest_command
 
 QUALITY_GATE_ORDER = (
     "markdownlint",
@@ -16,7 +17,6 @@ QUALITY_GATE_ORDER = (
     "pytest",
 )
 QUALITY_SCHEDULES = ("auto", "all-at-once", "phased")
-FAST_PYTEST_WORKERS = 4
 
 
 @dataclass(frozen=True)
@@ -34,19 +34,7 @@ class QualityPhase:
 
 def available_quality_gates(*, full_tests: bool) -> dict[str, QualityGate]:
     pytest_command = (
-        ("uv", "run", "pytest")
-        if full_tests
-        else (
-            "uv",
-            "run",
-            "pytest",
-            "-n",
-            str(FAST_PYTEST_WORKERS),
-            "-m",
-            "unit and not slow",
-            "--no-cov",
-            "-q",
-        )
+        ("uv", "run", "pytest") if full_tests else build_fast_pytest_command()
     )
     return {
         "markdownlint": QualityGate(

--- a/repo_support/quality_gates.py
+++ b/repo_support/quality_gates.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from pathlib import Path
 
 from repo_support.paths import repo_root
 
@@ -120,6 +121,7 @@ def apply_gate_environment(
     existing: Mapping[str, str],
     *,
     coverage_gate: bool,
+    coverage_file: Path | None = None,
 ) -> dict[str, str]:
     environment = dict(existing)
     if not coverage_gate:
@@ -130,6 +132,6 @@ def apply_gate_environment(
     coverage_addopt = f"--cov-config={coverage_config}"
     if coverage_addopt not in existing_addopts.split():
         environment["PYTEST_ADDOPTS"] = f"{existing_addopts} {coverage_addopt}".strip()
-    environment["COVERAGE_PROCESS_START"] = coverage_config
-    environment["COVERAGE_RCFILE"] = coverage_config
+    if coverage_file is not None:
+        environment["COVERAGE_FILE"] = str(coverage_file)
     return environment

--- a/tests/contract/test_repo_skill_scripts.py
+++ b/tests/contract/test_repo_skill_scripts.py
@@ -1,28 +1,60 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from datetime import UTC, datetime
 from decimal import Decimal
 from pathlib import Path
-from typing import TYPE_CHECKING
 
+import pytest
+
+from repo_support.paths import repo_root
 from tallylot.domain.checkpoints import BalanceSnapshot
 from tallylot.domain.instruments import InstrumentId
 from tallylot.domain.reconciliation import BalanceEvidence
 from tallylot.domain.temporal import TemporalPrecision
 from tallylot.domain.types import LocationId, SourceId
-from tallylot.infrastructure.serialization.filesystem import FilesystemArtifactStore
 from tallylot.infrastructure.storage import FilesystemEvidenceRepository
-from tests.support.skill_scripts import load_skill_main
-
-if TYPE_CHECKING:
-    import pytest
 
 
-def test_reconciliation_balance_skill_runner_executes_runtime_workflows(
+@pytest.mark.no_cover
+def test_balance_submission_skill_script_run_launches_as_real_process(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-    capsys: pytest.CaptureFixture[str],
+) -> None:
+    submission_root = tmp_path / "submission" / "manual-source"
+    output_root = tmp_path / "normalized" / "manual-source"
+
+    result = subprocess.run(
+        (
+            "python3",
+            str(
+                repo_root()
+                / ".agents/skills/balance-submission-operations/scripts/balance_submission_operations.py"
+            ),
+            "run",
+            "--source",
+            "manual-source",
+            "--submission-root",
+            str(submission_root),
+            "--output-root",
+            str(output_root),
+        ),
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["blocked"] is True
+    assert payload["stage"] == "inspect"
+    assert payload["ready_for_submit"] is False
+
+
+@pytest.mark.no_cover
+def test_reconciliation_balance_skill_script_run_launches_as_real_process(
+    tmp_path: Path,
 ) -> None:
     input_root = tmp_path / "normalized"
     analysis_root = tmp_path / "analysis"
@@ -76,40 +108,30 @@ def test_reconciliation_balance_skill_runner_executes_runtime_workflows(
         input_root / "issue-source" / "balance_evidence.csv",
         (),
     )
-    monkeypatch.chdir(tmp_path)
-    main = load_skill_main(
-        ".agents/skills/reconciliation-balance-operations/scripts/reconciliation_balance_operations.py"
-    )
 
-    exit_code = main(
+    result = subprocess.run(
         (
+            "python3",
+            str(
+                repo_root()
+                / ".agents/skills/reconciliation-balance-operations/scripts/reconciliation_balance_operations.py"
+            ),
             "run",
             "--input-root",
             str(input_root),
             "--analysis-root",
             str(analysis_root),
-        )
-    )
-    captured = capsys.readouterr()
-
-    assert exit_code == 0
-    assert captured.err == ""
-    payload = json.loads(captured.out)
-    summary = json.loads(
-        (analysis_root / "balance_reconciliation_summary.json").read_text(
-            encoding="utf-8"
-        )
-    )
-    blocker_rows = FilesystemArtifactStore().read_rows(
-        analysis_root / "balance_reconciliation_blockers.csv"
+        ),
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
     )
 
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
     assert payload["summary_output_ref"] == str(
         analysis_root / "balance_reconciliation_summary.json"
     )
-    assert summary["latest_portfolio_clean_date"] == ""
-    assert summary["latest_portfolio_source_backed_date"] == ""
-    assert summary["latest_clean_source_date"] == "2026-03-23"
-    assert summary["latest_source_backed_date"] == "2026-03-23"
-    assert summary["latest_observed_assertion_date"] == "2026-03-23"
-    assert blocker_rows[0]["source"] == "issue-source"
+    assert payload["latest_clean_source_date"] == "2026-03-23"
+    assert payload["latest_source_backed_date"] == "2026-03-23"

--- a/tests/contract/test_standards_guards.py
+++ b/tests/contract/test_standards_guards.py
@@ -366,7 +366,7 @@ def test_delivery_guardrails_doc_is_routed_and_layered() -> None:
         repo_root() / ".claude/commands/implementation-checkpoint.md"
     ).read_text(encoding="utf-8")
     hardening_route_text = (
-        repo_root() / ".claude" / "commands" / "pr-hardening-review.md"
+        repo_root() / ".claude" / "commands" / "pr-review.md"
     ).read_text(encoding="utf-8")
 
     assert "platform-native enforcement" in guardrails_text
@@ -404,11 +404,12 @@ def test_delivery_guardrails_doc_is_routed_and_layered() -> None:
     assert "tools/docs_maintenance/metadata.py" in agents_text
     assert "docs/reference/repository-history.md" in agents_text
     assert "docs/standards/delivery-guardrails.md" in agents_text
-    assert ".claude/commands/pr-hardening-review.md" in agents_text
+    assert ".claude/commands/pr-review.md" in agents_text
     assert "delivery guardrails layered across platform settings" in roadmap_text
     assert "control-plane ownership routing" in roadmap_text
     assert "audit local CODEOWNERS coverage and live GitHub delivery" in roadmap_text
     assert "settings together without broad context loading" in roadmap_text
+    assert "repo-native PR review routing" in roadmap_text
     assert (
         "if standards, docs placement, doc authoring rules, or agent-default enforcement changed"
         in checkpoint_text
@@ -420,14 +421,25 @@ def test_delivery_guardrails_doc_is_routed_and_layered() -> None:
     assert "shell-safe commit and PR authoring rules" in checkpoint_text
     assert "scratch workflow bookkeeping" in checkpoint_text
     assert "search for an existing issue first" in checkpoint_text
+    assert "`human_docs`" in guardrails_text
+    assert "`control_plane_text`" in guardrails_text
+    assert "`repo_code_or_tooling`" in guardrails_text
+    assert "`ci_or_release`" in guardrails_text
+    assert "surface-specific targeted checks still apply" in guardrails_text
+    assert (
+        "every applicable changed surface group has completed a clean"
+        in guardrails_text
+    )
+    assert "tools.audit_pr_review" in hardening_route_text
+    assert "tools.run_pr_review_checks" in hardening_route_text
     assert "full clean loop has completed with no new" in hardening_route_text
     assert "invent findings to hit a quota" in hardening_route_text
     assert (
         "stop only after a full pass yields no new meaningful findings"
-        in guardrails_text
+        not in guardrails_text
     )
     assert (
-        "Continue steps 1 through 5 until a full pass yields no new meaningful"
+        "Continue steps 1 through 5 until every applicable changed surface group has"
         in hardening_route_text
     )
 
@@ -437,7 +449,7 @@ def test_repo_local_routing_does_not_depend_on_removed_global_safety_skills() ->
         encoding="utf-8"
     )
     hardening_route_text = (
-        repo_root() / ".claude" / "commands" / "pr-hardening-review.md"
+        repo_root() / ".claude" / "commands" / "pr-review.md"
     ).read_text(encoding="utf-8")
 
     for relative_path in (
@@ -458,15 +470,18 @@ def test_repo_local_routing_does_not_depend_on_removed_global_safety_skills() ->
     )
     assert "AGENTS.md`, its task-routing table" in guardrails_text
     assert "checkpoint commits during the loop" in guardrails_text
+    assert "applicable surface groups" in guardrails_text
     assert (
         "Repair every finding from that pass before starting the next pass"
         in hardening_route_text
     )
-    assert "create bounded checkpoint commits during the" in hardening_route_text
+    assert "create a bounded checkpoint commit" in hardening_route_text
     assert (
         "relevant delivery guidance or skills before updating the PR"
         in hardening_route_text
     )
+    assert "tools.audit_pr_review" in hardening_route_text
+    assert "tools.run_pr_review_checks" in hardening_route_text
 
 
 def test_control_plane_codeowners_file_exists_and_covers_guardrail_paths() -> None:
@@ -486,7 +501,9 @@ def test_control_plane_codeowners_file_exists_and_covers_guardrail_paths() -> No
         "tools/install_git_hooks.py",
         "tools/pre_commit_hook.py",
         "tools/audit_delivery_guardrails.py",
+        "tools/audit_pr_review.py",
         "tools/message_standards.py",
+        "tools/run_pr_review_checks.py",
         "tools/validate_commit_message.py",
         "tools/validate_pr_metadata.py",
         "tools/run_quality_gates.py",

--- a/tests/contract/test_standards_guards.py
+++ b/tests/contract/test_standards_guards.py
@@ -333,15 +333,20 @@ def test_delivery_standards_pin_merge_subject_and_repair_label_rules() -> None:
     assert "<pr title> (#<pr number>)" in implementation_text
     assert "<pr title> (#<pr number>)" in agents_text
     assert "<pr title> (#<pr number>)" in checkpoint_text
+    assert "Issue linkage:" in commits_text
+    assert "Issue linkage:" in issues_text
+    assert "Issue linkage:" in pr_template_text
     assert "Follow-ups:" in commits_text
     assert "optional `Follow-ups:` section is allowed" in commits_text
     assert "Follow-ups:" in pr_template_text
+    assert '"Issue linkage"' in message_standards_text
     assert 'PR_BODY_OPTIONAL_SECTIONS = ("Follow-ups",)' in message_standards_text
     assert "PR_BODY_OPTIONAL_SECTIONS" in pr_validator_text
+    assert "`Issue linkage:`" in pr_validator_text
     assert "GENERATED_SQUASH_COMMIT_OPTIONAL_SECTIONS" in commit_validator_text
-    assert "- Closes #123:" in commits_text
-    assert "Follow-ups:" in issues_text
-    assert "`Follow-ups:` with `- Refs #123`" in issues_text
+    assert "`- Closes #123: <problem statement>`" in commits_text
+    assert "`- Refs #123`" in issues_text
+    assert "`- None: ...`" in issues_text
     assert "duplicate/superseded label" in commits_text
     assert "duplicate/superseded label" in implementation_text
     assert "duplicate/superseded label" in agents_text

--- a/tests/contract/test_standards_guards.py
+++ b/tests/contract/test_standards_guards.py
@@ -353,6 +353,11 @@ def test_delivery_standards_pin_merge_subject_and_repair_label_rules() -> None:
     assert "duplicate/superseded label" in implementation_text
     assert "duplicate/superseded label" in agents_text
     assert "duplicate/superseded label" in checkpoint_text
+    assert "Every authored commit must stay bounded to" in commits_text
+    assert "multiple bounded checkpoint commits" in commits_text
+    assert "keep each authored commit bounded" in implementation_text
+    assert "split it into\n   multiple bounded checkpoint commits" in checkpoint_text
+    assert "keep every authored commit bounded to one reviewable slice" in agents_text
 
 
 def test_delivery_guardrails_doc_is_routed_and_layered() -> None:

--- a/tests/contract/test_standards_guards.py
+++ b/tests/contract/test_standards_guards.py
@@ -437,24 +437,28 @@ def test_delivery_guardrails_doc_is_routed_and_layered() -> None:
     assert "surface-specific targeted checks still apply" in guardrails_text
     assert "duplicate `quality-gates-full` pass" in guardrails_text
     assert (
-        "every applicable changed surface group has completed a clean"
-        in guardrails_text
+        "every applicable changed surface group has been revisited" in guardrails_text
     )
+    assert "issue-finding with open outcome" in guardrails_text
     assert "tools.audit_pr_review" in hardening_route_text
     assert "tools.run_pr_review_checks" in hardening_route_text
     assert (
         "green runner never replaces the mandatory red-team repair" in guardrails_text
     )
     assert (
-        "green `tools.run_pr_review_checks` result as a clean pass"
+        "green `tools.run_pr_review_checks` result as a no-findings"
         in hardening_route_text
     )
-    assert "full clean loop has completed with no new" in hardening_route_text
+    assert "issue-finding loop" in hardening_route_text
     assert "invent findings to hit a quota" in hardening_route_text
     assert (
         "stop only after a full pass yields no new meaningful findings"
         not in guardrails_text
     )
+    assert "clean hardening pass" not in guardrails_text
+    assert "full clean loop" not in hardening_route_text
+    assert "claiming a clean pass" not in hardening_route_text
+    assert "final PR review" not in hardening_route_text
     assert (
         "Continue steps 1 through 5 until every applicable changed surface group has"
         in hardening_route_text
@@ -485,6 +489,7 @@ def test_repo_local_routing_does_not_depend_on_removed_global_safety_skills() ->
         "repair every finding from that pass before starting the next pass"
         in guardrails_text
     )
+    assert "issue-finding with open outcome" in hardening_route_text
     assert "AGENTS.md`, its task-routing table" in guardrails_text
     assert "checkpoint commits during the loop" in guardrails_text
     assert "applicable surface groups" in guardrails_text
@@ -492,12 +497,11 @@ def test_repo_local_routing_does_not_depend_on_removed_global_safety_skills() ->
         "Repair every finding from that pass before starting the next pass"
         in hardening_route_text
     )
-    assert "verification evidence for the current red-team pass" in hardening_route_text
+    assert "verification evidence for the current" in hardening_route_text
+    assert "red-team pass" in hardening_route_text
     assert "create a bounded checkpoint commit" in hardening_route_text
-    assert (
-        "relevant delivery guidance or skills before updating the PR"
-        in hardening_route_text
-    )
+    assert "relevant delivery guidance or skills" in hardening_route_text
+    assert "updating the PR state" in hardening_route_text
     assert "tools.audit_pr_review" in hardening_route_text
     assert "tools.run_pr_review_checks" in hardening_route_text
 

--- a/tests/contract/test_standards_guards.py
+++ b/tests/contract/test_standards_guards.py
@@ -336,6 +336,8 @@ def test_delivery_standards_pin_merge_subject_and_repair_label_rules() -> None:
     assert "Issue linkage:" in commits_text
     assert "Issue linkage:" in issues_text
     assert "Issue linkage:" in pr_template_text
+    assert "file/stdin authoring forms" in commits_text
+    assert "shell-sensitive text" in commits_text
     assert "Follow-ups:" in commits_text
     assert "optional `Follow-ups:` section is allowed" in commits_text
     assert "Follow-ups:" in pr_template_text
@@ -394,7 +396,8 @@ def test_delivery_guardrails_doc_is_routed_and_layered() -> None:
     )
     assert "use the `markdown` skill if available" in agents_text
     assert (
-        "use\n  the `code-change-safety` skill as the starting workflow" in agents_text
+        "use\n  the repo-local workflow for the active surface and reload the narrow repo\n  guidance listed in this file before editing."
+        in agents_text
     )
     assert "docs/standards/issues.md" in agents_text
     assert ".claude/commands/issue-workflow.md" in agents_text
@@ -411,9 +414,10 @@ def test_delivery_guardrails_doc_is_routed_and_layered() -> None:
         in checkpoint_text
     )
     assert (
-        "use `code-change-safety` for repo changes and `markdown` for Markdown/docs"
+        "use `markdown` for Markdown/docs work when that skill is available"
         in checkpoint_text
     )
+    assert "shell-safe commit and PR authoring rules" in checkpoint_text
     assert "scratch workflow bookkeeping" in checkpoint_text
     assert "search for an existing issue first" in checkpoint_text
     assert "full clean loop has completed with no new" in hardening_route_text
@@ -426,6 +430,28 @@ def test_delivery_guardrails_doc_is_routed_and_layered() -> None:
         "Continue steps 1 through 5 until a full pass yields no new meaningful"
         in hardening_route_text
     )
+
+
+def test_repo_local_routing_does_not_depend_on_removed_global_safety_skills() -> None:
+    guardrails_text = (repo_root() / "docs/standards/delivery-guardrails.md").read_text(
+        encoding="utf-8"
+    )
+    hardening_route_text = (
+        repo_root() / ".claude" / "commands" / "pr-hardening-review.md"
+    ).read_text(encoding="utf-8")
+
+    for relative_path in (
+        "AGENTS.md",
+        ".agents/skills/implementation-workflow/SKILL.md",
+        ".agents/skills/issue-workflow/SKILL.md",
+        ".agents/skills/docs-authoring/SKILL.md",
+        ".claude/commands/implementation-checkpoint.md",
+        "docs/standards/delivery-guardrails.md",
+    ):
+        text = (repo_root() / relative_path).read_text(encoding="utf-8")
+        assert "code-change-safety" not in text
+        assert "git-delivery-safety" not in text
+        assert "docs-change-safety" not in text
     assert (
         "repair every finding from that pass before starting the next pass"
         in guardrails_text

--- a/tests/contract/test_standards_guards.py
+++ b/tests/contract/test_standards_guards.py
@@ -384,9 +384,11 @@ def test_delivery_guardrails_doc_is_routed_and_layered() -> None:
     assert "duplicate or superseded label" in guardrails_text
     assert "tools.audit_delivery_guardrails" in guardrails_text
     assert "single review-capable collaborator" in guardrails_text
+    assert ".github/actions/**" in guardrails_text
     assert ".github/ISSUE_TEMPLATE/**" in guardrails_text
     assert "docs/status/current-state.md" in guardrails_text
     assert "tools/docs_maintenance/cli.py" in guardrails_text
+    assert "tools/benchmark_quality_gates.py" in guardrails_text
     assert "`markdown` skill" in guardrails_text
     assert "human docs, agent" in guardrails_text
     assert "standards/delivery-guardrails.md" in docs_index_text
@@ -415,6 +417,8 @@ def test_delivery_guardrails_doc_is_routed_and_layered() -> None:
     assert "audit local CODEOWNERS coverage and live GitHub delivery" in roadmap_text
     assert "settings together without broad context loading" in roadmap_text
     assert "repo-native PR review routing" in roadmap_text
+    assert "benchmark-backed" in roadmap_text
+    assert "one opaque parity shell" in roadmap_text
     assert (
         "if standards, docs placement, doc authoring rules, or agent-default enforcement changed"
         in checkpoint_text
@@ -496,6 +500,7 @@ def test_control_plane_codeowners_file_exists_and_covers_guardrail_paths() -> No
     codeowners_text = codeowners_path.read_text(encoding="utf-8")
     required_entries = (
         ".agents/skills/**",
+        ".github/actions/**",
         ".github/ISSUE_TEMPLATE/**",
         ".github/workflows/**",
         ".github/pull_request_template.md",
@@ -507,6 +512,7 @@ def test_control_plane_codeowners_file_exists_and_covers_guardrail_paths() -> No
         "tools/pre_commit_hook.py",
         "tools/audit_delivery_guardrails.py",
         "tools/audit_pr_review.py",
+        "tools/benchmark_quality_gates.py",
         "tools/message_standards.py",
         "tools/run_pr_review_checks.py",
         "tools/validate_commit_message.py",

--- a/tests/contract/test_standards_guards.py
+++ b/tests/contract/test_standards_guards.py
@@ -435,12 +435,20 @@ def test_delivery_guardrails_doc_is_routed_and_layered() -> None:
     assert "`repo_code_or_tooling`" in guardrails_text
     assert "`ci_or_release`" in guardrails_text
     assert "surface-specific targeted checks still apply" in guardrails_text
+    assert "duplicate `quality-gates-full` pass" in guardrails_text
     assert (
         "every applicable changed surface group has completed a clean"
         in guardrails_text
     )
     assert "tools.audit_pr_review" in hardening_route_text
     assert "tools.run_pr_review_checks" in hardening_route_text
+    assert (
+        "green runner never replaces the mandatory red-team repair" in guardrails_text
+    )
+    assert (
+        "green `tools.run_pr_review_checks` result as a clean pass"
+        in hardening_route_text
+    )
     assert "full clean loop has completed with no new" in hardening_route_text
     assert "invent findings to hit a quota" in hardening_route_text
     assert (
@@ -484,6 +492,7 @@ def test_repo_local_routing_does_not_depend_on_removed_global_safety_skills() ->
         "Repair every finding from that pass before starting the next pass"
         in hardening_route_text
     )
+    assert "verification evidence for the current red-team pass" in hardening_route_text
     assert "create a bounded checkpoint commit" in hardening_route_text
     assert (
         "relevant delivery guidance or skills before updating the PR"

--- a/tests/support/skill_scripts.py
+++ b/tests/support/skill_scripts.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import importlib.util
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from types import ModuleType
+from typing import cast
+
+from repo_support.paths import repo_root
+
+
+def load_skill_main(relative_path: str) -> Callable[[Sequence[str] | None], int]:
+    script_path = repo_root() / relative_path
+    if script_path.is_file() is False:
+        raise FileNotFoundError(f"missing repo skill script: {script_path}")
+    module = _load_script_module(script_path)
+    main = getattr(module, "main", None)
+    if not callable(main):
+        raise AttributeError(
+            f"skill script does not expose a callable main: {script_path}"
+        )
+    return cast(Callable[[Sequence[str] | None], int], main)
+
+
+def _load_script_module(script_path: Path) -> ModuleType:
+    module_name = "_tallylot_test_skill_" + "_".join(script_path.parts[-5:])
+    module_name = module_name.replace("-", "_").replace(".", "_")
+    spec = importlib.util.spec_from_file_location(module_name, script_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"could not load repo skill script: {script_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module

--- a/tests/unit/test_audit_pr_review.py
+++ b/tests/unit/test_audit_pr_review.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import json
+
+from pytest import CaptureFixture, MonkeyPatch
+
+from repo_support.pr_review import classify_changed_paths
+import tools.audit_pr_review as audit_pr_review
+
+
+def _docs_changed_paths(
+    base_sha: str | None = None, head_sha: str | None = None
+) -> tuple[str, ...]:
+    del base_sha, head_sha
+    return ("docs/guides/source-intake.md",)
+
+
+def _unmapped_changed_paths(
+    base_sha: str | None = None, head_sha: str | None = None
+) -> tuple[str, ...]:
+    del base_sha, head_sha
+    return ("notes/todo.md",)
+
+
+def test_docs_only_diff_maps_to_human_docs() -> None:
+    plan = classify_changed_paths(("docs/guides/source-intake.md",))
+
+    assert plan.surface_groups == ("human_docs",)
+    assert plan.verification_level == "docs-maintenance"
+    assert [check.name for check in plan.targeted_checks] == ["docs-maintenance"]
+    assert plan.unmapped_paths == ()
+
+
+def test_control_plane_diff_maps_to_targeted_review_surface() -> None:
+    plan = classify_changed_paths((".agents/skills/pr-review/SKILL.md",))
+
+    assert plan.surface_groups == ("control_plane_text",)
+    assert plan.verification_level == "control-plane-targeted"
+    assert [check.name for check in plan.targeted_checks] == [
+        "docs-maintenance",
+        "repo-agent-skills",
+    ]
+
+
+def test_repo_code_diff_maps_to_full_quality_gates() -> None:
+    plan = classify_changed_paths(("src/tallylot/interfaces/cli/source.py",))
+
+    assert plan.surface_groups == ("repo_code_or_tooling",)
+    assert plan.verification_level == "quality-gates-full"
+    assert "design and ownership" in plan.review_domains
+
+
+def test_ci_workflow_diff_maps_to_ci_parity() -> None:
+    plan = classify_changed_paths((".github/workflows/pr-review.yml",))
+
+    assert plan.surface_groups == ("ci_or_release",)
+    assert plan.verification_level == "ci-parity"
+    assert [check.name for check in plan.targeted_checks] == [
+        "delivery-guardrails-audit",
+        "run-pr-review-checks",
+    ]
+
+
+def test_mixed_diff_uses_strongest_verification_level() -> None:
+    plan = classify_changed_paths(
+        ("docs/guides/source-intake.md", "src/tallylot/interfaces/cli/source.py")
+    )
+
+    assert plan.surface_groups == ("human_docs", "repo_code_or_tooling")
+    assert plan.verification_level == "quality-gates-full"
+    assert [check.name for check in plan.targeted_checks] == ["docs-maintenance"]
+
+
+def test_unmapped_paths_are_reported() -> None:
+    plan = classify_changed_paths(("notes/todo.md",))
+
+    assert plan.surface_groups == ()
+    assert plan.unmapped_paths == ("notes/todo.md",)
+
+
+def test_audit_pr_review_can_emit_json(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(audit_pr_review, "changed_paths", _docs_changed_paths)
+
+    assert audit_pr_review.main(["--json"]) == 0
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["surface_groups"] == ["human_docs"]
+    assert report["verification_level"] == "docs-maintenance"
+
+
+def test_audit_pr_review_fails_closed_for_unmapped_paths(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(audit_pr_review, "changed_paths", _unmapped_changed_paths)
+
+    assert audit_pr_review.main([]) == 1
+    assert "unmapped paths" in capsys.readouterr().out

--- a/tests/unit/test_audit_pr_review.py
+++ b/tests/unit/test_audit_pr_review.py
@@ -27,6 +27,11 @@ def test_docs_only_diff_maps_to_human_docs() -> None:
 
     assert plan.surface_groups == ("human_docs",)
     assert plan.verification_level == "docs-maintenance"
+    assert plan.requires_full_quality_gates is False
+    assert plan.requires_ci_parity is False
+    assert plan.requires_pre_merge_packaging_verification is False
+    assert plan.requires_test_stress_checks is False
+    assert plan.requires_coverage_hotspot_report is False
     assert [check.name for check in plan.targeted_checks] == ["docs-maintenance"]
     assert plan.unmapped_paths == ()
 
@@ -36,6 +41,8 @@ def test_control_plane_diff_maps_to_targeted_review_surface() -> None:
 
     assert plan.surface_groups == ("control_plane_text",)
     assert plan.verification_level == "control-plane-targeted"
+    assert plan.requires_full_quality_gates is False
+    assert plan.requires_ci_parity is False
     assert [check.name for check in plan.targeted_checks] == [
         "docs-maintenance",
         "repo-agent-skills",
@@ -43,11 +50,29 @@ def test_control_plane_diff_maps_to_targeted_review_surface() -> None:
 
 
 def test_repo_code_diff_maps_to_full_quality_gates() -> None:
+    plan = classify_changed_paths(
+        ("src/tallylot/application/normalization/normalize_source.py",)
+    )
+
+    assert plan.surface_groups == ("repo_code_or_tooling",)
+    assert plan.verification_level == "quality-gates-full"
+    assert plan.requires_full_quality_gates is True
+    assert plan.requires_ci_parity is False
+    assert plan.requires_pre_merge_packaging_verification is False
+    assert plan.requires_test_stress_checks is True
+    assert plan.requires_coverage_hotspot_report is True
+    assert "design and ownership" in plan.review_domains
+
+
+def test_packaging_sensitive_repo_code_adds_pre_merge_packaging_verification() -> None:
     plan = classify_changed_paths(("src/tallylot/interfaces/cli/source.py",))
 
     assert plan.surface_groups == ("repo_code_or_tooling",)
     assert plan.verification_level == "quality-gates-full"
-    assert "design and ownership" in plan.review_domains
+    assert plan.requires_full_quality_gates is True
+    assert plan.requires_pre_merge_packaging_verification is True
+    assert plan.requires_test_stress_checks is True
+    assert plan.requires_coverage_hotspot_report is True
 
 
 def test_ci_workflow_diff_maps_to_ci_parity() -> None:
@@ -55,6 +80,11 @@ def test_ci_workflow_diff_maps_to_ci_parity() -> None:
 
     assert plan.surface_groups == ("ci_or_release",)
     assert plan.verification_level == "ci-parity"
+    assert plan.requires_full_quality_gates is False
+    assert plan.requires_ci_parity is True
+    assert plan.requires_pre_merge_packaging_verification is False
+    assert plan.requires_test_stress_checks is True
+    assert plan.requires_coverage_hotspot_report is False
     assert [check.name for check in plan.targeted_checks] == [
         "delivery-guardrails-audit",
         "run-pr-review-checks",
@@ -66,16 +96,24 @@ def test_github_action_diff_maps_to_ci_parity() -> None:
 
     assert plan.surface_groups == ("ci_or_release",)
     assert plan.verification_level == "ci-parity"
+    assert plan.requires_ci_parity is True
+    assert plan.requires_test_stress_checks is True
     assert [check.name for check in plan.targeted_checks] == ["ci-parity-tooling"]
 
 
 def test_mixed_diff_uses_strongest_verification_level() -> None:
     plan = classify_changed_paths(
-        ("docs/guides/source-intake.md", "src/tallylot/interfaces/cli/source.py")
+        (
+            "docs/guides/source-intake.md",
+            "src/tallylot/application/normalization/normalize_source.py",
+        )
     )
 
     assert plan.surface_groups == ("human_docs", "repo_code_or_tooling")
     assert plan.verification_level == "quality-gates-full"
+    assert plan.requires_full_quality_gates is True
+    assert plan.requires_test_stress_checks is True
+    assert plan.requires_coverage_hotspot_report is True
     assert [check.name for check in plan.targeted_checks] == ["docs-maintenance"]
 
 
@@ -96,6 +134,7 @@ def test_audit_pr_review_can_emit_json(
     report = json.loads(capsys.readouterr().out)
     assert report["surface_groups"] == ["human_docs"]
     assert report["verification_level"] == "docs-maintenance"
+    assert report["requires_pre_merge_packaging_verification"] is False
 
 
 def test_audit_pr_review_fails_closed_for_unmapped_paths(

--- a/tests/unit/test_audit_pr_review.py
+++ b/tests/unit/test_audit_pr_review.py
@@ -61,6 +61,14 @@ def test_ci_workflow_diff_maps_to_ci_parity() -> None:
     ]
 
 
+def test_github_action_diff_maps_to_ci_parity() -> None:
+    plan = classify_changed_paths((".github/actions/setup-python-uv/action.yml",))
+
+    assert plan.surface_groups == ("ci_or_release",)
+    assert plan.verification_level == "ci-parity"
+    assert [check.name for check in plan.targeted_checks] == ["ci-parity-tooling"]
+
+
 def test_mixed_diff_uses_strongest_verification_level() -> None:
     plan = classify_changed_paths(
         ("docs/guides/source-intake.md", "src/tallylot/interfaces/cli/source.py")

--- a/tests/unit/test_audit_pr_review.py
+++ b/tests/unit/test_audit_pr_review.py
@@ -64,6 +64,16 @@ def test_repo_code_diff_maps_to_full_quality_gates() -> None:
     assert "design and ownership" in plan.review_domains
 
 
+def test_repo_root_conftest_maps_to_repo_code_review_surface() -> None:
+    plan = classify_changed_paths(("conftest.py",))
+
+    assert plan.surface_groups == ("repo_code_or_tooling",)
+    assert plan.verification_level == "quality-gates-full"
+    assert plan.requires_full_quality_gates is True
+    assert plan.requires_test_stress_checks is True
+    assert plan.unmapped_paths == ()
+
+
 def test_packaging_sensitive_repo_code_adds_pre_merge_packaging_verification() -> None:
     plan = classify_changed_paths(("src/tallylot/interfaces/cli/source.py",))
 
@@ -135,6 +145,7 @@ def test_audit_pr_review_can_emit_json(
     assert report["surface_groups"] == ["human_docs"]
     assert report["verification_level"] == "docs-maintenance"
     assert report["requires_pre_merge_packaging_verification"] is False
+    assert report["manual_red_team_review_required"] is True
 
 
 def test_audit_pr_review_fails_closed_for_unmapped_paths(
@@ -144,3 +155,15 @@ def test_audit_pr_review_fails_closed_for_unmapped_paths(
 
     assert audit_pr_review.main([]) == 1
     assert "unmapped paths" in capsys.readouterr().out
+
+
+def test_audit_pr_review_emits_red_team_review_reminder(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(audit_pr_review, "changed_paths", _docs_changed_paths)
+
+    assert audit_pr_review.main([]) == 0
+
+    output = capsys.readouterr().out
+    assert "manual red-team review: required" in output
+    assert "mandatory red-team repair loop" in output

--- a/tests/unit/test_audit_pr_review.py
+++ b/tests/unit/test_audit_pr_review.py
@@ -167,3 +167,4 @@ def test_audit_pr_review_emits_red_team_review_reminder(
     output = capsys.readouterr().out
     assert "manual red-team review: required" in output
     assert "mandatory red-team repair loop" in output
+    assert "next issue-finding pass" in output

--- a/tests/unit/test_balance_submission_skill.py
+++ b/tests/unit/test_balance_submission_skill.py
@@ -1,39 +1,41 @@
 from __future__ import annotations
 
 import json
-import subprocess
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from repo_support.paths import repo_root
 from tallylot.infrastructure.serialization.filesystem import FilesystemArtifactStore
+from tests.support.skill_scripts import load_skill_main
+
+if TYPE_CHECKING:
+    import pytest
 
 
 def test_balance_submission_skill_runner_resolves_repo_root_and_inspects_missing_values(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     submission_root = tmp_path / "submission" / "manual-source"
+    monkeypatch.chdir(tmp_path)
+    main = load_skill_main(
+        ".agents/skills/balance-submission-operations/scripts/balance_submission_operations.py"
+    )
 
-    result = subprocess.run(
+    exit_code = main(
         (
-            "python3",
-            str(
-                repo_root()
-                / ".agents/skills/balance-submission-operations/scripts/balance_submission_operations.py"
-            ),
             "inspect",
             "--source",
             "manual-source",
             "--submission-root",
             str(submission_root),
-        ),
-        cwd=tmp_path,
-        capture_output=True,
-        text=True,
-        check=False,
+        )
     )
+    captured = capsys.readouterr()
 
-    assert result.returncode == 0, result.stderr
-    payload = json.loads(result.stdout)
+    assert exit_code == 0
+    assert captured.err == ""
+    payload = json.loads(captured.out)
     assert payload["submission_root"] == str(submission_root)
     assert payload["ready_for_submit"] is False
     assert payload["issue_count"] >= 2
@@ -44,14 +46,18 @@ def test_balance_submission_skill_runner_resolves_repo_root_and_inspects_missing
 
 def test_balance_submission_skill_run_mode_does_not_guess_missing_values(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     submission_root = tmp_path / "submission" / "manual-source"
     output_root = tmp_path / "normalized" / "manual-source"
+    monkeypatch.chdir(tmp_path)
+    main = load_skill_main(
+        ".agents/skills/balance-submission-operations/scripts/balance_submission_operations.py"
+    )
 
-    result = subprocess.run(
+    exit_code = main(
         (
-            "python3",
-            ".agents/skills/balance-submission-operations/scripts/balance_submission_operations.py",
             "run",
             "--source",
             "manual-source",
@@ -59,15 +65,13 @@ def test_balance_submission_skill_run_mode_does_not_guess_missing_values(
             str(submission_root),
             "--output-root",
             str(output_root),
-        ),
-        cwd=repo_root(),
-        capture_output=True,
-        text=True,
-        check=False,
+        )
     )
+    captured = capsys.readouterr()
 
-    assert result.returncode == 0, result.stderr
-    payload = json.loads(result.stdout)
+    assert exit_code == 0
+    assert captured.err == ""
+    payload = json.loads(captured.out)
     assert payload["blocked"] is True
     assert payload["stage"] == "inspect"
     assert payload["ready_for_submit"] is False
@@ -76,6 +80,8 @@ def test_balance_submission_skill_run_mode_does_not_guess_missing_values(
 
 def test_balance_submission_skill_submit_writes_runtime_artifacts(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
     submission_root = tmp_path / "submission" / "manual-source"
     output_root = tmp_path / "normalized" / "manual-source"
@@ -146,11 +152,13 @@ def test_balance_submission_skill_submit_writes_runtime_artifacts(
             },
         ),
     )
+    monkeypatch.chdir(tmp_path)
+    main = load_skill_main(
+        ".agents/skills/balance-submission-operations/scripts/balance_submission_operations.py"
+    )
 
-    result = subprocess.run(
+    exit_code = main(
         (
-            "python3",
-            ".agents/skills/balance-submission-operations/scripts/balance_submission_operations.py",
             "submit",
             "--source",
             "manual-source",
@@ -158,15 +166,13 @@ def test_balance_submission_skill_submit_writes_runtime_artifacts(
             str(submission_root),
             "--output-root",
             str(output_root),
-        ),
-        cwd=repo_root(),
-        capture_output=True,
-        text=True,
-        check=False,
+        )
     )
+    captured = capsys.readouterr()
 
-    assert result.returncode == 0, result.stderr
-    payload = json.loads(result.stdout)
+    assert exit_code == 0
+    assert captured.err == ""
+    payload = json.loads(captured.out)
     assert payload["blocked"] is False
     assert payload["trust_tier"] == "operator_confirmed"
     assert payload["summary_path"] == str(

--- a/tests/unit/test_benchmark_quality_gates.py
+++ b/tests/unit/test_benchmark_quality_gates.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 
+import pytest
 from pytest import MonkeyPatch
 
 import tools.benchmark_quality_gates as benchmark_quality_gates
@@ -26,7 +28,12 @@ def test_benchmark_quality_gates_runs_selected_strategy(
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
-    assert benchmark_quality_gates.main(["--strategy", "fast-current"]) == 0
+    assert (
+        benchmark_quality_gates.main(
+            ["--strategy", "fast-current", "--warmup-count", "0", "--iterations", "1"]
+        )
+        == 0
+    )
     assert commands_seen == [
         (
             "uv",
@@ -50,3 +57,53 @@ def test_benchmark_quality_gates_strips_inherited_coverage_environment(
 
     assert "COVERAGE_PROCESS_START" not in environment
     assert "COVERAGE_RCFILE" not in environment
+
+
+def test_benchmark_quality_gates_writes_json_summary(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    output_path = tmp_path / "benchmark.json"
+
+    def fake_run(
+        command: tuple[str, ...],
+        *,
+        check: bool,
+        env: dict[str, str],
+    ) -> subprocess.CompletedProcess[str]:
+        del check, env
+        return subprocess.CompletedProcess(command, 0)
+
+    elapsed_values = iter((4.0, 6.0))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        "tools.benchmark_quality_gates.time.perf_counter",
+        lambda: next(elapsed_values),
+    )
+
+    assert (
+        benchmark_quality_gates.main(
+            [
+                "--strategy",
+                "fast-current",
+                "--warmup-count",
+                "0",
+                "--iterations",
+                "1",
+                "--json-out",
+                str(output_path),
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["warmup_count"] == 0
+    assert payload["measured_iterations"] == 1
+    assert payload["strategies"][0]["name"] == "fast-current"
+    assert payload["strategies"][0]["median_elapsed_seconds"] == 2.0
+
+
+def test_benchmark_quality_gates_rejects_invalid_iteration_counts() -> None:
+    with pytest.raises(SystemExit, match="--iterations must be at least 1"):
+        benchmark_quality_gates.main(["--iterations", "0"])

--- a/tests/unit/test_benchmark_quality_gates.py
+++ b/tests/unit/test_benchmark_quality_gates.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from pytest import MonkeyPatch
+
+import tools.benchmark_quality_gates as benchmark_quality_gates
+
+
+def _successful_completed_process(
+    command: tuple[str, ...],
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(command, 0)
+
+
+def test_benchmark_quality_gates_runs_selected_strategy(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    commands_seen: list[tuple[str, ...]] = []
+
+    def fake_run(
+        command: tuple[str, ...],
+        *,
+        check: bool,
+        env: dict[str, str],
+    ) -> subprocess.CompletedProcess[str]:
+        del check, env
+        commands_seen.append(command)
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert benchmark_quality_gates.main(["--strategy", "fast-current"]) == 0
+    assert commands_seen == [
+        (
+            "uv",
+            "run",
+            "python",
+            "-m",
+            "tools.run_quality_gates",
+            "--schedule",
+            "all-at-once",
+        )
+    ]
+
+
+def test_benchmark_quality_gates_cleans_coverage_files(tmp_path: Path) -> None:
+    coverage_path = tmp_path / ".coverage"
+    coverage_path.write_text("stale", encoding="utf-8")
+
+    with MonkeyPatch.context() as monkeypatch:
+        monkeypatch.chdir(tmp_path)
+
+        def fake_run(
+            command: tuple[str, ...],
+            *,
+            check: bool,
+            env: dict[str, str],
+        ) -> subprocess.CompletedProcess[str]:
+            del check, env
+            return _successful_completed_process(command)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert benchmark_quality_gates.main(["--strategy", "fast-optimized"]) == 0
+
+    assert coverage_path.exists() is False

--- a/tests/unit/test_benchmark_quality_gates.py
+++ b/tests/unit/test_benchmark_quality_gates.py
@@ -8,12 +8,6 @@ from pytest import MonkeyPatch
 import tools.benchmark_quality_gates as benchmark_quality_gates
 
 
-def _successful_completed_process(
-    command: tuple[str, ...],
-) -> subprocess.CompletedProcess[str]:
-    return subprocess.CompletedProcess(command, 0)
-
-
 def test_benchmark_quality_gates_runs_selected_strategy(
     monkeypatch: MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -46,23 +40,13 @@ def test_benchmark_quality_gates_runs_selected_strategy(
     ]
 
 
-def test_benchmark_quality_gates_cleans_coverage_files(tmp_path: Path) -> None:
-    coverage_path = tmp_path / ".coverage"
-    coverage_path.write_text("stale", encoding="utf-8")
+def test_benchmark_quality_gates_strips_inherited_coverage_environment(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COVERAGE_PROCESS_START", "stale-process-start")
+    monkeypatch.setenv("COVERAGE_RCFILE", "stale-rcfile")
 
-    with MonkeyPatch.context() as monkeypatch:
-        monkeypatch.chdir(tmp_path)
+    environment = benchmark_quality_gates._benchmark_environment()
 
-        def fake_run(
-            command: tuple[str, ...],
-            *,
-            check: bool,
-            env: dict[str, str],
-        ) -> subprocess.CompletedProcess[str]:
-            del check, env
-            return _successful_completed_process(command)
-
-        monkeypatch.setattr(subprocess, "run", fake_run)
-        assert benchmark_quality_gates.main(["--strategy", "fast-optimized"]) == 0
-
-    assert coverage_path.exists() is False
+    assert "COVERAGE_PROCESS_START" not in environment
+    assert "COVERAGE_RCFILE" not in environment

--- a/tests/unit/test_benchmark_tests.py
+++ b/tests/unit/test_benchmark_tests.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from pytest import MonkeyPatch
+
+import tools.benchmark_tests as benchmark_tests
+
+
+def test_benchmark_tests_adds_xdist_after_pytest_invocation() -> None:
+    suite = benchmark_tests.SUITES[0]
+
+    assert benchmark_tests._command_for_suite(suite, parallel=True) == (
+        "uv",
+        "run",
+        "pytest",
+        "-n",
+        "auto",
+        "tests/unit",
+        "--no-cov",
+        "-q",
+        "--durations=10",
+    )
+
+
+def test_benchmark_tests_cleans_coverage_files_for_full_suite(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    coverage_path = tmp_path / ".coverage"
+    coverage_path.write_text("stale", encoding="utf-8")
+
+    def fake_run(
+        command: tuple[str, ...],
+        *,
+        check: bool,
+        env: dict[str, str],
+    ) -> subprocess.CompletedProcess[str]:
+        del check, env
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert benchmark_tests.main(["--suite", "full"]) == 0
+    assert coverage_path.exists() is False

--- a/tests/unit/test_benchmark_tests.py
+++ b/tests/unit/test_benchmark_tests.py
@@ -24,12 +24,10 @@ def test_benchmark_tests_adds_xdist_after_pytest_invocation() -> None:
     )
 
 
-def test_benchmark_tests_cleans_coverage_files_for_full_suite(
-    monkeypatch: MonkeyPatch, tmp_path: Path
+def test_benchmark_tests_full_suite_uses_isolated_coverage_file(
+    monkeypatch: MonkeyPatch,
 ) -> None:
-    monkeypatch.chdir(tmp_path)
-    coverage_path = tmp_path / ".coverage"
-    coverage_path.write_text("stale", encoding="utf-8")
+    captured_environment: dict[str, str] = {}
 
     def fake_run(
         command: tuple[str, ...],
@@ -37,10 +35,13 @@ def test_benchmark_tests_cleans_coverage_files_for_full_suite(
         check: bool,
         env: dict[str, str],
     ) -> subprocess.CompletedProcess[str]:
-        del check, env
+        del check
+        captured_environment.update(env)
         return subprocess.CompletedProcess(command, 0)
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
     assert benchmark_tests.main(["--suite", "full"]) == 0
-    assert coverage_path.exists() is False
+    assert "COVERAGE_FILE" in captured_environment
+    assert Path(captured_environment["COVERAGE_FILE"]).is_absolute()
+    assert Path(captured_environment["COVERAGE_FILE"]).name == ".coverage"

--- a/tests/unit/test_benchmark_tests.py
+++ b/tests/unit/test_benchmark_tests.py
@@ -1,27 +1,23 @@
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 
+import pytest
 from pytest import MonkeyPatch
 
 import tools.benchmark_tests as benchmark_tests
 
 
-def test_benchmark_tests_adds_xdist_after_pytest_invocation() -> None:
-    suite = benchmark_tests.SUITES[0]
-
-    assert benchmark_tests._command_for_suite(suite, parallel=True) == (
-        "uv",
-        "run",
-        "pytest",
-        "-n",
-        "auto",
-        "tests/unit",
-        "--no-cov",
-        "-q",
-        "--durations=10",
-    )
+def test_benchmark_tests_exposes_expected_comparison_suites() -> None:
+    assert [suite.name for suite in benchmark_tests.SUITES] == [
+        "fast-unit-serial",
+        "fast-unit-n4",
+        "fast-unit-nauto",
+        "full-serial",
+        "full-nauto",
+    ]
 
 
 def test_benchmark_tests_full_suite_uses_isolated_coverage_file(
@@ -41,7 +37,74 @@ def test_benchmark_tests_full_suite_uses_isolated_coverage_file(
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
-    assert benchmark_tests.main(["--suite", "full"]) == 0
+    assert (
+        benchmark_tests.main(
+            ["--suite", "full-serial", "--warmup-count", "0", "--iterations", "1"]
+        )
+        == 0
+    )
     assert "COVERAGE_FILE" in captured_environment
     assert Path(captured_environment["COVERAGE_FILE"]).is_absolute()
     assert Path(captured_environment["COVERAGE_FILE"]).name == ".coverage"
+
+
+def test_benchmark_tests_strips_inherited_coverage_environment(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("COVERAGE_PROCESS_START", "stale-process-start")
+    monkeypatch.setenv("COVERAGE_RCFILE", "stale-rcfile")
+
+    environment = benchmark_tests._suite_environment(benchmark_tests.SUITES[0])
+
+    assert "COVERAGE_PROCESS_START" not in environment
+    assert "COVERAGE_RCFILE" not in environment
+
+
+def test_benchmark_tests_writes_json_summary(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    output_path = tmp_path / "benchmark.json"
+
+    def fake_run(
+        command: tuple[str, ...],
+        *,
+        check: bool,
+        env: dict[str, str],
+    ) -> subprocess.CompletedProcess[str]:
+        del check, env
+        return subprocess.CompletedProcess(command, 0)
+
+    elapsed_values = iter((2.0, 5.5))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        "tools.benchmark_tests.time.perf_counter",
+        lambda: next(elapsed_values),
+    )
+
+    assert (
+        benchmark_tests.main(
+            [
+                "--suite",
+                "fast-unit-n4",
+                "--warmup-count",
+                "0",
+                "--iterations",
+                "1",
+                "--json-out",
+                str(output_path),
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert payload["warmup_count"] == 0
+    assert payload["measured_iterations"] == 1
+    assert payload["suites"][0]["name"] == "fast-unit-n4"
+    assert payload["suites"][0]["median_elapsed_seconds"] == 3.5
+
+
+def test_benchmark_tests_reject_invalid_iteration_counts() -> None:
+    with pytest.raises(SystemExit, match="--warmup-count must be zero or greater"):
+        benchmark_tests.main(["--warmup-count", "-1"])

--- a/tests/unit/test_ci_parity_checks.py
+++ b/tests/unit/test_ci_parity_checks.py
@@ -172,16 +172,92 @@ def test_ci_parity_can_include_pr_metadata(
     assert "--head-sha" in steps_seen[0].command
 
 
+def test_ci_parity_can_run_granular_quality_steps(
+    monkeypatch: MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    steps_seen: list[ci_parity._ParityStep] = []
+
+    def fake_run_step(step: ci_parity._ParityStep) -> int:
+        steps_seen.append(step)
+        return 0
+
+    def fake_verify_built_wheel(dist_path: Path) -> tuple[int, str, str]:
+        del dist_path
+        return 0, "", ""
+
+    monkeypatch.setattr(ci_parity, "_run_step", fake_run_step)
+    monkeypatch.setattr(ci_parity, "_verify_built_wheel", fake_verify_built_wheel)
+
+    assert (
+        ci_parity.main(
+            [
+                "--step",
+                "lint-format",
+                "--step",
+                "types",
+                "--step",
+                "pylint",
+                "--step",
+                "tests",
+            ]
+        )
+        == 0
+    )
+    assert [step.name for step in steps_seen] == [
+        "lint-format",
+        "types",
+        "pylint",
+        "tests",
+    ]
+    assert steps_seen[0].command == (
+        "uv",
+        "run",
+        "python",
+        "-m",
+        "tools.run_quality_gates",
+        "--gate",
+        "markdownlint",
+        "--gate",
+        "actionlint",
+        "--gate",
+        "ruff",
+    )
+    assert steps_seen[-1].command == (
+        "uv",
+        "run",
+        "python",
+        "-m",
+        "tools.run_quality_gates",
+        "--full-tests",
+        "--gate",
+        "pytest",
+    )
+
+
+def test_ci_parity_rejects_mixed_quality_step_selection() -> None:
+    assert ci_parity.main(["--step", "quality", "--step", "tests"]) == 2
+
+
 def test_ci_workflow_uses_parity_runner_for_quality_job() -> None:
     workflow_text = (repo_root() / ".github/workflows/ci.yml").read_text(
         encoding="utf-8"
     )
 
-    assert "uv run python -m tools.run_ci_parity_checks" in workflow_text
+    assert "lint-format:" in workflow_text
+    assert "types:" in workflow_text
+    assert "pylint:" in workflow_text
+    assert "tests:" in workflow_text
+    assert "build:" in workflow_text
+    assert "tools.run_ci_parity_checks --step lint-format" in workflow_text
+    assert "tools.run_ci_parity_checks --step types" in workflow_text
+    assert "tools.run_ci_parity_checks --step pylint" in workflow_text
+    assert "tools.run_ci_parity_checks --step tests" in workflow_text
+    assert (
+        "tools.run_ci_parity_checks --step build --step verify-wheel" in workflow_text
+    )
     assert "pull_request" not in workflow_text
-    assert "run: uv run mypy" not in workflow_text
-    assert "run: uv run pyright" not in workflow_text
-    assert "run: uv run pytest" not in workflow_text
+    assert ".github/actions/setup-python-uv" in workflow_text
 
 
 def test_pr_review_workflow_runs_commit_metadata_and_pr_review_checks() -> None:
@@ -194,5 +270,7 @@ def test_pr_review_workflow_runs_commit_metadata_and_pr_review_checks() -> None:
     assert "pr-review:" in workflow_text
     assert "tools.validate_commit_message" in workflow_text
     assert "tools.validate_pr_metadata" in workflow_text
+    assert "tools.audit_pr_review" in workflow_text
     assert "tools.run_pr_review_checks" in workflow_text
     assert "tools.run_ci_parity_checks" not in workflow_text
+    assert ".github/actions/setup-python-uv" in workflow_text

--- a/tests/unit/test_ci_parity_checks.py
+++ b/tests/unit/test_ci_parity_checks.py
@@ -132,6 +132,7 @@ def test_ci_parity_can_include_pr_metadata(
         "Why:\n- explain\n\n"
         "What:\n- change\n\n"
         "Checks:\n- uv run pytest\n\n"
+        "Issue linkage:\n- None: parity validation test fixture\n\n"
         "Included checkpoints:\n- `ci: tighten parity`\n"
     )
     pr_body.write_text(

--- a/tests/unit/test_ci_parity_checks.py
+++ b/tests/unit/test_ci_parity_checks.py
@@ -178,6 +178,21 @@ def test_ci_workflow_uses_parity_runner_for_quality_job() -> None:
     )
 
     assert "uv run python -m tools.run_ci_parity_checks" in workflow_text
+    assert "pull_request" not in workflow_text
     assert "run: uv run mypy" not in workflow_text
     assert "run: uv run pyright" not in workflow_text
     assert "run: uv run pytest" not in workflow_text
+
+
+def test_pr_review_workflow_runs_commit_metadata_and_pr_review_checks() -> None:
+    workflow_text = (repo_root() / ".github/workflows/pr-review.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "pull_request:" in workflow_text
+    assert "commit-messages:" in workflow_text
+    assert "pr-review:" in workflow_text
+    assert "tools.validate_commit_message" in workflow_text
+    assert "tools.validate_pr_metadata" in workflow_text
+    assert "tools.run_pr_review_checks" in workflow_text
+    assert "tools.run_ci_parity_checks" not in workflow_text

--- a/tests/unit/test_commit_message_validator.py
+++ b/tests/unit/test_commit_message_validator.py
@@ -222,6 +222,29 @@ Checks:
     assert errors == ("subject must not end with a period",)
 
 
+def test_generic_commit_summary_is_rejected() -> None:
+    errors = _validate_commit_message_text(
+        """\
+docs: cleanup
+
+Why:
+- tighten docs
+
+What:
+- rewrite the standard
+
+Checks:
+- uv run pytest
+"""
+    )
+
+    assert errors == (
+        "subject summary must name a concrete repo surface or behavior; "
+        "generic summaries such as `cleanup`, `misc fixes`, and "
+        "`update branch` are not allowed",
+    )
+
+
 def test_malformed_scope_is_rejected() -> None:
     errors = _validate_commit_message_text(
         """\

--- a/tests/unit/test_delivery_guardrails_audit.py
+++ b/tests/unit/test_delivery_guardrails_audit.py
@@ -99,8 +99,10 @@ def test_missing_codeowners_entries_reports_missing_patterns() -> None:
     missing = audit._missing_codeowners_patterns(("AGENTS.md", "docs/standards/**"))
 
     assert ".agents/skills/**" in missing
+    assert ".github/actions/**" in missing
     assert ".github/ISSUE_TEMPLATE/**" in missing
     assert ".github/workflows/**" in missing
+    assert "tools/benchmark_quality_gates.py" in missing
     assert "tools/message_standards.py" in missing
     assert "tools/run_ci_parity_checks.py" in missing
     assert "tools/run_pr_review_checks.py" in missing

--- a/tests/unit/test_delivery_guardrails_audit.py
+++ b/tests/unit/test_delivery_guardrails_audit.py
@@ -13,8 +13,8 @@ def _protected_branch_payload() -> dict[str, object]:
             "strict": True,
             "contexts": ["commit-messages", "pr-review"],
             "checks": [
-                {"context": "commit-messages"},
-                {"context": "pr-review"},
+                {"context": "commit-messages", "app_id": 15368},
+                {"context": "pr-review", "app_id": 15368},
             ],
         },
         "required_pull_request_reviews": {
@@ -93,6 +93,32 @@ def test_evaluate_remote_guardrails_errors_for_missing_core_branch_controls() ->
     assert any("block force pushes" in error for error in report.errors)
     assert any("conversation resolution" in error for error in report.errors)
     assert any(".github/CODEOWNERS" in error for error in report.errors)
+
+
+def test_evaluate_remote_guardrails_errors_for_unpinned_required_status_checks() -> (
+    None
+):
+    payload = _protected_branch_payload()
+    payload["required_status_checks"] = {
+        "strict": True,
+        "contexts": ["commit-messages", "pr-review"],
+        "checks": [
+            {"context": "commit-messages", "app_id": 15368},
+            {"context": "pr-review", "app_id": None},
+        ],
+    }
+
+    report = audit._evaluate_remote_guardrails(
+        protection=payload,
+        rulesets=[],
+        collaborators=[{"login": "CrownOpsEng", "permissions": {"pull": True}}],
+        codeowners_patterns=audit.CONTROL_PLANE_CODEOWNER_PATTERNS,
+    )
+
+    assert any(
+        "pin required status checks to their app: pr-review" in error
+        for error in report.errors
+    )
 
 
 def test_missing_codeowners_entries_reports_missing_patterns() -> None:

--- a/tests/unit/test_delivery_guardrails_audit.py
+++ b/tests/unit/test_delivery_guardrails_audit.py
@@ -11,10 +11,10 @@ def _protected_branch_payload() -> dict[str, object]:
     return {
         "required_status_checks": {
             "strict": True,
-            "contexts": ["commit-messages", "quality"],
+            "contexts": ["commit-messages", "pr-review"],
             "checks": [
                 {"context": "commit-messages"},
-                {"context": "quality"},
+                {"context": "pr-review"},
             ],
         },
         "required_pull_request_reviews": {
@@ -103,6 +103,7 @@ def test_missing_codeowners_entries_reports_missing_patterns() -> None:
     assert ".github/workflows/**" in missing
     assert "tools/message_standards.py" in missing
     assert "tools/run_ci_parity_checks.py" in missing
+    assert "tools/run_pr_review_checks.py" in missing
 
 
 def test_rulesets_only_repo_does_not_fail_branch_protection_audit() -> None:

--- a/tests/unit/test_docs_runtime_parity.py
+++ b/tests/unit/test_docs_runtime_parity.py
@@ -171,6 +171,7 @@ def test_documented_claude_command_routes_exist() -> None:
         ".claude/commands/balance-submission-operations.md",
         ".claude/commands/implementation-checkpoint.md",
         ".claude/commands/issue-workflow.md",
+        ".claude/commands/pr-review.md",
         ".claude/commands/reconciliation-balance-operations.md",
         ".claude/commands/reconciliation-tax-build.md",
     )
@@ -193,6 +194,7 @@ def test_documented_claude_command_routes_are_not_ignored() -> None:
         ".claude/commands/balance-submission-operations.md",
         ".claude/commands/implementation-checkpoint.md",
         ".claude/commands/issue-workflow.md",
+        ".claude/commands/pr-review.md",
         ".claude/commands/reconciliation-balance-operations.md",
         ".claude/commands/reconciliation-tax-build.md",
     )

--- a/tests/unit/test_pr_metadata_validator.py
+++ b/tests/unit/test_pr_metadata_validator.py
@@ -9,6 +9,30 @@ from tools.validate_pr_metadata import (
 )
 
 
+def _body(
+    *,
+    why: str = "- keep multi-checkpoint history visible on main",
+    issue_linkage: str = "- Closes #34: preserve multi-checkpoint history on main",
+    follow_ups: str = "",
+    included_checkpoints: str = "- `docs: codify pull request standards`",
+) -> str:
+    body = (
+        "Why:\n"
+        f"{why}\n\n"
+        "What:\n"
+        "- document and validate pull request metadata\n\n"
+        "Checks:\n"
+        "- uv run python -m tools.run_quality_gates\n\n"
+        "Issue linkage:\n"
+        f"{issue_linkage}\n\n"
+        "Included checkpoints:\n"
+        f"{included_checkpoints}\n"
+    )
+    if follow_ups:
+        body += f"\nFollow-ups:\n{follow_ups}\n"
+    return body
+
+
 def test_pr_title_with_conventional_commit_subject_is_valid() -> None:
     errors = _validate_pr_title("refactor: preserve fact model guardrails")
 
@@ -26,43 +50,13 @@ def test_pr_title_without_conventional_commit_subject_is_rejected() -> None:
 
 
 def test_pr_body_with_required_sections_is_valid() -> None:
-    body = """\
-Why:
-- Closes #34: preserve multi-checkpoint history on main
-- keep multi-checkpoint history visible on main
-
-What:
-- document and validate pull request metadata
-
-Checks:
-- uv run python -m tools.run_quality_gates
-
-Included checkpoints:
-- `docs: codify pull request standards`
-"""
-
-    errors = _validate_pr_body(body)
+    errors = _validate_pr_body(_body())
 
     assert not errors
 
 
 def test_pr_body_tolerates_leading_html_comment() -> None:
-    body = """\
-<!-- markdownlint-disable-file MD041 MD032 -->
-
-Why:
-- Closes #34: preserve multi-checkpoint history on main
-- keep multi-checkpoint history visible on main
-
-What:
-- document and validate pull request metadata
-
-Checks:
-- uv run python -m tools.run_quality_gates
-
-Included checkpoints:
-- `docs: codify pull request standards`
-"""
+    body = f"<!-- markdownlint-disable-file MD041 MD032 -->\n\n{_body()}"
 
     errors = _validate_pr_body(body)
 
@@ -79,11 +73,34 @@ What:
 
 Checks:
 - uv run python -m tools.run_quality_gates
+
+Issue linkage:
+- Closes #34: preserve multi-checkpoint history on main
 """
 
     errors = _validate_pr_body(body)
 
     assert errors == ("missing `Included checkpoints:` section",)
+
+
+def test_pr_body_rejects_missing_issue_linkage_section() -> None:
+    body = """\
+Why:
+- keep multi-checkpoint history visible on main
+
+What:
+- document and validate pull request metadata
+
+Checks:
+- uv run python -m tools.run_quality_gates
+
+Included checkpoints:
+- `docs: codify pull request standards`
+"""
+
+    errors = _validate_pr_body(body)
+
+    assert errors == ("missing `Issue linkage:` section",)
 
 
 def test_pr_body_rejects_non_bullet_content() -> None:
@@ -96,6 +113,9 @@ What:
 
 Checks:
 - uv run python -m tools.run_quality_gates
+
+Issue linkage:
+- Closes #34: preserve multi-checkpoint history on main
 
 Included checkpoints:
 - `docs: codify pull request standards`
@@ -110,91 +130,84 @@ Included checkpoints:
 
 
 def test_pr_body_accepts_optional_follow_ups_section() -> None:
-    body = """\
-Why:
-- keep multi-checkpoint history visible on main
-
-What:
-- document and validate pull request metadata
-
-Checks:
-- uv run python -m tools.run_quality_gates
-
-Included checkpoints:
-- `docs: codify pull request standards`
-
-Follow-ups:
-- Refs #34: tighten merge-repair automation
-"""
-
-    errors = _validate_pr_body(body)
+    errors = _validate_pr_body(
+        _body(
+            issue_linkage="- Refs #34: preserve multi-checkpoint history on main",
+            follow_ups="- Refs #35: tighten merge-repair automation",
+        )
+    )
 
     assert not errors
 
 
-def test_pr_body_rejects_malformed_why_closing_bullet() -> None:
-    body = """\
-Why:
-- Closes #34
-- keep multi-checkpoint history visible on main
-
-What:
-- document and validate pull request metadata
-
-Checks:
-- uv run python -m tools.run_quality_gates
-
-Included checkpoints:
-- `docs: codify pull request standards`
-"""
-
-    errors = _validate_pr_body(body)
+def test_pr_body_rejects_issue_linkage_in_why() -> None:
+    errors = _validate_pr_body(
+        _body(
+            why="- Closes #34: preserve multi-checkpoint history on main",
+            issue_linkage="- Refs #34: preserve multi-checkpoint history on main",
+        )
+    )
 
     assert errors == (
-        "`Why:` issue-closing bullets must match `- Closes #123: problem statement`",
+        "`Why:` must describe the problem or constraint; move issue linkage "
+        "bullets to `Issue linkage:`",
     )
 
 
-def test_pr_body_rejects_late_why_closing_bullet() -> None:
-    body = """\
-Why:
-- keep multi-checkpoint history visible on main
-- Closes #34: preserve multi-checkpoint history on main
+def test_pr_body_rejects_malformed_issue_linkage_closing_bullet() -> None:
+    errors = _validate_pr_body(_body(issue_linkage="- Closes #34"))
 
-What:
-- document and validate pull request metadata
+    assert errors == (
+        "`Issue linkage:` closing bullets must match "
+        "`- Closes #123: problem statement`",
+    )
 
-Checks:
-- uv run python -m tools.run_quality_gates
 
-Included checkpoints:
-- `docs: codify pull request standards`
-"""
+def test_pr_body_rejects_bad_issue_linkage_reference_bullet() -> None:
+    errors = _validate_pr_body(_body(issue_linkage="- Refs #34 because it is related"))
 
-    errors = _validate_pr_body(body)
+    assert errors == (
+        "`Issue linkage:` reference bullets must match "
+        "`- Refs #123` or `- Refs #123: note`",
+    )
 
-    assert errors == ("`Why:` issue-closing bullets must come before other bullets",)
+
+def test_pr_body_accepts_explicit_none_issue_linkage() -> None:
+    errors = _validate_pr_body(
+        _body(issue_linkage="- None: trivial maintenance slice with no existing issue")
+    )
+
+    assert not errors
+
+
+def test_pr_body_rejects_bad_none_issue_linkage_bullet() -> None:
+    errors = _validate_pr_body(_body(issue_linkage="- None"))
+
+    assert errors == (
+        "`Issue linkage:` no-issue bullets must match `- None: explanation`",
+    )
+
+
+def test_pr_body_rejects_none_issue_linkage_with_other_bullets() -> None:
+    errors = _validate_pr_body(
+        _body(
+            issue_linkage=(
+                "- None: trivial maintenance slice with no existing issue\n"
+                "- Refs #34: preserve multi-checkpoint history on main"
+            )
+        )
+    )
+
+    assert errors == ("`Issue linkage:` `- None: ...` must be the only bullet",)
 
 
 def test_pr_body_rejects_bad_follow_up_bullet() -> None:
-    body = """\
-Why:
-- keep multi-checkpoint history visible on main
-
-What:
-- document and validate pull request metadata
-
-Checks:
-- uv run python -m tools.run_quality_gates
-
-Included checkpoints:
-- `docs: codify pull request standards`
-
-Follow-ups:
-- follow up in #34
-"""
-
-    errors = _validate_pr_body(body)
+    errors = _validate_pr_body(
+        _body(
+            issue_linkage="- Refs #34: preserve multi-checkpoint history on main",
+            follow_ups="- follow up in #35",
+        )
+    )
 
     assert errors == (
         "`Follow-ups:` bullets must match `- Refs #123` or `- Refs #123: note`",
@@ -202,20 +215,13 @@ Follow-ups:
 
 
 def test_pr_checkpoints_match_commit_subjects(monkeypatch: MonkeyPatch) -> None:
-    body = """\
-Why:
-- keep multi-checkpoint history visible on main
-
-What:
-- document and validate pull request metadata
-
-Checks:
-- uv run python -m tools.run_quality_gates
-
-Included checkpoints:
-- `docs: codify pull request standards`
-- `ci: tighten workflow metadata checks`
-"""
+    body = _body(
+        issue_linkage="- Refs #34: preserve multi-checkpoint history on main",
+        included_checkpoints=(
+            "- `docs: codify pull request standards`\n"
+            "- `ci: tighten workflow metadata checks`"
+        ),
+    )
 
     def fake_loader(base_sha: str, head_sha: str) -> tuple[str, ...]:
         del base_sha, head_sha
@@ -236,21 +242,10 @@ Included checkpoints:
 
 
 def test_pr_checkpoints_ignore_leading_html_comment(monkeypatch: MonkeyPatch) -> None:
-    body = """\
-<!-- markdownlint-disable-file MD041 MD032 -->
-
-Why:
-- keep multi-checkpoint history visible on main
-
-What:
-- document and validate pull request metadata
-
-Checks:
-- uv run python -m tools.run_quality_gates
-
-Included checkpoints:
-- `docs: codify pull request standards`
-"""
+    body = (
+        "<!-- markdownlint-disable-file MD041 MD032 -->\n\n"
+        f"{_body(issue_linkage='- Refs #34: preserve multi-checkpoint history on main')}"
+    )
 
     def fake_loader(base_sha: str, head_sha: str) -> tuple[str, ...]:
         del base_sha, head_sha
@@ -266,19 +261,10 @@ Included checkpoints:
 def test_pr_checkpoints_reject_non_exact_commit_subjects(
     monkeypatch: MonkeyPatch,
 ) -> None:
-    body = """\
-Why:
-- keep multi-checkpoint history visible on main
-
-What:
-- document and validate pull request metadata
-
-Checks:
-- uv run python -m tools.run_quality_gates
-
-Included checkpoints:
-- docs: codify pull request standards
-"""
+    body = _body(
+        issue_linkage="- Refs #34: preserve multi-checkpoint history on main",
+        included_checkpoints="- docs: codify pull request standards",
+    )
 
     def fake_loader(base_sha: str, head_sha: str) -> tuple[str, ...]:
         del base_sha, head_sha
@@ -294,19 +280,7 @@ Included checkpoints:
 
 
 def test_pr_checkpoints_reject_subject_mismatch(monkeypatch: MonkeyPatch) -> None:
-    body = """\
-Why:
-- keep multi-checkpoint history visible on main
-
-What:
-- document and validate pull request metadata
-
-Checks:
-- uv run python -m tools.run_quality_gates
-
-Included checkpoints:
-- `docs: codify pull request standards`
-"""
+    body = _body(issue_linkage="- Refs #34: preserve multi-checkpoint history on main")
 
     def fake_loader(base_sha: str, head_sha: str) -> tuple[str, ...]:
         del base_sha, head_sha

--- a/tests/unit/test_pr_metadata_validator.py
+++ b/tests/unit/test_pr_metadata_validator.py
@@ -49,6 +49,16 @@ def test_pr_title_without_conventional_commit_subject_is_rejected() -> None:
     )
 
 
+def test_pr_title_with_generic_summary_is_rejected() -> None:
+    errors = _validate_pr_title("docs: cleanup")
+
+    assert errors == (
+        "subject summary must name a concrete repo surface or behavior; "
+        "generic summaries such as `cleanup`, `misc fixes`, and "
+        "`update branch` are not allowed",
+    )
+
+
 def test_pr_body_with_required_sections_is_valid() -> None:
     errors = _validate_pr_body(_body())
 

--- a/tests/unit/test_pre_commit_hook.py
+++ b/tests/unit/test_pre_commit_hook.py
@@ -5,8 +5,10 @@ from pathlib import Path
 
 import pytest
 
+from repo_support.pytest_commands import build_fast_pytest_command
 import tools.install_git_hooks
 import tools.pre_commit_hook
+import tools.run_fast_pytest
 from tools.install_git_hooks import _COMMIT_MSG_HOOK_TEMPLATE, _HOOK_TEMPLATE
 from tools.pre_commit_hook import _format_candidates
 
@@ -200,3 +202,33 @@ def test_install_hooks_falls_back_to_default_external_environment(
         f"PROJECT_ENVIRONMENT={expected_environment}"
         in commit_msg_hook_path.read_text(encoding="utf-8")
     )
+
+
+def test_pre_commit_config_uses_repo_owned_fast_pytest_entrypoint() -> None:
+    config_text = Path(".pre-commit-config.yaml").read_text(encoding="utf-8")
+
+    assert "entry: uv run python -m tools.run_fast_pytest" in config_text
+    assert "--no-cov -q" not in config_text
+    assert 'pytest -m "unit and not slow"' not in config_text
+
+
+def test_run_fast_pytest_uses_shared_command_builder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured_command: tuple[str, ...] | None = None
+
+    def fake_run(
+        command: tuple[str, ...],
+        *,
+        check: bool,
+        env: dict[str, str],
+    ) -> subprocess.CompletedProcess[str]:
+        nonlocal captured_command
+        del check, env
+        captured_command = command
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert tools.run_fast_pytest.main([]) == 0
+    assert captured_command == build_fast_pytest_command()

--- a/tests/unit/test_quality_gates.py
+++ b/tests/unit/test_quality_gates.py
@@ -5,46 +5,53 @@ from pathlib import Path
 
 import pytest
 
+from repo_support.quality_gates import (
+    QUALITY_GATE_ORDER,
+    QualityGate,
+    QualityPhase,
+    available_quality_gates,
+)
 import tools.run_quality_gates
 from repo_support.paths import repo_root
-from tools.run_quality_gates import (
-    QualityGate,
-    _DEFAULT_TEST_COMMAND,
-    _FULL_TEST_COMMAND,
-    _quality_gates,
-)
+from tools.run_quality_gates import _phase_plan, _run_request
 
 
-def test_quality_gates_default_to_fast_commit_time_pytest() -> None:
-    gates = _quality_gates(full_tests=False)
+def test_quality_gates_default_to_repo_benchmarked_fast_schedule() -> None:
+    parse_args = getattr(tools.run_quality_gates, "_parse_args")
+    run_request = _run_request(parse_args(()))
 
-    assert [gate.name for gate in gates] == [
-        "markdownlint",
-        "actionlint",
-        "ruff",
-        "mypy",
-        "pyright",
-        "pylint",
-        "pytest",
-    ]
-    assert gates[0].command == (
-        "uv",
-        "run",
-        "pre-commit",
-        "run",
-        "markdownlint",
-        "--all-files",
+    assert _phase_plan(run_request) == (
+        QualityPhase(
+            name="quick-static",
+            gate_names=("markdownlint", "actionlint", "ruff", "mypy"),
+        ),
+        QualityPhase(
+            name="heavy-static",
+            gate_names=("pyright", "pylint"),
+        ),
+        QualityPhase(name="tests", gate_names=("pytest",)),
     )
-    assert gates[1].command == ("uv", "run", "actionlint", "-color")
-    assert gates[4].command == ("uv", "run", "pyright")
-    assert gates[5].command == ("uv", "run", "python", "-m", "tools.run_pylint")
-    assert gates[-1].command == _DEFAULT_TEST_COMMAND
 
 
-def test_quality_gates_can_switch_to_full_pytest() -> None:
-    gates = _quality_gates(full_tests=True)
+def test_quality_gates_default_to_all_at_once_for_full_tests() -> None:
+    parse_args = getattr(tools.run_quality_gates, "_parse_args")
+    run_request = _run_request(parse_args(("--full-tests",)))
 
-    assert gates[-1].command == _FULL_TEST_COMMAND
+    assert _phase_plan(run_request) == (
+        QualityPhase(name="all-at-once", gate_names=QUALITY_GATE_ORDER),
+    )
+
+
+def test_quality_gates_can_select_named_gates() -> None:
+    parse_args = getattr(tools.run_quality_gates, "_parse_args")
+    run_request = _run_request(
+        parse_args(("--gate", "markdownlint", "--gate", "pytest"))
+    )
+
+    assert _phase_plan(run_request) == (
+        QualityPhase(name="quick-static", gate_names=("markdownlint",)),
+        QualityPhase(name="tests", gate_names=("pytest",)),
+    )
 
 
 def test_run_gate_exports_external_uv_project_environment(
@@ -68,7 +75,7 @@ def test_run_gate_exports_external_uv_project_environment(
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
-    gate = _quality_gates(full_tests=False)[0]
+    gate = available_quality_gates(full_tests=False)["markdownlint"]
     tools.run_quality_gates._run_gate(gate)
 
     assert captured_environment["UV_PROJECT_ENVIRONMENT"] == str(
@@ -95,7 +102,7 @@ def test_run_gate_sets_absolute_coverage_config_for_pytest(
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
-    gate = _quality_gates(full_tests=True)[-1]
+    gate = available_quality_gates(full_tests=True)["pytest"]
     tools.run_quality_gates._run_gate(gate)
 
     coverage_config = str(repo_root() / "pyproject.toml")
@@ -136,17 +143,28 @@ def test_quality_gates_refresh_generated_pyright_config_before_running(
         calls.append("sync")
         return False
 
-    def fake_quality_gates(*, full_tests: bool) -> tuple[QualityGate, ...]:
-        del full_tests
-        return (QualityGate(name="noop", command=("uv",)),)
+    def fake_phase_plan(
+        run_request: tools.run_quality_gates._RunRequest,
+    ) -> tuple[QualityPhase, ...]:
+        del run_request
+        return (QualityPhase(name="noop", gate_names=("ruff",)),)
 
-    def fake_run_gate(
-        gate: QualityGate,
-    ) -> tuple[QualityGate, subprocess.CompletedProcess[str], float]:
-        return (
-            gate,
-            subprocess.CompletedProcess(gate.command, 0, stdout="", stderr=""),
-            0.0,
+    def fake_run_phase(
+        phase: QualityPhase,
+        *,
+        available_gates: dict[str, QualityGate],
+    ) -> tools.run_quality_gates.PhaseResult:
+        return tools.run_quality_gates.PhaseResult(
+            phase=phase,
+            gate_results=(
+                tools.run_quality_gates.GateResult(
+                    gate=available_gates["ruff"],
+                    returncode=0,
+                    stdout="",
+                    stderr="",
+                    elapsed=0.0,
+                ),
+            ),
         )
 
     monkeypatch.setattr(
@@ -154,8 +172,8 @@ def test_quality_gates_refresh_generated_pyright_config_before_running(
         "sync_pyright_config",
         fake_sync_pyright_config,
     )
-    monkeypatch.setattr(tools.run_quality_gates, "_quality_gates", fake_quality_gates)
-    monkeypatch.setattr(tools.run_quality_gates, "_run_gate", fake_run_gate)
+    monkeypatch.setattr(tools.run_quality_gates, "_phase_plan", fake_phase_plan)
+    monkeypatch.setattr(tools.run_quality_gates, "_run_phase", fake_run_phase)
 
     assert tools.run_quality_gates.main(()) == 0
 
@@ -166,12 +184,7 @@ def test_quality_gates_fail_when_generated_pyright_config_was_stale(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    def fake_quality_gates(*, full_tests: bool) -> tuple[QualityGate, ...]:
-        del full_tests
-        return ()
-
     monkeypatch.setattr(tools.run_quality_gates, "sync_pyright_config", lambda: True)
-    monkeypatch.setattr(tools.run_quality_gates, "_quality_gates", fake_quality_gates)
 
     assert tools.run_quality_gates.main(()) == 1
 

--- a/tests/unit/test_quality_gates.py
+++ b/tests/unit/test_quality_gates.py
@@ -106,9 +106,10 @@ def test_run_gate_sets_absolute_coverage_config_for_pytest(
     tools.run_quality_gates._run_gate(gate)
 
     coverage_config = str(repo_root() / "pyproject.toml")
-    assert captured_environment["COVERAGE_PROCESS_START"] == coverage_config
-    assert captured_environment["COVERAGE_RCFILE"] == coverage_config
     assert coverage_config in captured_environment["PYTEST_ADDOPTS"]
+    assert "COVERAGE_FILE" in captured_environment
+    assert Path(captured_environment["COVERAGE_FILE"]).is_absolute()
+    assert Path(captured_environment["COVERAGE_FILE"]).name == ".coverage"
 
 
 def test_pre_commit_config_keeps_hook_validations_without_ruff_duplication() -> None:

--- a/tests/unit/test_quality_gates.py
+++ b/tests/unit/test_quality_gates.py
@@ -5,6 +5,11 @@ from pathlib import Path
 
 import pytest
 
+from repo_support.paths import repo_root
+from repo_support.pytest_commands import (
+    DEFAULT_FAST_PYTEST_WORKERS,
+    build_fast_pytest_command,
+)
 from repo_support.quality_gates import (
     QUALITY_GATE_ORDER,
     QualityGate,
@@ -12,7 +17,6 @@ from repo_support.quality_gates import (
     available_quality_gates,
 )
 import tools.run_quality_gates
-from repo_support.paths import repo_root
 from tools.run_quality_gates import _phase_plan, _run_request
 
 
@@ -52,6 +56,73 @@ def test_quality_gates_can_select_named_gates() -> None:
         QualityPhase(name="quick-static", gate_names=("markdownlint",)),
         QualityPhase(name="tests", gate_names=("pytest",)),
     )
+
+
+def test_fast_quality_gate_uses_shared_pytest_command_builder() -> None:
+    assert available_quality_gates(full_tests=False)["pytest"].command == (
+        build_fast_pytest_command()
+    )
+
+
+def test_fast_pytest_defaults_to_four_workers() -> None:
+    assert build_fast_pytest_command() == (
+        "uv",
+        "run",
+        "pytest",
+        "-n",
+        str(DEFAULT_FAST_PYTEST_WORKERS),
+        "-m",
+        "unit and not slow",
+        "--no-cov",
+        "-q",
+    )
+
+
+@pytest.mark.parametrize(
+    ("worker_override", "expected_command"),
+    [
+        (
+            "4",
+            (
+                "uv",
+                "run",
+                "pytest",
+                "-n",
+                "4",
+                "-m",
+                "unit and not slow",
+                "--no-cov",
+                "-q",
+            ),
+        ),
+        (
+            "1",
+            (
+                "uv",
+                "run",
+                "pytest",
+                "-n",
+                "1",
+                "-m",
+                "unit and not slow",
+                "--no-cov",
+                "-q",
+            ),
+        ),
+        (
+            "0",
+            ("uv", "run", "pytest", "-m", "unit and not slow", "--no-cov", "-q"),
+        ),
+    ],
+)
+def test_fast_pytest_honors_worker_override(
+    monkeypatch: pytest.MonkeyPatch,
+    worker_override: str,
+    expected_command: tuple[str, ...],
+) -> None:
+    monkeypatch.setenv("TALLYLOT_FAST_PYTEST_WORKERS", worker_override)
+
+    assert build_fast_pytest_command() == expected_command
 
 
 def test_run_gate_exports_external_uv_project_environment(
@@ -107,9 +178,7 @@ def test_run_gate_sets_absolute_coverage_config_for_pytest(
 
     coverage_config = str(repo_root() / "pyproject.toml")
     assert coverage_config in captured_environment["PYTEST_ADDOPTS"]
-    assert "COVERAGE_FILE" in captured_environment
-    assert Path(captured_environment["COVERAGE_FILE"]).is_absolute()
-    assert Path(captured_environment["COVERAGE_FILE"]).name == ".coverage"
+    assert "COVERAGE_FILE" not in captured_environment
 
 
 def test_pre_commit_config_keeps_hook_validations_without_ruff_duplication() -> None:

--- a/tests/unit/test_repo_agent_skills.py
+++ b/tests/unit/test_repo_agent_skills.py
@@ -60,6 +60,17 @@ EXPECTED_SKILLS = {
             "shell-sensitive",
         ),
     ),
+    "pr-review": ExpectedSkill(
+        display_name="PR Review",
+        required_fragments=(
+            "docs/standards/delivery-guardrails.md",
+            "docs/standards/implementation.md",
+            "docs/standards/commits.md",
+            ".claude/commands/pr-review.md",
+            "tools.audit_pr_review",
+            "applicable surface groups",
+        ),
+    ),
     "balance-submission-operations": ExpectedSkill(
         display_name="Balance Submission",
         required_fragments=(

--- a/tests/unit/test_repo_agent_skills.py
+++ b/tests/unit/test_repo_agent_skills.py
@@ -69,6 +69,7 @@ EXPECTED_SKILLS = {
             ".claude/commands/pr-review.md",
             "tools.audit_pr_review",
             "applicable surface groups",
+            "green `tools.run_pr_review_checks` output as a clean pass",
         ),
     ),
     "balance-submission-operations": ExpectedSkill(

--- a/tests/unit/test_repo_agent_skills.py
+++ b/tests/unit/test_repo_agent_skills.py
@@ -27,6 +27,10 @@ EXPECTED_SKILLS = {
         display_name="Docs Authoring",
         required_fragments=(
             "docs/README.md",
+            "docs/status/current-state.md",
+            "docs/reference/repository-history.md",
+            "docs/standards/implementation.md",
+            "docs/standards/commits.md",
             "tools/docs_maintenance/cli.py",
             "tools/docs_maintenance/metadata.py",
             "uv run python -m tools.docs_maintenance sync --check",
@@ -39,6 +43,8 @@ EXPECTED_SKILLS = {
             "docs/standards/implementation.md",
             "docs/standards/commits.md",
             ".claude/commands/implementation-checkpoint.md",
+            "shell-safe commit/PR authoring path",
+            "shell-sensitive text",
         ),
     ),
     "issue-workflow": ExpectedSkill(
@@ -46,9 +52,12 @@ EXPECTED_SKILLS = {
         required_fragments=(
             "docs/standards/issues.md",
             "docs/standards/delivery-guardrails.md",
+            "docs/standards/commits.md",
             ".claude/commands/issue-workflow.md",
             "Summary",
             "Acceptance Criteria",
+            "shell-safe PR-body guidance",
+            "shell-sensitive",
         ),
     ),
     "balance-submission-operations": ExpectedSkill(

--- a/tests/unit/test_repo_agent_skills.py
+++ b/tests/unit/test_repo_agent_skills.py
@@ -69,7 +69,7 @@ EXPECTED_SKILLS = {
             ".claude/commands/pr-review.md",
             "tools.audit_pr_review",
             "applicable surface groups",
-            "green `tools.run_pr_review_checks` output as a clean pass",
+            "issue-finding with open outcome",
         ),
     ),
     "balance-submission-operations": ExpectedSkill(

--- a/tests/unit/test_report_coverage_hotspots.py
+++ b/tests/unit/test_report_coverage_hotspots.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import argparse
+
+from pytest import CaptureFixture, MonkeyPatch
+
+import tools.report_coverage_hotspots as coverage_hotspots
+
+
+def _sample_coverage_payload() -> dict[str, object]:
+    return {
+        "files": {
+            "src/tallylot/interfaces/cli/source.py": {
+                "summary": {
+                    "percent_covered": 40.0,
+                    "missing_lines": 12,
+                    "missing_branches": 6,
+                    "num_branches": 8,
+                }
+            },
+            "src/tallylot/application/normalization/normalize_source.py": {
+                "summary": {
+                    "percent_covered": 55.0,
+                    "missing_lines": 18,
+                    "missing_branches": 9,
+                    "num_branches": 12,
+                }
+            },
+            "src/tallylot/domain/transactions/models.py": {
+                "summary": {
+                    "percent_covered": 72.0,
+                    "missing_lines": 7,
+                    "missing_branches": 2,
+                    "num_branches": 10,
+                }
+            },
+            "src/tallylot/adapters/sources/platforms/binance/tests/test_adapter.py": {
+                "summary": {
+                    "percent_covered": 0.0,
+                    "missing_lines": 100,
+                    "missing_branches": 0,
+                    "num_branches": 0,
+                }
+            },
+            "tests/unit/test_quality_gates.py": {
+                "summary": {
+                    "percent_covered": 0.0,
+                    "missing_lines": 40,
+                    "missing_branches": 0,
+                    "num_branches": 0,
+                }
+            },
+        },
+        "totals": {"percent_covered": 68.0},
+    }
+
+
+def test_hotspot_report_sorts_sections_stably() -> None:
+    report = coverage_hotspots._hotspot_report(
+        _sample_coverage_payload(),
+        changed_files=(),
+        top=2,
+    )
+
+    assert [module.path for module in report.lowest_covered_modules] == [
+        "src/tallylot/interfaces/cli/source.py",
+        "src/tallylot/application/normalization/normalize_source.py",
+    ]
+    assert [module.path for module in report.highest_uncovered_branch_modules] == [
+        "src/tallylot/application/normalization/normalize_source.py",
+        "src/tallylot/interfaces/cli/source.py",
+    ]
+
+
+def test_hotspot_report_filters_changed_production_modules() -> None:
+    report = coverage_hotspots._hotspot_report(
+        _sample_coverage_payload(),
+        changed_files=(
+            "src/tallylot/domain/transactions/models.py",
+            "tests/unit/test_quality_gates.py",
+            "src/tallylot/interfaces/cli/source.py",
+        ),
+        top=5,
+    )
+
+    assert [module.path for module in report.changed_modules_below_average] == [
+        "src/tallylot/interfaces/cli/source.py"
+    ]
+
+
+def test_hotspot_report_omits_non_production_files() -> None:
+    modules = coverage_hotspots._module_coverages(_sample_coverage_payload())
+
+    assert [module.path for module in modules] == [
+        "src/tallylot/interfaces/cli/source.py",
+        "src/tallylot/application/normalization/normalize_source.py",
+        "src/tallylot/domain/transactions/models.py",
+    ]
+
+
+def test_hotspot_report_prints_readable_empty_sections(
+    capsys: CaptureFixture[str],
+) -> None:
+    report = coverage_hotspots.CoverageHotspots(
+        repo_average_coverage=90.0,
+        lowest_covered_modules=(),
+        highest_uncovered_branch_modules=(),
+        changed_modules_below_average=(),
+    )
+
+    coverage_hotspots._print_report(report)
+
+    output = capsys.readouterr().out
+    assert "lowest-covered production modules:" in output
+    assert "  - none" in output
+
+
+def test_hotspot_report_requires_full_diff_override_pair(
+    capsys: CaptureFixture[str],
+) -> None:
+    assert coverage_hotspots.main(["--base-sha", "abc123"]) == 2
+    assert "provide both --base-sha and --head-sha" in capsys.readouterr().out
+
+
+def test_hotspot_report_handles_missing_coverage_data(
+    monkeypatch: MonkeyPatch,
+    capsys: CaptureFixture[str],
+) -> None:
+    def fake_resolved_changed_files(args: argparse.Namespace) -> tuple[str, ...]:
+        del args
+        return ()
+
+    monkeypatch.setattr(coverage_hotspots, "_load_coverage_payload", lambda: None)
+    monkeypatch.setattr(
+        coverage_hotspots,
+        "_resolved_changed_files",
+        fake_resolved_changed_files,
+    )
+
+    assert coverage_hotspots.main([]) == 0
+    assert "no coverage data found" in capsys.readouterr().out

--- a/tests/unit/test_run_pr_review_checks.py
+++ b/tests/unit/test_run_pr_review_checks.py
@@ -138,7 +138,7 @@ def test_run_pr_review_checks_runs_expected_steps(
     output = capsys.readouterr().out
     assert "no changed paths detected" not in output
     assert run_pr_review_checks.REVIEW_LOOP_REMINDER in output
-    assert "continue the red-team review loop" in output
+    assert "next real issues" in output
 
 
 def test_run_pr_review_checks_explains_ci_parity_subsumes_quality(

--- a/tests/unit/test_run_pr_review_checks.py
+++ b/tests/unit/test_run_pr_review_checks.py
@@ -20,6 +20,16 @@ def _unmapped_changed_paths(
     return ("notes/todo.md",)
 
 
+def _mixed_ci_and_repo_code_changed_paths(
+    base_sha: str | None = None, head_sha: str | None = None
+) -> tuple[str, ...]:
+    del base_sha, head_sha
+    return (
+        ".github/workflows/ci.yml",
+        "src/tallylot/application/normalization/normalize_source.py",
+    )
+
+
 def test_docs_only_diff_runs_docs_maintenance_only() -> None:
     plan = classify_changed_paths(("docs/guides/source-intake.md",))
 
@@ -72,6 +82,23 @@ def test_ci_workflow_diff_runs_ci_parity_and_targeted_audits() -> None:
     ]
 
 
+def test_mixed_repo_code_and_ci_diff_uses_ci_parity_as_broad_runner() -> None:
+    plan = classify_changed_paths(
+        (
+            ".github/workflows/ci.yml",
+            "src/tallylot/application/normalization/normalize_source.py",
+        )
+    )
+
+    assert [step.name for step in run_pr_review_checks._steps_for_plan(plan)] == [
+        "delivery-guardrails-audit",
+        "ci-parity-tooling",
+        "ci-parity",
+        "test-stress-checks",
+        "coverage-hotspots",
+    ]
+
+
 def test_mixed_docs_and_code_diff_keeps_surface_specific_checks() -> None:
     plan = classify_changed_paths(
         ("docs/guides/source-intake.md", "src/tallylot/interfaces/cli/source.py")
@@ -108,4 +135,28 @@ def test_run_pr_review_checks_runs_expected_steps(
 
     assert run_pr_review_checks.main([]) == 0
     assert steps_seen == ["docs-maintenance"]
-    assert "no changed paths detected" not in capsys.readouterr().out
+    output = capsys.readouterr().out
+    assert "no changed paths detected" not in output
+    assert run_pr_review_checks.REVIEW_LOOP_REMINDER in output
+    assert "continue the red-team review loop" in output
+
+
+def test_run_pr_review_checks_explains_ci_parity_subsumes_quality(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(
+        run_pr_review_checks,
+        "changed_paths",
+        _mixed_ci_and_repo_code_changed_paths,
+    )
+
+    def fake_run_step(step: run_pr_review_checks.ReviewCheckStep) -> int:
+        del step
+        return 0
+
+    monkeypatch.setattr(run_pr_review_checks, "_run_step", fake_run_step)
+
+    assert run_pr_review_checks.main([]) == 0
+    output = capsys.readouterr().out
+    assert "ci-parity is the broad runner for this diff" in output
+    assert "duplicate quality-gates-full is intentionally skipped" in output

--- a/tests/unit/test_run_pr_review_checks.py
+++ b/tests/unit/test_run_pr_review_checks.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from pytest import CaptureFixture, MonkeyPatch
+
+from repo_support.pr_review import classify_changed_paths
+import tools.run_pr_review_checks as run_pr_review_checks
+
+
+def _docs_changed_paths(
+    base_sha: str | None = None, head_sha: str | None = None
+) -> tuple[str, ...]:
+    del base_sha, head_sha
+    return ("docs/guides/source-intake.md",)
+
+
+def _unmapped_changed_paths(
+    base_sha: str | None = None, head_sha: str | None = None
+) -> tuple[str, ...]:
+    del base_sha, head_sha
+    return ("notes/todo.md",)
+
+
+def test_docs_only_diff_runs_docs_maintenance_only() -> None:
+    plan = classify_changed_paths(("docs/guides/source-intake.md",))
+
+    assert [step.name for step in run_pr_review_checks._steps_for_plan(plan)] == [
+        "docs-maintenance"
+    ]
+
+
+def test_control_plane_route_diff_runs_targeted_policy_checks() -> None:
+    plan = classify_changed_paths((".claude/commands/pr-review.md",))
+
+    assert [step.name for step in run_pr_review_checks._steps_for_plan(plan)] == [
+        "docs-maintenance",
+        "standards-guards",
+        "docs-runtime-parity",
+    ]
+
+
+def test_repo_code_diff_runs_full_quality_gates() -> None:
+    plan = classify_changed_paths(("src/tallylot/interfaces/cli/source.py",))
+
+    assert [step.name for step in run_pr_review_checks._steps_for_plan(plan)] == [
+        "quality-gates-full"
+    ]
+
+
+def test_ci_workflow_diff_runs_ci_parity_and_targeted_audits() -> None:
+    plan = classify_changed_paths((".github/workflows/ci.yml",))
+
+    assert [step.name for step in run_pr_review_checks._steps_for_plan(plan)] == [
+        "delivery-guardrails-audit",
+        "ci-parity-tooling",
+        "ci-parity",
+    ]
+
+
+def test_mixed_docs_and_code_diff_keeps_surface_specific_checks() -> None:
+    plan = classify_changed_paths(
+        ("docs/guides/source-intake.md", "src/tallylot/interfaces/cli/source.py")
+    )
+
+    assert [step.name for step in run_pr_review_checks._steps_for_plan(plan)] == [
+        "docs-maintenance",
+        "quality-gates-full",
+    ]
+
+
+def test_run_pr_review_checks_fails_closed_for_unmapped_paths(
+    monkeypatch: MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(run_pr_review_checks, "changed_paths", _unmapped_changed_paths)
+
+    assert run_pr_review_checks.main([]) == 1
+
+
+def test_run_pr_review_checks_runs_expected_steps(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(run_pr_review_checks, "changed_paths", _docs_changed_paths)
+    steps_seen: list[str] = []
+
+    def fake_run_step(step: run_pr_review_checks.ReviewCheckStep) -> int:
+        steps_seen.append(step.name)
+        return 0
+
+    monkeypatch.setattr(run_pr_review_checks, "_run_step", fake_run_step)
+
+    assert run_pr_review_checks.main([]) == 0
+    assert steps_seen == ["docs-maintenance"]
+    assert "no changed paths detected" not in capsys.readouterr().out

--- a/tests/unit/test_run_pr_review_checks.py
+++ b/tests/unit/test_run_pr_review_checks.py
@@ -39,10 +39,25 @@ def test_control_plane_route_diff_runs_targeted_policy_checks() -> None:
 
 
 def test_repo_code_diff_runs_full_quality_gates() -> None:
+    plan = classify_changed_paths(
+        ("src/tallylot/application/normalization/normalize_source.py",)
+    )
+
+    assert [step.name for step in run_pr_review_checks._steps_for_plan(plan)] == [
+        "quality-gates-full",
+        "test-stress-checks",
+        "coverage-hotspots",
+    ]
+
+
+def test_packaging_sensitive_repo_code_runs_packaging_verification() -> None:
     plan = classify_changed_paths(("src/tallylot/interfaces/cli/source.py",))
 
     assert [step.name for step in run_pr_review_checks._steps_for_plan(plan)] == [
-        "quality-gates-full"
+        "quality-gates-full",
+        "test-stress-checks",
+        "pre-merge-packaging",
+        "coverage-hotspots",
     ]
 
 
@@ -53,6 +68,7 @@ def test_ci_workflow_diff_runs_ci_parity_and_targeted_audits() -> None:
         "delivery-guardrails-audit",
         "ci-parity-tooling",
         "ci-parity",
+        "test-stress-checks",
     ]
 
 
@@ -64,6 +80,9 @@ def test_mixed_docs_and_code_diff_keeps_surface_specific_checks() -> None:
     assert [step.name for step in run_pr_review_checks._steps_for_plan(plan)] == [
         "docs-maintenance",
         "quality-gates-full",
+        "test-stress-checks",
+        "pre-merge-packaging",
+        "coverage-hotspots",
     ]
 
 

--- a/tests/unit/test_run_pylint.py
+++ b/tests/unit/test_run_pylint.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
-
 import sys
 from pathlib import Path
 
+import pytest
+
 from repo_support import paths as repo_paths
 from repo_support.paths import repo_root
+import tools.run_pylint
 from tools.run_pylint import _ADAPTER_TEST_IGNORE_PATHS, _PylintTarget, _pylint_targets
 
 
@@ -65,3 +67,30 @@ def test_test_pylint_rcfile_disables_protected_access() -> None:
     config_text = (repo_root() / ".pylintrc-tests").read_text(encoding="utf-8")
 
     assert "protected-access" in config_text
+
+
+def test_run_pylint_main_runs_all_targets(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    targets = (
+        _PylintTarget(name="repo-code", command=("python", "-m", "pylint", "src")),
+        _PylintTarget(name="tests", command=("python", "-m", "pylint", "tests")),
+    )
+    seen: list[str] = []
+
+    monkeypatch.setattr(tools.run_pylint, "_pylint_targets", lambda: targets)
+
+    def fake_run_target(target: _PylintTarget) -> tools.run_pylint._PylintResult:
+        seen.append(target.name)
+        return tools.run_pylint._PylintResult(
+            target=target,
+            returncode=0,
+            stdout="ok",
+            stderr="",
+            elapsed=0.1,
+        )
+
+    monkeypatch.setattr(tools.run_pylint, "_run_target", fake_run_target)
+
+    assert tools.run_pylint.main(()) == 0
+    assert sorted(seen) == ["repo-code", "tests"]

--- a/tests/unit/test_run_test_stress_checks.py
+++ b/tests/unit/test_run_test_stress_checks.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import subprocess
+
+from pytest import CaptureFixture, MonkeyPatch
+
+import tools.run_test_stress_checks as stress_checks
+
+
+def test_stress_steps_match_repo_policy() -> None:
+    steps = stress_checks._stress_steps()
+
+    assert [step.name for step in steps] == [
+        "fast-unit-seed-a",
+        "fast-unit-seed-b",
+        "contract-seed-a",
+        "e2e-seed-a",
+    ]
+    assert steps[0].command == (
+        "uv",
+        "run",
+        "pytest",
+        "-n",
+        "4",
+        "-m",
+        "unit and not slow",
+        "--no-cov",
+        "-q",
+        "--randomly-seed",
+        "1729",
+    )
+    assert steps[0].serial_fallback_command == (
+        "uv",
+        "run",
+        "pytest",
+        "-m",
+        "unit and not slow",
+        "--no-cov",
+        "-q",
+        "--randomly-seed",
+        "1729",
+    )
+    assert steps[2].command == (
+        "uv",
+        "run",
+        "pytest",
+        "-m",
+        "contract",
+        "--no-cov",
+        "-q",
+        "--randomly-seed",
+        "1729",
+    )
+
+
+def test_stress_runner_short_circuits_on_first_failure(
+    monkeypatch: MonkeyPatch, capsys: CaptureFixture[str]
+) -> None:
+    commands_seen: list[tuple[str, ...]] = []
+
+    def fake_run(
+        command: tuple[str, ...],
+        *,
+        capture_output: bool,
+        text: bool,
+        check: bool,
+        env: dict[str, str],
+    ) -> subprocess.CompletedProcess[str]:
+        del capture_output, text, check, env
+        commands_seen.append(command)
+        return subprocess.CompletedProcess(command, 1, stdout="", stderr="boom")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert stress_checks.main([]) == 1
+    assert commands_seen == [stress_checks._stress_steps()[0].command]
+    output = capsys.readouterr().out
+    assert "--randomly-seed 1729" in output
+    assert "serial fallback" in output
+
+
+def test_stress_runner_stops_after_later_failure(monkeypatch: MonkeyPatch) -> None:
+    commands_seen: list[tuple[str, ...]] = []
+
+    def fake_run(
+        command: tuple[str, ...],
+        *,
+        capture_output: bool,
+        text: bool,
+        check: bool,
+        env: dict[str, str],
+    ) -> subprocess.CompletedProcess[str]:
+        del capture_output, text, check, env
+        commands_seen.append(command)
+        returncode = 1 if len(commands_seen) == 2 else 0
+        return subprocess.CompletedProcess(command, returncode, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert stress_checks.main([]) == 1
+    assert commands_seen == [
+        stress_checks._stress_steps()[0].command,
+        stress_checks._stress_steps()[1].command,
+    ]

--- a/tests/unit/test_skill_scripts.py
+++ b/tests/unit/test_skill_scripts.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.support.skill_scripts import load_skill_main
+
+
+def test_load_skill_main_returns_callable_for_repo_skill_script() -> None:
+    main = load_skill_main(
+        ".agents/skills/balance-submission-operations/scripts/balance_submission_operations.py"
+    )
+
+    assert callable(main)
+
+
+def test_load_skill_main_requires_existing_repo_skill_script() -> None:
+    with pytest.raises(FileNotFoundError):
+        load_skill_main(".agents/skills/missing/scripts/nope.py")

--- a/tools/audit_delivery_guardrails.py
+++ b/tools/audit_delivery_guardrails.py
@@ -149,6 +149,29 @@ def _required_status_contexts(protection: Mapping[str, object]) -> set[str]:
     return contexts
 
 
+def _required_status_check_app_ids(
+    protection: Mapping[str, object],
+) -> dict[str, int | None]:
+    required_status_checks = cast(
+        Mapping[str, object] | None,
+        protection.get("required_status_checks"),
+    )
+    if required_status_checks is None:
+        return {}
+
+    app_ids: dict[str, int | None] = {}
+    for raw_check in cast(list[object], required_status_checks.get("checks") or []):
+        if not isinstance(raw_check, Mapping):
+            continue
+        check = cast(Mapping[str, object], raw_check)
+        context = check.get("context")
+        if not isinstance(context, str):
+            continue
+        raw_app_id = check.get("app_id")
+        app_ids[context] = raw_app_id if isinstance(raw_app_id, int) else None
+    return app_ids
+
+
 def _collaborator_is_review_capable(collaborator: Mapping[str, object]) -> bool:
     permissions_object = collaborator.get("permissions")
     if not isinstance(permissions_object, Mapping):
@@ -203,6 +226,19 @@ def _evaluate_status_check_guardrails(
         errors.append(
             "branch protection is missing required status checks: "
             + ", ".join(missing_status_checks)
+        )
+
+    app_ids_by_context = _required_status_check_app_ids(protection)
+    unpinned_status_checks = sorted(
+        context
+        for context in expected_status_checks
+        if context in _required_status_contexts(protection)
+        and app_ids_by_context.get(context) is None
+    )
+    if unpinned_status_checks:
+        errors.append(
+            "branch protection must pin required status checks to their app: "
+            + ", ".join(unpinned_status_checks)
         )
     return tuple(errors)
 

--- a/tools/audit_delivery_guardrails.py
+++ b/tools/audit_delivery_guardrails.py
@@ -13,6 +13,7 @@ from repo_support.paths import repo_root
 REQUIRED_STATUS_CHECKS = ("commit-messages", "pr-review")
 CONTROL_PLANE_CODEOWNER_PATTERNS = (
     ".agents/skills/**",
+    ".github/actions/**",
     ".github/ISSUE_TEMPLATE/**",
     ".github/workflows/**",
     ".github/pull_request_template.md",
@@ -24,6 +25,7 @@ CONTROL_PLANE_CODEOWNER_PATTERNS = (
     "tools/pre_commit_hook.py",
     "tools/audit_delivery_guardrails.py",
     "tools/audit_pr_review.py",
+    "tools/benchmark_quality_gates.py",
     "tools/message_standards.py",
     "tools/validate_commit_message.py",
     "tools/validate_pr_metadata.py",

--- a/tools/audit_delivery_guardrails.py
+++ b/tools/audit_delivery_guardrails.py
@@ -10,7 +10,7 @@ from typing import Any, cast
 
 from repo_support.paths import repo_root
 
-REQUIRED_STATUS_CHECKS = ("commit-messages", "quality")
+REQUIRED_STATUS_CHECKS = ("commit-messages", "pr-review")
 CONTROL_PLANE_CODEOWNER_PATTERNS = (
     ".agents/skills/**",
     ".github/ISSUE_TEMPLATE/**",
@@ -23,11 +23,13 @@ CONTROL_PLANE_CODEOWNER_PATTERNS = (
     "tools/install_git_hooks.py",
     "tools/pre_commit_hook.py",
     "tools/audit_delivery_guardrails.py",
+    "tools/audit_pr_review.py",
     "tools/message_standards.py",
     "tools/validate_commit_message.py",
     "tools/validate_pr_metadata.py",
     "tools/run_quality_gates.py",
     "tools/run_ci_parity_checks.py",
+    "tools/run_pr_review_checks.py",
 )
 
 

--- a/tools/audit_pr_review.py
+++ b/tools/audit_pr_review.py
@@ -38,6 +38,7 @@ def _plan_to_json(plan: PrReviewPlan) -> dict[str, object]:
         ),
         "requires_test_stress_checks": plan.requires_test_stress_checks,
         "requires_coverage_hotspot_report": plan.requires_coverage_hotspot_report,
+        "manual_red_team_review_required": bool(plan.changed_paths),
         "unmapped_paths": list(plan.unmapped_paths),
     }
 
@@ -46,6 +47,7 @@ def _emit_text(plan: PrReviewPlan) -> None:
     if not plan.changed_paths:
         print("no changed paths detected")
         return
+    print("manual red-team review:", "required")
     print("surface groups:", ", ".join(plan.surface_groups) or "none")
     print("review domains:", ", ".join(plan.review_domains) or "none")
     print("verification level:", plan.verification_level)
@@ -68,6 +70,9 @@ def _emit_text(plan: PrReviewPlan) -> None:
         print("unmapped paths:")
         for path in plan.unmapped_paths:
             print(f"  - {path}")
+    print(
+        "review reminder: audit and verification do not replace the mandatory red-team repair loop"
+    )
 
 
 def main(argv: Sequence[str] | None = None) -> int:

--- a/tools/audit_pr_review.py
+++ b/tools/audit_pr_review.py
@@ -71,7 +71,9 @@ def _emit_text(plan: PrReviewPlan) -> None:
         for path in plan.unmapped_paths:
             print(f"  - {path}")
     print(
-        "review reminder: audit and verification do not replace the mandatory red-team repair loop"
+        "review reminder: audit and verification do not replace the mandatory "
+        "red-team repair loop; use this report to choose the next "
+        "issue-finding pass"
     )
 
 

--- a/tools/audit_pr_review.py
+++ b/tools/audit_pr_review.py
@@ -31,6 +31,13 @@ def _plan_to_json(plan: PrReviewPlan) -> dict[str, object]:
             for check in plan.targeted_checks
         ],
         "verification_level": plan.verification_level,
+        "requires_full_quality_gates": plan.requires_full_quality_gates,
+        "requires_ci_parity": plan.requires_ci_parity,
+        "requires_pre_merge_packaging_verification": (
+            plan.requires_pre_merge_packaging_verification
+        ),
+        "requires_test_stress_checks": plan.requires_test_stress_checks,
+        "requires_coverage_hotspot_report": plan.requires_coverage_hotspot_report,
         "unmapped_paths": list(plan.unmapped_paths),
     }
 
@@ -42,6 +49,17 @@ def _emit_text(plan: PrReviewPlan) -> None:
     print("surface groups:", ", ".join(plan.surface_groups) or "none")
     print("review domains:", ", ".join(plan.review_domains) or "none")
     print("verification level:", plan.verification_level)
+    print("full quality gates:", "yes" if plan.requires_full_quality_gates else "no")
+    print("ci parity:", "yes" if plan.requires_ci_parity else "no")
+    print(
+        "pre-merge packaging verification:",
+        "yes" if plan.requires_pre_merge_packaging_verification else "no",
+    )
+    print("stress checks:", "yes" if plan.requires_test_stress_checks else "no")
+    print(
+        "coverage hotspot report:",
+        "yes" if plan.requires_coverage_hotspot_report else "no",
+    )
     if plan.targeted_checks:
         print("targeted checks:")
         for check in plan.targeted_checks:

--- a/tools/audit_pr_review.py
+++ b/tools/audit_pr_review.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+
+from repo_support.pr_review import PrReviewPlan, changed_paths, classify_changed_paths
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Audit the current PR diff for repo-native review surface coverage."
+    )
+    parser.add_argument("--base-sha", help="Base commit SHA for the diff range.")
+    parser.add_argument("--head-sha", help="Head commit SHA for the diff range.")
+    parser.add_argument(
+        "--json", action="store_true", help="Emit the audit report as JSON."
+    )
+    return parser.parse_args(argv)
+
+
+def _plan_to_json(plan: PrReviewPlan) -> dict[str, object]:
+    return {
+        "changed_paths": list(plan.changed_paths),
+        "grouped_paths": {name: list(paths) for name, paths in plan.grouped_paths},
+        "surface_groups": list(plan.surface_groups),
+        "review_domains": list(plan.review_domains),
+        "targeted_checks": [
+            {"name": check.name, "command": list(check.command)}
+            for check in plan.targeted_checks
+        ],
+        "verification_level": plan.verification_level,
+        "unmapped_paths": list(plan.unmapped_paths),
+    }
+
+
+def _emit_text(plan: PrReviewPlan) -> None:
+    if not plan.changed_paths:
+        print("no changed paths detected")
+        return
+    print("surface groups:", ", ".join(plan.surface_groups) or "none")
+    print("review domains:", ", ".join(plan.review_domains) or "none")
+    print("verification level:", plan.verification_level)
+    if plan.targeted_checks:
+        print("targeted checks:")
+        for check in plan.targeted_checks:
+            print(f"  - {check.name}")
+    if plan.unmapped_paths:
+        print("unmapped paths:")
+        for path in plan.unmapped_paths:
+            print(f"  - {path}")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if (args.base_sha is None) != (args.head_sha is None):
+        print(
+            "provide both --base-sha and --head-sha when overriding the diff range",
+            file=sys.stderr,
+        )
+        return 2
+
+    plan = classify_changed_paths(
+        changed_paths(base_sha=args.base_sha, head_sha=args.head_sha)
+    )
+    if args.json:
+        print(json.dumps(_plan_to_json(plan), indent=2, sort_keys=True))
+    else:
+        _emit_text(plan)
+    if plan.unmapped_paths:
+        print(
+            "pr review audit failed: changed paths are not mapped to repo review surfaces",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/benchmark_quality_gates.py
+++ b/tools/benchmark_quality_gates.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import subprocess
 import time
 from collections.abc import Sequence
 from dataclasses import dataclass
+from pathlib import Path
+from statistics import median
 
 from tools.uv_environment import repo_uv_environment
 
@@ -15,6 +18,44 @@ class BenchmarkStrategy:
     name: str
     description: str
     command: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class BenchmarkMeasurement:
+    kind: str
+    iteration: int
+    returncode: int
+    elapsed: float
+
+
+@dataclass(frozen=True)
+class BenchmarkSummary:
+    strategy: BenchmarkStrategy
+    warmup_count: int
+    measured_iterations: int
+    measurements: tuple[BenchmarkMeasurement, ...]
+
+    @property
+    def measured_measurements(self) -> tuple[BenchmarkMeasurement, ...]:
+        return tuple(
+            measurement
+            for measurement in self.measurements
+            if measurement.kind == "measured"
+        )
+
+    @property
+    def median_elapsed(self) -> float:
+        return median(measurement.elapsed for measurement in self.measured_measurements)
+
+    @property
+    def measured_elapsed(self) -> tuple[float, ...]:
+        return tuple(measurement.elapsed for measurement in self.measured_measurements)
+
+    @property
+    def exit_code(self) -> int:
+        return max(
+            (measurement.returncode for measurement in self.measurements), default=0
+        )
 
 
 STRATEGIES = (
@@ -77,6 +118,23 @@ def _build_argument_parser() -> argparse.ArgumentParser:
         choices=tuple(strategy.name for strategy in STRATEGIES),
         help="Benchmark only the named strategy. May be passed multiple times.",
     )
+    parser.add_argument(
+        "--warmup-count",
+        type=int,
+        default=1,
+        help="Number of warmup runs to execute before measured iterations.",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=3,
+        help="Number of measured iterations to execute per selected strategy.",
+    )
+    parser.add_argument(
+        "--json-out",
+        type=Path,
+        help="Optional path for a JSON benchmark summary.",
+    )
     return parser
 
 
@@ -102,25 +160,124 @@ def _benchmark_environment() -> dict[str, str]:
     return environment
 
 
+def _validate_args(args: argparse.Namespace) -> None:
+    if args.warmup_count < 0:
+        raise ValueError("--warmup-count must be zero or greater")
+    if args.iterations < 1:
+        raise ValueError("--iterations must be at least 1")
+
+
+def _run_measurement(
+    strategy: BenchmarkStrategy,
+    *,
+    kind: str,
+    iteration: int,
+) -> BenchmarkMeasurement:
+    started = time.perf_counter()
+    result = subprocess.run(
+        strategy.command,
+        check=False,
+        env=_benchmark_environment(),
+    )
+    elapsed = time.perf_counter() - started
+    print(
+        f"[{kind}:{strategy.name}:{iteration}] exit={result.returncode} "
+        f"elapsed={elapsed:.2f}s",
+        flush=True,
+    )
+    return BenchmarkMeasurement(
+        kind=kind,
+        iteration=iteration,
+        returncode=result.returncode,
+        elapsed=elapsed,
+    )
+
+
+def _benchmark_strategy(
+    strategy: BenchmarkStrategy,
+    *,
+    warmup_count: int,
+    measured_iterations: int,
+) -> BenchmarkSummary:
+    print(f"[strategy:{strategy.name}] {strategy.description}", flush=True)
+    print(f"[command] {' '.join(strategy.command)}", flush=True)
+    measurements: list[BenchmarkMeasurement] = []
+    for iteration in range(1, warmup_count + 1):
+        measurements.append(
+            _run_measurement(strategy, kind="warmup", iteration=iteration)
+        )
+    for iteration in range(1, measured_iterations + 1):
+        measurements.append(
+            _run_measurement(strategy, kind="measured", iteration=iteration)
+        )
+    summary = BenchmarkSummary(
+        strategy=strategy,
+        warmup_count=warmup_count,
+        measured_iterations=measured_iterations,
+        measurements=tuple(measurements),
+    )
+    measured_elapsed = ", ".join(
+        f"{elapsed:.2f}" for elapsed in summary.measured_elapsed
+    )
+    print(
+        f"[summary:{strategy.name}] median={summary.median_elapsed:.2f}s "
+        f"measured=[{measured_elapsed}]",
+        flush=True,
+    )
+    return summary
+
+
+def _summary_payload(summary: BenchmarkSummary) -> dict[str, object]:
+    return {
+        "name": summary.strategy.name,
+        "description": summary.strategy.description,
+        "command": list(summary.strategy.command),
+        "warmup_count": summary.warmup_count,
+        "measured_iterations": summary.measured_iterations,
+        "median_elapsed_seconds": summary.median_elapsed,
+        "measured_elapsed_seconds": list(summary.measured_elapsed),
+        "measurements": [
+            {
+                "kind": measurement.kind,
+                "iteration": measurement.iteration,
+                "returncode": measurement.returncode,
+                "elapsed_seconds": measurement.elapsed,
+            }
+            for measurement in summary.measurements
+        ],
+    }
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parse_args(argv)
-    exit_code = 0
+    try:
+        _validate_args(args)
+    except ValueError as error:
+        raise SystemExit(str(error)) from error
 
-    for strategy in _selected_strategies(args.strategy):
-        print(f"[strategy:{strategy.name}] {strategy.description}", flush=True)
-        print(f"[command] {' '.join(strategy.command)}", flush=True)
-        started = time.perf_counter()
-        result = subprocess.run(
-            strategy.command,
-            check=False,
-            env=_benchmark_environment(),
+    summaries = [
+        _benchmark_strategy(
+            strategy,
+            warmup_count=args.warmup_count,
+            measured_iterations=args.iterations,
         )
-        elapsed = time.perf_counter() - started
-        print(f"[result] exit={result.returncode} elapsed={elapsed:.2f}s", flush=True)
-        if result.returncode != 0:
-            exit_code = result.returncode
-
-    return exit_code
+        for strategy in _selected_strategies(args.strategy)
+    ]
+    if args.json_out is not None:
+        args.json_out.write_text(
+            json.dumps(
+                {
+                    "warmup_count": args.warmup_count,
+                    "measured_iterations": args.iterations,
+                    "strategies": [_summary_payload(summary) for summary in summaries],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+    return max((summary.exit_code for summary in summaries), default=0)
 
 
 if __name__ == "__main__":

--- a/tools/benchmark_quality_gates.py
+++ b/tools/benchmark_quality_gates.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from tools.uv_environment import repo_uv_environment
+
+
+@dataclass(frozen=True)
+class BenchmarkStrategy:
+    name: str
+    description: str
+    command: tuple[str, ...]
+
+
+STRATEGIES = (
+    BenchmarkStrategy(
+        name="fast-current",
+        description="Current fast-gate baseline with all checks started together.",
+        command=(
+            "uv",
+            "run",
+            "python",
+            "-m",
+            "tools.run_quality_gates",
+            "--schedule",
+            "all-at-once",
+        ),
+    ),
+    BenchmarkStrategy(
+        name="fast-optimized",
+        description="Repo-benchmarked fast-gate schedule.",
+        command=("uv", "run", "python", "-m", "tools.run_quality_gates"),
+    ),
+    BenchmarkStrategy(
+        name="full-current",
+        description="Current full-gate baseline with all checks started together.",
+        command=(
+            "uv",
+            "run",
+            "python",
+            "-m",
+            "tools.run_quality_gates",
+            "--full-tests",
+            "--schedule",
+            "all-at-once",
+        ),
+    ),
+    BenchmarkStrategy(
+        name="full-phased",
+        description="Alternative phased full-gate schedule for comparison.",
+        command=(
+            "uv",
+            "run",
+            "python",
+            "-m",
+            "tools.run_quality_gates",
+            "--full-tests",
+            "--schedule",
+            "phased",
+        ),
+    ),
+)
+
+
+def _build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Benchmark quality gate scheduling strategies for this repo."
+    )
+    parser.add_argument(
+        "--strategy",
+        action="append",
+        choices=tuple(strategy.name for strategy in STRATEGIES),
+        help="Benchmark only the named strategy. May be passed multiple times.",
+    )
+    return parser
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    return _build_argument_parser().parse_args(argv)
+
+
+def _selected_strategies(
+    selected_names: Sequence[str] | None,
+) -> tuple[BenchmarkStrategy, ...]:
+    if not selected_names:
+        return STRATEGIES
+    selected = set(selected_names)
+    return tuple(strategy for strategy in STRATEGIES if strategy.name in selected)
+
+
+def _clean_runtime_artifacts() -> None:
+    for path in Path.cwd().glob(".coverage*"):
+        if path.is_file():
+            path.unlink()
+
+
+def _benchmark_environment() -> dict[str, str]:
+    environment = repo_uv_environment()
+    environment.pop("COVERAGE_PROCESS_START", None)
+    environment.pop("COVERAGE_RCFILE", None)
+    if "PYTEST_ADDOPTS" in os.environ and "PYTEST_ADDOPTS" not in environment:
+        environment["PYTEST_ADDOPTS"] = os.environ["PYTEST_ADDOPTS"]
+    return environment
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    exit_code = 0
+
+    for strategy in _selected_strategies(args.strategy):
+        _clean_runtime_artifacts()
+        print(f"[strategy:{strategy.name}] {strategy.description}", flush=True)
+        print(f"[command] {' '.join(strategy.command)}", flush=True)
+        started = time.perf_counter()
+        result = subprocess.run(
+            strategy.command,
+            check=False,
+            env=_benchmark_environment(),
+        )
+        elapsed = time.perf_counter() - started
+        print(f"[result] exit={result.returncode} elapsed={elapsed:.2f}s", flush=True)
+        if result.returncode != 0:
+            exit_code = result.returncode
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/benchmark_quality_gates.py
+++ b/tools/benchmark_quality_gates.py
@@ -6,7 +6,6 @@ import subprocess
 import time
 from collections.abc import Sequence
 from dataclasses import dataclass
-from pathlib import Path
 
 from tools.uv_environment import repo_uv_environment
 
@@ -94,12 +93,6 @@ def _selected_strategies(
     return tuple(strategy for strategy in STRATEGIES if strategy.name in selected)
 
 
-def _clean_runtime_artifacts() -> None:
-    for path in Path.cwd().glob(".coverage*"):
-        if path.is_file():
-            path.unlink()
-
-
 def _benchmark_environment() -> dict[str, str]:
     environment = repo_uv_environment()
     environment.pop("COVERAGE_PROCESS_START", None)
@@ -114,7 +107,6 @@ def main(argv: Sequence[str] | None = None) -> int:
     exit_code = 0
 
     for strategy in _selected_strategies(args.strategy):
-        _clean_runtime_artifacts()
         print(f"[strategy:{strategy.name}] {strategy.description}", flush=True)
         print(f"[command] {' '.join(strategy.command)}", flush=True)
         started = time.perf_counter()

--- a/tools/benchmark_tests.py
+++ b/tools/benchmark_tests.py
@@ -5,8 +5,10 @@ import os
 import subprocess
 import time
 from collections.abc import Sequence
+from contextlib import ExitStack
 from dataclasses import dataclass
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from repo_support.quality_gates import apply_gate_environment
 from tools.uv_environment import repo_uv_environment
@@ -105,19 +107,21 @@ def _command_for_suite(suite: BenchmarkSuite, *, parallel: bool) -> tuple[str, .
     return tuple(command)
 
 
-def _suite_environment(suite: BenchmarkSuite) -> dict[str, str]:
+def _suite_environment(
+    suite: BenchmarkSuite,
+    *,
+    coverage_file: Path | None = None,
+) -> dict[str, str]:
     environment = repo_uv_environment()
     environment.pop("COVERAGE_PROCESS_START", None)
     environment.pop("COVERAGE_RCFILE", None)
     if "PYTEST_ADDOPTS" in os.environ and "PYTEST_ADDOPTS" not in environment:
         environment["PYTEST_ADDOPTS"] = os.environ["PYTEST_ADDOPTS"]
-    return apply_gate_environment(environment, coverage_gate=suite.name == "full")
-
-
-def _clean_coverage_files() -> None:
-    for path in Path.cwd().glob(".coverage*"):
-        if path.is_file():
-            path.unlink()
+    return apply_gate_environment(
+        environment,
+        coverage_gate=suite.name == "full",
+        coverage_file=coverage_file,
+    )
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -126,16 +130,25 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     for suite in _selected_suites(args.suite):
         command = _command_for_suite(suite, parallel=args.parallel)
-        if suite.name == "full":
-            _clean_coverage_files()
         print(f"[suite:{suite.name}] {suite.description}", flush=True)
         print(f"[command] {' '.join(command)}", flush=True)
         started = time.perf_counter()
-        result = subprocess.run(
-            command,
-            check=False,
-            env=_suite_environment(suite),
-        )
+        with ExitStack() as stack:
+            temp_dir = (
+                stack.enter_context(
+                    TemporaryDirectory(
+                        prefix=f"tallylot-benchmark-{suite.name}-coverage-"
+                    )
+                )
+                if suite.name == "full"
+                else None
+            )
+            coverage_file = Path(temp_dir) / ".coverage" if temp_dir else None
+            result = subprocess.run(
+                command,
+                check=False,
+                env=_suite_environment(suite, coverage_file=coverage_file),
+            )
         elapsed = time.perf_counter() - started
         print(f"[result] exit={result.returncode} elapsed={elapsed:.2f}s")
         if result.returncode != 0:

--- a/tools/benchmark_tests.py
+++ b/tools/benchmark_tests.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import subprocess
 import time
@@ -8,6 +9,7 @@ from collections.abc import Sequence
 from contextlib import ExitStack
 from dataclasses import dataclass
 from pathlib import Path
+from statistics import median
 from tempfile import TemporaryDirectory
 
 from repo_support.quality_gates import apply_gate_environment
@@ -21,50 +23,100 @@ class BenchmarkSuite:
     command: tuple[str, ...]
 
 
+@dataclass(frozen=True)
+class BenchmarkMeasurement:
+    kind: str
+    iteration: int
+    returncode: int
+    elapsed: float
+
+
+@dataclass(frozen=True)
+class BenchmarkSummary:
+    suite: BenchmarkSuite
+    warmup_count: int
+    measured_iterations: int
+    measurements: tuple[BenchmarkMeasurement, ...]
+
+    @property
+    def measured_measurements(self) -> tuple[BenchmarkMeasurement, ...]:
+        return tuple(
+            measurement
+            for measurement in self.measurements
+            if measurement.kind == "measured"
+        )
+
+    @property
+    def median_elapsed(self) -> float:
+        return median(measurement.elapsed for measurement in self.measured_measurements)
+
+    @property
+    def measured_elapsed(self) -> tuple[float, ...]:
+        return tuple(measurement.elapsed for measurement in self.measured_measurements)
+
+    @property
+    def exit_code(self) -> int:
+        return max(
+            (measurement.returncode for measurement in self.measurements), default=0
+        )
+
+
 SUITES = (
     BenchmarkSuite(
-        name="unit",
-        description="Unit tests without coverage overhead.",
+        name="fast-unit-serial",
+        description="Fast unit slice without xdist.",
         command=(
             "uv",
             "run",
             "pytest",
-            "tests/unit",
+            "-m",
+            "unit and not slow",
             "--no-cov",
             "-q",
             "--durations=10",
         ),
     ),
     BenchmarkSuite(
-        name="contract",
-        description="Contract tests without coverage overhead.",
+        name="fast-unit-n4",
+        description="Fast unit slice with a fixed four-worker xdist pool.",
         command=(
             "uv",
             "run",
             "pytest",
-            "tests/contract",
+            "-n",
+            "4",
+            "-m",
+            "unit and not slow",
             "--no-cov",
             "-q",
             "--durations=10",
         ),
     ),
     BenchmarkSuite(
-        name="e2e",
-        description="E2E CLI tests without coverage overhead.",
+        name="fast-unit-nauto",
+        description="Fast unit slice with pytest-xdist auto worker selection.",
         command=(
             "uv",
             "run",
             "pytest",
-            "tests/e2e",
+            "-n",
+            "auto",
+            "-m",
+            "unit and not slow",
             "--no-cov",
             "-q",
             "--durations=10",
         ),
     ),
     BenchmarkSuite(
-        name="full",
-        description="Full test suite with project coverage requirements.",
+        name="full-serial",
+        description="Full test suite with coverage and no xdist.",
         command=("uv", "run", "pytest", "-q", "--durations=10"),
+    ),
+    BenchmarkSuite(
+        name="full-nauto",
+        description="Full test suite with coverage and pytest-xdist auto workers.",
+        command=("uv", "run", "pytest", "-n", "auto", "-q", "--durations=10"),
     ),
 )
 
@@ -80,9 +132,21 @@ def _build_argument_parser() -> argparse.ArgumentParser:
         help="Benchmark only the named suite. May be passed multiple times.",
     )
     parser.add_argument(
-        "--parallel",
-        action="store_true",
-        help="Run each selected suite with pytest-xdist using -n auto.",
+        "--warmup-count",
+        type=int,
+        default=1,
+        help="Number of warmup runs to execute before measured iterations.",
+    )
+    parser.add_argument(
+        "--iterations",
+        type=int,
+        default=3,
+        help="Number of measured iterations to execute per selected suite.",
+    )
+    parser.add_argument(
+        "--json-out",
+        type=Path,
+        help="Optional path for a JSON benchmark summary.",
     )
     return parser
 
@@ -100,13 +164,6 @@ def _selected_suites(
     return tuple(suite for suite in SUITES if suite.name in selected)
 
 
-def _command_for_suite(suite: BenchmarkSuite, *, parallel: bool) -> tuple[str, ...]:
-    command = list(suite.command)
-    if parallel:
-        command[3:3] = ["-n", "auto"]
-    return tuple(command)
-
-
 def _suite_environment(
     suite: BenchmarkSuite,
     *,
@@ -119,42 +176,136 @@ def _suite_environment(
         environment["PYTEST_ADDOPTS"] = os.environ["PYTEST_ADDOPTS"]
     return apply_gate_environment(
         environment,
-        coverage_gate=suite.name == "full",
+        coverage_gate=suite.name.startswith("full"),
         coverage_file=coverage_file,
     )
 
 
+def _validate_args(args: argparse.Namespace) -> None:
+    if args.warmup_count < 0:
+        raise ValueError("--warmup-count must be zero or greater")
+    if args.iterations < 1:
+        raise ValueError("--iterations must be at least 1")
+
+
+def _run_measurement(
+    suite: BenchmarkSuite,
+    *,
+    kind: str,
+    iteration: int,
+) -> BenchmarkMeasurement:
+    started = time.perf_counter()
+    with ExitStack() as stack:
+        temp_dir = (
+            stack.enter_context(
+                TemporaryDirectory(prefix=f"tallylot-benchmark-{suite.name}-coverage-")
+            )
+            if suite.name.startswith("full")
+            else None
+        )
+        coverage_file = Path(temp_dir) / ".coverage" if temp_dir else None
+        result = subprocess.run(
+            suite.command,
+            check=False,
+            env=_suite_environment(suite, coverage_file=coverage_file),
+        )
+    elapsed = time.perf_counter() - started
+    print(
+        f"[{kind}:{suite.name}:{iteration}] exit={result.returncode} "
+        f"elapsed={elapsed:.2f}s",
+        flush=True,
+    )
+    return BenchmarkMeasurement(
+        kind=kind,
+        iteration=iteration,
+        returncode=result.returncode,
+        elapsed=elapsed,
+    )
+
+
+def _benchmark_suite(
+    suite: BenchmarkSuite,
+    *,
+    warmup_count: int,
+    measured_iterations: int,
+) -> BenchmarkSummary:
+    print(f"[suite:{suite.name}] {suite.description}", flush=True)
+    print(f"[command] {' '.join(suite.command)}", flush=True)
+    measurements: list[BenchmarkMeasurement] = []
+    for iteration in range(1, warmup_count + 1):
+        measurements.append(_run_measurement(suite, kind="warmup", iteration=iteration))
+    for iteration in range(1, measured_iterations + 1):
+        measurements.append(
+            _run_measurement(suite, kind="measured", iteration=iteration)
+        )
+    summary = BenchmarkSummary(
+        suite=suite,
+        warmup_count=warmup_count,
+        measured_iterations=measured_iterations,
+        measurements=tuple(measurements),
+    )
+    measured_elapsed = ", ".join(
+        f"{elapsed:.2f}" for elapsed in summary.measured_elapsed
+    )
+    print(
+        f"[summary:{suite.name}] median={summary.median_elapsed:.2f}s "
+        f"measured=[{measured_elapsed}]",
+        flush=True,
+    )
+    return summary
+
+
+def _summary_payload(summary: BenchmarkSummary) -> dict[str, object]:
+    return {
+        "name": summary.suite.name,
+        "description": summary.suite.description,
+        "command": list(summary.suite.command),
+        "warmup_count": summary.warmup_count,
+        "measured_iterations": summary.measured_iterations,
+        "median_elapsed_seconds": summary.median_elapsed,
+        "measured_elapsed_seconds": list(summary.measured_elapsed),
+        "measurements": [
+            {
+                "kind": measurement.kind,
+                "iteration": measurement.iteration,
+                "returncode": measurement.returncode,
+                "elapsed_seconds": measurement.elapsed,
+            }
+            for measurement in summary.measurements
+        ],
+    }
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parse_args(argv)
-    exit_code = 0
+    try:
+        _validate_args(args)
+    except ValueError as error:
+        raise SystemExit(str(error)) from error
 
-    for suite in _selected_suites(args.suite):
-        command = _command_for_suite(suite, parallel=args.parallel)
-        print(f"[suite:{suite.name}] {suite.description}", flush=True)
-        print(f"[command] {' '.join(command)}", flush=True)
-        started = time.perf_counter()
-        with ExitStack() as stack:
-            temp_dir = (
-                stack.enter_context(
-                    TemporaryDirectory(
-                        prefix=f"tallylot-benchmark-{suite.name}-coverage-"
-                    )
-                )
-                if suite.name == "full"
-                else None
+    summaries = [
+        _benchmark_suite(
+            suite,
+            warmup_count=args.warmup_count,
+            measured_iterations=args.iterations,
+        )
+        for suite in _selected_suites(args.suite)
+    ]
+    if args.json_out is not None:
+        args.json_out.write_text(
+            json.dumps(
+                {
+                    "warmup_count": args.warmup_count,
+                    "measured_iterations": args.iterations,
+                    "suites": [_summary_payload(summary) for summary in summaries],
+                },
+                indent=2,
+                sort_keys=True,
             )
-            coverage_file = Path(temp_dir) / ".coverage" if temp_dir else None
-            result = subprocess.run(
-                command,
-                check=False,
-                env=_suite_environment(suite, coverage_file=coverage_file),
-            )
-        elapsed = time.perf_counter() - started
-        print(f"[result] exit={result.returncode} elapsed={elapsed:.2f}s")
-        if result.returncode != 0:
-            exit_code = result.returncode
-
-    return exit_code
+            + "\n",
+            encoding="utf-8",
+        )
+    return max((summary.exit_code for summary in summaries), default=0)
 
 
 if __name__ == "__main__":

--- a/tools/benchmark_tests.py
+++ b/tools/benchmark_tests.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 import argparse
+import os
 import subprocess
-import sys
 import time
 from collections.abc import Sequence
 from dataclasses import dataclass
+from pathlib import Path
+
+from repo_support.quality_gates import apply_gate_environment
+from tools.uv_environment import repo_uv_environment
 
 
 @dataclass(frozen=True)
@@ -19,28 +23,54 @@ SUITES = (
     BenchmarkSuite(
         name="unit",
         description="Unit tests without coverage overhead.",
-        command=("pytest", "tests/unit", "--no-cov", "-q", "--durations=10"),
+        command=(
+            "uv",
+            "run",
+            "pytest",
+            "tests/unit",
+            "--no-cov",
+            "-q",
+            "--durations=10",
+        ),
     ),
     BenchmarkSuite(
         name="contract",
         description="Contract tests without coverage overhead.",
-        command=("pytest", "tests/contract", "--no-cov", "-q", "--durations=10"),
+        command=(
+            "uv",
+            "run",
+            "pytest",
+            "tests/contract",
+            "--no-cov",
+            "-q",
+            "--durations=10",
+        ),
     ),
     BenchmarkSuite(
         name="e2e",
         description="E2E CLI tests without coverage overhead.",
-        command=("pytest", "tests/e2e", "--no-cov", "-q", "--durations=10"),
+        command=(
+            "uv",
+            "run",
+            "pytest",
+            "tests/e2e",
+            "--no-cov",
+            "-q",
+            "--durations=10",
+        ),
     ),
     BenchmarkSuite(
         name="full",
         description="Full test suite with project coverage requirements.",
-        command=("pytest", "-q", "--durations=10"),
+        command=("uv", "run", "pytest", "-q", "--durations=10"),
     ),
 )
 
 
 def _build_argument_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Benchmark pytest suite segments for this repo.")
+    parser = argparse.ArgumentParser(
+        description="Benchmark pytest suite segments for this repo."
+    )
     parser.add_argument(
         "--suite",
         action="append",
@@ -59,7 +89,9 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     return _build_argument_parser().parse_args(argv)
 
 
-def _selected_suites(selected_names: Sequence[str] | None) -> tuple[BenchmarkSuite, ...]:
+def _selected_suites(
+    selected_names: Sequence[str] | None,
+) -> tuple[BenchmarkSuite, ...]:
     if not selected_names:
         return SUITES
     selected = set(selected_names)
@@ -69,8 +101,23 @@ def _selected_suites(selected_names: Sequence[str] | None) -> tuple[BenchmarkSui
 def _command_for_suite(suite: BenchmarkSuite, *, parallel: bool) -> tuple[str, ...]:
     command = list(suite.command)
     if parallel:
-        command[1:1] = ["-n", "auto"]
+        command[3:3] = ["-n", "auto"]
     return tuple(command)
+
+
+def _suite_environment(suite: BenchmarkSuite) -> dict[str, str]:
+    environment = repo_uv_environment()
+    environment.pop("COVERAGE_PROCESS_START", None)
+    environment.pop("COVERAGE_RCFILE", None)
+    if "PYTEST_ADDOPTS" in os.environ and "PYTEST_ADDOPTS" not in environment:
+        environment["PYTEST_ADDOPTS"] = os.environ["PYTEST_ADDOPTS"]
+    return apply_gate_environment(environment, coverage_gate=suite.name == "full")
+
+
+def _clean_coverage_files() -> None:
+    for path in Path.cwd().glob(".coverage*"):
+        if path.is_file():
+            path.unlink()
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -79,10 +126,16 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     for suite in _selected_suites(args.suite):
         command = _command_for_suite(suite, parallel=args.parallel)
+        if suite.name == "full":
+            _clean_coverage_files()
         print(f"[suite:{suite.name}] {suite.description}", flush=True)
-        print(f"[command] uv run {' '.join(command)}", flush=True)
+        print(f"[command] {' '.join(command)}", flush=True)
         started = time.perf_counter()
-        result = subprocess.run([sys.executable, "-m", "pytest", *command[1:]], check=False)
+        result = subprocess.run(
+            command,
+            check=False,
+            env=_suite_environment(suite),
+        )
         elapsed = time.perf_counter() - started
         print(f"[result] exit={result.returncode} elapsed={elapsed:.2f}s")
         if result.returncode != 0:

--- a/tools/message_standards.py
+++ b/tools/message_standards.py
@@ -21,6 +21,7 @@ PR_BODY_REQUIRED_SECTIONS = (
     "Why",
     "What",
     "Checks",
+    "Issue linkage",
     "Included checkpoints",
 )
 PR_BODY_OPTIONAL_SECTIONS = ("Follow-ups",)

--- a/tools/message_standards.py
+++ b/tools/message_standards.py
@@ -34,6 +34,14 @@ SUBJECT_PATTERN = re.compile(
 )
 FOOTER_PATTERN = re.compile(r"^(?:BREAKING CHANGE|[A-Za-z][A-Za-z0-9-]*):(?: .+)?$")
 LABEL_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9 -]*:(?: .+)?$")
+GENERIC_SUMMARY_PHRASES = frozenset(
+    {
+        "cleanup",
+        "misc fix",
+        "misc fixes",
+        "update branch",
+    }
+)
 
 
 def validate_subject_line(subject: str) -> tuple[str, ...]:
@@ -42,11 +50,19 @@ def validate_subject_line(subject: str) -> tuple[str, ...]:
         errors.append("subject must be 72 characters or fewer")
     if subject.endswith("."):
         errors.append("subject must not end with a period")
-    if SUBJECT_PATTERN.fullmatch(subject) is None:
+    match = SUBJECT_PATTERN.fullmatch(subject)
+    if match is None:
         allowed_types = ", ".join(ALLOWED_TYPES)
         errors.append(
             "subject must match `type(scope): imperative summary` or "
             f"`type: imperative summary` using one of: {allowed_types}"
+        )
+        return tuple(errors)
+    if match.group("summary").strip().lower() in GENERIC_SUMMARY_PHRASES:
+        errors.append(
+            "subject summary must name a concrete repo surface or behavior; "
+            "generic summaries such as `cleanup`, `misc fixes`, and "
+            "`update branch` are not allowed"
         )
     return tuple(errors)
 

--- a/tools/report_coverage_hotspots.py
+++ b/tools/report_coverage_hotspots.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import tempfile
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import cast
+
+from repo_support.paths import repo_root
+from repo_support.pr_review import changed_paths
+from tools.uv_environment import repo_uv_environment
+
+
+@dataclass(frozen=True)
+class ModuleCoverage:
+    path: str
+    percent_covered: float
+    missing_lines: int
+    missing_branches: int
+    num_branches: int
+
+
+@dataclass(frozen=True)
+class CoverageHotspots:
+    repo_average_coverage: float
+    lowest_covered_modules: tuple[ModuleCoverage, ...]
+    highest_uncovered_branch_modules: tuple[ModuleCoverage, ...]
+    changed_modules_below_average: tuple[ModuleCoverage, ...]
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Report coverage hotspots from the latest full-suite coverage data."
+    )
+    parser.add_argument(
+        "--changed-file",
+        action="append",
+        help="Repo-relative changed production file to highlight. May be passed multiple times.",
+    )
+    parser.add_argument(
+        "--base-sha", help="Base commit SHA for inferring changed files."
+    )
+    parser.add_argument(
+        "--head-sha", help="Head commit SHA for inferring changed files."
+    )
+    parser.add_argument(
+        "--top",
+        type=int,
+        default=5,
+        help="Maximum number of modules to show in each hotspot section.",
+    )
+    return parser.parse_args(argv)
+
+
+def _is_production_module(path: str) -> bool:
+    pure_path = PurePosixPath(path)
+    return pure_path.parts[:2] == ("src", "tallylot") and "tests" not in pure_path.parts
+
+
+def _normalize_changed_files(paths: Iterable[str]) -> tuple[str, ...]:
+    normalized: list[str] = []
+    for path in paths:
+        normalized_path = PurePosixPath(path).as_posix()
+        if _is_production_module(normalized_path):
+            normalized.append(normalized_path)
+    return tuple(dict.fromkeys(normalized))
+
+
+def _resolved_changed_files(args: argparse.Namespace) -> tuple[str, ...]:
+    if (args.base_sha is None) != (args.head_sha is None):
+        raise ValueError(
+            "provide both --base-sha and --head-sha when overriding the diff range"
+        )
+    if args.changed_file:
+        return _normalize_changed_files(args.changed_file)
+    if args.base_sha is not None and args.head_sha is not None:
+        return _normalize_changed_files(
+            changed_paths(base_sha=args.base_sha, head_sha=args.head_sha)
+        )
+    return _normalize_changed_files(changed_paths())
+
+
+def _load_coverage_payload() -> dict[str, object] | None:
+    coverage_data_path = repo_root() / ".coverage"
+    if not coverage_data_path.exists():
+        return None
+
+    with tempfile.TemporaryDirectory(prefix="tallylot-coverage-hotspots-") as temp_dir:
+        output_path = Path(temp_dir) / "coverage.json"
+        result = subprocess.run(
+            ("uv", "run", "coverage", "json", "-o", str(output_path)),
+            capture_output=True,
+            text=True,
+            check=False,
+            env=repo_uv_environment(),
+        )
+        if result.stdout:
+            print(result.stdout.rstrip())
+        if result.stderr:
+            print(result.stderr.rstrip())
+        if not output_path.exists():
+            return None
+        return cast(
+            dict[str, object],
+            json.loads(output_path.read_text(encoding="utf-8")),
+        )
+
+
+def _float_value(value: object) -> float:
+    if isinstance(value, bool):
+        return float(int(value))
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        return float(value)
+    return 0.0
+
+
+def _int_value(value: object) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        return int(value)
+    return 0
+
+
+def _module_coverages(
+    coverage_payload: dict[str, object],
+) -> tuple[ModuleCoverage, ...]:
+    files_object = coverage_payload.get("files")
+    if not isinstance(files_object, Mapping):
+        return ()
+    files = cast(Mapping[object, object], files_object)
+
+    modules: list[ModuleCoverage] = []
+    for path_object, file_payload_object in files.items():
+        if not isinstance(path_object, str) or not _is_production_module(path_object):
+            continue
+        if not isinstance(file_payload_object, Mapping):
+            continue
+        file_payload = cast(Mapping[str, object], file_payload_object)
+        summary_object = file_payload.get("summary")
+        if not isinstance(summary_object, Mapping):
+            continue
+        summary = cast(Mapping[str, object], summary_object)
+        modules.append(
+            ModuleCoverage(
+                path=path_object,
+                percent_covered=_float_value(summary.get("percent_covered", 0.0)),
+                missing_lines=_int_value(summary.get("missing_lines", 0)),
+                missing_branches=_int_value(summary.get("missing_branches", 0)),
+                num_branches=_int_value(summary.get("num_branches", 0)),
+            )
+        )
+    return tuple(modules)
+
+
+def _hotspot_report(
+    coverage_payload: dict[str, object],
+    *,
+    changed_files: Iterable[str],
+    top: int,
+) -> CoverageHotspots:
+    modules = _module_coverages(coverage_payload)
+    totals_object = coverage_payload.get("totals")
+    repo_average_coverage = (
+        _float_value(
+            cast(Mapping[str, object], totals_object).get("percent_covered", 0.0)
+        )
+        if isinstance(totals_object, Mapping)
+        else 0.0
+    )
+    normalized_changed_files = set(_normalize_changed_files(changed_files))
+
+    lowest_covered_modules = tuple(
+        sorted(
+            modules,
+            key=lambda module: (
+                module.percent_covered,
+                -module.missing_lines,
+                module.path,
+            ),
+        )[:top]
+    )
+    highest_uncovered_branch_modules = tuple(
+        sorted(
+            (module for module in modules if module.num_branches > 0),
+            key=lambda module: (
+                -module.missing_branches,
+                module.percent_covered,
+                module.path,
+            ),
+        )[:top]
+    )
+    changed_modules_below_average = tuple(
+        sorted(
+            (
+                module
+                for module in modules
+                if module.path in normalized_changed_files
+                and module.percent_covered < repo_average_coverage
+            ),
+            key=lambda module: (
+                module.percent_covered,
+                -module.missing_lines,
+                module.path,
+            ),
+        )[:top]
+    )
+    return CoverageHotspots(
+        repo_average_coverage=repo_average_coverage,
+        lowest_covered_modules=lowest_covered_modules,
+        highest_uncovered_branch_modules=highest_uncovered_branch_modules,
+        changed_modules_below_average=changed_modules_below_average,
+    )
+
+
+def _print_section(
+    title: str, modules: Sequence[ModuleCoverage], *, branch_view: bool
+) -> None:
+    print(title)
+    if not modules:
+        print("  - none")
+        return
+    for module in modules:
+        branch_summary = (
+            f", missing_branches={module.missing_branches}/{module.num_branches}"
+            if branch_view
+            else ""
+        )
+        print(
+            f"  - {module.path}: coverage={module.percent_covered:.1f}% "
+            f"missing_lines={module.missing_lines}{branch_summary}"
+        )
+
+
+def _print_report(report: CoverageHotspots) -> None:
+    print(
+        f"repo average coverage={report.repo_average_coverage:.1f}%",
+        flush=True,
+    )
+    _print_section(
+        "lowest-covered production modules:",
+        report.lowest_covered_modules,
+        branch_view=False,
+    )
+    _print_section(
+        "highest uncovered-branch production modules:",
+        report.highest_uncovered_branch_modules,
+        branch_view=True,
+    )
+    _print_section(
+        "changed production modules below repo average:",
+        report.changed_modules_below_average,
+        branch_view=False,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if args.top < 1:
+        print("--top must be at least 1", flush=True)
+        return 2
+    try:
+        changed_files = _resolved_changed_files(args)
+    except ValueError as error:
+        print(str(error), flush=True)
+        return 2
+
+    coverage_payload = _load_coverage_payload()
+    if coverage_payload is None:
+        print(
+            "no coverage data found; run the full test suite before reporting hotspots"
+        )
+        return 0
+
+    report = _hotspot_report(
+        coverage_payload, changed_files=changed_files, top=args.top
+    )
+    _print_report(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_ci_parity_checks.py
+++ b/tools/run_ci_parity_checks.py
@@ -18,6 +18,17 @@ class _ParityStep:
     command: tuple[str, ...]
 
 
+QUALITY_STEP_CHOICES = ("quality", "lint-format", "types", "pylint", "tests")
+PARITY_STEP_CHOICES = (
+    "commit-messages",
+    "pr-metadata",
+    *QUALITY_STEP_CHOICES,
+    "build",
+    "verify-wheel",
+)
+_QUALITY_SUBSTEP_NAMES = frozenset({"lint-format", "types", "pylint", "tests"})
+
+
 def _git_stdout(*args: str) -> str:
     result = subprocess.run(
         ("git", *args),
@@ -58,7 +69,9 @@ def _pr_validation_shas() -> tuple[str, str]:
 
 
 def _build_argument_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Run local checks that mirror the GitHub Actions CI workflow.")
+    parser = argparse.ArgumentParser(
+        description="Run local checks that mirror the GitHub Actions CI workflow."
+    )
     parser.add_argument(
         "--include-commit-messages",
         action="store_true",
@@ -71,6 +84,12 @@ def _build_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--pr-body-file",
         help="Path to a file containing the pull request body to validate for the current branch.",
+    )
+    parser.add_argument(
+        "--step",
+        action="append",
+        choices=PARITY_STEP_CHOICES,
+        help="Run only the named parity step. May be passed multiple times.",
     )
     return parser
 
@@ -96,7 +115,11 @@ def _verify_built_wheel(dist_dir: Path) -> tuple[int, str, str]:
             check=False,
         )
         if install_result.returncode != 0:
-            return install_result.returncode, install_result.stdout, install_result.stderr
+            return (
+                install_result.returncode,
+                install_result.stdout,
+                install_result.stderr,
+            )
 
         verify_result = subprocess.run(
             (str(cli_path), "--help"),
@@ -125,77 +148,163 @@ def _run_step(step: _ParityStep) -> int:
     return result.returncode
 
 
+def _quality_command(*gate_names: str, full_tests: bool = False) -> tuple[str, ...]:
+    command = ["uv", "run", "python", "-m", "tools.run_quality_gates"]
+    if full_tests:
+        command.append("--full-tests")
+    for gate_name in gate_names:
+        command.extend(("--gate", gate_name))
+    return tuple(command)
+
+
+def _selected_steps(args: argparse.Namespace) -> tuple[str, ...] | None:
+    if args.step is None:
+        return None
+    selected_steps = tuple(args.step)
+    if "quality" in selected_steps and any(
+        step_name in _QUALITY_SUBSTEP_NAMES for step_name in selected_steps
+    ):
+        raise ValueError(
+            "do not combine `quality` with `lint-format`, `types`, `pylint`, or `tests`"
+        )
+    return selected_steps
+
+
+def _commit_message_step() -> _ParityStep:
+    return _ParityStep(
+        name="commit-messages",
+        command=(
+            "uv",
+            "run",
+            "python",
+            "-m",
+            "tools.validate_commit_message",
+            "--rev-range",
+            _commit_message_range(),
+        ),
+    )
+
+
+def _pr_metadata_step(pr_title: str, pr_body_file: str) -> _ParityStep:
+    base_sha, head_sha = _pr_validation_shas()
+    pr_body = Path(pr_body_file).read_text(encoding="utf-8")
+    return _ParityStep(
+        name="pr-metadata",
+        command=(
+            "uv",
+            "run",
+            "python",
+            "-m",
+            "tools.validate_pr_metadata",
+            "--title",
+            pr_title,
+            "--body",
+            pr_body,
+            "--base-sha",
+            base_sha,
+            "--head-sha",
+            head_sha,
+        ),
+    )
+
+
+def _quality_parity_step(step_name: str) -> _ParityStep | None:
+    command_by_step_name = {
+        "quality": _quality_command(full_tests=True),
+        "lint-format": _quality_command("markdownlint", "actionlint", "ruff"),
+        "types": _quality_command("mypy", "pyright"),
+        "pylint": _quality_command("pylint"),
+        "tests": _quality_command("pytest", full_tests=True),
+        "build": ("uv", "build"),
+        "verify-wheel": (),
+    }
+    if step_name not in command_by_step_name:
+        raise ValueError(f"unsupported parity step: {step_name}")
+    command = command_by_step_name[step_name]
+    if not command:
+        return None
+    return _ParityStep(name=step_name, command=command)
+
+
+def _parity_steps(
+    *,
+    include_commit_messages: bool,
+    pr_title: str | None,
+    pr_body_file: str | None,
+    selected_steps: tuple[str, ...] | None,
+) -> tuple[_ParityStep, ...]:
+    base_steps = (
+        ("quality", "build", "verify-wheel")
+        if selected_steps is None
+        else selected_steps
+    )
+
+    steps: list[_ParityStep] = []
+    if include_commit_messages:
+        steps.append(_commit_message_step())
+    if pr_title is not None and pr_body_file is not None:
+        steps.append(_pr_metadata_step(pr_title, pr_body_file))
+
+    for step_name in base_steps:
+        if step_name == "commit-messages":
+            if include_commit_messages:
+                continue
+            steps.append(_commit_message_step())
+            continue
+        if step_name == "pr-metadata":
+            if pr_title is None or pr_body_file is None:
+                raise ValueError(
+                    "provide both --pr-title and --pr-body-file when running the `pr-metadata` step"
+                )
+            continue
+        parity_step = _quality_parity_step(step_name)
+        if parity_step is None:
+            continue
+        steps.append(parity_step)
+    if "verify-wheel" in base_steps:
+        steps.append(_ParityStep(name="verify-wheel", command=()))
+    return tuple(steps)
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parse_args(argv)
     if (args.pr_title is None) != (args.pr_body_file is None):
-        print("provide both --pr-title and --pr-body-file when validating PR metadata", flush=True)
+        print(
+            "provide both --pr-title and --pr-body-file when validating PR metadata",
+            flush=True,
+        )
+        return 2
+    try:
+        selected_steps = _selected_steps(args)
+        steps = _parity_steps(
+            include_commit_messages=args.include_commit_messages,
+            pr_title=args.pr_title,
+            pr_body_file=args.pr_body_file,
+            selected_steps=selected_steps,
+        )
+    except ValueError as error:
+        print(str(error), flush=True)
         return 2
 
-    steps: list[_ParityStep] = []
-    if args.include_commit_messages:
-        steps.append(
-            _ParityStep(
-                name="commit-messages",
-                command=(
-                    "uv",
-                    "run",
-                    "python",
-                    "-m",
-                    "tools.validate_commit_message",
-                    "--rev-range",
-                    _commit_message_range(),
-                ),
-            )
-        )
-    if args.pr_title is not None and args.pr_body_file is not None:
-        base_sha, head_sha = _pr_validation_shas()
-        pr_body = Path(args.pr_body_file).read_text(encoding="utf-8")
-        steps.append(
-            _ParityStep(
-                name="pr-metadata",
-                command=(
-                    "uv",
-                    "run",
-                    "python",
-                    "-m",
-                    "tools.validate_pr_metadata",
-                    "--title",
-                    args.pr_title,
-                    "--body",
-                    pr_body,
-                    "--base-sha",
-                    base_sha,
-                    "--head-sha",
-                    head_sha,
-                ),
-            )
-        )
-    steps.append(
-        _ParityStep(
-            name="quality",
-            command=("uv", "run", "python", "-m", "tools.run_quality_gates", "--full-tests"),
-        )
-    )
-
+    dist_dir = Path("dist")
     for step in steps:
+        if step.name == "build":
+            shutil.rmtree(dist_dir, ignore_errors=True)
+        if step.name == "verify-wheel":
+            started = time.perf_counter()
+            verify_code, stdout, stderr = _verify_built_wheel(dist_dir)
+            elapsed = time.perf_counter() - started
+            print(f"[verify-wheel] exit={verify_code} elapsed={elapsed:.2f}s")
+            if stdout:
+                print(stdout.rstrip())
+            if stderr:
+                print(stderr.rstrip())
+            if verify_code != 0:
+                return verify_code
+            continue
         if _run_step(step) != 0:
             return 1
-
-    dist_dir = Path("dist")
-    shutil.rmtree(dist_dir, ignore_errors=True)
-    build_status = _run_step(_ParityStep(name="build", command=("uv", "build")))
-    if build_status != 0:
-        return build_status
-
-    started = time.perf_counter()
-    verify_code, stdout, stderr = _verify_built_wheel(dist_dir)
-    elapsed = time.perf_counter() - started
-    print(f"[verify-wheel] exit={verify_code} elapsed={elapsed:.2f}s")
-    if stdout:
-        print(stdout.rstrip())
-    if stderr:
-        print(stderr.rstrip())
-    return verify_code
+    return 0
 
 
 if __name__ == "__main__":

--- a/tools/run_fast_pytest.py
+++ b/tools/run_fast_pytest.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import subprocess
+from collections.abc import Sequence
+
+from repo_support.pytest_commands import build_fast_pytest_command
+from tools.uv_environment import repo_uv_environment
+
+
+def _command() -> tuple[str, ...]:
+    return build_fast_pytest_command()
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    del argv
+    return subprocess.run(
+        _command(),
+        check=False,
+        env=repo_uv_environment(),
+    ).returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_pr_review_checks.py
+++ b/tools/run_pr_review_checks.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from repo_support.pr_review import PrReviewPlan, changed_paths, classify_changed_paths
+from tools.uv_environment import repo_uv_environment
+
+
+@dataclass(frozen=True)
+class ReviewCheckStep:
+    name: str
+    command: tuple[str, ...]
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run repo-native PR review checks for the current diff."
+    )
+    parser.add_argument("--base-sha", help="Base commit SHA for the diff range.")
+    parser.add_argument("--head-sha", help="Head commit SHA for the diff range.")
+    return parser.parse_args(argv)
+
+
+def _steps_for_plan(plan: PrReviewPlan) -> tuple[ReviewCheckStep, ...]:
+    steps = [
+        ReviewCheckStep(name=check.name, command=check.command)
+        for check in plan.targeted_checks
+    ]
+    if plan.verification_level == "quality-gates-full":
+        steps.append(
+            ReviewCheckStep(
+                name="quality-gates-full",
+                command=(
+                    "uv",
+                    "run",
+                    "python",
+                    "-m",
+                    "tools.run_quality_gates",
+                    "--full-tests",
+                ),
+            )
+        )
+    elif plan.verification_level == "ci-parity":
+        steps.append(
+            ReviewCheckStep(
+                name="ci-parity",
+                command=("uv", "run", "python", "-m", "tools.run_ci_parity_checks"),
+            )
+        )
+    return tuple(steps)
+
+
+def _run_step(step: ReviewCheckStep) -> int:
+    started = time.perf_counter()
+    result = subprocess.run(
+        step.command,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=repo_uv_environment(),
+    )
+    elapsed = time.perf_counter() - started
+    print(f"[{step.name}] exit={result.returncode} elapsed={elapsed:.2f}s")
+    if result.stdout:
+        print(result.stdout.rstrip())
+    if result.stderr:
+        print(result.stderr.rstrip())
+    return result.returncode
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    if (args.base_sha is None) != (args.head_sha is None):
+        print(
+            "provide both --base-sha and --head-sha when overriding the diff range",
+            file=sys.stderr,
+        )
+        return 2
+
+    plan = classify_changed_paths(
+        changed_paths(base_sha=args.base_sha, head_sha=args.head_sha)
+    )
+    if plan.unmapped_paths:
+        print(
+            "pr review checks failed: changed paths are not mapped to repo review surfaces",
+            file=sys.stderr,
+        )
+        for path in plan.unmapped_paths:
+            print(f"  - {path}", file=sys.stderr)
+        return 1
+    if not plan.changed_paths:
+        print("no changed paths detected")
+        return 0
+
+    for step in _steps_for_plan(plan):
+        if _run_step(step) != 0:
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_pr_review_checks.py
+++ b/tools/run_pr_review_checks.py
@@ -15,6 +15,7 @@ from tools.uv_environment import repo_uv_environment
 class ReviewCheckStep:
     name: str
     command: tuple[str, ...]
+    blocking: bool = True
 
 
 def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -31,7 +32,7 @@ def _steps_for_plan(plan: PrReviewPlan) -> tuple[ReviewCheckStep, ...]:
         ReviewCheckStep(name=check.name, command=check.command)
         for check in plan.targeted_checks
     ]
-    if plan.verification_level == "quality-gates-full":
+    if plan.requires_full_quality_gates:
         steps.append(
             ReviewCheckStep(
                 name="quality-gates-full",
@@ -45,11 +46,43 @@ def _steps_for_plan(plan: PrReviewPlan) -> tuple[ReviewCheckStep, ...]:
                 ),
             )
         )
-    elif plan.verification_level == "ci-parity":
+    if plan.requires_ci_parity:
         steps.append(
             ReviewCheckStep(
                 name="ci-parity",
                 command=("uv", "run", "python", "-m", "tools.run_ci_parity_checks"),
+            )
+        )
+    if plan.requires_test_stress_checks:
+        steps.append(
+            ReviewCheckStep(
+                name="test-stress-checks",
+                command=("uv", "run", "python", "-m", "tools.run_test_stress_checks"),
+            )
+        )
+    if plan.requires_pre_merge_packaging_verification:
+        steps.append(
+            ReviewCheckStep(
+                name="pre-merge-packaging",
+                command=(
+                    "uv",
+                    "run",
+                    "python",
+                    "-m",
+                    "tools.run_ci_parity_checks",
+                    "--step",
+                    "build",
+                    "--step",
+                    "verify-wheel",
+                ),
+            )
+        )
+    if plan.requires_coverage_hotspot_report:
+        steps.append(
+            ReviewCheckStep(
+                name="coverage-hotspots",
+                command=("uv", "run", "python", "-m", "tools.report_coverage_hotspots"),
+                blocking=False,
             )
         )
     return tuple(steps)
@@ -98,8 +131,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         return 0
 
     for step in _steps_for_plan(plan):
-        if _run_step(step) != 0:
+        returncode = _run_step(step)
+        if returncode != 0 and step.blocking:
             return 1
+        if returncode != 0 and not step.blocking:
+            print(f"[{step.name}] non-blocking failure; continuing", flush=True)
     return 0
 
 

--- a/tools/run_pr_review_checks.py
+++ b/tools/run_pr_review_checks.py
@@ -12,7 +12,7 @@ from tools.uv_environment import repo_uv_environment
 
 REVIEW_LOOP_REMINDER = (
     "review reminder: passing verification does not complete the mandatory "
-    "red-team repair loop or authorize PR readiness"
+    "red-team repair loop, decide the pass outcome, or authorize PR readiness"
 )
 
 
@@ -156,7 +156,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         if returncode != 0 and not step.blocking:
             print(f"[{step.name}] non-blocking failure; continuing", flush=True)
     print(
-        "verification complete: continue the red-team review loop before calling the pass clean"
+        "verification complete: use this evidence in the current issue-finding "
+        "pass, then go look for the next real issues"
     )
     return 0
 

--- a/tools/run_pr_review_checks.py
+++ b/tools/run_pr_review_checks.py
@@ -10,12 +10,27 @@ from dataclasses import dataclass
 from repo_support.pr_review import PrReviewPlan, changed_paths, classify_changed_paths
 from tools.uv_environment import repo_uv_environment
 
+REVIEW_LOOP_REMINDER = (
+    "review reminder: passing verification does not complete the mandatory "
+    "red-team repair loop or authorize PR readiness"
+)
+
 
 @dataclass(frozen=True)
 class ReviewCheckStep:
     name: str
     command: tuple[str, ...]
     blocking: bool = True
+
+
+def _verification_note(plan: PrReviewPlan) -> str | None:
+    if plan.verification_level == "ci-parity" and plan.requires_full_quality_gates:
+        return (
+            "verification note: ci-parity is the broad runner for this diff and "
+            "already includes the full quality, build, and wheel parity path, "
+            "so duplicate quality-gates-full is intentionally skipped"
+        )
+    return None
 
 
 def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
@@ -32,7 +47,7 @@ def _steps_for_plan(plan: PrReviewPlan) -> tuple[ReviewCheckStep, ...]:
         ReviewCheckStep(name=check.name, command=check.command)
         for check in plan.targeted_checks
     ]
-    if plan.requires_full_quality_gates:
+    if plan.verification_level == "quality-gates-full":
         steps.append(
             ReviewCheckStep(
                 name="quality-gates-full",
@@ -46,7 +61,7 @@ def _steps_for_plan(plan: PrReviewPlan) -> tuple[ReviewCheckStep, ...]:
                 ),
             )
         )
-    if plan.requires_ci_parity:
+    if plan.verification_level == "ci-parity":
         steps.append(
             ReviewCheckStep(
                 name="ci-parity",
@@ -130,12 +145,19 @@ def main(argv: Sequence[str] | None = None) -> int:
         print("no changed paths detected")
         return 0
 
+    print(REVIEW_LOOP_REMINDER)
+    verification_note = _verification_note(plan)
+    if verification_note is not None:
+        print(verification_note)
     for step in _steps_for_plan(plan):
         returncode = _run_step(step)
         if returncode != 0 and step.blocking:
             return 1
         if returncode != 0 and not step.blocking:
             print(f"[{step.name}] non-blocking failure; continuing", flush=True)
+    print(
+        "verification complete: continue the red-team review loop before calling the pass clean"
+    )
     return 0
 
 

--- a/tools/run_pylint.py
+++ b/tools/run_pylint.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import subprocess
 import sys
+import time
 from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -14,6 +16,15 @@ from repo_support.pyright_config import adapter_test_roots
 class _PylintTarget:
     name: str
     command: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _PylintResult:
+    target: _PylintTarget
+    returncode: int
+    stdout: str
+    stderr: str
+    elapsed: float
 
 
 _ADAPTER_TEST_IGNORE_PATHS = r"^src/tallylot/adapters/.*/tests(/.*)?$"
@@ -49,18 +60,46 @@ def _pylint_targets(*, root: Path | None = None) -> tuple[_PylintTarget, ...]:
     )
 
 
-def _run_target(target: _PylintTarget) -> int:
-    result = subprocess.run(target.command, check=False)
-    return result.returncode
+def _run_target(target: _PylintTarget) -> _PylintResult:
+    started = time.perf_counter()
+    result = subprocess.run(
+        target.command,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return _PylintResult(
+        target=target,
+        returncode=result.returncode,
+        stdout=result.stdout,
+        stderr=result.stderr,
+        elapsed=time.perf_counter() - started,
+    )
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     del argv
     exit_code = 0
-    for target in _pylint_targets():
-        print(f"[pylint:{target.name}] {' '.join(target.command[2:])}", flush=True)
-        if _run_target(target) != 0:
-            exit_code = 1
+    targets = _pylint_targets()
+    with ThreadPoolExecutor(max_workers=len(targets)) as executor:
+        futures = {executor.submit(_run_target, target): target for target in targets}
+        for future in as_completed(futures):
+            result = future.result()
+            print(
+                f"[pylint:{result.target.name}] exit={result.returncode} "
+                f"elapsed={result.elapsed:.2f}s"
+            )
+            print(
+                f"[pylint:{result.target.name}:command] "
+                f"{' '.join(result.target.command[2:])}",
+                flush=True,
+            )
+            if result.stdout:
+                print(result.stdout.rstrip())
+            if result.stderr:
+                print(result.stderr.rstrip())
+            if result.returncode != 0:
+                exit_code = 1
     return exit_code
 
 

--- a/tools/run_quality_gates.py
+++ b/tools/run_quality_gates.py
@@ -5,7 +5,10 @@ import subprocess
 import time
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
+from contextlib import ExitStack
 from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from repo_support.quality_gates import (
     QUALITY_GATE_ORDER,
@@ -98,13 +101,22 @@ def _phase_plan(run_request: _RunRequest) -> tuple[QualityPhase, ...]:
 
 def _run_gate(gate: QualityGate) -> GateResult:
     started = time.perf_counter()
-    result = subprocess.run(
-        gate.command,
-        capture_output=True,
-        text=True,
-        check=False,
-        env=_gate_environment(gate),
-    )
+    with ExitStack() as stack:
+        coverage_file: Path | None = None
+        if gate.coverage_gate:
+            coverage_dir = Path(
+                stack.enter_context(
+                    TemporaryDirectory(prefix=f"tallylot-{gate.name}-coverage-")
+                )
+            )
+            coverage_file = coverage_dir / ".coverage"
+        result = subprocess.run(
+            gate.command,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=_gate_environment(gate, coverage_file=coverage_file),
+        )
     return GateResult(
         gate=gate,
         returncode=result.returncode,
@@ -114,10 +126,15 @@ def _run_gate(gate: QualityGate) -> GateResult:
     )
 
 
-def _gate_environment(gate: QualityGate) -> dict[str, str]:
+def _gate_environment(
+    gate: QualityGate,
+    *,
+    coverage_file: Path | None = None,
+) -> dict[str, str]:
     return apply_gate_environment(
         repo_uv_environment(),
         coverage_gate=gate.coverage_gate,
+        coverage_file=coverage_file,
     )
 
 

--- a/tools/run_quality_gates.py
+++ b/tools/run_quality_gates.py
@@ -7,35 +7,69 @@ from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 
-from repo_support.paths import repo_root
+from repo_support.quality_gates import (
+    QUALITY_GATE_ORDER,
+    QUALITY_SCHEDULES,
+    QualityGate,
+    QualityPhase,
+    apply_gate_environment,
+    available_quality_gates,
+    quality_phase_plan,
+)
 from repo_support.pyright_config import sync_pyright_config
 from tools.uv_environment import repo_uv_environment
 
 
 @dataclass(frozen=True)
-class QualityGate:
+class GateResult:
+    gate: QualityGate
+    returncode: int
+    stdout: str
+    stderr: str
+    elapsed: float
+
+
+@dataclass(frozen=True)
+class PhaseResult:
+    phase: QualityPhase
+    gate_results: tuple[GateResult, ...]
+
+
+@dataclass(frozen=True)
+class RunSummary:
+    phase_results: tuple[PhaseResult, ...]
+    total_elapsed: float
+
+
+@dataclass(frozen=True)
+class _RunRequest:
     name: str
-    command: tuple[str, ...]
-
-
-_DEFAULT_TEST_COMMAND = (
-    "uv",
-    "run",
-    "pytest",
-    "-m",
-    "unit and not slow",
-    "--no-cov",
-    "-q",
-)
-_FULL_TEST_COMMAND = ("uv", "run", "pytest")
+    full_tests: bool
+    schedule: str
+    selected_gate_names: tuple[str, ...]
 
 
 def _build_argument_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(description="Run local quality gates in parallel.")
+    parser = argparse.ArgumentParser(description="Run local quality gates.")
     parser.add_argument(
         "--full-tests",
         action="store_true",
         help="Run the full pytest suite instead of the fast commit-time subset.",
+    )
+    parser.add_argument(
+        "--gate",
+        action="append",
+        choices=QUALITY_GATE_ORDER,
+        help="Run only the named quality gate. May be passed multiple times.",
+    )
+    parser.add_argument(
+        "--schedule",
+        choices=QUALITY_SCHEDULES,
+        default="auto",
+        help=(
+            "Quality gate scheduling strategy. `auto` uses the repo-benchmarked "
+            "default for the selected test mode."
+        ),
     )
     return parser
 
@@ -44,27 +78,25 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     return _build_argument_parser().parse_args(argv)
 
 
-def _quality_gates(*, full_tests: bool) -> tuple[QualityGate, ...]:
-    test_command = _FULL_TEST_COMMAND if full_tests else _DEFAULT_TEST_COMMAND
-    return (
-        QualityGate(
-            name="markdownlint",
-            command=("uv", "run", "pre-commit", "run", "markdownlint", "--all-files"),
-        ),
-        QualityGate(name="actionlint", command=("uv", "run", "actionlint", "-color")),
-        QualityGate(name="ruff", command=("uv", "run", "ruff", "check", ".")),
-        QualityGate(name="mypy", command=("uv", "run", "mypy")),
-        QualityGate(name="pyright", command=("uv", "run", "pyright")),
-        QualityGate(
-            name="pylint", command=("uv", "run", "python", "-m", "tools.run_pylint")
-        ),
-        QualityGate(name="pytest", command=test_command),
+def _run_request(args: argparse.Namespace) -> _RunRequest:
+    selected_gate_names = tuple(args.gate or ())
+    return _RunRequest(
+        name="full" if args.full_tests else "fast",
+        full_tests=args.full_tests,
+        schedule=args.schedule,
+        selected_gate_names=selected_gate_names,
     )
 
 
-def _run_gate(
-    gate: QualityGate,
-) -> tuple[QualityGate, subprocess.CompletedProcess[str], float]:
+def _phase_plan(run_request: _RunRequest) -> tuple[QualityPhase, ...]:
+    return quality_phase_plan(
+        full_tests=run_request.full_tests,
+        schedule=run_request.schedule,
+        selected_gate_names=run_request.selected_gate_names or None,
+    )
+
+
+def _run_gate(gate: QualityGate) -> GateResult:
     started = time.perf_counter()
     result = subprocess.run(
         gate.command,
@@ -73,27 +105,81 @@ def _run_gate(
         check=False,
         env=_gate_environment(gate),
     )
-    return gate, result, time.perf_counter() - started
+    return GateResult(
+        gate=gate,
+        returncode=result.returncode,
+        stdout=result.stdout,
+        stderr=result.stderr,
+        elapsed=time.perf_counter() - started,
+    )
 
 
 def _gate_environment(gate: QualityGate) -> dict[str, str]:
-    environment = repo_uv_environment()
-    if gate.name != "pytest":
-        return environment
+    return apply_gate_environment(
+        repo_uv_environment(),
+        coverage_gate=gate.coverage_gate,
+    )
 
-    coverage_config = str(repo_root() / "pyproject.toml")
-    existing_addopts = environment.get("PYTEST_ADDOPTS", "").strip()
-    coverage_addopt = f"--cov-config={coverage_config}"
-    if coverage_addopt not in existing_addopts.split():
-        environment["PYTEST_ADDOPTS"] = f"{existing_addopts} {coverage_addopt}".strip()
-    environment["COVERAGE_PROCESS_START"] = coverage_config
-    environment["COVERAGE_RCFILE"] = coverage_config
-    return environment
+
+def _print_gate_result(gate_result: GateResult) -> None:
+    print(
+        f"[{gate_result.gate.name}] exit={gate_result.returncode} "
+        f"elapsed={gate_result.elapsed:.2f}s"
+    )
+    if gate_result.stdout:
+        print(gate_result.stdout.rstrip())
+    if gate_result.stderr:
+        print(gate_result.stderr.rstrip())
+
+
+def _run_phase(
+    phase: QualityPhase,
+    *,
+    available_gates: dict[str, QualityGate],
+) -> PhaseResult:
+    print(f"[phase:{phase.name}] gates={', '.join(phase.gate_names)}", flush=True)
+    gate_results: list[GateResult] = []
+    gates = tuple(available_gates[gate_name] for gate_name in phase.gate_names)
+    with ThreadPoolExecutor(max_workers=len(gates)) as executor:
+        futures = {executor.submit(_run_gate, gate): gate.name for gate in gates}
+        for future in as_completed(futures):
+            gate_result = future.result()
+            gate_results.append(gate_result)
+            _print_gate_result(gate_result)
+    ordered_results = tuple(
+        sorted(
+            gate_results,
+            key=lambda gate_result: QUALITY_GATE_ORDER.index(gate_result.gate.name),
+        )
+    )
+    return PhaseResult(phase=phase, gate_results=ordered_results)
+
+
+def _print_summary(summary: RunSummary) -> None:
+    print("[summary] quality gate phases", flush=True)
+    for phase_result in summary.phase_results:
+        failures = sum(
+            1
+            for gate_result in phase_result.gate_results
+            if gate_result.returncode != 0
+        )
+        phase_elapsed = max(
+            (gate_result.elapsed for gate_result in phase_result.gate_results),
+            default=0.0,
+        )
+        gate_names = ", ".join(
+            gate_result.gate.name for gate_result in phase_result.gate_results
+        )
+        print(
+            f"[summary:{phase_result.phase.name}] gates={gate_names} "
+            f"failures={failures} elapsed~={phase_elapsed:.2f}s"
+        )
+    print(f"[summary] total elapsed={summary.total_elapsed:.2f}s")
 
 
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parse_args(argv)
-    failures = 0
+    run_request = _run_request(args)
     if sync_pyright_config():
         print(
             "[pyright-config] pyrightconfig.tests.json was out of sync and has "
@@ -101,21 +187,29 @@ def main(argv: Sequence[str] | None = None) -> int:
             flush=True,
         )
         return 1
-    quality_gates = _quality_gates(full_tests=args.full_tests)
 
-    with ThreadPoolExecutor(max_workers=len(quality_gates)) as executor:
-        futures = {executor.submit(_run_gate, gate): gate for gate in quality_gates}
-        for future in as_completed(futures):
-            gate, result, elapsed = future.result()
-            print(f"[{gate.name}] exit={result.returncode} elapsed={elapsed:.2f}s")
-            if result.stdout:
-                print(result.stdout.rstrip())
-            if result.stderr:
-                print(result.stderr.rstrip())
-            if result.returncode != 0:
-                failures = 1
+    available_gates = available_quality_gates(full_tests=run_request.full_tests)
+    phase_results: list[PhaseResult] = []
+    started = time.perf_counter()
+    for phase in _phase_plan(run_request):
+        phase_result = _run_phase(phase, available_gates=available_gates)
+        phase_results.append(phase_result)
+        if any(
+            gate_result.returncode != 0 for gate_result in phase_result.gate_results
+        ):
+            summary = RunSummary(
+                phase_results=tuple(phase_results),
+                total_elapsed=time.perf_counter() - started,
+            )
+            _print_summary(summary)
+            return 1
 
-    return failures
+    summary = RunSummary(
+        phase_results=tuple(phase_results),
+        total_elapsed=time.perf_counter() - started,
+    )
+    _print_summary(summary)
+    return 0
 
 
 if __name__ == "__main__":

--- a/tools/run_quality_gates.py
+++ b/tools/run_quality_gates.py
@@ -5,10 +5,7 @@ import subprocess
 import time
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from contextlib import ExitStack
 from dataclasses import dataclass
-from pathlib import Path
-from tempfile import TemporaryDirectory
 
 from repo_support.quality_gates import (
     QUALITY_GATE_ORDER,
@@ -101,22 +98,13 @@ def _phase_plan(run_request: _RunRequest) -> tuple[QualityPhase, ...]:
 
 def _run_gate(gate: QualityGate) -> GateResult:
     started = time.perf_counter()
-    with ExitStack() as stack:
-        coverage_file: Path | None = None
-        if gate.coverage_gate:
-            coverage_dir = Path(
-                stack.enter_context(
-                    TemporaryDirectory(prefix=f"tallylot-{gate.name}-coverage-")
-                )
-            )
-            coverage_file = coverage_dir / ".coverage"
-        result = subprocess.run(
-            gate.command,
-            capture_output=True,
-            text=True,
-            check=False,
-            env=_gate_environment(gate, coverage_file=coverage_file),
-        )
+    result = subprocess.run(
+        gate.command,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=_gate_environment(gate),
+    )
     return GateResult(
         gate=gate,
         returncode=result.returncode,
@@ -128,13 +116,10 @@ def _run_gate(gate: QualityGate) -> GateResult:
 
 def _gate_environment(
     gate: QualityGate,
-    *,
-    coverage_file: Path | None = None,
 ) -> dict[str, str]:
     return apply_gate_environment(
         repo_uv_environment(),
         coverage_gate=gate.coverage_gate,
-        coverage_file=coverage_file,
     )
 
 

--- a/tools/run_test_stress_checks.py
+++ b/tools/run_test_stress_checks.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import subprocess
+import time
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from repo_support.pytest_commands import build_fast_pytest_command
+from tools.uv_environment import repo_uv_environment
+
+FAST_STRESS_WORKERS = 4
+PRIMARY_RANDOM_SEED = 1729
+SECONDARY_RANDOM_SEED = 8191
+
+
+@dataclass(frozen=True)
+class StressStep:
+    name: str
+    marker_expression: str
+    command: tuple[str, ...]
+    serial_fallback_command: tuple[str, ...]
+    seed: int
+    workers: int
+
+
+def _marker_pytest_command(
+    marker_expression: str,
+    *,
+    seed: int,
+    workers: int,
+) -> tuple[str, ...]:
+    if marker_expression == "unit and not slow":
+        command = list(build_fast_pytest_command(workers=workers))
+    else:
+        command = ["uv", "run", "pytest"]
+        if workers > 0:
+            command.extend(("-n", str(workers)))
+        command.extend(("-m", marker_expression, "--no-cov", "-q"))
+    command.extend(("--randomly-seed", str(seed)))
+    return tuple(command)
+
+
+def _stress_steps() -> tuple[StressStep, ...]:
+    return (
+        StressStep(
+            name="fast-unit-seed-a",
+            marker_expression="unit and not slow",
+            command=_marker_pytest_command(
+                "unit and not slow",
+                seed=PRIMARY_RANDOM_SEED,
+                workers=FAST_STRESS_WORKERS,
+            ),
+            serial_fallback_command=_marker_pytest_command(
+                "unit and not slow",
+                seed=PRIMARY_RANDOM_SEED,
+                workers=0,
+            ),
+            seed=PRIMARY_RANDOM_SEED,
+            workers=FAST_STRESS_WORKERS,
+        ),
+        StressStep(
+            name="fast-unit-seed-b",
+            marker_expression="unit and not slow",
+            command=_marker_pytest_command(
+                "unit and not slow",
+                seed=SECONDARY_RANDOM_SEED,
+                workers=FAST_STRESS_WORKERS,
+            ),
+            serial_fallback_command=_marker_pytest_command(
+                "unit and not slow",
+                seed=SECONDARY_RANDOM_SEED,
+                workers=0,
+            ),
+            seed=SECONDARY_RANDOM_SEED,
+            workers=FAST_STRESS_WORKERS,
+        ),
+        StressStep(
+            name="contract-seed-a",
+            marker_expression="contract",
+            command=_marker_pytest_command(
+                "contract", seed=PRIMARY_RANDOM_SEED, workers=0
+            ),
+            serial_fallback_command=_marker_pytest_command(
+                "contract", seed=PRIMARY_RANDOM_SEED, workers=0
+            ),
+            seed=PRIMARY_RANDOM_SEED,
+            workers=0,
+        ),
+        StressStep(
+            name="e2e-seed-a",
+            marker_expression="e2e",
+            command=_marker_pytest_command("e2e", seed=PRIMARY_RANDOM_SEED, workers=0),
+            serial_fallback_command=_marker_pytest_command(
+                "e2e", seed=PRIMARY_RANDOM_SEED, workers=0
+            ),
+            seed=PRIMARY_RANDOM_SEED,
+            workers=0,
+        ),
+    )
+
+
+def _print_reproduction(step: StressStep) -> None:
+    print("[repro] rerun the failing stress step:", flush=True)
+    print(f"[repro] {' '.join(step.command)}", flush=True)
+    print(
+        f"[repro] workers={step.workers} seed={step.seed} "
+        f"marker={step.marker_expression}",
+        flush=True,
+    )
+    print("[repro] serial fallback:", flush=True)
+    print(f"[repro] {' '.join(step.serial_fallback_command)}", flush=True)
+
+
+def _run_step(step: StressStep) -> int:
+    started = time.perf_counter()
+    result = subprocess.run(
+        step.command,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=repo_uv_environment(),
+    )
+    elapsed = time.perf_counter() - started
+    print(f"[{step.name}] exit={result.returncode} elapsed={elapsed:.2f}s", flush=True)
+    if result.stdout:
+        print(result.stdout.rstrip(), flush=True)
+    if result.stderr:
+        print(result.stderr.rstrip(), flush=True)
+    if result.returncode != 0:
+        _print_reproduction(step)
+    return result.returncode
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    del argv
+    for step in _stress_steps():
+        if _run_step(step) != 0:
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/validate_pr_metadata.py
+++ b/tools/validate_pr_metadata.py
@@ -14,10 +14,13 @@ from tools.message_standards import (
 )
 
 FOLLOW_UP_PATTERN = re.compile(r"^- Refs #\d+(?:: .+\S)?$")
-CLOSING_BULLET_PATTERN = re.compile(r"^- Closes #\d+: .+\S$")
-CLOSING_KEYWORD_PREFIX = re.compile(
+ISSUE_LINKAGE_CLOSING_PATTERN = re.compile(r"^- Closes #\d+: .+\S$")
+ISSUE_LINKAGE_NONE_PATTERN = re.compile(r"^- None: .+\S$")
+ISSUE_CLOSING_KEYWORD_PREFIX = re.compile(
     r"^- (?:Close[sd]?|Fix(?:e[sd])?|Resolve[sd]?) #\d+", re.IGNORECASE
 )
+ISSUE_REFERENCE_PREFIX = re.compile(r"^- Refs?\b", re.IGNORECASE)
+ISSUE_NONE_PREFIX = re.compile(r"^- None\b", re.IGNORECASE)
 
 
 def _normalize_body_lines(body: str) -> tuple[str, ...]:
@@ -88,6 +91,71 @@ def _validate_pr_title(title: str) -> tuple[str, ...]:
     return validate_subject_line(stripped)
 
 
+def _validate_why_entries(entries: tuple[str, ...]) -> tuple[str, ...]:
+    for entry in entries:
+        if ISSUE_CLOSING_KEYWORD_PREFIX.match(entry) or FOLLOW_UP_PATTERN.fullmatch(
+            entry
+        ):
+            return (
+                "`Why:` must describe the problem or constraint; move issue linkage "
+                "bullets to `Issue linkage:`",
+            )
+    return ()
+
+
+def _issue_linkage_error(entry: str) -> str | None:
+    if (
+        ISSUE_LINKAGE_CLOSING_PATTERN.fullmatch(entry)
+        or FOLLOW_UP_PATTERN.fullmatch(entry)
+        or ISSUE_LINKAGE_NONE_PATTERN.fullmatch(entry)
+    ):
+        return None
+    if ISSUE_CLOSING_KEYWORD_PREFIX.match(entry):
+        return (
+            "`Issue linkage:` closing bullets must match "
+            "`- Closes #123: problem statement`"
+        )
+    if ISSUE_REFERENCE_PREFIX.match(entry):
+        return (
+            "`Issue linkage:` reference bullets must match "
+            "`- Refs #123` or `- Refs #123: note`"
+        )
+    if ISSUE_NONE_PREFIX.match(entry):
+        return "`Issue linkage:` no-issue bullets must match `- None: explanation`"
+    return (
+        "`Issue linkage:` bullets must match "
+        "`- Closes #123: problem statement`, `- Refs #123`, "
+        "`- Refs #123: note`, or `- None: explanation`"
+    )
+
+
+def _validate_issue_linkage_entries(entries: tuple[str, ...]) -> tuple[str, ...]:
+    errors: list[str] = []
+    for entry in entries:
+        entry_error = _issue_linkage_error(entry)
+        if entry_error is None:
+            continue
+        errors.append(entry_error)
+        return tuple(errors)
+
+    none_entries = tuple(
+        entry for entry in entries if ISSUE_LINKAGE_NONE_PATTERN.fullmatch(entry)
+    )
+    if none_entries and len(entries) != 1:
+        errors.append("`Issue linkage:` `- None: ...` must be the only bullet")
+    return tuple(errors)
+
+
+def _validate_follow_up_entries(entries: tuple[str, ...]) -> tuple[str, ...]:
+    for entry in entries:
+        if FOLLOW_UP_PATTERN.fullmatch(entry):
+            continue
+        return (
+            "`Follow-ups:` bullets must match `- Refs #123` or `- Refs #123: note`",
+        )
+    return ()
+
+
 def _validate_pr_body(body: str) -> tuple[str, ...]:
     lines = _normalize_body_lines(body)
     if not lines:
@@ -103,29 +171,9 @@ def _validate_pr_body(body: str) -> tuple[str, ...]:
         )
     )
     parsed_sections = _parse_sections(body)
-
-    saw_non_closing_why_bullet = False
-    for entry in parsed_sections["Why"]:
-        if CLOSING_BULLET_PATTERN.fullmatch(entry):
-            if saw_non_closing_why_bullet:
-                errors.append(
-                    "`Why:` issue-closing bullets must come before other bullets"
-                )
-            continue
-        if CLOSING_KEYWORD_PREFIX.match(entry):
-            errors.append(
-                "`Why:` issue-closing bullets must match `- Closes #123: problem statement`"
-            )
-        saw_non_closing_why_bullet = True
-
-    for entry in parsed_sections["Follow-ups"]:
-        if FOLLOW_UP_PATTERN.fullmatch(entry):
-            continue
-        errors.append(
-            "`Follow-ups:` bullets must match `- Refs #123` or `- Refs #123: note`"
-        )
-        break
-
+    errors.extend(_validate_why_entries(parsed_sections["Why"]))
+    errors.extend(_validate_issue_linkage_entries(parsed_sections["Issue linkage"]))
+    errors.extend(_validate_follow_up_entries(parsed_sections["Follow-ups"]))
     return tuple(errors)
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -717,6 +717,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-randomly"
+version = "3.16.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/68/d221ed7f4a2a49a664da721b8e87b52af6dd317af2a6cb51549cf17ac4b8/pytest_randomly-3.16.0.tar.gz", hash = "sha256:11bf4d23a26484de7860d82f726c0629837cf4064b79157bd18ec9d41d7feb26", size = 13367 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/70/b31577d7c46d8e2f9baccfed5067dd8475262a2331ffb0bfdf19361c9bde/pytest_randomly-3.16.0-py3-none-any.whl", hash = "sha256:8633d332635a1a0983d3bba19342196807f6afb17c3eef78e02c2f85dade45d6", size = 8396 },
+]
+
+[[package]]
 name = "pytest-xdist"
 version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -883,6 +895,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-randomly" },
     { name = "pytest-xdist" },
     { name = "pyyaml" },
     { name = "reportlab" },
@@ -910,6 +923,7 @@ dev = [
     { name = "pyright", specifier = ">=1.1.399,<2.0.0" },
     { name = "pytest", specifier = ">=8.3.5,<9.0.0" },
     { name = "pytest-cov", specifier = ">=6.0.0,<7.0.0" },
+    { name = "pytest-randomly", specifier = ">=3.16.0,<4.0.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1,<4.0.0" },
     { name = "pyyaml", specifier = ">=6.0.3,<7.0.0" },
     { name = "reportlab", specifier = ">=4.4.0,<5.0.0" },


### PR DESCRIPTION
Why:
- harden repo-native PR review routing, verification, and delivery guardrails around mandatory review loops and PR-only status enforcement
- reduce duplicated broad verification while keeping CI parity comprehensive for mixed repo-code and CI diffs
- make the review route itself enforce issue-finding posture so upcoming passes are not pre-labeled as clean, final, or publish-ready

What:
- move PR review routing and checks into repo-native audit and runner tooling with aligned standards, route, and skill coverage
- benchmark and split verification lanes, enforce explicit PR issue linkage, and keep ci-parity as the strongest broad runner when it already subsumes quality, build, and wheel verification
- close review-loop gaps by mapping repo-root test support, making verification-only reminders explicit, requiring app-pinned required PR statuses in the delivery audit, and hardening the review route against premature clean/final-pass framing

Checks:
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.audit_delivery_guardrails
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_pr_review_checks
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pytest --no-cov -q tests/unit/test_audit_pr_review.py tests/unit/test_run_pr_review_checks.py tests/unit/test_repo_agent_skills.py tests/contract/test_standards_guards.py

Issue linkage:
- None: searched CrownOpsEng/tallylot issues and found no existing issue that cleanly owns this multi-checkpoint PR review, verification, and route-hardening slice

Included checkpoints:
- `ci(guardrails): require explicit PR issue linkage`
- `refactor(agent-routing): drop global safety skill overlap`
- `refactor(pr-review): make review routing repo-native`
- `fix(commits): tighten bounded checkpoint discipline`
- `perf(quality): benchmark and split verification flow`
- `perf(tests): cut covered script overhead`
- `feat(verification): harden repo-native verification lanes`
- `fix(pr-review): close review-loop guardrail gaps`
- `fix(guardrails): require app-pinned review checks`
- `fix(pr-review): enforce issue-finding review loops`
