### PR TITLE
feat(balances): unify historical balance artifacts and intake parity

### DIFF
--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -7,7 +7,7 @@ runs:
     - uses: actions/setup-python@v6
       with:
         python-version: "3.12"
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       with:
         path: ~/.cache/uv
         key: uv-${{ runner.os }}-py312-${{ hashFiles('uv.lock') }}


### PR DESCRIPTION
Why:
- Re-running intake on the same source was losing historical balance provenance, so rebuilt outputs could drift from the raw evidence.
- The old split between balance evidence, confirmations, and latest-only balances made the workflow hard to reason about and easy to regress.

What:
- Replace the old evidence/confirmation split with `balance_snapshots.csv` and `balance_references.csv`.
- Add shared balance code for targets, snapshots, references, provider discovery, and native asset IDs.
- Keep statement PDFs and supporting artifacts in the typed intake path so rebuilds preserve source-backed balance coverage.
- Update docs, skill scripts, fixtures, and tests to match the renamed artifacts and flow.
- Move the setup-python-uv composite action to actions/cache@v5 so GitHub Actions uses a Node 24-compatible cache action.

Checks:
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.audit_pr_review`
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests`
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run tallylot reconciliation balances check --input-root /home/user/tallylot-workspace/working/normalized --output-root /home/user/tallylot-workspace/analysis/reconciliation/pr64-full-afterfix/check`
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run tallylot reconciliation balances summarize --coverage /home/user/tallylot-workspace/analysis/reconciliation/pr64-full/balance_coverage.csv --check-summary /home/user/tallylot-workspace/analysis/reconciliation/pr64-full-afterfix/check/balance_check_summary.csv --output /home/user/tallylot-workspace/analysis/reconciliation/pr64-full-afterfix/balance_reconciliation_summary.json`
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pytest -q --no-cov tests/unit/test_run_pr_review_checks.py tests/unit/test_commit_message_validator.py tests/unit/docs_runtime_parity`
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_ci_parity_checks`

Issue linkage:
- None: no existing issue applies

Included checkpoints:
- `feat(intake): complete capture intake rebuild (#62)`
- `refactor(balances): unify balance snapshots and references`
- `refactor(balances): add provider discovery and native asset ids`
- `docs(balances): align architecture and rollout guidance`
- `feat(balances): add shared historical balance seam`
- `fix(intake): skip blank-source capture inventory rows`
- `fix(statement-evidence): keep wallet-scoped balance references separate`
- `fix(binance): route statement PDFs into intake capture`
- `fix(intake): preserve supporting copies in blocked captures`
- `refactor(evm-explorer): split transfer translation modules`
- `fix(intake): preserve support copies in blocked captures`
- `feat(balance): omit empty diagnostic sidecars`
- `docs(balance): clarify balance output guidance`
- `fix(balance): stabilize submission and cross-source matching`
- `docs(balance): neutralize balance terminology`
- `fix(standards): accept issue linkage in generated mainline commit bodies`
- `fix(balances): harden submission and summary outputs`
- `fix(standards): rename generated commit body allowance`
- `fix(balance): align submission and review hardening`
- `fix(crypto-com): match intake on headers and warn cash purchases`
- `fix(balance): harden balance reconciliation and Ronin coverage`
- `fix(balances): accept dotted generic location ids`
- `refactor(balance): extract runtime helpers`
- `refactor(balance): rehome exact balance workflows`
- `refactor(balances): reset runtime readiness semantics`
- `refactor(balances): centralize merge policy`
- `docs(balance): align balance docs and help text`
- `refactor(adapters): bundle translation batch inputs`
- `fix(pr-review): point docs parity to current test package`
- `fix(ci): move cache action to Node 24 runtime`
