### PR TITLE
fix(repo): raise module limits and fix worktree hooks

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -15,4 +15,4 @@ disable =
 
 [FORMAT]
 max-line-length = 120
-max-module-lines = 500
+max-module-lines = 600

--- a/.pylintrc-tests
+++ b/.pylintrc-tests
@@ -16,4 +16,4 @@ disable =
 
 [FORMAT]
 max-line-length = 120
-max-module-lines = 500
+max-module-lines = 600

--- a/docs/standards/engineering.md
+++ b/docs/standards/engineering.md
@@ -72,12 +72,12 @@ Repo-native support boundaries:
 
 Default to one responsibility per module.
 
-- Keep most modules under roughly 200 lines.
-- Start a split review once a module approaches 300 lines.
-- Refactor before extending beyond 400 lines unless the file is mostly
+- Keep most modules under roughly 300 lines.
+- Start a split review once a module approaches 400 lines.
+- Refactor before extending beyond 500 lines unless the file is mostly
   declarative models, typed schemas, or protocol definitions.
-- Treat `400` lines as the official repo refactor limit.
-- Enforced limit is `500` lines as the hard-stop lint ceiling.
+- Treat `500` lines as the official repo refactor limit.
+- Enforced limit is `600` lines as the hard-stop lint ceiling.
 - Keep the repo standard tighter than the enforcement ceiling so refactor
   expectations stay ahead of the hard-stop lint cap.
 - Refactor by bounded concept, not by arbitrary suffixes.

--- a/repo_support/pr_review_paths.py
+++ b/repo_support/pr_review_paths.py
@@ -17,6 +17,7 @@ CONTROL_PLANE_PREFIXES = (
 REPO_CODE_OR_TOOLING_EXACT_PATHS = ("conftest.py",)
 CI_OR_RELEASE_EXACT_PATHS = (
     ".pre-commit-config.yaml",
+    ".pylintrc",
     ".pylintrc-tests",
     "pyproject.toml",
     "pyrightconfig.json",

--- a/tests/contract/test_standards_guards.py
+++ b/tests/contract/test_standards_guards.py
@@ -276,21 +276,21 @@ def test_module_size_policy_remains_aligned() -> None:
         encoding="utf-8"
     )
 
-    assert "max-module-lines = 500" in pylint_text
-    assert "max-module-lines = 500" in test_pylint_text
+    assert "max-module-lines = 600" in pylint_text
+    assert "max-module-lines = 600" in test_pylint_text
     assert (
-        re.search(r"Refactor before extending beyond 400 lines", standards_text)
+        re.search(r"Refactor before extending beyond 500 lines", standards_text)
         is not None
     )
     assert (
         re.search(
-            r"Treat `400` lines as the official repo refactor limit", standards_text
+            r"Treat `500` lines as the official repo refactor limit", standards_text
         )
         is not None
     )
     assert (
         re.search(
-            r"Enforced limit is `500` lines as the hard-stop lint ceiling",
+            r"Enforced limit is `600` lines as the hard-stop lint ceiling",
             standards_text,
         )
         is not None

--- a/tests/unit/test_audit_pr_review.py
+++ b/tests/unit/test_audit_pr_review.py
@@ -111,6 +111,16 @@ def test_github_action_diff_maps_to_ci_parity() -> None:
     assert [check.name for check in plan.targeted_checks] == ["ci-parity-tooling"]
 
 
+def test_pylint_config_diff_maps_to_ci_parity() -> None:
+    plan = classify_changed_paths((".pylintrc",))
+
+    assert plan.surface_groups == ("ci_or_release",)
+    assert plan.verification_level == "ci-parity"
+    assert plan.requires_ci_parity is True
+    assert plan.requires_test_stress_checks is True
+    assert plan.unmapped_paths == ()
+
+
 def test_mixed_diff_uses_strongest_verification_level() -> None:
     plan = classify_changed_paths(
         (

--- a/tests/unit/test_pre_commit_hook.py
+++ b/tests/unit/test_pre_commit_hook.py
@@ -36,9 +36,14 @@ def test_pre_commit_wrapper_fails_when_commit_msg_hook_is_missing(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    hooks_dir = tmp_path / ".git" / "hooks"
+    hooks_dir = tmp_path / "common-git" / "hooks"
     hooks_dir.mkdir(parents=True)
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        tools.pre_commit_hook,
+        "_commit_msg_hook_path",
+        lambda: hooks_dir / "commit-msg",
+    )
 
     assert tools.pre_commit_hook.main([]) == 1
 
@@ -50,12 +55,17 @@ def test_pre_commit_wrapper_rejects_stale_commit_msg_hook(
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    hooks_dir = tmp_path / ".git" / "hooks"
+    hooks_dir = tmp_path / "common-git" / "hooks"
     hooks_dir.mkdir(parents=True)
     (hooks_dir / "commit-msg").write_text(
         "#!/usr/bin/env bash\nexit 0\n", encoding="utf-8"
     )
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        tools.pre_commit_hook,
+        "_commit_msg_hook_path",
+        lambda: hooks_dir / "commit-msg",
+    )
 
     assert tools.pre_commit_hook.main([]) == 1
 
@@ -81,13 +91,18 @@ def test_pre_commit_wrapper_runs_when_commit_msg_hook_is_installed(
         pre_commit_calls.append("run")
         return 0
 
-    hooks_dir = tmp_path / ".git" / "hooks"
+    hooks_dir = tmp_path / "common-git" / "hooks"
     hooks_dir.mkdir(parents=True)
     (hooks_dir / "commit-msg").write_text(
         "#!/usr/bin/env bash\npre_commit hook-impl --hook-type=commit-msg\n",
         encoding="utf-8",
     )
     monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(
+        tools.pre_commit_hook,
+        "_commit_msg_hook_path",
+        lambda: hooks_dir / "commit-msg",
+    )
     monkeypatch.setattr(tools.pre_commit_hook, "_git_paths", fake_git_paths)
     monkeypatch.setattr(
         tools.pre_commit_hook, "_format_and_stage", fake_format_and_stage
@@ -97,6 +112,54 @@ def test_pre_commit_wrapper_runs_when_commit_msg_hook_is_installed(
     assert tools.pre_commit_hook.main([]) == 0
     assert format_calls == [()]
     assert pre_commit_calls == ["run"]
+
+
+def test_pre_commit_wrapper_uses_resolved_hook_dir_for_pre_commit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    common_hooks = tmp_path / "common-git" / "hooks"
+    common_hooks.mkdir(parents=True)
+    (common_hooks / "commit-msg").write_text(
+        "#!/usr/bin/env bash\npre_commit hook-impl --hook-type=commit-msg\n",
+        encoding="utf-8",
+    )
+    commands: list[tuple[str, ...]] = []
+
+    def fake_git_path(path: str) -> Path:
+        if path == "hooks":
+            return common_hooks
+        if path == "hooks/commit-msg":
+            return common_hooks / "commit-msg"
+        raise AssertionError(path)
+
+    def fake_run_command(
+        command: list[str], *, env: dict[str, str] | None = None
+    ) -> int:
+        del env
+        commands.append(tuple(command))
+        return 0
+
+    def fake_git_paths(*args: str) -> tuple[str, ...]:
+        del args
+        return ()
+
+    def fake_format_and_stage(paths: tuple[str, ...]) -> int:
+        del paths
+        return 0
+
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(tools.pre_commit_hook, "_git_path", fake_git_path)
+    monkeypatch.setattr(tools.pre_commit_hook, "_git_paths", fake_git_paths)
+    monkeypatch.setattr(
+        tools.pre_commit_hook, "_format_and_stage", fake_format_and_stage
+    )
+    monkeypatch.setattr(tools.pre_commit_hook, "_run_command", fake_run_command)
+
+    assert tools.pre_commit_hook.main([]) == 0
+    assert commands
+    assert "--hook-dir" in commands[0]
+    assert str(common_hooks.resolve()) in commands[0]
 
 
 def test_install_hook_template_execs_repo_pre_commit_wrapper() -> None:
@@ -119,8 +182,16 @@ def test_install_hooks_syncs_environment_before_writing_repo_hooks(
         check: bool,
         cwd: Path,
         env: dict[str, str] | None = None,
+        capture_output: bool = False,
+        text: bool = False,
     ) -> subprocess.CompletedProcess[str]:
         assert check is True
+        if command[:3] == ["git", "rev-parse", "--git-path"]:
+            assert capture_output is True
+            assert text is True
+            return subprocess.CompletedProcess(
+                command, 0, stdout=f".git/{command[3]}\n"
+            )
         commands.append(
             (
                 tuple(command),
@@ -183,8 +254,16 @@ def test_install_hooks_falls_back_to_default_external_environment(
         check: bool,
         cwd: Path,
         env: dict[str, str] | None = None,
+        capture_output: bool = False,
+        text: bool = False,
     ) -> subprocess.CompletedProcess[str]:
         del check, cwd, env
+        if command[:3] == ["git", "rev-parse", "--git-path"]:
+            assert capture_output is True
+            assert text is True
+            return subprocess.CompletedProcess(
+                command, 0, stdout=f".git/{command[3]}\n"
+            )
         return subprocess.CompletedProcess(command, 0)
 
     monkeypatch.setattr("tools.install_git_hooks.sys.executable", "/usr/bin/python3")
@@ -202,6 +281,43 @@ def test_install_hooks_falls_back_to_default_external_environment(
         f"PROJECT_ENVIRONMENT={expected_environment}"
         in commit_msg_hook_path.read_text(encoding="utf-8")
     )
+
+
+def test_install_hooks_writes_to_git_resolved_hook_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    common_hooks = tmp_path / "common-git" / "hooks"
+
+    def fake_run(
+        command: list[str],
+        *,
+        check: bool,
+        cwd: Path,
+        env: dict[str, str] | None = None,
+        capture_output: bool = False,
+        text: bool = False,
+    ) -> subprocess.CompletedProcess[str]:
+        del check, cwd, env
+        if command[:3] == ["git", "rev-parse", "--git-path"]:
+            assert capture_output is True
+            assert text is True
+            return subprocess.CompletedProcess(
+                command, 0, stdout=f"{common_hooks / Path(command[3]).name}\n"
+            )
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr("tools.install_git_hooks.sys.executable", "/usr/bin/python3")
+    monkeypatch.setattr("tools.install_git_hooks.sys.prefix", "/usr")
+    monkeypatch.setattr("tools.install_git_hooks.sys.base_prefix", "/usr")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    tools.install_git_hooks._install_hooks(tmp_path)
+
+    assert (common_hooks / "pre-commit").is_file()
+    assert (common_hooks / "commit-msg").is_file()
+    assert not (tmp_path / ".git" / "hooks" / "pre-commit").exists()
+    assert not (tmp_path / ".git" / "hooks" / "commit-msg").exists()
 
 
 def test_pre_commit_config_uses_repo_owned_fast_pytest_entrypoint() -> None:

--- a/tools/install_git_hooks.py
+++ b/tools/install_git_hooks.py
@@ -78,6 +78,18 @@ def _hook_project_environment() -> str:
     return _installed_project_environment() or default_project_environment()
 
 
+def _git_path(repo_root: Path, path: str) -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--git-path", path],
+        check=True,
+        capture_output=True,
+        cwd=repo_root,
+        text=True,
+    )
+    hook_path = Path(result.stdout.strip())
+    return hook_path if hook_path.is_absolute() else repo_root / hook_path
+
+
 def _install_hooks(repo_root: Path) -> None:
     subprocess.run(
         ["git", "config", "--local", "commit.template", ".gitmessage.txt"],
@@ -94,7 +106,8 @@ def _install_hooks(repo_root: Path) -> None:
         "project_environment": shlex.quote(_hook_project_environment()),
         "python": shlex.quote(sys.executable),
     }
-    hook_path = repo_root / ".git/hooks/pre-commit"
+    hook_path = _git_path(repo_root, "hooks/pre-commit")
+    hook_path.parent.mkdir(parents=True, exist_ok=True)
     hook_path.write_text(
         _HOOK_TEMPLATE.format(**hook_format_args),
         encoding="utf-8",
@@ -102,7 +115,8 @@ def _install_hooks(repo_root: Path) -> None:
     hook_path.chmod(
         hook_path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH
     )
-    commit_msg_hook_path = repo_root / ".git/hooks/commit-msg"
+    commit_msg_hook_path = _git_path(repo_root, "hooks/commit-msg")
+    commit_msg_hook_path.parent.mkdir(parents=True, exist_ok=True)
     commit_msg_hook_path.write_text(
         _COMMIT_MSG_HOOK_TEMPLATE.format(**hook_format_args),
         encoding="utf-8",

--- a/tools/pre_commit_hook.py
+++ b/tools/pre_commit_hook.py
@@ -6,7 +6,6 @@ import subprocess
 from pathlib import Path
 
 PYTHON_SUFFIXES = {".py", ".pyi"}
-_COMMIT_MSG_HOOK_PATH = Path(".git/hooks/commit-msg")
 _COMMIT_MSG_HOOK_NEEDLES = (
     "--hook-type=commit-msg",
     "pre_commit",
@@ -22,6 +21,24 @@ def _git_paths(*args: str) -> tuple[str, ...]:
     )
     lines = [line.strip() for line in result.stdout.splitlines() if line.strip()]
     return tuple(lines)
+
+
+def _git_path(path: str) -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--git-path", path],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return Path(result.stdout.strip())
+
+
+def _hook_dir_path() -> Path:
+    return _git_path("hooks")
+
+
+def _commit_msg_hook_path() -> Path:
+    return _git_path("hooks/commit-msg")
 
 
 def _format_candidates(
@@ -52,14 +69,15 @@ def _run_pre_commit() -> int:
         "--config=.pre-commit-config.yaml",
         "--hook-type=pre-commit",
         "--hook-dir",
-        str(Path(".git/hooks").resolve()),
+        str(_hook_dir_path().resolve()),
         "--",
     ]
     return _run_command(command, env=env)
 
 
 def _require_commit_message_hook() -> int:
-    if not _COMMIT_MSG_HOOK_PATH.is_file():
+    hook_path = _commit_msg_hook_path()
+    if not hook_path.is_file():
         print(
             "repo commit-msg hook is not installed; run "
             '`UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" '
@@ -68,7 +86,7 @@ def _require_commit_message_hook() -> int:
         )
         return 1
 
-    hook_text = _COMMIT_MSG_HOOK_PATH.read_text(encoding="utf-8")
+    hook_text = hook_path.read_text(encoding="utf-8")
     if all(needle in hook_text for needle in _COMMIT_MSG_HOOK_NEEDLES):
         return 0
 


### PR DESCRIPTION
Why:
- Reduce premature module fragmentation while keeping refactor guidance ahead of the lint hard stop.
- Keep linked-worktree hook installation and PR review surface detection from blocking normal PR delivery.

What:
- Raise module size guidance thresholds by 100 lines and align Pylint ceilings plus standards guard assertions.
- Resolve repo hook paths through Git so linked worktrees can install and validate hooks correctly.
- Classify the production Pylint config with the existing CI/release review surface.

Checks:
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.docs_maintenance sync --check
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pytest tests/contract/test_standards_guards.py -q --no-cov
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pytest tests/unit/test_pre_commit_hook.py -q --no-cov
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pytest tests/unit/test_audit_pr_review.py tests/unit/test_run_pr_review_checks.py -q --no-cov
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.install_git_hooks
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.audit_pr_review
- UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_pr_review_checks

Issue linkage:
- None: no existing issue covered the module-limit adjustment or linked-worktree hook-path repair.

Included checkpoints:
- `docs(standards): raise module line limits`
- `fix(tools): resolve git hooks path from worktrees`
- `fix(pr-review): classify pylint config changes`