### PR TITLE
feat(normalization): plan translation inputs before adapter translation

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -80,14 +80,22 @@ reconciliation, accounting, and tax work expands.
 Scope:
 
 - keep direct fact artifacts as the only runtime model
+- add capture-scoped translation input planning as a required fact-path
+  stabilization step so adapters describe valid input candidates and the core
+  planner selects deterministic selected, superseded, or blocked plans from
+  event-time coverage and freshness metadata
 - center intake on explicit capture identity, capture registries, and
   raw-evidence preservation instead of inferred capture buckets
 - keep inferred period and capture heuristics as report metadata only; they do
   not control runtime identity, routing, or normalization ownership
 - finish adapter parity and projection parity coverage on the current fact
   model
+- keep file-selection policy in `application/normalization/` rather than in
+  adapter-local filename or path-order heuristics
 - keep review and issue outputs explicit for ambiguous direction, precision, or
   classification decisions
+- persist translation planner artifacts showing candidate descriptions, plan
+  decisions, and blocking issues before translation begins
 - continue tightening overlap heuristics, duplicate detection, file-family
   signatures, and capture acceptance rules where capture ownership is still
   ambiguous
@@ -105,12 +113,18 @@ Scope:
   metadata
 - make source assembly rerun-safe by rewriting its owned generated artifact
   surface deterministically on each run
+- migrate adapters to the planner path in stages, starting with Coinbase and
+  then other adapters that still pick one export by filename or path heuristic
 - add a repo-native semantic parity validator for unchanged raw inputs
 
 Exit criteria:
 
 - supported adapters emit facts without normalized-transaction-era wrapper
   lanes
+- planner-enabled adapters no longer choose winning translation inputs by path
+  order or lexical filename order
+- selected, superseded, and blocked translation inputs are explicit
+  normalization artifacts before fact translation runs
 - CoinTracking CSV projection remains correct from facts alone
 - remaining normalization ambiguity paths emit explicit reviews or blocking
   issues instead of silent coercion

--- a/docs/concepts/reconciliation-tax-architecture.md
+++ b/docs/concepts/reconciliation-tax-architecture.md
@@ -315,6 +315,33 @@ Rules:
 - checkpoint submission row models stay validated at the boundary with
   `pydantic` so malformed or unsupported rows fail with explicit issues
 
+### 18. Plan Translation Inputs In Core Before Adapter Translation
+
+Capture-scoped normalization must decide which raw source files are translated
+before adapter row translation runs.
+
+Rules:
+
+- adapters describe every valid translation input candidate for the capture,
+  including coverage, freshness, grouping, replaceability, and comparability
+  metadata
+- the core planner in `application/normalization/` selects the deterministic
+  candidate plan and records selected, superseded, and blocked outcomes before
+  translation begins
+- event-time coverage outranks path order, filename order, and discovery order
+- ambiguous overlap, incomparable candidates, unknown coverage, or unresolved
+  freshness ties are blocking normalization concerns, not adapter-local
+  heuristics
+- planner artifacts must preserve raw-input provenance explicitly through
+  candidate and decision outputs rather than hiding file selection inside
+  adapter code
+- migrated adapters translate only the selected plan; legacy adapters may stay
+  on the fallback `translate(...)` path until their candidate semantics are
+  modeled accurately
+- Coinbase is the first migrated adapter and future migrations should proceed
+  in stages from path-order or filename-order adapters toward richer grouped
+  multi-file inputs
+
 ## Target Architecture
 
 Core abstractions added from this point forward must stay neutral enough to
@@ -344,8 +371,9 @@ is inherently specific.
 - `application/profiling/`
   - capture profile construction, inventory inspection, and timezone review
 - `application/normalization/`
-  - orchestrate one capture's translation into fact artifacts, source-backed
-    evidence, and fact-backed balance packages through `application/balances`
+  - orchestrate one capture's translation-input planning, translation into fact
+    artifacts, source-backed evidence, and fact-backed balance packages through
+    `application/balances`
 - `application/balances/`
   - target planning, snapshot derivation, reference resolution, exact-balance
     inspection and check workflows, cross-source corroboration, summary and
@@ -403,6 +431,9 @@ Rules:
   artifacts
 - source adapters return `SourceTranslationBatch`; they do not emit output
   rows, checkpoint decisions, or tax policy decisions directly
+- planner-enabled source adapters describe translation input candidates and
+  translate only the selected plan; they do not choose winning files
+  independently once they opt into the planner contract
 - CoinTracking-specific column defaults, `Tx-ID` behavior, and row-shape
   metadata stay inside the CoinTracking output adapter package rather than in
   provider-local source code

--- a/docs/guides/write-an-adapter.md
+++ b/docs/guides/write-an-adapter.md
@@ -21,12 +21,16 @@ automatically.
 - Keep adapters pure with respect to filesystem layout except for reading their
   assigned input paths.
 - Treat source adapters as translation adapters, not orchestration centers.
+- When an adapter opts into translation input planning, describe every valid
+  translation candidate and let the core planner choose the selected plan.
 - Prefer existing adapter support seams for stable cross-provider work such as
   file-family dispatch, CSV traversal, draft compilation, issue construction,
   wallet-record construction, and output projection so new adapters stay thin.
 - Publish stable file-family ids from schema or content signatures before using
   filename or path hints. Translation code should consume those adapter-declared
   family ids rather than rediscovering provider filenames in each workflow.
+- Do not keep file-winner selection inside adapter-local path-order or
+  filename-order heuristics once the planner contract is available.
 - Keep shared support adapter-agnostic. It should work from registry-resolved
   manifests and adapter-published translation contracts, not from concrete
   provider ids hard-coded into support modules.
@@ -94,8 +98,9 @@ automatically.
 
 Working source adapters should follow four steps:
 
-1. parse provider exports into provider-local typed records
-2. select a provider-local translation rule or grouped-operation rule
+1. describe valid translation input candidates when the adapter can opt into
+   core planning
+2. parse provider exports into provider-local typed records
 3. emit shared adapter drafts plus explicit issues or reviews
 4. let shared compiler or projection support build runtime artifacts
 
@@ -113,8 +118,23 @@ leg shape through explicit `LegShapeLimit` entries.
 
 The core service should resolve the adapter through the registry and supply
 only the minimal context the adapter needs to translate correctly. Export
-families, translation registries, and provider-local coverage declarations come
-from the adapter package itself, not from a support-layer provider table.
+families, translation registries, candidate descriptions, and provider-local
+coverage declarations come from the adapter package itself, not from a
+support-layer provider table.
+
+Planner-enabled adapters should expose these responsibilities:
+
+- `describe_translation_inputs(...)` returns every valid candidate for the
+  capture with coverage, freshness, grouping, comparability, and member-path
+  metadata
+- the core planner selects the deterministic plan and writes
+  `translation_input_candidates.json`, `translation_input_plan.json`, and
+  `translation_input_issues.csv` before translation starts
+- `translate_selected_inputs(...)` consumes only the selected candidate ids in
+  plan order and must not redo winner-selection logic internally
+- adapters that cannot yet describe meaningful overlap or replacement semantics
+  should stay on the legacy `translate(...)` fallback path until they can be
+  migrated safely
 
 Mixed captures must fail explicitly. If profiling detects incompatible adapter
 families in one raw source directory, the adapter should rely on the shared

--- a/docs/status/current-state.md
+++ b/docs/status/current-state.md
@@ -39,6 +39,11 @@ The repo currently ships typed replacements for the core workflow capabilities:
 - capture-scoped source normalization with explicit fact artifacts, derived
   balance snapshots, unified balance references, and archive member provenance
   under `working/normalized/captures/<capture_uid>/`
+- planner-enabled capture normalization that writes
+  `translation_input_candidates.json`, `translation_input_plan.json`, and
+  `translation_input_issues.csv` before translation, blocks ambiguous file
+  selection, and records translation planner metrics in
+  `normalization_summary.json`
 - source assembly via `source assemble`, producing reconciliation-ready source
   datasets under `working/normalized/sources/<source>/` and rewrites its owned
   generated artifact set on rerun
@@ -81,6 +86,11 @@ The repo currently ships typed replacements for the core workflow capabilities:
   capture root under `evidence/raw/source/<source>/<capture_label>/` with
   matching `capture.json` metadata. They reject source roots, arbitrary
   directories, and mismatched capture metadata.
+- Planner-enabled adapters describe translation input candidates and the core
+  normalization flow chooses the selected plan. If overlap, coverage, or
+  freshness ambiguity would change the factual dataset, normalization stops
+  before writing `facts.csv`, `balance_snapshots.csv`, or
+  `balance_references.csv`.
 - Capture-scoped normalized outputs live under `working/normalized/captures/`.
 - Reconciliation reads assembled source datasets under
   `working/normalized/sources/`.
@@ -119,6 +129,14 @@ The repo currently ships typed replacements for the core workflow capabilities:
   `issue_count_delta`, `review_count_delta`, and `reason`.
 - Repo docs and repo-local agent entrypoints must describe only implemented
   commands and artifacts.
+
+## Current Migration Notes
+
+- Translation input planning is opt-in per adapter during the first slice.
+- Coinbase is the first planner-enabled adapter and now describes retail CSV
+  candidates instead of choosing one file by path order.
+- Legacy adapters still use the fallback `translate(...)` path until their
+  candidate semantics are modeled well enough to migrate safely.
 
 ## Deferred Surface
 

--- a/src/tallylot/adapters/sources/platforms/coinbase/adapter.py
+++ b/src/tallylot/adapters/sources/platforms/coinbase/adapter.py
@@ -30,9 +30,17 @@ from tallylot.ports.source_profiles import (
     SourceProfile,
 )
 from tallylot.ports.source_translation import SourceTranslationBatch
+from tallylot.ports.translation_inputs import (
+    TranslationInputCandidate,
+    TranslationInputPlan,
+)
 
 from .matching import RETAIL_HEADER, match_coinbase_inventory
-from .normalization import translate_coinbase_exports
+from .normalization import (
+    describe_translation_inputs,
+    translate_coinbase_exports,
+    translate_selected_inputs,
+)
 from .pdf_balances import match_statement_document as _match_statement_document
 from .pdf_balances import parse_statement_document as _parse_statement_document
 
@@ -128,6 +136,19 @@ class _CoinbaseAdapter:
         self, profile: SourceProfile, raw_dir: Path
     ) -> SourceTranslationBatch:
         return translate_coinbase_exports(profile, raw_dir)
+
+    def describe_translation_inputs(
+        self, profile: SourceProfile, raw_dir: Path
+    ) -> tuple[TranslationInputCandidate, ...]:
+        return describe_translation_inputs(profile, raw_dir)
+
+    def translate_selected_inputs(
+        self,
+        profile: SourceProfile,
+        raw_dir: Path,
+        plan: TranslationInputPlan,
+    ) -> SourceTranslationBatch:
+        return translate_selected_inputs(profile, raw_dir, plan)
 
 
 ADAPTER = _CoinbaseAdapter()

--- a/src/tallylot/adapters/sources/platforms/coinbase/normalization.py
+++ b/src/tallylot/adapters/sources/platforms/coinbase/normalization.py
@@ -1,8 +1,10 @@
-"""Coinbase retail normalization orchestration."""
+"""Coinbase retail translation helpers."""
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
 from pathlib import Path
+import re
 
 from tallylot.adapters.support import IssueSpec, issue_record, read_csv_row_contexts
 from tallylot.adapters.support.drafts import (
@@ -11,36 +13,119 @@ from tallylot.adapters.support.drafts import (
     translation_batch_from_drafts,
 )
 from tallylot.domain.issues import IssueRecord
-from tallylot.ports.source_profiles import SourceProfile
+from tallylot.ports.source_profiles import FileInventoryEntry, SourceProfile
 from tallylot.ports.source_translation import SourceTranslationBatch
+from tallylot.ports.translation_inputs import (
+    TranslationCoverageMode,
+    TranslationCoverageWindow,
+    TranslationFreshness,
+    TranslationFreshnessKind,
+    TranslationInputCandidate,
+    TranslationInputPlan,
+    TranslationSelectionMode,
+    translation_input_content_fingerprint,
+    translation_input_coverage_from_inventory_entry,
+)
 
 from .asset_migrations import normalize_asset_migration as _normalize_asset_migration
-from .matching import retail_path as _retail_path
+from .matching import RETAIL_HEADER
 from .retail_rows import normalize_retail_row as _normalize_row
+
+_SELECTION_GROUP = "coinbase:retail_export"
+_FAMILY_ID = "retail_export"
+_EXPORT_DATE_PREFIX_PATTERN = re.compile(r"^(?P<date>\d{4}-\d{2}-\d{2})\b")
+
+
+def describe_translation_inputs(
+    profile: SourceProfile, raw_dir: Path
+) -> tuple[TranslationInputCandidate, ...]:
+    del raw_dir
+    candidates: list[TranslationInputCandidate] = []
+    for entry in _retail_inventory_entries(profile):
+        coverage = translation_input_coverage_from_inventory_entry(entry)
+        freshness = _candidate_freshness(entry)
+        candidates.append(
+            TranslationInputCandidate(
+                candidate_id=_candidate_id(entry),
+                selection_group=_SELECTION_GROUP,
+                family_id=_FAMILY_ID,
+                member_relative_paths=(entry.relative_path,),
+                selection_mode=TranslationSelectionMode.REPLACEABLE_RANGE,
+                coverage=coverage,
+                freshness=freshness,
+                content_fingerprint=translation_input_content_fingerprint(
+                    member_sha256s=(entry.sha256,),
+                    family_id=_FAMILY_ID,
+                    selection_group=_SELECTION_GROUP,
+                    selection_mode=TranslationSelectionMode.REPLACEABLE_RANGE,
+                ),
+                comparison_key=_SELECTION_GROUP,
+                description=_candidate_description(entry, coverage),
+                comparable=True,
+            )
+        )
+    return tuple(candidates)
+
+
+def translate_selected_inputs(
+    profile: SourceProfile,
+    raw_dir: Path,
+    plan: TranslationInputPlan,
+) -> SourceTranslationBatch:
+    candidates = {
+        candidate.candidate_id: candidate
+        for candidate in describe_translation_inputs(profile, raw_dir)
+    }
+    if not plan.selected_candidate_ids:
+        return _missing_retail_csv_batch(profile)
+    drafts: list[EconomicActivityDraft] = []
+    issues: list[IssueRecord] = []
+    for candidate_id in plan.selected_candidate_ids:
+        candidate = candidates.get(candidate_id)
+        if candidate is None:
+            raise ValueError(
+                f"translation plan selected unknown Coinbase candidate: {candidate_id}"
+            )
+        for member_relative_path in candidate.member_relative_paths:
+            path = _entry_path(raw_dir, member_relative_path)
+            if path is None:
+                raise ValueError(
+                    f"selected Coinbase candidate member is missing from raw capture: {member_relative_path}"
+                )
+            selected_batch = _translate_retail_file(profile, path)
+            drafts.extend(selected_batch.drafts)
+            issues.extend(selected_batch.issues)
+    return translation_batch_from_drafts(
+        TranslationBatchDrafts(drafts=tuple(drafts), issues=tuple(issues))
+    )
 
 
 def translate_coinbase_exports(
     profile: SourceProfile, raw_dir: Path
 ) -> SourceTranslationBatch:
-    retail_path = _retail_path(raw_dir)
-    if retail_path is None:
-        return translation_batch_from_drafts(
-            TranslationBatchDrafts(
-                issues=(
-                    issue_record(
-                        IssueSpec(
-                            source=str(profile.source),
-                            adapter_id="coinbase",
-                            issue_id="coinbase:missing_retail_csv",
-                            kind="missing_required_input",
-                            message="Coinbase retail all-time CSV is required for deterministic normalization.",
-                            severity="high",
-                        )
-                    ),
-                ),
-            )
+    candidates = describe_translation_inputs(profile, raw_dir)
+    if not candidates:
+        return _missing_retail_csv_batch(profile)
+    if len(candidates) > 1:
+        raise ValueError(
+            "Coinbase retail translation requires translation input planning when "
+            "more than one retail export candidate is present"
         )
+    candidate = next(iter(candidates))
+    return translate_selected_inputs(
+        profile,
+        raw_dir,
+        TranslationInputPlan(
+            selected_candidate_ids=(candidate.candidate_id,),
+            decisions=(),
+            blocked=False,
+        ),
+    )
 
+
+def _translate_retail_file(
+    profile: SourceProfile, retail_path: Path
+) -> SourceTranslationBatch:
     drafts: list[EconomicActivityDraft] = []
     issues: list[IssueRecord] = []
     asset_migrations: dict[str, list[dict[str, str]]] = {}
@@ -91,3 +176,102 @@ def translate_coinbase_exports(
     return translation_batch_from_drafts(
         TranslationBatchDrafts(drafts=tuple(drafts), issues=tuple(issues))
     )
+
+
+def _missing_retail_csv_batch(profile: SourceProfile) -> SourceTranslationBatch:
+    return translation_batch_from_drafts(
+        TranslationBatchDrafts(
+            issues=(
+                issue_record(
+                    IssueSpec(
+                        source=str(profile.source),
+                        adapter_id="coinbase",
+                        issue_id="coinbase:missing_retail_csv",
+                        kind="missing_required_input",
+                        message=(
+                            "Coinbase retail all-time CSV is required for deterministic normalization."
+                        ),
+                        severity="high",
+                    )
+                ),
+            ),
+        )
+    )
+
+
+def _retail_inventory_entries(
+    profile: SourceProfile,
+) -> tuple[FileInventoryEntry, ...]:
+    return tuple(
+        entry
+        for entry in sorted(profile.file_inventory, key=lambda item: item.relative_path)
+        if _is_retail_export_entry(entry)
+    )
+
+
+def _is_retail_export_entry(entry: FileInventoryEntry) -> bool:
+    if entry.suffix.lower() != ".csv" or entry.row_count in {None, 0}:
+        return False
+    return entry.header == RETAIL_HEADER
+
+
+def _candidate_id(entry: FileInventoryEntry) -> str:
+    return f"{_SELECTION_GROUP}:{entry.relative_path}"
+
+
+def _candidate_freshness(entry: FileInventoryEntry) -> TranslationFreshness:
+    export_timestamp = _export_timestamp_from_entry(entry)
+    if export_timestamp is not None:
+        return TranslationFreshness(
+            kind=TranslationFreshnessKind.EXPORT_TIMESTAMP,
+            timestamp=export_timestamp,
+            rank=None,
+        )
+    rank = 2 if _is_all_time_export(entry) else 1
+    return TranslationFreshness(
+        kind=TranslationFreshnessKind.ADAPTER_RANK,
+        timestamp=None,
+        rank=rank,
+    )
+
+
+def _candidate_description(
+    entry: FileInventoryEntry,
+    coverage: TranslationCoverageWindow,
+) -> str:
+    if coverage.mode is TranslationCoverageMode.UNKNOWN:
+        return f"Coinbase retail export file {entry.relative_path}"
+    start = _coverage_text(coverage.start_at)
+    end = _coverage_text(coverage.end_at)
+    if start and end:
+        return f"Coinbase retail export file {entry.relative_path} covering {start} to {end} UTC"
+    return f"Coinbase retail export file {entry.relative_path}"
+
+
+def _coverage_text(value: object) -> str:
+    if not isinstance(value, datetime):
+        return ""
+    return value.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def _entry_path(raw_dir: Path, relative_path: str) -> Path | None:
+    candidate = raw_dir / relative_path
+    if candidate.exists():
+        return candidate
+    return None
+
+
+def _export_timestamp_from_entry(entry: FileInventoryEntry) -> datetime | None:
+    if entry.export_timestamp.strip():
+        return datetime.strptime(entry.export_timestamp, "%Y-%m-%d %H:%M:%S").replace(
+            tzinfo=UTC
+        )
+    match = _EXPORT_DATE_PREFIX_PATTERN.match(entry.relative_path)
+    if match is None:
+        return None
+    return datetime.strptime(match.group("date"), "%Y-%m-%d").replace(tzinfo=UTC)
+
+
+def _is_all_time_export(entry: FileInventoryEntry) -> bool:
+    normalized_path = entry.relative_path.lower()
+    return "all time" in normalized_path or "all-time" in normalized_path

--- a/src/tallylot/adapters/sources/platforms/coinbase/tests/test_normalize.py
+++ b/src/tallylot/adapters/sources/platforms/coinbase/tests/test_normalize.py
@@ -11,6 +11,7 @@ from tallylot.application.evidence.statement_extraction import (
     StatementExtractionService,
 )
 from tallylot.application.profiling import BuildProfileUseCase
+from tallylot.ports.source_profiles import SourceProfile
 from tallylot.domain.transactions import (
     AccountingIntentHint,
     EconomicKind,
@@ -19,7 +20,6 @@ from tallylot.domain.transactions import (
 )
 from tallylot.infrastructure.discovery import build_registry
 from tallylot.infrastructure.serialization.filesystem import FilesystemArtifactStore
-from tests.support.services import build_source_profile
 
 
 def _make_pdf(path: Path, *lines: str) -> None:
@@ -31,11 +31,20 @@ def _make_pdf(path: Path, *lines: str) -> None:
     pdf.save()
 
 
+def _coinbase_profile(raw_dir: Path) -> SourceProfile:
+    return BuildProfileUseCase(
+        build_registry(), FilesystemArtifactStore()
+    ).create_profile(
+        "coinbase",
+        raw_dir,
+    )
+
+
 def test_coinbase_adapter_reports_missing_retail_csv_as_explicit_issue(
     tmp_path: Path,
 ) -> None:
     result = _CoinbaseAdapter().translate(
-        build_source_profile(adapter_id="coinbase", raw_dir=str(tmp_path)),
+        _coinbase_profile(tmp_path),
         tmp_path,
     )
 
@@ -60,7 +69,7 @@ def test_coinbase_adapter_normalizes_buy_row_from_header_detected_csv(
     )
 
     result = _CoinbaseAdapter().translate(
-        build_source_profile(adapter_id="coinbase", raw_dir=str(raw_dir)),
+        _coinbase_profile(raw_dir),
         raw_dir,
     )
     facts = compile_activity_drafts(result.drafts)
@@ -101,7 +110,7 @@ def test_coinbase_adapter_normalizes_sell_send_and_receive_rows(tmp_path: Path) 
     )
 
     result = _CoinbaseAdapter().translate(
-        build_source_profile(adapter_id="coinbase", raw_dir=str(raw_dir)),
+        _coinbase_profile(raw_dir),
         raw_dir,
     )
     facts = compile_activity_drafts(result.drafts)
@@ -150,7 +159,7 @@ def test_coinbase_adapter_surfaces_unsupported_rows_without_dropping_supported_r
     )
 
     result = _CoinbaseAdapter().translate(
-        build_source_profile(adapter_id="coinbase", raw_dir=str(raw_dir)),
+        _coinbase_profile(raw_dir),
         raw_dir,
     )
     facts = compile_activity_drafts(result.drafts)
@@ -177,7 +186,7 @@ def test_coinbase_adapter_preserves_title_row_issue_line_numbers(
     )
 
     result = _CoinbaseAdapter().translate(
-        build_source_profile(adapter_id="coinbase", raw_dir=str(raw_dir)),
+        _coinbase_profile(raw_dir),
         raw_dir,
     )
 
@@ -203,7 +212,7 @@ def test_coinbase_adapter_normalizes_reward_income_and_asset_migration_pair(
     )
 
     result = _CoinbaseAdapter().translate(
-        build_source_profile(adapter_id="coinbase", raw_dir=str(raw_dir)),
+        _coinbase_profile(raw_dir),
         raw_dir,
     )
     facts = compile_activity_drafts(result.drafts)

--- a/src/tallylot/adapters/sources/platforms/coinbase/tests/test_translation_inputs.py
+++ b/src/tallylot/adapters/sources/platforms/coinbase/tests/test_translation_inputs.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+from tallylot.adapters.sources.platforms.coinbase.adapter import _CoinbaseAdapter
+from tallylot.adapters.support.drafts import compile_activity_drafts
+from tallylot.application.normalization.translation_inputs import (
+    plan_translation_inputs,
+)
+from tallylot.application.profiling import BuildProfileUseCase
+from tallylot.domain.transactions import EconomicKind
+from tallylot.infrastructure.discovery import build_registry
+from tallylot.infrastructure.serialization.filesystem import FilesystemArtifactStore
+from tallylot.ports.source_profiles import SourceProfile
+
+
+def test_coinbase_planner_selects_newer_broader_all_time_export(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    older_path = raw_dir / "2021 Statement.csv"
+    newer_path = raw_dir / "2026-03-23 Statement - All Time.csv"
+    older_path.write_text(older_retail_csv(), encoding="utf-8")
+    newer_path.write_text(newer_all_time_retail_csv(), encoding="utf-8")
+    adapter = _CoinbaseAdapter()
+    profile = coinbase_profile(raw_dir)
+
+    result = plan_translation_inputs(
+        profile=profile,
+        candidates=adapter.describe_translation_inputs(profile, raw_dir),
+    )
+    decisions = {decision.candidate_id: decision for decision in result.plan.decisions}
+
+    assert result.plan.blocked is False
+    assert result.plan.selected_candidate_ids == (
+        f"coinbase:retail_export:{newer_path.name}",
+    )
+    assert decisions[f"coinbase:retail_export:{older_path.name}"].status == (
+        "superseded_replaced"
+    )
+    assert decisions[
+        f"coinbase:retail_export:{newer_path.name}"
+    ].replaces_candidate_ids == (f"coinbase:retail_export:{older_path.name}",)
+
+
+def test_coinbase_selected_plan_preserves_asset_migration_rows_without_aliasing(
+    tmp_path: Path,
+) -> None:
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "2021 Statement.csv").write_text(older_retail_csv(), encoding="utf-8")
+    newer_path = raw_dir / "2026-03-23 Statement - All Time.csv"
+    newer_path.write_text(newer_all_time_retail_csv(), encoding="utf-8")
+    adapter = _CoinbaseAdapter()
+    profile = coinbase_profile(raw_dir)
+    planning_result = plan_translation_inputs(
+        profile=profile,
+        candidates=adapter.describe_translation_inputs(profile, raw_dir),
+    )
+
+    batch = adapter.translate_selected_inputs(profile, raw_dir, planning_result.plan)
+    facts = compile_activity_drafts(batch.drafts)
+    migration_event = next(
+        fact for fact in facts if fact.economic_kind is EconomicKind.ASSET_MIGRATION
+    )
+
+    assert migration_event.timestamp == datetime(
+        2025,
+        10,
+        17,
+        13,
+        38,
+        17,
+        tzinfo=UTC,
+    )
+    assert {str(leg.instrument_id) for leg in migration_event.legs} == {
+        "symbol:MATIC@coinbase",
+        "symbol:POL@coinbase",
+    }
+
+
+def test_coinbase_planner_blocks_ambiguous_overlapping_retail_exports(
+    tmp_path: Path,
+) -> None:
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "2021 statement a.csv").write_text(
+        retail_csv_with_amount("tx-a", "1.00000000"),
+        encoding="utf-8",
+    )
+    (raw_dir / "2021 statement b.csv").write_text(
+        retail_csv_with_amount("tx-b", "2.00000000"),
+        encoding="utf-8",
+    )
+    adapter = _CoinbaseAdapter()
+    profile = coinbase_profile(raw_dir)
+
+    result = plan_translation_inputs(
+        profile=profile,
+        candidates=adapter.describe_translation_inputs(profile, raw_dir),
+    )
+
+    assert result.plan.blocked is True
+    assert {decision.status for decision in result.plan.decisions} == {
+        "blocked_ambiguous_freshness"
+    }
+
+
+def coinbase_profile(raw_dir: Path) -> SourceProfile:
+    return BuildProfileUseCase(
+        build_registry(), FilesystemArtifactStore()
+    ).create_profile(
+        "coinbase",
+        raw_dir,
+    )
+
+
+def older_retail_csv() -> str:
+    return (
+        "Transactions\n"
+        "User,Example User,acct\n"
+        "ID,Timestamp,Transaction Type,Asset,Quantity Transacted,Price Currency,Price at Transaction,"
+        "Subtotal,Total (inclusive of fees and/or spread),Fees and/or Spread,Notes\n"
+        "legacy-1,2021-12-30 08:56:53 UTC,Receive,FET,1.9859001,CAD,$0.64,$1.27098,$1.27098,$0.00,"
+        "Received 1.9859001 FET\n"
+    )
+
+
+def newer_all_time_retail_csv() -> str:
+    return (
+        "Transactions\n"
+        "User,Example User,acct\n"
+        "ID,Timestamp,Transaction Type,Asset,Quantity Transacted,Price Currency,Price at Transaction,"
+        "Subtotal,Total (inclusive of fees and/or spread),Fees and/or Spread,Notes\n"
+        "legacy-1,2021-12-30 08:56:53 UTC,Receive,FET,1.9859001,CAD,$0.64,$1.27098,$1.27098,$0.00,"
+        "Received 1.9859001 FET\n"
+        "reward-1,2023-03-18 01:28:49 UTC,Reward Income,ADA,0.000021,CAD,$0.48,$0.00,$0.00,$0.00,"
+        "Received 0.000021 ADA from Coinbase Rewards\n"
+        "migration-neg,2025-10-17 13:38:17 UTC,Asset Migration,MATIC,-1.65526374,CAD,$0.25,-$0.42,-$0.42,$0.00,\n"
+        "migration-pos,2025-10-17 13:38:17 UTC,Asset Migration,POL,1.65526374,CAD,$0.25,$0.42,$0.42,$0.00,\n"
+    )
+
+
+def retail_csv_with_amount(transaction_id: str, amount: str) -> str:
+    return (
+        "Transactions\n"
+        "User,Example User,acct\n"
+        "ID,Timestamp,Transaction Type,Asset,Quantity Transacted,Price Currency,Price at Transaction,"
+        "Subtotal,Total (inclusive of fees and/or spread),Fees and/or Spread,Notes\n"
+        f"{transaction_id},2021-12-30 08:56:53 UTC,Receive,FET,{amount},CAD,$0.64,$1.27098,$1.27098,$0.00,"
+        "Received FET\n"
+    )

--- a/src/tallylot/adapters/sources/platforms/gtrade/tests/test_adapter.py
+++ b/src/tallylot/adapters/sources/platforms/gtrade/tests/test_adapter.py
@@ -5,7 +5,12 @@ from pathlib import Path
 
 from tallylot.adapters.sources.platforms.gtrade.adapter import _GTradeAdapter
 from tallylot.adapters.support.drafts import compile_activity_drafts
-from tallylot.domain.transactions import AccountingIntentHint, EconomicKind, ProjectionHint, TaxTreatmentHint
+from tallylot.domain.transactions import (
+    AccountingIntentHint,
+    EconomicKind,
+    ProjectionHint,
+    TaxTreatmentHint,
+)
 from tests.support.adapter_packs import fixture_raw_dir, profile_and_adapter
 from tests.support.services import build_source_profile
 
@@ -44,7 +49,9 @@ def test_gtrade_location_inventory_includes_alias_issue() -> None:
     raw_dir = fixture_raw_dir("gtrade", "realized_pnl_alias")
 
     profile, adapter = profile_and_adapter("GTrade 1CT", raw_dir)
-    evidence, issues = adapter.extract_location_inventory("GTrade 1CT", raw_dir, profile)
+    evidence, issues = adapter.extract_location_inventory(
+        "GTrade 1CT", raw_dir, profile
+    )
 
     assert str(profile.adapter_id) == "gtrade"
     assert any(str(row.location_id) == "gtrade_1ct:alias:bb4d" for row in evidence)
@@ -59,10 +66,28 @@ def test_gtrade_adapter_surfaces_invalid_rows_without_crashing(tmp_path: Path) -
     )
 
     result = _GTradeAdapter().translate(
-        build_source_profile(adapter_id="gtrade", raw_dir=str(raw_dir), source="GTrade"),
+        build_source_profile(
+            adapter_id="gtrade", raw_dir=str(raw_dir), source="GTrade"
+        ),
         raw_dir,
     )
 
     assert not compile_activity_drafts(result.drafts)
     assert len(result.issues) == 1
     assert result.issues[0].kind == "unsupported_row"
+
+
+def test_gtrade_adapter_accepts_filename_anchored_day_first_profile_dates(
+    tmp_path: Path,
+) -> None:
+    raw_dir = tmp_path
+    (raw_dir / "2023-05-06 My_Trading_History_Report.csv").write_text(
+        "DATE,PAIR,ADDR,DESCRIPTION,PNL\n06/05/2023,BTCUSD,bb4d,profit,10\n",
+        encoding="utf-8",
+    )
+
+    profile, adapter = profile_and_adapter("GTrade", raw_dir)
+    summary, issues = adapter.validate_profile_timezones(profile)
+
+    assert summary["status"] == "passed"
+    assert issues == ()

--- a/src/tallylot/adapters/support/timezones.py
+++ b/src/tallylot/adapters/support/timezones.py
@@ -91,8 +91,10 @@ def _validate_timezone_inventory(
     profile: SourceProfile,
     spec: _TimezoneValidationSpec,
 ) -> tuple[dict[str, JsonValue], tuple[IssueRecord, ...]]:
-    dated_items = tuple(item for item in profile.file_inventory if item.date_field)
-    rows_with_dates = sum(1 for item in profile.file_inventory if item.date_field)
+    dated_items = tuple(
+        item for item in profile.file_inventory if _has_dated_rows(item)
+    )
+    rows_with_dates = sum(1 for item in profile.file_inventory if _has_dated_rows(item))
     mode_counts: dict[str, int] = {}
     timezone_values: dict[str, int] = {}
     issues: list[IssueRecord] = []
@@ -116,6 +118,10 @@ def _validate_timezone_inventory(
         "accepted_modes": list(sorted(spec.accepted_modes)),
         "timezone_values": cast(dict[str, JsonValue], dict(timezone_values)),
     }, tuple(issues)
+
+
+def _has_dated_rows(entry: FileInventoryEntry) -> bool:
+    return bool(entry.date_field) and entry.row_count != 0
 
 
 def _inventory_timezone_issue(

--- a/src/tallylot/application/intake/file_facts/inspection.py
+++ b/src/tallylot/application/intake/file_facts/inspection.py
@@ -89,8 +89,10 @@ ACCOUNT_SEGMENT_PATTERN = re.compile(r"account[-_ ]?[a-z0-9]+", re.IGNORECASE)
 
 def inspect_intake_file(path: Path, *, relative_path: str) -> IntakeFileFacts:
     if path.suffix.lower() != ".csv":
+        scope_tokens = _scope_tokens(relative_path, [], [])
         return IntakeFileFacts(
-            scope_tokens=tuple(sorted(_scope_tokens(relative_path, [], []))),
+            scope_tokens=tuple(sorted(scope_tokens)),
+            routing_scope_tokens=_routing_scope_tokens(relative_path, [], []),
             network_hints=_network_hints(relative_path, (), [], []),
         )
 
@@ -106,6 +108,7 @@ def inspect_intake_file(path: Path, *, relative_path: str) -> IntakeFileFacts:
         observed_period_end=_observed_period_end(timestamp_values),
         observed_period_label=_observed_period_label(timestamp_values),
         scope_tokens=tuple(sorted(scope_tokens)),
+        routing_scope_tokens=_routing_scope_tokens(relative_path, rows, title_rows),
         network_hints=network_hints,
     )
 
@@ -244,6 +247,80 @@ def _network_hints(
         seen.add(network)
         hints.append(network)
     return tuple(hints)
+
+
+def _routing_scope_tokens(
+    relative_path: str,
+    rows: list[dict[str, str]],
+    title_rows: list[list[str]],
+) -> tuple[str, ...]:
+    path_tokens = _identifier_scope_tokens(relative_path)
+    title_tokens = _title_identifier_scope_tokens(title_rows)
+    row_token_sets = _row_identifier_scope_token_sets(rows)
+    selected_tokens: set[str] = set()
+    if not row_token_sets:
+        selected_tokens = _single_identifier(path_tokens) or _single_identifier(
+            title_tokens
+        )
+    else:
+        row_identifiers: set[str] = set()
+        for row_tokens in row_token_sets:
+            row_identifiers.update(row_tokens)
+        common_tokens = set(row_token_sets[0])
+        for row_tokens in row_token_sets[1:]:
+            common_tokens.intersection_update(row_tokens)
+        selected_tokens = _select_routing_tokens(
+            common_tokens, path_tokens=path_tokens, title_tokens=title_tokens
+        )
+        if not selected_tokens:
+            selected_tokens = _single_identifier(path_tokens & row_identifiers)
+        if not selected_tokens:
+            selected_tokens = _single_identifier(title_tokens & row_identifiers)
+    return tuple(sorted(selected_tokens))
+
+
+def _single_identifier(tokens: set[str]) -> set[str]:
+    if len(tokens) == 1:
+        return set(tokens)
+    return set()
+
+
+def _select_routing_tokens(
+    common_tokens: set[str],
+    *,
+    path_tokens: set[str],
+    title_tokens: set[str],
+) -> set[str]:
+    if not common_tokens:
+        return set()
+    if len(common_tokens) == 1:
+        return common_tokens
+    path_common = path_tokens & common_tokens
+    if len(path_common) == 1:
+        return path_common
+    title_common = title_tokens & common_tokens
+    if len(title_common) == 1:
+        return title_common
+    return set()
+
+
+def _title_identifier_scope_tokens(title_rows: list[list[str]]) -> set[str]:
+    tokens: set[str] = set()
+    for title_row in title_rows[:50]:
+        title_text = " ".join(cell.strip() for cell in title_row)
+        tokens.update(_identifier_scope_tokens(title_text))
+    return tokens
+
+
+def _row_identifier_scope_token_sets(rows: list[dict[str, str]]) -> list[set[str]]:
+    token_sets: list[set[str]] = []
+    for row in rows[:50]:
+        row_tokens = {
+            token for value in row.values() for token in _identifier_scope_tokens(value)
+        }
+        if row_tokens:
+            token_sets.append(row_tokens)
+    return token_sets
 
 
 def _row_dict(header: tuple[str, ...], row: list[str]) -> dict[str, str]:

--- a/src/tallylot/application/intake/inventory.py
+++ b/src/tallylot/application/intake/inventory.py
@@ -26,15 +26,22 @@ def resolve_inventory_route(
     source_folder: str,
     facts: IntakeFileFacts,
 ) -> InventoryRouteDecision:
-    identifiers = _inventory_identifiers(facts.scope_tokens)
+    identifiers = _inventory_identifiers(
+        facts.routing_scope_tokens or facts.scope_tokens
+    )
     if not identifiers:
         return InventoryRouteDecision(
             source_folder=source_folder,
             inventory_match_status="unmatched",
         )
 
-    evidence_rows = _read_rows(artifacts, workspace_root / "analysis" / "inventory" / "location_inventory_evidence.csv")
-    source_rows = _read_rows(artifacts, workspace_root / "analysis" / "issues" / "source_inventory.csv")
+    evidence_rows = _read_rows(
+        artifacts,
+        workspace_root / "analysis" / "inventory" / "location_inventory_evidence.csv",
+    )
+    source_rows = _read_rows(
+        artifacts, workspace_root / "analysis" / "issues" / "source_inventory.csv"
+    )
     inventory_match = _inventory_match_decision(
         identifiers=identifiers,
         evidence_rows=evidence_rows,
@@ -43,7 +50,9 @@ def resolve_inventory_route(
     if inventory_match is not None:
         return inventory_match
 
-    generic_source_folder = _generic_wallet_source_folder(identifiers, facts.network_hints)
+    generic_source_folder = _generic_wallet_source_folder(
+        identifiers, facts.network_hints
+    )
     if generic_source_folder:
         return InventoryRouteDecision(
             source_folder=generic_source_folder,
@@ -65,10 +74,16 @@ def _inventory_match_decision(
         return None
 
     candidate_rows = [
-        row for row in evidence_rows if (row.get("normalized_identifier") or "").strip().lower() in identifiers
+        row
+        for row in evidence_rows
+        if (row.get("normalized_identifier") or "").strip().lower() in identifiers
     ]
     distinct_sources = sorted(
-        {(row.get("source") or "").strip() for row in candidate_rows if (row.get("source") or "").strip()}
+        {
+            (row.get("source") or "").strip()
+            for row in candidate_rows
+            if (row.get("source") or "").strip()
+        }
     )
     if len(distinct_sources) == 1 and any(
         (row.get("source") or "").strip() == distinct_sources[0] for row in source_rows
@@ -104,10 +119,12 @@ def _inventory_identifiers(scope_tokens: tuple[str, ...]) -> set[str]:
     }
 
 
-def _generic_wallet_source_folder(identifiers: set[str], network_hints: tuple[str, ...]) -> str:
-    if not identifiers or not network_hints:
+def _generic_wallet_source_folder(
+    identifiers: set[str], network_hints: tuple[str, ...]
+) -> str:
+    if len(identifiers) != 1 or not network_hints:
         return ""
-    identifier = sorted(identifiers)[0]
+    identifier = next(iter(identifiers))
     network = network_hints[0].strip().lower()
     if not network:
         return ""

--- a/src/tallylot/application/normalization/contracts.py
+++ b/src/tallylot/application/normalization/contracts.py
@@ -25,6 +25,11 @@ class NormalizeResponse:
     balance_count: int
     issue_count: int
     review_count: int
+    translation_candidate_count: int = 0
+    translation_selected_count: int = 0
+    translation_superseded_count: int = 0
+    translation_blocked_count: int = 0
+    translation_planner_used: bool = False
 
 
 @dataclass(frozen=True)

--- a/src/tallylot/application/normalization/models.py
+++ b/src/tallylot/application/normalization/models.py
@@ -30,3 +30,12 @@ class NormalizationWindowStats:
     facts_outside_window: int
     issues_outside_window: int
     reviews_outside_window: int
+
+
+@dataclass(frozen=True)
+class NormalizationTranslationMetrics:
+    translation_candidate_count: int
+    translation_selected_count: int
+    translation_superseded_count: int
+    translation_blocked_count: int
+    translation_planner_used: bool

--- a/src/tallylot/application/normalization/normalize_source.py
+++ b/src/tallylot/application/normalization/normalize_source.py
@@ -50,6 +50,7 @@ from .models import (
 )
 from .summary import build_normalization_summary
 from .translation import execute_translation
+from .translation import TranslationExecutionContext
 from .window import (
     filter_drafts_by_window,
     filter_issues_by_window,
@@ -117,10 +118,12 @@ class NormalizeSourceUseCase:
             adapter=adapter,
             profile=profile,
             raw_dir=raw_dir,
-            output_dir=output_dir,
-            capture_metadata=capture_metadata,
-            artifacts=self._artifacts,
-            evidence=self._evidence,
+            context=TranslationExecutionContext(
+                output_dir=output_dir,
+                capture_metadata=capture_metadata,
+                artifacts=self._artifacts,
+                evidence=self._evidence,
+            ),
         )
         result = translation_result.batch
         statement_result = self._statement_extraction.extract_source_balance_references(

--- a/src/tallylot/application/normalization/normalize_source.py
+++ b/src/tallylot/application/normalization/normalize_source.py
@@ -44,8 +44,12 @@ from tallylot.ports.source_translation import SourceTranslationBatch
 
 from .annotations import annotation_records_from_drafts, location_annotation_records
 from .artifacts import write_normalization_artifacts
-from .models import NormalizationOutputs, NormalizationWindowStats
+from .models import (
+    NormalizationOutputs,
+    NormalizationWindowStats,
+)
 from .summary import build_normalization_summary
+from .translation import execute_translation
 from .window import (
     filter_drafts_by_window,
     filter_issues_by_window,
@@ -91,6 +95,7 @@ class NormalizeSourceUseCase:
         profile = self._profile_use_case.create_profile(
             request.source,
             raw_dir,
+            capture_metadata=capture_metadata,
             inspect_archives=request.inspect_archives,
         )
         profile = _profile_with_window_hints(profile, request)
@@ -108,7 +113,16 @@ class NormalizeSourceUseCase:
             raise ValueError(
                 f"source adapter {profile.adapter_id} is not supported for normalization in this phase"
             )
-        result = adapter.translate(profile, raw_dir)
+        translation_result = execute_translation(
+            adapter=adapter,
+            profile=profile,
+            raw_dir=raw_dir,
+            output_dir=output_dir,
+            capture_metadata=capture_metadata,
+            artifacts=self._artifacts,
+            evidence=self._evidence,
+        )
+        result = translation_result.batch
         statement_result = self._statement_extraction.extract_source_balance_references(
             profile, raw_dir
         )
@@ -197,6 +211,7 @@ class NormalizeSourceUseCase:
                     issues_outside_window=issues_outside_window,
                     reviews_outside_window=reviews_outside_window,
                 ),
+                translation_metrics=translation_result.metrics,
             ),
         )
         append_capture_status_record(
@@ -218,6 +233,11 @@ class NormalizeSourceUseCase:
             balance_count=len(balance_snapshots),
             issue_count=len(outputs.issues),
             review_count=len(review_records),
+            translation_candidate_count=translation_result.metrics.translation_candidate_count,
+            translation_selected_count=translation_result.metrics.translation_selected_count,
+            translation_superseded_count=translation_result.metrics.translation_superseded_count,
+            translation_blocked_count=translation_result.metrics.translation_blocked_count,
+            translation_planner_used=translation_result.metrics.translation_planner_used,
         )
 
 

--- a/src/tallylot/application/normalization/summary.py
+++ b/src/tallylot/application/normalization/summary.py
@@ -6,6 +6,9 @@ from collections import Counter
 from typing import cast
 
 from tallylot.application.normalization.contracts import NormalizeRequest
+from tallylot.application.normalization.models import (
+    NormalizationTranslationMetrics,
+)
 from tallylot.domain.issues import NormalizationReviewRecord
 from tallylot.domain.types import JsonValue
 from tallylot.ports.source_profiles import SourceProfile
@@ -19,6 +22,7 @@ def build_normalization_summary(
     profile: SourceProfile,
     outputs: NormalizationOutputs,
     window_stats: NormalizationWindowStats,
+    translation_metrics: NormalizationTranslationMetrics,
 ) -> JsonValue:
     return cast(
         JsonValue,
@@ -38,6 +42,11 @@ def build_normalization_summary(
             "reviews_outside_normalization_window": window_stats.reviews_outside_window,
             "normalization_window_start": request.window_start or "",
             "normalization_window_end": request.window_end or "",
+            "translation_candidate_count": translation_metrics.translation_candidate_count,
+            "translation_selected_count": translation_metrics.translation_selected_count,
+            "translation_superseded_count": translation_metrics.translation_superseded_count,
+            "translation_blocked_count": translation_metrics.translation_blocked_count,
+            "translation_planner_used": translation_metrics.translation_planner_used,
         },
     )
 

--- a/src/tallylot/application/normalization/translation.py
+++ b/src/tallylot/application/normalization/translation.py
@@ -1,0 +1,78 @@
+"""Translation execution for normalization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from tallylot.application.normalization.models import NormalizationTranslationMetrics
+from tallylot.application.normalization.translation_inputs import (
+    plan_translation_inputs,
+    translation_metrics_from_result,
+    write_translation_input_artifacts,
+)
+from tallylot.ports.artifacts import ArtifactStorePort
+from tallylot.ports.captures import CaptureMetadata
+from tallylot.ports.evidence import EvidenceRepositoryPort
+from tallylot.ports.source_adapters import SourceAdapter
+from tallylot.ports.source_profiles import SourceProfile
+from tallylot.ports.source_translation import SourceTranslationBatch
+from tallylot.ports.translation_inputs import TranslationInputPlanningAdapter
+
+
+@dataclass(frozen=True)
+class TranslationExecutionResult:
+    batch: SourceTranslationBatch
+    metrics: NormalizationTranslationMetrics
+
+
+def execute_translation(
+    *,
+    adapter: SourceAdapter,
+    profile: SourceProfile,
+    raw_dir: Path,
+    output_dir: Path,
+    capture_metadata: CaptureMetadata | None,
+    artifacts: ArtifactStorePort,
+    evidence: EvidenceRepositoryPort,
+) -> TranslationExecutionResult:
+    if not isinstance(adapter, TranslationInputPlanningAdapter):
+        return TranslationExecutionResult(
+            batch=adapter.translate(profile, raw_dir),
+            metrics=NormalizationTranslationMetrics(
+                translation_candidate_count=0,
+                translation_selected_count=0,
+                translation_superseded_count=0,
+                translation_blocked_count=0,
+                translation_planner_used=False,
+            ),
+        )
+
+    planning_result = plan_translation_inputs(
+        profile=profile,
+        candidates=adapter.describe_translation_inputs(profile, raw_dir),
+        capture_metadata=capture_metadata,
+    )
+    write_translation_input_artifacts(
+        artifacts,
+        evidence,
+        output_dir,
+        profile=profile,
+        capture_metadata=capture_metadata,
+        result=planning_result,
+    )
+    metrics = translation_metrics_from_result(planning_result, planner_used=True)
+    if planning_result.plan.blocked:
+        raise ValueError(
+            "translation input planning blocked normalization; inspect "
+            f"{output_dir / 'translation_input_plan.json'} and "
+            f"{output_dir / 'translation_input_issues.csv'}"
+        )
+    return TranslationExecutionResult(
+        batch=adapter.translate_selected_inputs(
+            profile,
+            raw_dir,
+            planning_result.plan,
+        ),
+        metrics=metrics,
+    )

--- a/src/tallylot/application/normalization/translation.py
+++ b/src/tallylot/application/normalization/translation.py
@@ -9,6 +9,9 @@ from tallylot.application.normalization.models import NormalizationTranslationMe
 from tallylot.application.normalization.translation_inputs import (
     plan_translation_inputs,
     translation_metrics_from_result,
+)
+from tallylot.application.normalization.translation_inputs.artifacts import (
+    TranslationArtifactContext,
     write_translation_input_artifacts,
 )
 from tallylot.ports.artifacts import ArtifactStorePort
@@ -26,15 +29,20 @@ class TranslationExecutionResult:
     metrics: NormalizationTranslationMetrics
 
 
+@dataclass(frozen=True)
+class TranslationExecutionContext:
+    output_dir: Path
+    capture_metadata: CaptureMetadata | None
+    artifacts: ArtifactStorePort
+    evidence: EvidenceRepositoryPort
+
+
 def execute_translation(
     *,
     adapter: SourceAdapter,
     profile: SourceProfile,
     raw_dir: Path,
-    output_dir: Path,
-    capture_metadata: CaptureMetadata | None,
-    artifacts: ArtifactStorePort,
-    evidence: EvidenceRepositoryPort,
+    context: TranslationExecutionContext,
 ) -> TranslationExecutionResult:
     if not isinstance(adapter, TranslationInputPlanningAdapter):
         return TranslationExecutionResult(
@@ -51,22 +59,24 @@ def execute_translation(
     planning_result = plan_translation_inputs(
         profile=profile,
         candidates=adapter.describe_translation_inputs(profile, raw_dir),
-        capture_metadata=capture_metadata,
+        capture_metadata=context.capture_metadata,
     )
     write_translation_input_artifacts(
-        artifacts,
-        evidence,
-        output_dir,
-        profile=profile,
-        capture_metadata=capture_metadata,
+        artifacts=context.artifacts,
+        evidence=context.evidence,
+        context=TranslationArtifactContext(
+            output_dir=context.output_dir,
+            profile=profile,
+            capture_metadata=context.capture_metadata,
+        ),
         result=planning_result,
     )
     metrics = translation_metrics_from_result(planning_result, planner_used=True)
     if planning_result.plan.blocked:
         raise ValueError(
             "translation input planning blocked normalization; inspect "
-            f"{output_dir / 'translation_input_plan.json'} and "
-            f"{output_dir / 'translation_input_issues.csv'}"
+            f"{context.output_dir / 'translation_input_plan.json'} and "
+            f"{context.output_dir / 'translation_input_issues.csv'}"
         )
     return TranslationExecutionResult(
         batch=adapter.translate_selected_inputs(

--- a/src/tallylot/application/normalization/translation_inputs/__init__.py
+++ b/src/tallylot/application/normalization/translation_inputs/__init__.py
@@ -1,0 +1,17 @@
+"""Translation input planning for source normalization."""
+
+from .artifacts import write_translation_input_artifacts
+from .models import (
+    PLANNER_VERSION,
+    TranslationInputPlanningResult,
+)
+from .planner import (
+    plan_translation_inputs,
+)
+
+__all__ = [
+    "PLANNER_VERSION",
+    "TranslationInputPlanningResult",
+    "plan_translation_inputs",
+    "write_translation_input_artifacts",
+]

--- a/src/tallylot/application/normalization/translation_inputs/__init__.py
+++ b/src/tallylot/application/normalization/translation_inputs/__init__.py
@@ -4,6 +4,7 @@ from .artifacts import write_translation_input_artifacts
 from .models import (
     PLANNER_VERSION,
     TranslationInputPlanningResult,
+    translation_metrics_from_result,
 )
 from .planner import (
     plan_translation_inputs,
@@ -13,5 +14,6 @@ __all__ = [
     "PLANNER_VERSION",
     "TranslationInputPlanningResult",
     "plan_translation_inputs",
+    "translation_metrics_from_result",
     "write_translation_input_artifacts",
 ]

--- a/src/tallylot/application/normalization/translation_inputs/artifacts.py
+++ b/src/tallylot/application/normalization/translation_inputs/artifacts.py
@@ -1,0 +1,125 @@
+"""Translation input planning artifact writers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import cast
+
+from tallylot.application.normalization.translation_inputs.models import (
+    PLANNER_VERSION,
+    TranslationInputPlanningResult,
+)
+from tallylot.domain.value_objects import format_timestamp
+from tallylot.domain.types import JsonValue
+from tallylot.ports.artifacts import ArtifactStorePort
+from tallylot.ports.captures import CaptureMetadata
+from tallylot.ports.evidence import EvidenceRepositoryPort
+from tallylot.ports.source_profiles import SourceProfile
+from tallylot.ports.translation_inputs import (
+    TranslationInputCandidate,
+    TranslationPlanDecision,
+)
+
+
+def write_translation_input_artifacts(
+    artifacts: ArtifactStorePort,
+    evidence: EvidenceRepositoryPort,
+    output_dir: Path,
+    *,
+    profile: SourceProfile,
+    capture_metadata: CaptureMetadata | None,
+    result: TranslationInputPlanningResult,
+) -> None:
+    artifacts.write_json(
+        output_dir / "translation_input_candidates.json",
+        cast(
+            JsonValue,
+            {
+                "planner_version": PLANNER_VERSION,
+                "adapter_id": str(profile.adapter_id),
+                "capture_uid": _capture_uid(profile, capture_metadata),
+                "candidates": [
+                    _candidate_to_json(candidate) for candidate in result.candidates
+                ],
+            },
+        ),
+    )
+    artifacts.write_json(
+        output_dir / "translation_input_plan.json",
+        cast(
+            JsonValue,
+            {
+                "planner_version": PLANNER_VERSION,
+                "adapter_id": str(profile.adapter_id),
+                "capture_uid": _capture_uid(profile, capture_metadata),
+                "selected_candidate_ids": list(result.plan.selected_candidate_ids),
+                "decisions": [
+                    _decision_to_json(decision) for decision in result.plan.decisions
+                ],
+                "blocked": result.plan.blocked,
+            },
+        ),
+    )
+    evidence.write_issue_records(
+        output_dir / "translation_input_issues.csv",
+        result.issues,
+    )
+
+
+def _candidate_to_json(candidate: TranslationInputCandidate) -> dict[str, object]:
+    return {
+        "candidate_id": candidate.candidate_id,
+        "selection_group": candidate.selection_group,
+        "family_id": candidate.family_id,
+        "member_relative_paths": list(candidate.member_relative_paths),
+        "selection_mode": candidate.selection_mode.value,
+        "coverage": {
+            "start_at": _optional_timestamp(candidate.coverage.start_at),
+            "start_precision": _optional_text(candidate.coverage.start_precision),
+            "end_at": _optional_timestamp(candidate.coverage.end_at),
+            "end_precision": _optional_text(candidate.coverage.end_precision),
+            "mode": candidate.coverage.mode.value,
+        },
+        "freshness": {
+            "kind": candidate.freshness.kind.value,
+            "timestamp": _optional_timestamp(candidate.freshness.timestamp),
+            "rank": candidate.freshness.rank,
+        },
+        "content_fingerprint": candidate.content_fingerprint,
+        "comparison_key": candidate.comparison_key,
+        "description": candidate.description,
+        "comparable": candidate.comparable,
+        "notes": list(candidate.notes),
+    }
+
+
+def _decision_to_json(decision: TranslationPlanDecision) -> dict[str, object]:
+    return {
+        "candidate_id": decision.candidate_id,
+        "status": decision.status,
+        "reason": decision.reason,
+        "replaces_candidate_ids": list(decision.replaces_candidate_ids),
+        "conflicts_with_candidate_ids": list(decision.conflicts_with_candidate_ids),
+    }
+
+
+def _capture_uid(
+    profile: SourceProfile,
+    capture_metadata: CaptureMetadata | None,
+) -> str:
+    if capture_metadata is not None:
+        return str(capture_metadata.capture_uid)
+    return profile.metadata.get("capture_uid", "")
+
+
+def _optional_timestamp(value: object) -> str:
+    if value is None:
+        return ""
+    return format_timestamp(cast(datetime, value))
+
+
+def _optional_text(value: object) -> str:
+    if value is None:
+        return ""
+    return str(value)

--- a/src/tallylot/application/normalization/translation_inputs/artifacts.py
+++ b/src/tallylot/application/normalization/translation_inputs/artifacts.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 from typing import cast
@@ -22,23 +23,31 @@ from tallylot.ports.translation_inputs import (
 )
 
 
+@dataclass(frozen=True)
+class TranslationArtifactContext:
+    output_dir: Path
+    profile: SourceProfile
+    capture_metadata: CaptureMetadata | None
+
+
 def write_translation_input_artifacts(
+    *,
     artifacts: ArtifactStorePort,
     evidence: EvidenceRepositoryPort,
-    output_dir: Path,
-    *,
-    profile: SourceProfile,
-    capture_metadata: CaptureMetadata | None,
+    context: TranslationArtifactContext,
     result: TranslationInputPlanningResult,
 ) -> None:
     artifacts.write_json(
-        output_dir / "translation_input_candidates.json",
+        context.output_dir / "translation_input_candidates.json",
         cast(
             JsonValue,
             {
                 "planner_version": PLANNER_VERSION,
-                "adapter_id": str(profile.adapter_id),
-                "capture_uid": _capture_uid(profile, capture_metadata),
+                "adapter_id": str(context.profile.adapter_id),
+                "capture_uid": _capture_uid(
+                    context.profile,
+                    context.capture_metadata,
+                ),
                 "candidates": [
                     _candidate_to_json(candidate) for candidate in result.candidates
                 ],
@@ -46,13 +55,16 @@ def write_translation_input_artifacts(
         ),
     )
     artifacts.write_json(
-        output_dir / "translation_input_plan.json",
+        context.output_dir / "translation_input_plan.json",
         cast(
             JsonValue,
             {
                 "planner_version": PLANNER_VERSION,
-                "adapter_id": str(profile.adapter_id),
-                "capture_uid": _capture_uid(profile, capture_metadata),
+                "adapter_id": str(context.profile.adapter_id),
+                "capture_uid": _capture_uid(
+                    context.profile,
+                    context.capture_metadata,
+                ),
                 "selected_candidate_ids": list(result.plan.selected_candidate_ids),
                 "decisions": [
                     _decision_to_json(decision) for decision in result.plan.decisions
@@ -62,7 +74,7 @@ def write_translation_input_artifacts(
         ),
     )
     evidence.write_issue_records(
-        output_dir / "translation_input_issues.csv",
+        context.output_dir / "translation_input_issues.csv",
         result.issues,
     )
 

--- a/src/tallylot/application/normalization/translation_inputs/freshness.py
+++ b/src/tallylot/application/normalization/translation_inputs/freshness.py
@@ -1,0 +1,83 @@
+"""Freshness ordering helpers for translation input planning."""
+
+from __future__ import annotations
+
+from datetime import UTC
+
+from tallylot.ports.translation_inputs import (
+    TranslationFreshness,
+    TranslationFreshnessKind,
+    TranslationInputCandidate,
+)
+
+_FRESHNESS_KIND_PRECEDENCE = {
+    TranslationFreshnessKind.EXPORT_TIMESTAMP: 3,
+    TranslationFreshnessKind.CAPTURE_COMPLETED_AT: 2,
+    TranslationFreshnessKind.ADAPTER_RANK: 1,
+    TranslationFreshnessKind.UNKNOWN: 0,
+}
+
+
+def all_identical_candidates(
+    candidates: tuple[TranslationInputCandidate, ...],
+) -> bool:
+    first = candidates[0]
+    return all(
+        candidate.coverage == first.coverage
+        and candidate.content_fingerprint == first.content_fingerprint
+        for candidate in candidates[1:]
+    )
+
+
+def freshest_candidates(
+    candidates: tuple[TranslationInputCandidate, ...],
+) -> tuple[TranslationInputCandidate, ...]:
+    if not candidates:
+        return ()
+    highest_key = max(
+        freshness_sort_key(candidate.freshness) for candidate in candidates
+    )
+    return tuple(
+        candidate
+        for candidate in candidates
+        if freshness_sort_key(candidate.freshness) == highest_key
+    )
+
+
+def deterministic_duplicate_winner(
+    candidates: tuple[TranslationInputCandidate, ...],
+) -> TranslationInputCandidate:
+    return sorted(
+        candidates,
+        key=lambda candidate: (
+            -freshness_precedence(candidate.freshness.kind),
+            -freshness_sort_numeric_value(candidate.freshness),
+            candidate.candidate_id,
+        ),
+    )[0]
+
+
+def freshness_precedence(kind: TranslationFreshnessKind) -> int:
+    return _FRESHNESS_KIND_PRECEDENCE[kind]
+
+
+def freshness_sort_key(
+    freshness: TranslationFreshness,
+) -> tuple[int, float]:
+    return (
+        freshness_precedence(freshness.kind),
+        freshness_sort_numeric_value(freshness),
+    )
+
+
+def freshness_sort_numeric_value(freshness: TranslationFreshness) -> float:
+    if freshness.kind in {
+        TranslationFreshnessKind.EXPORT_TIMESTAMP,
+        TranslationFreshnessKind.CAPTURE_COMPLETED_AT,
+    }:
+        if freshness.timestamp is None:
+            return float("-inf")
+        return freshness.timestamp.astimezone(UTC).timestamp()
+    if freshness.kind is TranslationFreshnessKind.ADAPTER_RANK:
+        return float("-inf") if freshness.rank is None else float(freshness.rank)
+    return float("-inf")

--- a/src/tallylot/application/normalization/translation_inputs/models.py
+++ b/src/tallylot/application/normalization/translation_inputs/models.py
@@ -15,6 +15,9 @@ from tallylot.ports.translation_inputs import (
     TranslationPlanDecision,
 )
 
+from .freshness import freshness_precedence, freshness_sort_numeric_value
+from .overlap import MAX_COVERAGE_BOUND, MIN_COVERAGE_BOUND
+
 PLANNER_VERSION = "translation-input-planner-v1"
 
 
@@ -84,9 +87,6 @@ def build_translation_plan(
 def selected_candidate_sort_key(
     candidate: TranslationInputCandidate,
 ) -> tuple[object, ...]:
-    from .freshness import freshness_precedence, freshness_sort_numeric_value
-    from .overlap import MAX_COVERAGE_BOUND, MIN_COVERAGE_BOUND
-
     return (
         candidate.coverage.start_at or MIN_COVERAGE_BOUND,
         candidate.coverage.end_at or MAX_COVERAGE_BOUND,

--- a/src/tallylot/application/normalization/translation_inputs/models.py
+++ b/src/tallylot/application/normalization/translation_inputs/models.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from tallylot.application.normalization.models import (
+    NormalizationTranslationMetrics,
+)
 from tallylot.domain.issues import IssueRecord
 from tallylot.ports.source_profiles import FileInventoryEntry
 from tallylot.ports.translation_inputs import (
@@ -31,6 +34,28 @@ class CandidateContext:
     @property
     def valid(self) -> bool:
         return not self.validation_errors
+
+
+def translation_metrics_from_result(
+    result: TranslationInputPlanningResult,
+    *,
+    planner_used: bool,
+) -> NormalizationTranslationMetrics:
+    return NormalizationTranslationMetrics(
+        translation_candidate_count=len(result.candidates),
+        translation_selected_count=len(result.plan.selected_candidate_ids),
+        translation_superseded_count=sum(
+            1
+            for decision in result.plan.decisions
+            if decision.status in {"superseded_identical", "superseded_replaced"}
+        ),
+        translation_blocked_count=sum(
+            1
+            for decision in result.plan.decisions
+            if decision.status.startswith("blocked")
+        ),
+        translation_planner_used=planner_used,
+    )
 
 
 def build_translation_plan(

--- a/src/tallylot/application/normalization/translation_inputs/models.py
+++ b/src/tallylot/application/normalization/translation_inputs/models.py
@@ -1,0 +1,71 @@
+"""Translation input planning result models."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tallylot.domain.issues import IssueRecord
+from tallylot.ports.source_profiles import FileInventoryEntry
+from tallylot.ports.translation_inputs import (
+    TranslationInputCandidate,
+    TranslationInputPlan,
+    TranslationPlanDecision,
+)
+
+PLANNER_VERSION = "translation-input-planner-v1"
+
+
+@dataclass(frozen=True)
+class TranslationInputPlanningResult:
+    candidates: tuple[TranslationInputCandidate, ...]
+    plan: TranslationInputPlan
+    issues: tuple[IssueRecord, ...]
+
+
+@dataclass(frozen=True)
+class CandidateContext:
+    candidate: TranslationInputCandidate
+    member_entries: tuple[FileInventoryEntry, ...]
+    validation_errors: tuple[str, ...]
+
+    @property
+    def valid(self) -> bool:
+        return not self.validation_errors
+
+
+def build_translation_plan(
+    *,
+    contexts: dict[str, CandidateContext],
+    decisions: dict[str, TranslationPlanDecision],
+) -> TranslationInputPlan:
+    return TranslationInputPlan(
+        selected_candidate_ids=tuple(
+            candidate_id
+            for candidate_id, decision in sorted(
+                decisions.items(),
+                key=lambda item: selected_candidate_sort_key(
+                    contexts[item[0]].candidate
+                ),
+            )
+            if decision.status == "selected"
+        ),
+        decisions=tuple(decisions[candidate_id] for candidate_id in sorted(decisions)),
+        blocked=any(
+            decision.status.startswith("blocked") for decision in decisions.values()
+        ),
+    )
+
+
+def selected_candidate_sort_key(
+    candidate: TranslationInputCandidate,
+) -> tuple[object, ...]:
+    from .freshness import freshness_precedence, freshness_sort_numeric_value
+    from .overlap import MAX_COVERAGE_BOUND, MIN_COVERAGE_BOUND
+
+    return (
+        candidate.coverage.start_at or MIN_COVERAGE_BOUND,
+        candidate.coverage.end_at or MAX_COVERAGE_BOUND,
+        -freshness_precedence(candidate.freshness.kind),
+        -freshness_sort_numeric_value(candidate.freshness),
+        candidate.candidate_id,
+    )

--- a/src/tallylot/application/normalization/translation_inputs/overlap.py
+++ b/src/tallylot/application/normalization/translation_inputs/overlap.py
@@ -1,0 +1,109 @@
+"""Coverage overlap helpers for translation input planning."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from itertools import combinations
+from typing import Literal
+
+from tallylot.ports.translation_inputs import (
+    TranslationCoverageMode,
+    TranslationCoverageWindow,
+    TranslationInputCandidate,
+)
+
+MIN_COVERAGE_BOUND = datetime.min.replace(tzinfo=UTC)
+MAX_COVERAGE_BOUND = datetime.max.replace(tzinfo=UTC)
+
+CoverageRelation = Literal[
+    "disjoint", "equal", "contains", "within", "partial", "unknown"
+]
+
+
+def coverage_bounds(
+    coverage: TranslationCoverageWindow,
+) -> tuple[datetime, datetime] | None:
+    if coverage.mode is TranslationCoverageMode.UNKNOWN:
+        return None
+    return (
+        coverage.start_at or MIN_COVERAGE_BOUND,
+        coverage.end_at or MAX_COVERAGE_BOUND,
+    )
+
+
+def coverage_relation(
+    left: TranslationCoverageWindow,
+    right: TranslationCoverageWindow,
+) -> CoverageRelation:
+    left_bounds = coverage_bounds(left)
+    right_bounds = coverage_bounds(right)
+    if left_bounds is None or right_bounds is None:
+        return "unknown"
+    left_start, left_end = left_bounds
+    right_start, right_end = right_bounds
+    if left_end < right_start or right_end < left_start:
+        return "disjoint"
+    if left_bounds == right_bounds and left.mode is right.mode:
+        return "equal"
+    if left_start <= right_start and left_end >= right_end:
+        return "contains"
+    if right_start <= left_start and right_end >= left_end:
+        return "within"
+    return "partial"
+
+
+def overlap_components(
+    candidates: tuple[TranslationInputCandidate, ...],
+) -> tuple[tuple[TranslationInputCandidate, ...], ...]:
+    adjacency: dict[str, set[str]] = {
+        candidate.candidate_id: set() for candidate in candidates
+    }
+    candidate_by_id = {candidate.candidate_id: candidate for candidate in candidates}
+    for left, right in combinations(candidates, 2):
+        if coverage_relation(left.coverage, right.coverage) == "disjoint":
+            continue
+        adjacency[left.candidate_id].add(right.candidate_id)
+        adjacency[right.candidate_id].add(left.candidate_id)
+
+    components: list[tuple[TranslationInputCandidate, ...]] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate.candidate_id in seen:
+            continue
+        stack = [candidate.candidate_id]
+        component_ids: list[str] = []
+        while stack:
+            candidate_id = stack.pop()
+            if candidate_id in seen:
+                continue
+            seen.add(candidate_id)
+            component_ids.append(candidate_id)
+            stack.extend(sorted(adjacency[candidate_id] - seen))
+        components.append(
+            tuple(
+                sorted(
+                    (candidate_by_id[candidate_id] for candidate_id in component_ids),
+                    key=lambda item: item.candidate_id,
+                )
+            )
+        )
+    return tuple(components)
+
+
+def winner_contains_all_candidates(
+    *,
+    winner: TranslationInputCandidate,
+    candidates: tuple[TranslationInputCandidate, ...],
+) -> bool:
+    winner_bounds = coverage_bounds(winner.coverage)
+    if winner_bounds is None:
+        return False
+    winner_start, winner_end = winner_bounds
+    for candidate in candidates:
+        candidate_bounds = coverage_bounds(candidate.coverage)
+        if candidate_bounds is None:
+            return False
+        candidate_start, candidate_end = candidate_bounds
+        if winner_start > candidate_start or winner_end < candidate_end:
+            return False
+    return True

--- a/src/tallylot/application/normalization/translation_inputs/planner.py
+++ b/src/tallylot/application/normalization/translation_inputs/planner.py
@@ -72,6 +72,7 @@ def plan_translation_inputs(
                 invalid_group_issues(
                     profile=profile,
                     group_contexts_value=group_contexts_value,
+                    status=failure.status,
                     reason=failure.reason,
                 )
             )
@@ -106,6 +107,7 @@ def plan_translation_inputs(
                 invalid_group_issues(
                     profile=profile,
                     group_contexts_value=group_contexts_value,
+                    status="blocked_invalid_candidate",
                     reason=reason,
                 )
             )

--- a/src/tallylot/application/normalization/translation_inputs/planner.py
+++ b/src/tallylot/application/normalization/translation_inputs/planner.py
@@ -1,0 +1,141 @@
+"""Deterministic translation input planning."""
+
+from __future__ import annotations
+
+from tallylot.domain.issues import IssueRecord
+from tallylot.ports.captures import CaptureMetadata
+from tallylot.ports.source_profiles import SourceProfile
+from tallylot.ports.translation_inputs import (
+    TranslationInputCandidate,
+    TranslationPlanDecision,
+)
+
+from .models import (
+    TranslationInputPlanningResult,
+    build_translation_plan,
+)
+from .selection import invalid_group_issues, plan_group
+from .validation import (
+    group_contexts,
+    group_failures,
+    group_policy,
+    validate_candidates,
+)
+
+
+def plan_translation_inputs(
+    *,
+    profile: SourceProfile,
+    candidates: tuple[TranslationInputCandidate, ...],
+    capture_metadata: CaptureMetadata | None = None,
+) -> TranslationInputPlanningResult:
+    ordered_candidates = tuple(sorted(candidates, key=lambda item: item.candidate_id))
+    contexts = validate_candidates(
+        candidates=ordered_candidates,
+        inventory_by_path={
+            entry.relative_path: entry for entry in profile.file_inventory
+        },
+        capture_metadata=capture_metadata,
+    )
+
+    issues: list[IssueRecord] = []
+    decisions: dict[str, TranslationPlanDecision] = {}
+    failures = group_failures(contexts)
+    for context in contexts.values():
+        if context.valid:
+            continue
+        issues.append(
+            IssueRecord(
+                issue_id=(
+                    f"{profile.adapter_id}:{context.candidate.candidate_id}:"
+                    "blocked_invalid_candidate"
+                ),
+                source=str(profile.source),
+                adapter_id=str(profile.adapter_id),
+                severity="high",
+                kind="blocked_invalid_candidate",
+                message="; ".join(context.validation_errors),
+                raw_file=(
+                    context.candidate.member_relative_paths[0]
+                    if context.candidate.member_relative_paths
+                    else ""
+                ),
+                status="needs_review",
+            )
+        )
+
+    for group_id, group_contexts_value in group_contexts(contexts).items():
+        group_candidates = tuple(context.candidate for context in group_contexts_value)
+        failure = failures.get(group_id)
+        if failure is not None:
+            issues.extend(
+                invalid_group_issues(
+                    profile=profile,
+                    group_contexts_value=group_contexts_value,
+                    reason=failure.reason,
+                )
+            )
+            for context in group_contexts_value:
+                reason = (
+                    "; ".join(context.validation_errors)
+                    if context.validation_errors
+                    else failure.reason
+                )
+                decisions[context.candidate.candidate_id] = TranslationPlanDecision(
+                    candidate_id=context.candidate.candidate_id,
+                    status=failure.status,
+                    reason=reason,
+                    conflicts_with_candidate_ids=tuple(
+                        sorted(
+                            candidate.candidate_id
+                            for candidate in group_candidates
+                            if candidate.candidate_id != context.candidate.candidate_id
+                        )
+                    ),
+                )
+            continue
+
+        policy = group_policy(group_candidates)
+        if policy is None:
+            reason = (
+                "translation input candidates in the same selection group must share "
+                "appendable_range or replaceable_range semantics, unless the group "
+                "contains exclusive_snapshot candidates"
+            )
+            issues.extend(
+                invalid_group_issues(
+                    profile=profile,
+                    group_contexts_value=group_contexts_value,
+                    reason=reason,
+                )
+            )
+            for context in group_contexts_value:
+                decisions[context.candidate.candidate_id] = TranslationPlanDecision(
+                    candidate_id=context.candidate.candidate_id,
+                    status="blocked_invalid_candidate",
+                    reason=reason,
+                    conflicts_with_candidate_ids=tuple(
+                        sorted(
+                            candidate.candidate_id
+                            for candidate in group_candidates
+                            if candidate.candidate_id != context.candidate.candidate_id
+                        )
+                    ),
+                )
+            continue
+
+        planned_group = plan_group(
+            profile=profile,
+            candidates=group_candidates,
+            selection_mode=policy,
+        )
+        issues.extend(planned_group.issues)
+        decisions.update(
+            {decision.candidate_id: decision for decision in planned_group.decisions}
+        )
+
+    return TranslationInputPlanningResult(
+        candidates=ordered_candidates,
+        plan=build_translation_plan(contexts=contexts, decisions=decisions),
+        issues=tuple(issues),
+    )

--- a/src/tallylot/application/normalization/translation_inputs/selection.py
+++ b/src/tallylot/application/normalization/translation_inputs/selection.py
@@ -1,0 +1,307 @@
+"""Translation input group selection rules."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from tallylot.domain.issues import IssueRecord
+from tallylot.ports.source_profiles import SourceProfile
+from tallylot.ports.translation_inputs import (
+    TranslationInputCandidate,
+    TranslationPlanDecision,
+    TranslationPlanDecisionStatus,
+    TranslationSelectionMode,
+)
+
+from .freshness import (
+    all_identical_candidates,
+    deterministic_duplicate_winner,
+    freshest_candidates,
+)
+from .models import CandidateContext
+from .overlap import overlap_components, winner_contains_all_candidates
+
+
+@dataclass(frozen=True)
+class PlannedGroup:
+    decisions: tuple[TranslationPlanDecision, ...]
+    issues: tuple[IssueRecord, ...]
+
+
+def plan_group(
+    *,
+    profile: SourceProfile,
+    candidates: tuple[TranslationInputCandidate, ...],
+    selection_mode: TranslationSelectionMode,
+) -> PlannedGroup:
+    if selection_mode is TranslationSelectionMode.EXCLUSIVE_SNAPSHOT:
+        return plan_exclusive_group(profile=profile, candidates=candidates)
+
+    decisions: list[TranslationPlanDecision] = []
+    issues: list[IssueRecord] = []
+    for component in overlap_components(candidates):
+        planned_component = plan_overlap_component(
+            profile=profile,
+            candidates=component,
+            selection_mode=selection_mode,
+        )
+        decisions.extend(planned_component.decisions)
+        issues.extend(planned_component.issues)
+    return PlannedGroup(decisions=tuple(decisions), issues=tuple(issues))
+
+
+def plan_exclusive_group(
+    *,
+    profile: SourceProfile,
+    candidates: tuple[TranslationInputCandidate, ...],
+) -> PlannedGroup:
+    if len(candidates) == 1:
+        candidate = candidates[0]
+        return PlannedGroup(
+            decisions=(
+                TranslationPlanDecision(
+                    candidate_id=candidate.candidate_id,
+                    status="selected",
+                    reason="exclusive snapshot group contains one candidate",
+                ),
+            ),
+            issues=(),
+        )
+
+    freshest = freshest_candidates(candidates)
+    if len(freshest) != 1 and not all_identical_candidates(candidates):
+        return blocked_group(
+            profile=profile,
+            candidates=candidates,
+            status="blocked_ambiguous_freshness",
+            reason="exclusive snapshot candidates do not have a unique freshest winner",
+        )
+    winner = deterministic_duplicate_winner(freshest or candidates)
+    return build_supersession_plan(
+        profile=profile,
+        candidates=candidates,
+        winner=winner,
+    )
+
+
+def plan_overlap_component(
+    *,
+    profile: SourceProfile,
+    candidates: tuple[TranslationInputCandidate, ...],
+    selection_mode: TranslationSelectionMode,
+) -> PlannedGroup:
+    if len(candidates) == 1:
+        candidate = candidates[0]
+        return PlannedGroup(
+            decisions=(
+                TranslationPlanDecision(
+                    candidate_id=candidate.candidate_id,
+                    status="selected",
+                    reason="candidate is disjoint within its selection group",
+                ),
+            ),
+            issues=(),
+        )
+    if any(not candidate.comparable for candidate in candidates):
+        return blocked_group(
+            profile=profile,
+            candidates=candidates,
+            status="blocked_incomparable_candidates",
+            reason="overlapping candidates are marked incomparable by the adapter",
+        )
+    if len({candidate.comparison_key for candidate in candidates}) != 1:
+        return blocked_group(
+            profile=profile,
+            candidates=candidates,
+            status="blocked_incomparable_candidates",
+            reason="overlapping candidates do not share a comparison key",
+        )
+    if selection_mode is TranslationSelectionMode.APPENDABLE_RANGE:
+        if not all_identical_candidates(candidates):
+            return blocked_group(
+                profile=profile,
+                candidates=candidates,
+                status="blocked_partial_overlap",
+                reason=(
+                    "appendable range candidates overlap and cannot be merged without "
+                    "an exact identical replacement"
+                ),
+            )
+        winner = deterministic_duplicate_winner(
+            freshest_candidates(candidates) or candidates
+        )
+        return build_supersession_plan(
+            profile=profile,
+            candidates=candidates,
+            winner=winner,
+        )
+
+    freshest = freshest_candidates(candidates)
+    if len(freshest) != 1 and not all_identical_candidates(candidates):
+        return blocked_group(
+            profile=profile,
+            candidates=candidates,
+            status="blocked_ambiguous_freshness",
+            reason="replaceable range candidates do not have a unique freshest winner",
+        )
+    winner = deterministic_duplicate_winner(freshest or candidates)
+    if not winner_contains_all_candidates(winner=winner, candidates=candidates):
+        return blocked_group(
+            profile=profile,
+            candidates=candidates,
+            status="blocked_partial_overlap",
+            reason=(
+                "replaceable range candidates overlap, but the freshest winner does "
+                "not fully supersede the overlapping set"
+            ),
+        )
+    return build_supersession_plan(
+        profile=profile,
+        candidates=candidates,
+        winner=winner,
+    )
+
+
+def invalid_group_issues(
+    *,
+    profile: SourceProfile,
+    group_contexts_value: tuple[CandidateContext, ...],
+    reason: str,
+) -> tuple[IssueRecord, ...]:
+    candidate_ids = tuple(
+        sorted(context.candidate.candidate_id for context in group_contexts_value)
+    )
+    return tuple(
+        issue_for_candidate(
+            profile=profile,
+            candidate=context.candidate,
+            status="blocked_invalid_candidate",
+            reason=reason,
+            conflicts_with_candidate_ids=tuple(
+                candidate_id
+                for candidate_id in candidate_ids
+                if candidate_id != context.candidate.candidate_id
+            ),
+        )
+        for context in group_contexts_value
+    )
+
+
+def blocked_group(
+    *,
+    profile: SourceProfile,
+    candidates: tuple[TranslationInputCandidate, ...],
+    status: TranslationPlanDecisionStatus,
+    reason: str,
+) -> PlannedGroup:
+    return PlannedGroup(
+        decisions=tuple(
+            TranslationPlanDecision(
+                candidate_id=candidate.candidate_id,
+                status=status,
+                reason=reason,
+                conflicts_with_candidate_ids=tuple(
+                    sorted(
+                        other.candidate_id
+                        for other in candidates
+                        if other.candidate_id != candidate.candidate_id
+                    )
+                ),
+            )
+            for candidate in candidates
+        ),
+        issues=tuple(
+            issue_for_candidate(
+                profile=profile,
+                candidate=candidate,
+                status=status,
+                reason=reason,
+                conflicts_with_candidate_ids=tuple(
+                    sorted(
+                        other.candidate_id
+                        for other in candidates
+                        if other.candidate_id != candidate.candidate_id
+                    )
+                ),
+            )
+            for candidate in candidates
+        ),
+    )
+
+
+def issue_for_candidate(
+    *,
+    profile: SourceProfile,
+    candidate: TranslationInputCandidate,
+    status: TranslationPlanDecisionStatus,
+    reason: str,
+    conflicts_with_candidate_ids: tuple[str, ...] = (),
+    replaces_candidate_ids: tuple[str, ...] = (),
+) -> IssueRecord:
+    candidate_path = (
+        candidate.member_relative_paths[0] if candidate.member_relative_paths else ""
+    )
+    conflict_text = ""
+    if conflicts_with_candidate_ids:
+        conflict_text = f" Conflicts: {', '.join(conflicts_with_candidate_ids)}."
+    replace_text = ""
+    if replaces_candidate_ids:
+        replace_text = f" Replaces: {', '.join(replaces_candidate_ids)}."
+    return IssueRecord(
+        issue_id=f"{profile.adapter_id}:{candidate.candidate_id}:{status}",
+        source=str(profile.source),
+        adapter_id=str(profile.adapter_id),
+        severity="high",
+        kind=status,
+        message=f"{reason}{replace_text}{conflict_text}",
+        raw_file=candidate_path,
+        status="needs_review",
+    )
+
+
+def build_supersession_plan(
+    *,
+    profile: SourceProfile,
+    candidates: tuple[TranslationInputCandidate, ...],
+    winner: TranslationInputCandidate,
+) -> PlannedGroup:
+    replaced_candidate_ids = tuple(
+        sorted(
+            candidate.candidate_id
+            for candidate in candidates
+            if candidate.candidate_id != winner.candidate_id
+        )
+    )
+    decisions: list[TranslationPlanDecision] = [
+        TranslationPlanDecision(
+            candidate_id=winner.candidate_id,
+            status="selected",
+            reason="winner selected for deterministic translation input planning",
+            replaces_candidate_ids=replaced_candidate_ids,
+        )
+    ]
+    for candidate in candidates:
+        if candidate.candidate_id == winner.candidate_id:
+            continue
+        decisions.append(
+            TranslationPlanDecision(
+                candidate_id=candidate.candidate_id,
+                status=superseded_status(candidate, winner),
+                reason="superseded by the selected translation input candidate",
+                conflicts_with_candidate_ids=(winner.candidate_id,),
+            )
+        )
+    return PlannedGroup(decisions=tuple(decisions), issues=())
+
+
+def superseded_status(
+    candidate: TranslationInputCandidate,
+    winner: TranslationInputCandidate,
+) -> Literal["superseded_identical", "superseded_replaced"]:
+    if (
+        candidate.coverage == winner.coverage
+        and candidate.content_fingerprint == winner.content_fingerprint
+    ):
+        return "superseded_identical"
+    return "superseded_replaced"

--- a/src/tallylot/application/normalization/translation_inputs/selection.py
+++ b/src/tallylot/application/normalization/translation_inputs/selection.py
@@ -167,6 +167,7 @@ def invalid_group_issues(
     *,
     profile: SourceProfile,
     group_contexts_value: tuple[CandidateContext, ...],
+    status: TranslationPlanDecisionStatus,
     reason: str,
 ) -> tuple[IssueRecord, ...]:
     candidate_ids = tuple(
@@ -176,7 +177,7 @@ def invalid_group_issues(
         issue_for_candidate(
             profile=profile,
             candidate=context.candidate,
-            status="blocked_invalid_candidate",
+            status=status,
             reason=reason,
             conflicts_with_candidate_ids=tuple(
                 candidate_id

--- a/src/tallylot/application/normalization/translation_inputs/selection.py
+++ b/src/tallylot/application/normalization/translation_inputs/selection.py
@@ -78,11 +78,7 @@ def plan_exclusive_group(
             reason="exclusive snapshot candidates do not have a unique freshest winner",
         )
     winner = deterministic_duplicate_winner(freshest or candidates)
-    return build_supersession_plan(
-        profile=profile,
-        candidates=candidates,
-        winner=winner,
-    )
+    return build_supersession_plan(candidates=candidates, winner=winner)
 
 
 def plan_overlap_component(
@@ -103,64 +99,17 @@ def plan_overlap_component(
             ),
             issues=(),
         )
-    if any(not candidate.comparable for candidate in candidates):
+    incomparability_reason = _incomparability_reason(candidates)
+    if incomparability_reason is not None:
         return blocked_group(
             profile=profile,
             candidates=candidates,
             status="blocked_incomparable_candidates",
-            reason="overlapping candidates are marked incomparable by the adapter",
-        )
-    if len({candidate.comparison_key for candidate in candidates}) != 1:
-        return blocked_group(
-            profile=profile,
-            candidates=candidates,
-            status="blocked_incomparable_candidates",
-            reason="overlapping candidates do not share a comparison key",
+            reason=incomparability_reason,
         )
     if selection_mode is TranslationSelectionMode.APPENDABLE_RANGE:
-        if not all_identical_candidates(candidates):
-            return blocked_group(
-                profile=profile,
-                candidates=candidates,
-                status="blocked_partial_overlap",
-                reason=(
-                    "appendable range candidates overlap and cannot be merged without "
-                    "an exact identical replacement"
-                ),
-            )
-        winner = deterministic_duplicate_winner(
-            freshest_candidates(candidates) or candidates
-        )
-        return build_supersession_plan(
-            profile=profile,
-            candidates=candidates,
-            winner=winner,
-        )
-
-    freshest = freshest_candidates(candidates)
-    if len(freshest) != 1 and not all_identical_candidates(candidates):
-        return blocked_group(
-            profile=profile,
-            candidates=candidates,
-            status="blocked_ambiguous_freshness",
-            reason="replaceable range candidates do not have a unique freshest winner",
-        )
-    winner = deterministic_duplicate_winner(freshest or candidates)
-    if not winner_contains_all_candidates(winner=winner, candidates=candidates):
-        return blocked_group(
-            profile=profile,
-            candidates=candidates,
-            status="blocked_partial_overlap",
-            reason=(
-                "replaceable range candidates overlap, but the freshest winner does "
-                "not fully supersede the overlapping set"
-            ),
-        )
-    return build_supersession_plan(
-        profile=profile,
-        candidates=candidates,
-        winner=winner,
-    )
+        return _plan_appendable_component(profile=profile, candidates=candidates)
+    return _plan_replaceable_component(profile=profile, candidates=candidates)
 
 
 def invalid_group_issues(
@@ -238,7 +187,6 @@ def issue_for_candidate(
     status: TranslationPlanDecisionStatus,
     reason: str,
     conflicts_with_candidate_ids: tuple[str, ...] = (),
-    replaces_candidate_ids: tuple[str, ...] = (),
 ) -> IssueRecord:
     candidate_path = (
         candidate.member_relative_paths[0] if candidate.member_relative_paths else ""
@@ -246,16 +194,13 @@ def issue_for_candidate(
     conflict_text = ""
     if conflicts_with_candidate_ids:
         conflict_text = f" Conflicts: {', '.join(conflicts_with_candidate_ids)}."
-    replace_text = ""
-    if replaces_candidate_ids:
-        replace_text = f" Replaces: {', '.join(replaces_candidate_ids)}."
     return IssueRecord(
         issue_id=f"{profile.adapter_id}:{candidate.candidate_id}:{status}",
         source=str(profile.source),
         adapter_id=str(profile.adapter_id),
         severity="high",
         kind=status,
-        message=f"{reason}{replace_text}{conflict_text}",
+        message=f"{reason}{conflict_text}",
         raw_file=candidate_path,
         status="needs_review",
     )
@@ -263,7 +208,6 @@ def issue_for_candidate(
 
 def build_supersession_plan(
     *,
-    profile: SourceProfile,
     candidates: tuple[TranslationInputCandidate, ...],
     winner: TranslationInputCandidate,
 ) -> PlannedGroup:
@@ -294,6 +238,64 @@ def build_supersession_plan(
             )
         )
     return PlannedGroup(decisions=tuple(decisions), issues=())
+
+
+def _incomparability_reason(
+    candidates: tuple[TranslationInputCandidate, ...],
+) -> str | None:
+    if any(not candidate.comparable for candidate in candidates):
+        return "overlapping candidates are marked incomparable by the adapter"
+    if len({candidate.comparison_key for candidate in candidates}) != 1:
+        return "overlapping candidates do not share a comparison key"
+    return None
+
+
+def _plan_appendable_component(
+    *,
+    profile: SourceProfile,
+    candidates: tuple[TranslationInputCandidate, ...],
+) -> PlannedGroup:
+    if not all_identical_candidates(candidates):
+        return blocked_group(
+            profile=profile,
+            candidates=candidates,
+            status="blocked_partial_overlap",
+            reason=(
+                "appendable range candidates overlap and cannot be merged without "
+                "an exact identical replacement"
+            ),
+        )
+    winner = deterministic_duplicate_winner(
+        freshest_candidates(candidates) or candidates
+    )
+    return build_supersession_plan(candidates=candidates, winner=winner)
+
+
+def _plan_replaceable_component(
+    *,
+    profile: SourceProfile,
+    candidates: tuple[TranslationInputCandidate, ...],
+) -> PlannedGroup:
+    freshest = freshest_candidates(candidates)
+    if len(freshest) != 1 and not all_identical_candidates(candidates):
+        return blocked_group(
+            profile=profile,
+            candidates=candidates,
+            status="blocked_ambiguous_freshness",
+            reason="replaceable range candidates do not have a unique freshest winner",
+        )
+    winner = deterministic_duplicate_winner(freshest or candidates)
+    if not winner_contains_all_candidates(winner=winner, candidates=candidates):
+        return blocked_group(
+            profile=profile,
+            candidates=candidates,
+            status="blocked_partial_overlap",
+            reason=(
+                "replaceable range candidates overlap, but the freshest winner does "
+                "not fully supersede the overlapping set"
+            ),
+        )
+    return build_supersession_plan(candidates=candidates, winner=winner)
 
 
 def superseded_status(

--- a/src/tallylot/application/normalization/translation_inputs/validation.py
+++ b/src/tallylot/application/normalization/translation_inputs/validation.py
@@ -1,0 +1,300 @@
+"""Translation input candidate validation."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import datetime
+from itertools import combinations
+
+from tallylot.domain.value_objects import require_utc_datetime
+from tallylot.ports.captures import CaptureMetadata
+from tallylot.ports.source_profiles import FileInventoryEntry
+from tallylot.ports.translation_inputs import (
+    TranslationCoverageMode,
+    TranslationCoverageWindow,
+    TranslationFreshness,
+    TranslationFreshnessKind,
+    TranslationInputCandidate,
+    TranslationPlanDecisionStatus,
+    TranslationSelectionMode,
+    translation_input_content_fingerprint,
+)
+
+from .models import CandidateContext
+
+
+@dataclass(frozen=True)
+class GroupFailure:
+    status: TranslationPlanDecisionStatus
+    reason: str
+
+
+def validate_candidates(
+    *,
+    candidates: tuple[TranslationInputCandidate, ...],
+    inventory_by_path: dict[str, FileInventoryEntry],
+    capture_metadata: CaptureMetadata | None,
+) -> dict[str, CandidateContext]:
+    duplicate_candidate_ids = duplicated_candidate_ids(candidates)
+    return {
+        candidate.candidate_id: validate_candidate(
+            candidate,
+            inventory_by_path=inventory_by_path,
+            capture_metadata=capture_metadata,
+            duplicate_candidate_ids=duplicate_candidate_ids,
+        )
+        for candidate in candidates
+    }
+
+
+def group_contexts(
+    contexts: dict[str, CandidateContext],
+) -> dict[str, tuple[CandidateContext, ...]]:
+    grouped: dict[str, list[CandidateContext]] = defaultdict(list)
+    for context in contexts.values():
+        grouped[context.candidate.selection_group].append(context)
+    return {
+        group_id: tuple(
+            sorted(group_candidates, key=lambda item: item.candidate.candidate_id)
+        )
+        for group_id, group_candidates in grouped.items()
+    }
+
+
+def group_failures(
+    contexts: dict[str, CandidateContext],
+) -> dict[str, GroupFailure]:
+    failures: dict[str, GroupFailure] = {}
+    for group_id, group_candidates in group_contexts(contexts).items():
+        if any(not context.valid for context in group_candidates):
+            failures[group_id] = GroupFailure(
+                status="blocked_invalid_candidate",
+                reason="candidate validation errors prevent deterministic planning",
+            )
+            continue
+        if len(group_candidates) > 1 and any(
+            context.candidate.coverage.mode is TranslationCoverageMode.UNKNOWN
+            for context in group_candidates
+        ):
+            failures[group_id] = GroupFailure(
+                status="blocked_unknown_coverage",
+                reason=(
+                    "translation input planning cannot compare multiple candidates "
+                    "when any candidate has unknown event-time coverage"
+                ),
+            )
+            continue
+        if has_invalid_member_overlap(group_candidates):
+            failures[group_id] = GroupFailure(
+                status="blocked_invalid_candidate",
+                reason=(
+                    "candidate members overlap inside one selection group without "
+                    "an exact alternative candidate definition"
+                ),
+            )
+    return failures
+
+
+def group_policy(
+    candidates: tuple[TranslationInputCandidate, ...],
+) -> TranslationSelectionMode | None:
+    modes = {candidate.selection_mode for candidate in candidates}
+    if TranslationSelectionMode.EXCLUSIVE_SNAPSHOT in modes:
+        return TranslationSelectionMode.EXCLUSIVE_SNAPSHOT
+    if len(modes) == 1:
+        return next(iter(modes))
+    return None
+
+
+def group_block_reason(group_contexts_value: tuple[CandidateContext, ...]) -> str:
+    candidate_ids = ", ".join(
+        context.candidate.candidate_id for context in group_contexts_value
+    )
+    return f"translation input group is invalid: {candidate_ids}"
+
+
+def validate_candidate(
+    candidate: TranslationInputCandidate,
+    *,
+    inventory_by_path: dict[str, FileInventoryEntry],
+    capture_metadata: CaptureMetadata | None,
+    duplicate_candidate_ids: set[str],
+) -> CandidateContext:
+    member_entries: list[FileInventoryEntry] = []
+    errors: list[str] = []
+    if candidate.candidate_id in duplicate_candidate_ids:
+        errors.append(f"candidate id {candidate.candidate_id!r} is duplicated")
+    if not candidate.selection_group.strip():
+        errors.append("selection_group must be a non-empty string")
+    if not candidate.family_id.strip():
+        errors.append("family_id must be a non-empty string")
+    if not candidate.comparison_key.strip():
+        errors.append("comparison_key must be a non-empty string")
+    if not candidate.description.strip():
+        errors.append("description must be a non-empty string")
+    if not candidate.member_relative_paths:
+        errors.append("candidate must include at least one member path")
+    if len(set(candidate.member_relative_paths)) != len(
+        candidate.member_relative_paths
+    ):
+        errors.append("candidate member paths must be unique")
+    for member_path in candidate.member_relative_paths:
+        entry = inventory_by_path.get(member_path)
+        if entry is None:
+            errors.append(
+                f"member path {member_path!r} was not found in profile inventory"
+            )
+            continue
+        member_entries.append(entry)
+    if candidate.content_fingerprint.strip() == "":
+        errors.append("content_fingerprint must be non-empty")
+    elif member_entries:
+        expected_fingerprint = translation_input_content_fingerprint(
+            member_sha256s=tuple(sorted(entry.sha256 for entry in member_entries)),
+            family_id=candidate.family_id,
+            selection_group=candidate.selection_group,
+            selection_mode=candidate.selection_mode,
+        )
+        if candidate.content_fingerprint != expected_fingerprint:
+            errors.append(
+                "content_fingerprint does not match candidate member inventory"
+            )
+    errors.extend(validate_coverage(candidate.coverage))
+    errors.extend(
+        validate_freshness(
+            candidate.freshness,
+            capture_metadata=capture_metadata,
+        )
+    )
+    return CandidateContext(
+        candidate=candidate,
+        member_entries=tuple(member_entries),
+        validation_errors=tuple(errors),
+    )
+
+
+def validate_coverage(coverage: TranslationCoverageWindow) -> tuple[str, ...]:
+    errors: list[str] = []
+    if coverage.mode is TranslationCoverageMode.UNKNOWN:
+        if any(
+            value is not None
+            for value in (
+                coverage.start_at,
+                coverage.start_precision,
+                coverage.end_at,
+                coverage.end_precision,
+            )
+        ):
+            errors.append("unknown coverage cannot carry bounds or precisions")
+        return tuple(errors)
+    if coverage.mode is TranslationCoverageMode.BOUNDED:
+        if coverage.start_at is None or coverage.end_at is None:
+            errors.append("bounded coverage requires start_at and end_at")
+        if coverage.start_precision is None or coverage.end_precision is None:
+            errors.append("bounded coverage requires start_precision and end_precision")
+    elif coverage.mode is TranslationCoverageMode.UNBOUNDED_START:
+        if coverage.start_at is not None or coverage.start_precision is not None:
+            errors.append("unbounded_start coverage cannot carry a start bound")
+        if coverage.end_at is None or coverage.end_precision is None:
+            errors.append("unbounded_start coverage requires an end bound")
+    elif coverage.mode is TranslationCoverageMode.UNBOUNDED_END:
+        if coverage.end_at is not None or coverage.end_precision is not None:
+            errors.append("unbounded_end coverage cannot carry an end bound")
+        if coverage.start_at is None or coverage.start_precision is None:
+            errors.append("unbounded_end coverage requires a start bound")
+    if coverage.start_at is not None:
+        validate_utc_datetime(coverage.start_at, errors, label="coverage start_at")
+    if coverage.end_at is not None:
+        validate_utc_datetime(coverage.end_at, errors, label="coverage end_at")
+    if (
+        coverage.start_at is not None
+        and coverage.end_at is not None
+        and coverage.start_at > coverage.end_at
+    ):
+        errors.append("coverage start_at must not be after end_at")
+    return tuple(errors)
+
+
+def validate_freshness(
+    freshness: TranslationFreshness,
+    *,
+    capture_metadata: CaptureMetadata | None,
+) -> tuple[str, ...]:
+    errors: list[str] = []
+    if freshness.kind is TranslationFreshnessKind.UNKNOWN:
+        if freshness.timestamp is not None or freshness.rank is not None:
+            errors.append("unknown freshness cannot carry timestamp or rank")
+        return tuple(errors)
+    if freshness.kind in {
+        TranslationFreshnessKind.EXPORT_TIMESTAMP,
+        TranslationFreshnessKind.CAPTURE_COMPLETED_AT,
+    }:
+        if freshness.timestamp is None:
+            errors.append(f"{freshness.kind.value} freshness requires timestamp")
+        if freshness.rank is not None:
+            errors.append(f"{freshness.kind.value} freshness cannot carry rank")
+        if freshness.timestamp is not None:
+            validate_utc_datetime(
+                freshness.timestamp,
+                errors,
+                label=f"{freshness.kind.value} freshness timestamp",
+            )
+    elif freshness.kind is TranslationFreshnessKind.ADAPTER_RANK:
+        if freshness.rank is None:
+            errors.append("adapter_rank freshness requires rank")
+        if freshness.timestamp is not None:
+            errors.append("adapter_rank freshness cannot carry timestamp")
+    if (
+        freshness.kind is TranslationFreshnessKind.CAPTURE_COMPLETED_AT
+        and capture_metadata is not None
+        and freshness.timestamp is not None
+        and freshness.timestamp != capture_metadata.intake_completed_at
+    ):
+        errors.append(
+            "capture_completed_at freshness must match the capture metadata completion time"
+        )
+    return tuple(errors)
+
+
+def validate_utc_datetime(
+    value: datetime,
+    errors: list[str],
+    *,
+    label: str,
+) -> None:
+    try:
+        require_utc_datetime(value, label=label)
+    except ValueError as error:
+        errors.append(str(error))
+
+
+def duplicated_candidate_ids(
+    candidates: tuple[TranslationInputCandidate, ...],
+) -> set[str]:
+    counts: dict[str, int] = defaultdict(int)
+    for candidate in candidates:
+        counts[candidate.candidate_id] += 1
+    return {candidate_id for candidate_id, count in counts.items() if count > 1}
+
+
+def has_invalid_member_overlap(
+    group_contexts_value: tuple[CandidateContext, ...],
+) -> bool:
+    member_signatures = {
+        context.candidate.candidate_id: tuple(
+            sorted(context.candidate.member_relative_paths)
+        )
+        for context in group_contexts_value
+    }
+    for left, right in combinations(group_contexts_value, 2):
+        left_members = set(left.candidate.member_relative_paths)
+        right_members = set(right.candidate.member_relative_paths)
+        if not left_members.intersection(right_members):
+            continue
+        if (
+            member_signatures[left.candidate.candidate_id]
+            != member_signatures[right.candidate.candidate_id]
+        ):
+            return True
+    return False

--- a/src/tallylot/application/normalization/translation_inputs/validation.py
+++ b/src/tallylot/application/normalization/translation_inputs/validation.py
@@ -177,32 +177,9 @@ def validate_candidate(
 def validate_coverage(coverage: TranslationCoverageWindow) -> tuple[str, ...]:
     errors: list[str] = []
     if coverage.mode is TranslationCoverageMode.UNKNOWN:
-        if any(
-            value is not None
-            for value in (
-                coverage.start_at,
-                coverage.start_precision,
-                coverage.end_at,
-                coverage.end_precision,
-            )
-        ):
-            errors.append("unknown coverage cannot carry bounds or precisions")
+        errors.extend(_validate_unknown_coverage(coverage))
         return tuple(errors)
-    if coverage.mode is TranslationCoverageMode.BOUNDED:
-        if coverage.start_at is None or coverage.end_at is None:
-            errors.append("bounded coverage requires start_at and end_at")
-        if coverage.start_precision is None or coverage.end_precision is None:
-            errors.append("bounded coverage requires start_precision and end_precision")
-    elif coverage.mode is TranslationCoverageMode.UNBOUNDED_START:
-        if coverage.start_at is not None or coverage.start_precision is not None:
-            errors.append("unbounded_start coverage cannot carry a start bound")
-        if coverage.end_at is None or coverage.end_precision is None:
-            errors.append("unbounded_start coverage requires an end bound")
-    elif coverage.mode is TranslationCoverageMode.UNBOUNDED_END:
-        if coverage.end_at is not None or coverage.end_precision is not None:
-            errors.append("unbounded_end coverage cannot carry an end bound")
-        if coverage.start_at is None or coverage.start_precision is None:
-            errors.append("unbounded_end coverage requires a start bound")
+    errors.extend(_validate_known_coverage_mode(coverage))
     if coverage.start_at is not None:
         validate_utc_datetime(coverage.start_at, errors, label="coverage start_at")
     if coverage.end_at is not None:
@@ -213,6 +190,67 @@ def validate_coverage(coverage: TranslationCoverageWindow) -> tuple[str, ...]:
         and coverage.start_at > coverage.end_at
     ):
         errors.append("coverage start_at must not be after end_at")
+    return tuple(errors)
+
+
+def _validate_unknown_coverage(
+    coverage: TranslationCoverageWindow,
+) -> tuple[str, ...]:
+    if any(
+        value is not None
+        for value in (
+            coverage.start_at,
+            coverage.start_precision,
+            coverage.end_at,
+            coverage.end_precision,
+        )
+    ):
+        return ("unknown coverage cannot carry bounds or precisions",)
+    return ()
+
+
+def _validate_known_coverage_mode(
+    coverage: TranslationCoverageWindow,
+) -> tuple[str, ...]:
+    if coverage.mode is TranslationCoverageMode.BOUNDED:
+        return _validate_bounded_coverage(coverage)
+    if coverage.mode is TranslationCoverageMode.UNBOUNDED_START:
+        return _validate_unbounded_start_coverage(coverage)
+    if coverage.mode is TranslationCoverageMode.UNBOUNDED_END:
+        return _validate_unbounded_end_coverage(coverage)
+    return ()
+
+
+def _validate_bounded_coverage(
+    coverage: TranslationCoverageWindow,
+) -> tuple[str, ...]:
+    errors: list[str] = []
+    if coverage.start_at is None or coverage.end_at is None:
+        errors.append("bounded coverage requires start_at and end_at")
+    if coverage.start_precision is None or coverage.end_precision is None:
+        errors.append("bounded coverage requires start_precision and end_precision")
+    return tuple(errors)
+
+
+def _validate_unbounded_start_coverage(
+    coverage: TranslationCoverageWindow,
+) -> tuple[str, ...]:
+    errors: list[str] = []
+    if coverage.start_at is not None or coverage.start_precision is not None:
+        errors.append("unbounded_start coverage cannot carry a start bound")
+    if coverage.end_at is None or coverage.end_precision is None:
+        errors.append("unbounded_start coverage requires an end bound")
+    return tuple(errors)
+
+
+def _validate_unbounded_end_coverage(
+    coverage: TranslationCoverageWindow,
+) -> tuple[str, ...]:
+    errors: list[str] = []
+    if coverage.end_at is not None or coverage.end_precision is not None:
+        errors.append("unbounded_end coverage cannot carry an end bound")
+    if coverage.start_at is None or coverage.start_precision is None:
+        errors.append("unbounded_end coverage requires a start bound")
     return tuple(errors)
 
 

--- a/src/tallylot/application/profiling/build_profile.py
+++ b/src/tallylot/application/profiling/build_profile.py
@@ -17,7 +17,9 @@ from tallylot.application.workspace.filesystem import (
 )
 from tallylot.domain.issues import IssueRecord
 from tallylot.domain.types import AdapterId, JsonValue, SourceId
+from tallylot.domain.value_objects import format_timestamp
 from tallylot.ports.artifacts import ArtifactStorePort
+from tallylot.ports.captures import CaptureMetadata
 from tallylot.ports.source_adapters import SourceAdapter, SourceAdapterRegistryPort
 from tallylot.ports.source_profiles import FileInventoryEntry, SourceProfile
 
@@ -47,6 +49,7 @@ class BuildProfileUseCase:
         profile = self.create_profile(
             request.source,
             raw_dir,
+            capture_metadata=capture_context.metadata,
             inspect_archives=request.inspect_archives,
         )
         self.write_profile_artifacts(profile, output_dir)
@@ -75,6 +78,7 @@ class BuildProfileUseCase:
         source: str,
         raw_dir: Path,
         *,
+        capture_metadata: CaptureMetadata | None = None,
         inspect_archives: bool = True,
     ) -> SourceProfile:
         inventory, scan_issues = build_inventory(
@@ -106,6 +110,20 @@ class BuildProfileUseCase:
                     family_analysis.recognized_adapter_ids
                 ),
                 "scan_issue_count": str(len(scan_issues) + len(family_analysis.issues)),
+                **(
+                    {
+                        "capture_uid": str(capture_metadata.capture_uid),
+                        "capture_label": capture_metadata.capture_label,
+                        "capture_completed_at": format_timestamp(
+                            capture_metadata.intake_completed_at
+                        ),
+                        "capture_started_at": format_timestamp(
+                            capture_metadata.intake_started_at
+                        ),
+                    }
+                    if capture_metadata is not None
+                    else {}
+                ),
             },
             scan_issues=(*scan_issues, *family_analysis.issues),
         )

--- a/src/tallylot/application/profiling/csv_inventory.py
+++ b/src/tallylot/application/profiling/csv_inventory.py
@@ -11,6 +11,12 @@ from io import TextIOBase
 from itertools import zip_longest
 from pathlib import Path
 
+from .date_inference import (
+    filename_anchored_date_only_format,
+    infer_date_only_format as infer_profile_date_only_format,
+    is_iso_date_only,
+)
+
 _HEADER_SCAN_LIMIT = 25
 _HEADER_KEYWORDS = (
     "account",
@@ -78,11 +84,20 @@ def is_timestamp_field(name: str) -> bool:
 def timestamp_resolution(value: str) -> str:
     if not value:
         return ""
-    if len(value.strip()) == 10 and value.count("-") == 2:
+    text = value.strip()
+    if len(text) == 10 and text.count("-") == 2:
         return "date_only"
-    if ":" in value:
+    if ":" in text:
         return "second"
     return "unknown"
+
+
+def infer_date_only_format(
+    values: list[str],
+    *,
+    filename: str = "",
+) -> str | None:
+    return infer_profile_date_only_format(values, filename=filename)
 
 
 def value_has_non_utc_offset(value: str) -> bool:
@@ -114,12 +129,18 @@ def format_timezone_value(value: timezone) -> str:
 
 
 def parse_inventory_timestamp(
-    value: str, *, source_timezone: timezone | None
+    value: str,
+    *,
+    source_timezone: timezone | None,
+    filename: str = "",
+    date_only_format: str | None = None,
 ) -> datetime | None:
     text = value.strip()
     if not text:
         return None
-    exact_match = _exact_inventory_timestamp(text)
+    exact_match = _exact_inventory_timestamp(
+        text, filename=filename, date_only_format=date_only_format
+    )
     if exact_match is not None:
         return exact_match
     for fmt in ("%Y-%m-%d %H:%M:%S", "%y-%m-%d %H:%M:%S"):
@@ -176,22 +197,34 @@ def _row_values(row: Mapping[str, str | list[str]]) -> list[str]:
     return values
 
 
-def _exact_inventory_timestamp(text: str) -> datetime | None:
+def _exact_inventory_timestamp(
+    text: str,
+    *,
+    filename: str = "",
+    date_only_format: str | None = None,
+) -> datetime | None:
+    parsed: datetime | None = None
     if text.endswith(" UTC"):
-        return _try_datetime(text, "%Y-%m-%d %H:%M:%S UTC", tzinfo=UTC)
-    if text.endswith("Z"):
+        parsed = _try_datetime(text, "%Y-%m-%d %H:%M:%S UTC", tzinfo=UTC)
+    elif text.endswith("Z"):
         for fmt in ("%Y-%m-%dT%H:%M:%S.%fZ", "%Y-%m-%dT%H:%M:%SZ"):
             parsed = _try_datetime(text, fmt, tzinfo=UTC)
             if parsed is not None:
-                return parsed
-    if value_has_non_utc_offset(text):
+                break
+    elif value_has_non_utc_offset(text):
         try:
-            return datetime.strptime(text, "%Y-%m-%d %H:%M:%S%z").astimezone(UTC)
+            parsed = datetime.strptime(text, "%Y-%m-%d %H:%M:%S%z").astimezone(UTC)
         except ValueError:
-            return None
-    if len(text) == 10 and text.count("-") == 2:
-        return _try_datetime(text, "%Y-%m-%d", tzinfo=UTC)
-    return None
+            parsed = None
+    elif is_iso_date_only(text):
+        parsed = _try_datetime(text, "%Y-%m-%d", tzinfo=UTC)
+    elif date_only_format is not None:
+        parsed = _try_datetime(text, date_only_format, tzinfo=UTC)
+    else:
+        anchored_format = filename_anchored_date_only_format(text, filename=filename)
+        if anchored_format is not None:
+            parsed = _try_datetime(text, anchored_format, tzinfo=UTC)
+    return parsed
 
 
 def _try_datetime(

--- a/src/tallylot/application/profiling/date_inference.py
+++ b/src/tallylot/application/profiling/date_inference.py
@@ -1,0 +1,229 @@
+"""Date-only inference helpers for CSV profiling."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+
+_SLASH_DATE_PATTERN = re.compile(r"(?P<first>\d{2})/(?P<second>\d{2})/(?P<year>\d{4})$")
+_FILENAME_DATE_PATTERN = re.compile(
+    r"(?P<year>\d{4})[-_.](?P<month>\d{2})[-_.](?P<day>\d{2})"
+)
+_DATE_FORMATS = ("%d/%m/%Y", "%m/%d/%Y")
+
+
+@dataclass(frozen=True)
+class _SlashDateToken:
+    first: int
+    second: int
+    year: int
+    raw: str
+
+
+@dataclass(frozen=True)
+class _SlashDateCandidate:
+    date_format: str
+    token_count: int
+    parsed_values: tuple[datetime, ...]
+
+
+def infer_date_only_format(
+    values: list[str],
+    *,
+    filename: str = "",
+) -> str | None:
+    normalized_values = [value.strip() for value in values if value.strip()]
+    iso_values = [value for value in normalized_values if is_iso_date_only(value)]
+    slash_tokens = _slash_date_tokens(normalized_values)
+    if iso_values and not slash_tokens:
+        return "%Y-%m-%d"
+    if not slash_tokens or iso_values:
+        return None
+
+    candidates = _slash_candidates(slash_tokens)
+    formats_to_try = (
+        _slash_date_format_from_component_bounds(slash_tokens),
+        _slash_date_format_from_chronology(slash_tokens, candidates),
+        _slash_date_format_from_filename_anchor(candidates, filename=filename),
+    )
+    return next((fmt for fmt in formats_to_try if fmt is not None), None)
+
+
+def filename_anchored_date_only_format(value: str, *, filename: str) -> str | None:
+    tokens = _slash_date_tokens([value])
+    if not tokens:
+        return None
+    return _slash_date_format_from_filename_anchor(
+        _slash_candidates(tokens), filename=filename
+    )
+
+
+def is_iso_date_only(text: str) -> bool:
+    return len(text) == 10 and text.count("-") == 2
+
+
+def _slash_date_tokens(values: list[str]) -> tuple[_SlashDateToken, ...]:
+    tokens: list[_SlashDateToken] = []
+    for value in values:
+        match = _SLASH_DATE_PATTERN.fullmatch(value)
+        if match is None:
+            continue
+        tokens.append(
+            _SlashDateToken(
+                first=int(match.group("first")),
+                second=int(match.group("second")),
+                year=int(match.group("year")),
+                raw=value,
+            )
+        )
+    return tuple(tokens)
+
+
+def _slash_candidates(
+    tokens: tuple[_SlashDateToken, ...],
+) -> tuple[_SlashDateCandidate, ...]:
+    return tuple(
+        _SlashDateCandidate(
+            date_format=date_format,
+            token_count=len(tokens),
+            parsed_values=tuple(
+                parsed
+                for token in tokens
+                if (parsed := _try_datetime(token.raw, date_format)) is not None
+            ),
+        )
+        for date_format in _DATE_FORMATS
+    )
+
+
+def _slash_date_format_from_component_bounds(
+    tokens: tuple[_SlashDateToken, ...],
+) -> str | None:
+    day_first_evidence = any(token.second <= 12 < token.first for token in tokens)
+    month_first_evidence = any(token.first <= 12 < token.second for token in tokens)
+    if day_first_evidence == month_first_evidence:
+        return None
+    return "%d/%m/%Y" if day_first_evidence else "%m/%d/%Y"
+
+
+def _slash_date_format_from_chronology(
+    tokens: tuple[_SlashDateToken, ...],
+    candidates: tuple[_SlashDateCandidate, ...],
+) -> str | None:
+    candidate_map = {candidate.date_format: candidate for candidate in candidates}
+    supported_formats = [
+        candidate.date_format
+        for candidate in candidates
+        if _chronology_supports_inference(tokens, candidate.parsed_values)
+    ]
+    if len(supported_formats) != 1:
+        return None
+
+    winner = supported_formats[0]
+    loser = next(date_format for date_format in _DATE_FORMATS if date_format != winner)
+    winner_candidate = candidate_map[winner]
+    loser_candidate = candidate_map[loser]
+    if not _has_decisive_chronology_witness(
+        winner_candidate.parsed_values, loser_candidate.parsed_values
+    ):
+        return None
+    return winner
+
+
+def _chronology_supports_inference(
+    tokens: tuple[_SlashDateToken, ...],
+    parsed_values: tuple[datetime, ...],
+) -> bool:
+    if len(parsed_values) != len(tokens) or len(parsed_values) < 3:
+        return False
+    if not _slash_components_vary(tokens):
+        return False
+    if not all(
+        left <= right
+        for left, right in zip(parsed_values, parsed_values[1:], strict=False)
+    ):
+        return False
+    adjacent_gaps = [
+        (right - left).days
+        for left, right in zip(parsed_values, parsed_values[1:], strict=False)
+    ]
+    return bool(adjacent_gaps) and max(adjacent_gaps) <= 45
+
+
+def _slash_components_vary(tokens: tuple[_SlashDateToken, ...]) -> bool:
+    first_values = {token.first for token in tokens}
+    second_values = {token.second for token in tokens}
+    return len(first_values) > 1 and len(second_values) > 1
+
+
+def _has_decisive_chronology_witness(
+    winner_values: tuple[datetime, ...],
+    loser_values: tuple[datetime, ...],
+) -> bool:
+    for winner_left, winner_right, loser_left, loser_right in zip(
+        winner_values,
+        winner_values[1:],
+        loser_values,
+        loser_values[1:],
+        strict=False,
+    ):
+        winner_gap = (winner_right - winner_left).days
+        loser_gap = (loser_right - loser_left).days
+        if 0 <= winner_gap <= 7 and (loser_gap < 0 or loser_gap > 21):
+            return True
+    return False
+
+
+def _slash_date_format_from_filename_anchor(
+    candidates: tuple[_SlashDateCandidate, ...],
+    *,
+    filename: str,
+) -> str | None:
+    if not filename:
+        return None
+    matching_formats = [
+        candidate.date_format
+        for candidate in candidates
+        if _filename_matches_any_slash_date(candidate, filename=filename)
+    ]
+    if len(matching_formats) == 1:
+        return matching_formats[0]
+    return None
+
+
+def _filename_matches_any_slash_date(
+    candidate: _SlashDateCandidate,
+    *,
+    filename: str,
+) -> bool:
+    if len(candidate.parsed_values) != candidate.token_count:
+        return False
+    if not candidate.parsed_values:
+        return False
+
+    anchored_dates: list[datetime] = []
+    for filename_match in _FILENAME_DATE_PATTERN.finditer(filename):
+        try:
+            anchored_dates.append(
+                datetime(
+                    int(filename_match.group("year")),
+                    int(filename_match.group("month")),
+                    int(filename_match.group("day")),
+                    tzinfo=UTC,
+                )
+            )
+        except ValueError:
+            continue
+    return bool(anchored_dates) and any(
+        anchored.date() == parsed.date()
+        for anchored in anchored_dates
+        for parsed in candidate.parsed_values
+    )
+
+
+def _try_datetime(text: str, fmt: str) -> datetime | None:
+    try:
+        return datetime.strptime(text, fmt).replace(tzinfo=UTC)
+    except ValueError:
+        return None

--- a/src/tallylot/application/profiling/inventory.py
+++ b/src/tallylot/application/profiling/inventory.py
@@ -58,6 +58,9 @@ def build_inventory(
                     date_field=timezone_details.date_field,
                     min_timestamp=timezone_details.min_timestamp,
                     max_timestamp=timezone_details.max_timestamp,
+                    observed_period_start=timezone_details.observed_period_start,
+                    observed_period_end=timezone_details.observed_period_end,
+                    observed_period_label=timezone_details.observed_period_label,
                     timestamp_resolution=timezone_details.timestamp_resolution,
                     timezone_mode=timezone_details.timezone_mode,
                     timezone_value=timezone_details.timezone_value,
@@ -120,6 +123,9 @@ class TimezoneDetails:
     date_field: str = ""
     min_timestamp: str = ""
     max_timestamp: str = ""
+    observed_period_start: str = ""
+    observed_period_end: str = ""
+    observed_period_label: str = ""
     timestamp_resolution: str = ""
     timezone_mode: str = ""
     timezone_value: str = ""
@@ -193,13 +199,41 @@ def csv_timezone_details(
     max_timestamp = (
         parsed_values[-1].strftime("%Y-%m-%d %H:%M:%S") if parsed_values else ""
     )
+    observed_period_start = _observed_period_start(min_timestamp)
+    observed_period_end = _observed_period_end(max_timestamp)
+    observed_period_label = _observed_period_label(
+        observed_period_start, observed_period_end
+    )
 
     return TimezoneDetails(
         date_field=timestamp_field,
         min_timestamp=min_timestamp,
         max_timestamp=max_timestamp,
+        observed_period_start=observed_period_start,
+        observed_period_end=observed_period_end,
+        observed_period_label=observed_period_label,
         timestamp_resolution=resolution,
         timezone_mode=timezone_mode,
         timezone_value=timezone_value,
         timezone_conflict=timezone_conflict,
     )
+
+
+def _observed_period_start(min_timestamp: str) -> str:
+    if not min_timestamp:
+        return ""
+    return min_timestamp[:10]
+
+
+def _observed_period_end(max_timestamp: str) -> str:
+    if not max_timestamp:
+        return ""
+    return max_timestamp[:10]
+
+
+def _observed_period_label(start: str, end: str) -> str:
+    if not start or not end:
+        return ""
+    start_month = start[:7]
+    end_month = end[:7]
+    return start_month if start_month == end_month else f"{start_month}..{end_month}"

--- a/src/tallylot/application/profiling/inventory.py
+++ b/src/tallylot/application/profiling/inventory.py
@@ -12,6 +12,7 @@ from tallylot.application.intake.archive import scanned_tree_files
 from tallylot.application.profiling.csv_inventory import (
     filename_timezone,
     format_timezone_value,
+    infer_date_only_format,
     inventory_csv_content,
     is_timestamp_field,
     parse_inventory_timestamp,
@@ -160,7 +161,12 @@ def csv_timezone_details(
     ]
     sample_value = values[0] if values else ""
     header_utc = "utc" in timestamp_field.lower()
-    resolution = timestamp_resolution(sample_value)
+    date_only_format = infer_date_only_format(values, filename=filename)
+    resolution = (
+        "date_only"
+        if date_only_format is not None
+        else timestamp_resolution(sample_value)
+    )
     source_timezone = filename_timezone(filename)
     timezone_mode = ""
     timezone_value = ""
@@ -181,7 +187,7 @@ def csv_timezone_details(
     elif source_timezone is not None and sample_value:
         timezone_mode = "filename_offset"
         timezone_value = format_timezone_value(source_timezone)
-    elif resolution == "date_only":
+    elif date_only_format is not None:
         timezone_mode = "date_only"
     elif sample_value:
         timezone_mode = "naive"
@@ -189,7 +195,14 @@ def csv_timezone_details(
     parsed_values = [
         parsed
         for value in values
-        if (parsed := parse_inventory_timestamp(value, source_timezone=source_timezone))
+        if (
+            parsed := parse_inventory_timestamp(
+                value,
+                source_timezone=source_timezone,
+                filename=filename,
+                date_only_format=date_only_format,
+            )
+        )
         is not None
     ]
     parsed_values.sort()

--- a/src/tallylot/ports/intake_routing.py
+++ b/src/tallylot/ports/intake_routing.py
@@ -15,6 +15,7 @@ class IntakeFileFacts:
     observed_period_end: str = ""
     observed_period_label: str = ""
     scope_tokens: tuple[str, ...] = ()
+    routing_scope_tokens: tuple[str, ...] = ()
     network_hints: tuple[str, ...] = ()
 
 

--- a/src/tallylot/ports/translation_inputs.py
+++ b/src/tallylot/ports/translation_inputs.py
@@ -1,0 +1,190 @@
+"""Translation input planning boundary types and shared helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from hashlib import sha256
+import json
+from pathlib import Path
+from typing import Literal, Protocol, runtime_checkable
+
+from tallylot.domain.temporal import TemporalPrecision
+from tallylot.domain.value_objects import parse_timestamp, require_utc_datetime
+from tallylot.ports.source_profiles import FileInventoryEntry, SourceProfile
+from tallylot.ports.source_translation import SourceTranslationBatch
+
+
+class TranslationCoverageMode(StrEnum):
+    BOUNDED = "bounded"
+    UNBOUNDED_START = "unbounded_start"
+    UNBOUNDED_END = "unbounded_end"
+    UNKNOWN = "unknown"
+
+
+class TranslationSelectionMode(StrEnum):
+    APPENDABLE_RANGE = "appendable_range"
+    REPLACEABLE_RANGE = "replaceable_range"
+    EXCLUSIVE_SNAPSHOT = "exclusive_snapshot"
+
+
+class TranslationFreshnessKind(StrEnum):
+    EXPORT_TIMESTAMP = "export_timestamp"
+    CAPTURE_COMPLETED_AT = "capture_completed_at"
+    ADAPTER_RANK = "adapter_rank"
+    UNKNOWN = "unknown"
+
+
+TranslationPlanDecisionStatus = Literal[
+    "selected",
+    "superseded_identical",
+    "superseded_replaced",
+    "blocked_partial_overlap",
+    "blocked_ambiguous_freshness",
+    "blocked_unknown_coverage",
+    "blocked_incomparable_candidates",
+    "blocked_invalid_candidate",
+]
+
+
+@dataclass(frozen=True)
+class TranslationCoverageWindow:
+    start_at: datetime | None
+    start_precision: TemporalPrecision | None
+    end_at: datetime | None
+    end_precision: TemporalPrecision | None
+    mode: TranslationCoverageMode
+
+
+@dataclass(frozen=True)
+class TranslationFreshness:
+    kind: TranslationFreshnessKind
+    timestamp: datetime | None
+    rank: int | None
+
+
+@dataclass(frozen=True)
+class TranslationInputCandidate:
+    candidate_id: str
+    selection_group: str
+    family_id: str
+    member_relative_paths: tuple[str, ...]
+    selection_mode: TranslationSelectionMode
+    coverage: TranslationCoverageWindow
+    freshness: TranslationFreshness
+    content_fingerprint: str
+    comparison_key: str
+    description: str
+    comparable: bool
+    notes: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class TranslationPlanDecision:
+    candidate_id: str
+    status: TranslationPlanDecisionStatus
+    reason: str
+    replaces_candidate_ids: tuple[str, ...] = ()
+    conflicts_with_candidate_ids: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class TranslationInputPlan:
+    selected_candidate_ids: tuple[str, ...]
+    decisions: tuple[TranslationPlanDecision, ...]
+    blocked: bool
+
+
+@runtime_checkable
+class TranslationInputPlanningAdapter(Protocol):
+    def describe_translation_inputs(
+        self, profile: SourceProfile, raw_dir: Path
+    ) -> tuple[TranslationInputCandidate, ...]: ...
+
+    def translate_selected_inputs(
+        self,
+        profile: SourceProfile,
+        raw_dir: Path,
+        plan: TranslationInputPlan,
+    ) -> SourceTranslationBatch: ...
+
+
+def translation_input_coverage_from_inventory_entry(
+    entry: FileInventoryEntry,
+) -> TranslationCoverageWindow:
+    start_at, end_at, precision = _coverage_bounds_from_inventory_entry(entry)
+    if start_at is None and end_at is None:
+        return TranslationCoverageWindow(
+            start_at=None,
+            start_precision=None,
+            end_at=None,
+            end_precision=None,
+            mode=TranslationCoverageMode.UNKNOWN,
+        )
+    if start_at is None:
+        return TranslationCoverageWindow(
+            start_at=None,
+            start_precision=None,
+            end_at=end_at,
+            end_precision=precision,
+            mode=TranslationCoverageMode.UNBOUNDED_START,
+        )
+    if end_at is None:
+        return TranslationCoverageWindow(
+            start_at=start_at,
+            start_precision=precision,
+            end_at=None,
+            end_precision=None,
+            mode=TranslationCoverageMode.UNBOUNDED_END,
+        )
+    return TranslationCoverageWindow(
+        start_at=start_at,
+        start_precision=precision,
+        end_at=end_at,
+        end_precision=precision,
+        mode=TranslationCoverageMode.BOUNDED,
+    )
+
+
+def translation_input_content_fingerprint(
+    *,
+    member_sha256s: tuple[str, ...],
+    family_id: str,
+    selection_group: str,
+    selection_mode: TranslationSelectionMode,
+) -> str:
+    payload = {
+        "family_id": family_id,
+        "member_sha256s": sorted(member_sha256s),
+        "selection_group": selection_group,
+        "selection_mode": selection_mode.value,
+    }
+    return sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _coverage_bounds_from_inventory_entry(
+    entry: FileInventoryEntry,
+) -> tuple[datetime | None, datetime | None, TemporalPrecision | None]:
+    precision = (
+        TemporalPrecision.DATE
+        if entry.timestamp_resolution == "date_only"
+        else TemporalPrecision.TIMESTAMP
+        if entry.min_timestamp or entry.max_timestamp
+        else None
+    )
+    start_at = _parse_inventory_timestamp(entry.min_timestamp)
+    end_at = _parse_inventory_timestamp(entry.max_timestamp)
+    return start_at, end_at, precision
+
+
+def _parse_inventory_timestamp(value: str) -> datetime | None:
+    text = value.strip()
+    if not text:
+        return None
+    try:
+        return require_utc_datetime(parse_timestamp(text), label="inventory timestamp")
+    except ValueError:
+        return None

--- a/tests/e2e/test_cli.py
+++ b/tests/e2e/test_cli.py
@@ -206,6 +206,88 @@ def test_source_normalize_cli_rejects_mismatched_capture_root(tmp_path: Path) ->
     assert "does not match requested source" in result.stdout
 
 
+def test_source_normalize_cli_writes_translation_planner_artifacts_for_coinbase(
+    tmp_path: Path,
+) -> None:
+    raw_capture_root = materialize_capture_root(tmp_path, source="coinbase")
+    older_name = "2021 Statement.csv"
+    newer_name = "2026-03-23 Statement - All Time.csv"
+    (raw_capture_root / older_name).write_text(
+        _coinbase_older_retail_csv(),
+        encoding="utf-8",
+    )
+    (raw_capture_root / newer_name).write_text(
+        _coinbase_newer_all_time_retail_csv(),
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "normalized"
+
+    result = runner.invoke(
+        app,
+        [
+            "source",
+            "normalize",
+            "--source",
+            "coinbase",
+            "--raw-dir",
+            str(raw_capture_root),
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+    candidates = json.loads(
+        (output_dir / "translation_input_candidates.json").read_text(encoding="utf-8")
+    )
+    plan = json.loads(
+        (output_dir / "translation_input_plan.json").read_text(encoding="utf-8")
+    )
+
+    assert result.exit_code == 0
+    assert {candidate["candidate_id"] for candidate in candidates["candidates"]} == {
+        f"coinbase:retail_export:{older_name}",
+        f"coinbase:retail_export:{newer_name}",
+    }
+    assert plan["selected_candidate_ids"] == [f"coinbase:retail_export:{newer_name}"]
+    assert (output_dir / "facts.csv").exists()
+
+
+def test_source_normalize_cli_returns_nonzero_for_blocked_coinbase_plan(
+    tmp_path: Path,
+) -> None:
+    raw_capture_root = materialize_capture_root(tmp_path, source="coinbase")
+    (raw_capture_root / "2021 statement a.csv").write_text(
+        _coinbase_retail_csv_with_amount("tx-a", "1.00000000"),
+        encoding="utf-8",
+    )
+    (raw_capture_root / "2021 statement b.csv").write_text(
+        _coinbase_retail_csv_with_amount("tx-b", "2.00000000"),
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "normalized"
+
+    result = runner.invoke(
+        app,
+        [
+            "source",
+            "normalize",
+            "--source",
+            "coinbase",
+            "--raw-dir",
+            str(raw_capture_root),
+            "--output-dir",
+            str(output_dir),
+        ],
+    )
+    plan = json.loads(
+        (output_dir / "translation_input_plan.json").read_text(encoding="utf-8")
+    )
+
+    assert result.exit_code == 2
+    assert "translation input planning blocked normalization" in result.stdout
+    assert plan["blocked"] is True
+    assert not (output_dir / "facts.csv").exists()
+
+
 def test_source_manifest_cli(tmp_path: Path) -> None:
     source_dir = tmp_path / "capture"
     source_dir.mkdir()
@@ -1360,6 +1442,43 @@ def _write_submission_rows(submission_root: Path, *, source: str) -> None:
                 "notes": "confirmation",
             },
         ),
+    )
+
+
+def _coinbase_older_retail_csv() -> str:
+    return (
+        "Transactions\n"
+        "User,Example User,acct\n"
+        "ID,Timestamp,Transaction Type,Asset,Quantity Transacted,Price Currency,Price at Transaction,"
+        "Subtotal,Total (inclusive of fees and/or spread),Fees and/or Spread,Notes\n"
+        "legacy-1,2021-12-30 08:56:53 UTC,Receive,FET,1.9859001,CAD,$0.64,$1.27098,$1.27098,$0.00,"
+        "Received 1.9859001 FET\n"
+    )
+
+
+def _coinbase_newer_all_time_retail_csv() -> str:
+    return (
+        "Transactions\n"
+        "User,Example User,acct\n"
+        "ID,Timestamp,Transaction Type,Asset,Quantity Transacted,Price Currency,Price at Transaction,"
+        "Subtotal,Total (inclusive of fees and/or spread),Fees and/or Spread,Notes\n"
+        "legacy-1,2021-12-30 08:56:53 UTC,Receive,FET,1.9859001,CAD,$0.64,$1.27098,$1.27098,$0.00,"
+        "Received 1.9859001 FET\n"
+        "reward-1,2023-03-18 01:28:49 UTC,Reward Income,ADA,0.000021,CAD,$0.48,$0.00,$0.00,$0.00,"
+        "Received 0.000021 ADA from Coinbase Rewards\n"
+        "migration-neg,2025-10-17 13:38:17 UTC,Asset Migration,MATIC,-1.65526374,CAD,$0.25,-$0.42,-$0.42,$0.00,\n"
+        "migration-pos,2025-10-17 13:38:17 UTC,Asset Migration,POL,1.65526374,CAD,$0.25,$0.42,$0.42,$0.00,\n"
+    )
+
+
+def _coinbase_retail_csv_with_amount(transaction_id: str, amount: str) -> str:
+    return (
+        "Transactions\n"
+        "User,Example User,acct\n"
+        "ID,Timestamp,Transaction Type,Asset,Quantity Transacted,Price Currency,Price at Transaction,"
+        "Subtotal,Total (inclusive of fees and/or spread),Fees and/or Spread,Notes\n"
+        f"{transaction_id},2021-12-30 08:56:53 UTC,Receive,FET,{amount},CAD,$0.64,$1.27098,$1.27098,$0.00,"
+        "Received FET\n"
     )
 
 

--- a/tests/fixtures/adapter_packs/binance/latest_statement_workbooks/expected/normalization_summary.json
+++ b/tests/fixtures/adapter_packs/binance/latest_statement_workbooks/expected/normalization_summary.json
@@ -13,5 +13,10 @@
   "review_summary": [],
   "reviews_outside_normalization_window": 0,
   "snapshot_count": 3,
-  "source": "Binance"
+  "source": "Binance",
+  "translation_blocked_count": 0,
+  "translation_candidate_count": 0,
+  "translation_planner_used": false,
+  "translation_selected_count": 0,
+  "translation_superseded_count": 0
 }

--- a/tests/fixtures/adapter_packs/binance/mixed_history/expected/normalization_summary.json
+++ b/tests/fixtures/adapter_packs/binance/mixed_history/expected/normalization_summary.json
@@ -13,5 +13,10 @@
   "review_summary": [],
   "reviews_outside_normalization_window": 0,
   "snapshot_count": 7,
-  "source": "Binance"
+  "source": "Binance",
+  "translation_blocked_count": 0,
+  "translation_candidate_count": 0,
+  "translation_planner_used": false,
+  "translation_selected_count": 0,
+  "translation_superseded_count": 0
 }

--- a/tests/fixtures/adapter_packs/coinbase/missing_retail_csv/expected/normalization_summary.json
+++ b/tests/fixtures/adapter_packs/coinbase/missing_retail_csv/expected/normalization_summary.json
@@ -13,5 +13,10 @@
   "review_summary": [],
   "reviews_outside_normalization_window": 0,
   "snapshot_count": 0,
-  "source": "Coinbase"
+  "source": "Coinbase",
+  "translation_blocked_count": 0,
+  "translation_candidate_count": 0,
+  "translation_planner_used": true,
+  "translation_selected_count": 0,
+  "translation_superseded_count": 0
 }

--- a/tests/fixtures/adapter_packs/coinbase/mixed_statement_aux_pdfs/expected/normalization_summary.json
+++ b/tests/fixtures/adapter_packs/coinbase/mixed_statement_aux_pdfs/expected/normalization_summary.json
@@ -13,5 +13,10 @@
   "review_summary": [],
   "reviews_outside_normalization_window": 0,
   "snapshot_count": 2,
-  "source": "coinbase"
+  "source": "coinbase",
+  "translation_blocked_count": 0,
+  "translation_candidate_count": 1,
+  "translation_planner_used": true,
+  "translation_selected_count": 1,
+  "translation_superseded_count": 0
 }

--- a/tests/fixtures/adapter_packs/coinbase/retail_buy_renamed/expected/normalization_summary.json
+++ b/tests/fixtures/adapter_packs/coinbase/retail_buy_renamed/expected/normalization_summary.json
@@ -13,5 +13,10 @@
   "review_summary": [],
   "reviews_outside_normalization_window": 0,
   "snapshot_count": 2,
-  "source": "Future Exchange"
+  "source": "Future Exchange",
+  "translation_blocked_count": 0,
+  "translation_candidate_count": 1,
+  "translation_planner_used": true,
+  "translation_selected_count": 1,
+  "translation_superseded_count": 0
 }

--- a/tests/fixtures/adapter_packs/crypto_com/transaction_kinds/expected/normalization_summary.json
+++ b/tests/fixtures/adapter_packs/crypto_com/transaction_kinds/expected/normalization_summary.json
@@ -13,5 +13,10 @@
   "review_summary": [],
   "reviews_outside_normalization_window": 0,
   "snapshot_count": 2,
-  "source": "Future Card"
+  "source": "Future Card",
+  "translation_blocked_count": 0,
+  "translation_candidate_count": 0,
+  "translation_planner_used": false,
+  "translation_selected_count": 0,
+  "translation_superseded_count": 0
 }

--- a/tests/fixtures/adapter_packs/evm_explorer/chain_scoped_deposit/expected/normalization_summary.json
+++ b/tests/fixtures/adapter_packs/evm_explorer/chain_scoped_deposit/expected/normalization_summary.json
@@ -13,5 +13,10 @@
   "review_summary": [],
   "reviews_outside_normalization_window": 0,
   "snapshot_count": 1,
-  "source": "bsc-wallet"
+  "source": "bsc-wallet",
+  "translation_blocked_count": 0,
+  "translation_candidate_count": 0,
+  "translation_planner_used": false,
+  "translation_selected_count": 0,
+  "translation_superseded_count": 0
 }

--- a/tests/fixtures/adapter_packs/evm_explorer/suspicious_nft_review/expected/normalization_summary.json
+++ b/tests/fixtures/adapter_packs/evm_explorer/suspicious_nft_review/expected/normalization_summary.json
@@ -13,5 +13,10 @@
   "review_summary": [],
   "reviews_outside_normalization_window": 0,
   "snapshot_count": 0,
-  "source": "bsc-wallet"
+  "source": "bsc-wallet",
+  "translation_blocked_count": 0,
+  "translation_candidate_count": 0,
+  "translation_planner_used": false,
+  "translation_selected_count": 0,
+  "translation_superseded_count": 0
 }

--- a/tests/fixtures/adapter_packs/evm_explorer/timestamped_portfolio_balance/expected/normalization_summary.json
+++ b/tests/fixtures/adapter_packs/evm_explorer/timestamped_portfolio_balance/expected/normalization_summary.json
@@ -25,5 +25,10 @@
   ],
   "reviews_outside_normalization_window": 0,
   "snapshot_count": 2,
-  "source": "eth-wallet-fixture"
+  "source": "eth-wallet-fixture",
+  "translation_blocked_count": 0,
+  "translation_candidate_count": 0,
+  "translation_planner_used": false,
+  "translation_selected_count": 0,
+  "translation_superseded_count": 0
 }

--- a/tests/fixtures/adapter_packs/gtrade/realized_pnl_alias/expected/normalization_summary.json
+++ b/tests/fixtures/adapter_packs/gtrade/realized_pnl_alias/expected/normalization_summary.json
@@ -13,5 +13,10 @@
   "review_summary": [],
   "reviews_outside_normalization_window": 0,
   "snapshot_count": 1,
-  "source": "GTrade 1CT"
+  "source": "GTrade 1CT",
+  "translation_blocked_count": 0,
+  "translation_candidate_count": 0,
+  "translation_planner_used": false,
+  "translation_selected_count": 0,
+  "translation_superseded_count": 0
 }

--- a/tests/fixtures/adapter_packs/ledger_live/grouped_swap/expected/normalization_summary.json
+++ b/tests/fixtures/adapter_packs/ledger_live/grouped_swap/expected/normalization_summary.json
@@ -13,5 +13,10 @@
   "review_summary": [],
   "reviews_outside_normalization_window": 0,
   "snapshot_count": 2,
-  "source": "ledger-live-main"
+  "source": "ledger-live-main",
+  "translation_blocked_count": 0,
+  "translation_candidate_count": 0,
+  "translation_planner_used": false,
+  "translation_selected_count": 0,
+  "translation_superseded_count": 0
 }

--- a/tests/fixtures/adapter_packs/near/staking_and_wallet/expected/normalization_summary.json
+++ b/tests/fixtures/adapter_packs/near/staking_and_wallet/expected/normalization_summary.json
@@ -13,5 +13,10 @@
   "review_summary": [],
   "reviews_outside_normalization_window": 0,
   "snapshot_count": 2,
-  "source": "capture-near"
+  "source": "capture-near",
+  "translation_blocked_count": 0,
+  "translation_candidate_count": 0,
+  "translation_planner_used": false,
+  "translation_selected_count": 0,
+  "translation_superseded_count": 0
 }

--- a/tests/fixtures/adapter_packs/shakepay/cash_crypto_mix/expected/normalization_summary.json
+++ b/tests/fixtures/adapter_packs/shakepay/cash_crypto_mix/expected/normalization_summary.json
@@ -13,5 +13,10 @@
   "review_summary": [],
   "reviews_outside_normalization_window": 0,
   "snapshot_count": 2,
-  "source": "Shakepay"
+  "source": "Shakepay",
+  "translation_blocked_count": 0,
+  "translation_candidate_count": 0,
+  "translation_planner_used": false,
+  "translation_selected_count": 0,
+  "translation_superseded_count": 0
 }

--- a/tests/fixtures/adapter_packs/shakepay/monthly_statement_aux_pdfs/expected/normalization_summary.json
+++ b/tests/fixtures/adapter_packs/shakepay/monthly_statement_aux_pdfs/expected/normalization_summary.json
@@ -13,5 +13,10 @@
   "review_summary": [],
   "reviews_outside_normalization_window": 0,
   "snapshot_count": 2,
-  "source": "shakepay"
+  "source": "shakepay",
+  "translation_blocked_count": 0,
+  "translation_candidate_count": 0,
+  "translation_planner_used": false,
+  "translation_selected_count": 0,
+  "translation_superseded_count": 0
 }

--- a/tests/fixtures/adapter_packs/structured_csv/basic/expected/normalization_summary.json
+++ b/tests/fixtures/adapter_packs/structured_csv/basic/expected/normalization_summary.json
@@ -23,5 +23,10 @@
   ],
   "reviews_outside_normalization_window": 0,
   "snapshot_count": 3,
-  "source": "Structured Example"
+  "source": "Structured Example",
+  "translation_blocked_count": 0,
+  "translation_candidate_count": 0,
+  "translation_planner_used": false,
+  "translation_selected_count": 0,
+  "translation_superseded_count": 0
 }

--- a/tests/fixtures/adapter_packs/wealthsimple/broker_trade/expected/normalization_summary.json
+++ b/tests/fixtures/adapter_packs/wealthsimple/broker_trade/expected/normalization_summary.json
@@ -13,5 +13,10 @@
   "review_summary": [],
   "reviews_outside_normalization_window": 0,
   "snapshot_count": 2,
-  "source": "Future Broker"
+  "source": "Future Broker",
+  "translation_blocked_count": 0,
+  "translation_candidate_count": 0,
+  "translation_planner_used": false,
+  "translation_selected_count": 0,
+  "translation_superseded_count": 0
 }

--- a/tests/fixtures/adapter_packs/wealthsimple/mixed_activity_review/expected/normalization_summary.json
+++ b/tests/fixtures/adapter_packs/wealthsimple/mixed_activity_review/expected/normalization_summary.json
@@ -13,5 +13,10 @@
   "review_summary": [],
   "reviews_outside_normalization_window": 0,
   "snapshot_count": 2,
-  "source": "WealthSimple"
+  "source": "WealthSimple",
+  "translation_blocked_count": 0,
+  "translation_candidate_count": 0,
+  "translation_planner_used": false,
+  "translation_selected_count": 0,
+  "translation_superseded_count": 0
 }

--- a/tests/unit/adapters/support/test_timezones.py
+++ b/tests/unit/adapters/support/test_timezones.py
@@ -178,3 +178,27 @@ def test_passed_timezone_summary_accepts_shakepay_local_wall_clock_exports() -> 
     assert summary["issue_count"] == 0
     assert summary["mode_counts"] == {"naive": 1}
     assert not issues
+
+
+def test_passed_timezone_summary_ignores_empty_header_only_files() -> None:
+    profile = build_source_profile(
+        adapter_id="coinbase",
+        source="coinbase",
+        file_inventory=(
+            FileInventoryEntry(
+                relative_path="empty-retail-export.csv",
+                suffix=".csv",
+                size_bytes=1,
+                sha256="fixture",
+                row_count=0,
+                date_field="Timestamp",
+            ),
+        ),
+    )
+
+    summary, issues = passed_timezone_summary(profile, mode="value_utc")
+
+    assert summary["status"] == "passed"
+    assert summary["issue_count"] == 0
+    assert summary["rows_with_dates"] == 0
+    assert not issues

--- a/tests/unit/application/intake/file_facts/test_inspection.py
+++ b/tests/unit/application/intake/file_facts/test_inspection.py
@@ -199,6 +199,29 @@ def test_inspect_intake_file_preserves_title_row_wallet_scope_tokens(
     assert route.source_folder.startswith("ethereum-wallet-bc1")
 
 
+def test_inspect_intake_file_prefers_identifier_common_across_rows_for_routing(
+    tmp_path: Path,
+) -> None:
+    wallet = "0xbb4d728717a8ea00b316366daa695d41f6fdc722"
+    path = tmp_path / f"Account1-bsc export-{wallet}.csv"
+    path.write_text(
+        "DateTime (UTC),From,To,ContractAddress\n"
+        "2022-01-02 02:23:57,0x01c952174c24e1210d26961d456a77a39e1f0bb0,"
+        f"{wallet},\n"
+        f"2022-01-02 13:07:19,{wallet},0x10ed43c718714eb63d5aa57b78b54704e256024e,\n",
+        encoding="utf-8",
+    )
+
+    facts = inspect_intake_file(path, relative_path=f"incoming/{path.name}")
+
+    assert set(facts.scope_tokens) >= {
+        "evm:0x01c952174c24e1210d26961d456a77a39e1f0bb0",
+        "evm:0x10ed43c718714eb63d5aa57b78b54704e256024e",
+        f"evm:{wallet}",
+    }
+    assert facts.routing_scope_tokens == (f"evm:{wallet}",)
+
+
 def test_inspect_intake_file_keeps_network_hint_order_from_title_rows(
     tmp_path: Path,
 ) -> None:

--- a/tests/unit/application/intake/test_inventory.py
+++ b/tests/unit/application/intake/test_inventory.py
@@ -7,7 +7,9 @@ from tallylot.infrastructure.serialization import FilesystemArtifactStore
 from tallylot.ports.intake_routing import IntakeFileFacts
 
 
-def test_resolve_inventory_route_returns_unmatched_without_identifiers(tmp_path: Path) -> None:
+def test_resolve_inventory_route_returns_unmatched_without_identifiers(
+    tmp_path: Path,
+) -> None:
     decision = resolve_inventory_route(
         artifacts=FilesystemArtifactStore(),
         workspace_root=tmp_path,
@@ -19,7 +21,9 @@ def test_resolve_inventory_route_returns_unmatched_without_identifiers(tmp_path:
     assert decision.inventory_match_status == "unmatched"
 
 
-def test_resolve_inventory_route_uses_unique_inventory_source_match(tmp_path: Path) -> None:
+def test_resolve_inventory_route_uses_unique_inventory_source_match(
+    tmp_path: Path,
+) -> None:
     artifacts = FilesystemArtifactStore()
     workspace_root = tmp_path
     _write_inventory_rows(
@@ -41,7 +45,9 @@ def test_resolve_inventory_route_uses_unique_inventory_source_match(tmp_path: Pa
     assert decision.review_required == "no"
 
 
-def test_resolve_inventory_route_flags_ambiguous_inventory_matches(tmp_path: Path) -> None:
+def test_resolve_inventory_route_flags_ambiguous_inventory_matches(
+    tmp_path: Path,
+) -> None:
     artifacts = FilesystemArtifactStore()
     workspace_root = tmp_path
     _write_inventory_rows(
@@ -71,7 +77,9 @@ def test_resolve_inventory_route_flags_ambiguous_inventory_matches(tmp_path: Pat
     assert "eth-wallet-ledger" in decision.review_reason
 
 
-def test_resolve_inventory_route_falls_back_to_generic_network_scope(tmp_path: Path) -> None:
+def test_resolve_inventory_route_falls_back_to_generic_network_scope(
+    tmp_path: Path,
+) -> None:
     decision = resolve_inventory_route(
         artifacts=FilesystemArtifactStore(),
         workspace_root=tmp_path,
@@ -84,6 +92,48 @@ def test_resolve_inventory_route_falls_back_to_generic_network_scope(tmp_path: P
 
     assert decision.source_folder == "ethereum-wallet-0xabcdef12"
     assert decision.inventory_match_status == "generic_scope_routing"
+
+
+def test_resolve_inventory_route_prefers_routing_scope_tokens_over_broad_identifiers(
+    tmp_path: Path,
+) -> None:
+    artifacts = FilesystemArtifactStore()
+    workspace_root = tmp_path
+    _write_inventory_rows(
+        artifacts,
+        workspace_root,
+        evidence_rows=[
+            {
+                "normalized_identifier": "0xbb4d728717a8ea00b316366daa695d41f6fdc722",
+                "source": "bsc-wallet-main",
+            },
+            {
+                "normalized_identifier": "0x10ed43c718714eb63d5aa57b78b54704e256024e",
+                "source": "pancakeswap-router",
+            },
+        ],
+        source_rows=[
+            {"source": "bsc-wallet-main"},
+            {"source": "pancakeswap-router"},
+        ],
+    )
+
+    decision = resolve_inventory_route(
+        artifacts=artifacts,
+        workspace_root=workspace_root,
+        source_folder="wallet-candidate",
+        facts=IntakeFileFacts(
+            scope_tokens=(
+                "evm:0xbb4d728717a8ea00b316366daa695d41f6fdc722",
+                "evm:0x10ed43c718714eb63d5aa57b78b54704e256024e",
+            ),
+            routing_scope_tokens=("evm:0xbb4d728717a8ea00b316366daa695d41f6fdc722",),
+            network_hints=("bsc",),
+        ),
+    )
+
+    assert decision.source_folder == "bsc-wallet-main"
+    assert decision.inventory_match_status == "inventory_source_match"
 
 
 def _write_inventory_rows(

--- a/tests/unit/application/normalization/translation_inputs/__init__.py
+++ b/tests/unit/application/normalization/translation_inputs/__init__.py
@@ -1,0 +1,1 @@
+"""Translation input planning unit tests."""

--- a/tests/unit/application/normalization/translation_inputs/test_normalization_integration.py
+++ b/tests/unit/application/normalization/translation_inputs/test_normalization_integration.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import cast, override
+
+import pytest
+
+from tallylot.application.normalization import NormalizeRequest
+from tallylot.application.resource_refs import to_resource_ref
+from tallylot.domain.types import JsonValue
+from tallylot.infrastructure.serialization.filesystem import FilesystemArtifactStore
+from tallylot.ports.source_adapters import SourceAdapter
+from tallylot.ports.source_profiles import FileInventoryEntry, SourceProfile
+from tallylot.ports.source_translation import SourceTranslationBatch
+from tallylot.ports.translation_inputs import (
+    TranslationCoverageMode,
+    TranslationCoverageWindow,
+    TranslationFreshness,
+    TranslationFreshnessKind,
+    TranslationInputCandidate,
+    TranslationInputPlan,
+    TranslationSelectionMode,
+    translation_input_content_fingerprint,
+    translation_input_coverage_from_inventory_entry,
+)
+from repo_support.capture_roots import materialize_capture_root
+from tests.support.services import (
+    FakeSourceRegistry,
+    MatchingSourceAdapter,
+    build_registry_backed_normalization_service,
+)
+
+
+class TrackingArtifactStore(FilesystemArtifactStore):
+    def __init__(self, events: list[str]) -> None:
+        super().__init__()
+        self._events = events
+
+    @override
+    def write_json(self, path: Path, payload: JsonValue) -> None:
+        super().write_json(path, payload)
+        self._events.append(path.name)
+
+
+class PlanningAdapter(MatchingSourceAdapter):
+    def __init__(
+        self,
+        adapter_id: str,
+        *,
+        candidate_mode: str,
+        events: list[str] | None = None,
+    ) -> None:
+        super().__init__(adapter_id)
+        self._candidate_mode = candidate_mode
+        self._events = events if events is not None else []
+        self.translate_called = False
+        self.translate_selected_called = False
+
+    @override
+    def translate(
+        self, profile: SourceProfile, raw_dir: Path
+    ) -> SourceTranslationBatch:
+        del profile, raw_dir
+        self.translate_called = True
+        raise AssertionError(
+            "planner-enabled adapters should use translate_selected_inputs"
+        )
+
+    def describe_translation_inputs(
+        self,
+        profile: SourceProfile,
+        raw_dir: Path,
+    ) -> tuple[TranslationInputCandidate, ...]:
+        del raw_dir
+        entries = tuple(
+            entry for entry in profile.file_inventory if entry.suffix == ".csv"
+        )
+        if self._candidate_mode == "single":
+            return (candidate_from_entry(entries[0], candidate_id="single"),)
+        if self._candidate_mode == "blocked":
+            return (
+                candidate_from_entry(
+                    entries[0],
+                    candidate_id="first",
+                    coverage=unknown_coverage(),
+                    freshness=unknown_freshness(),
+                ),
+                candidate_from_entry(
+                    entries[1],
+                    candidate_id="second",
+                    coverage=unknown_coverage(),
+                    freshness=unknown_freshness(),
+                ),
+            )
+        return (
+            candidate_from_entry(
+                entries[0],
+                candidate_id="older",
+                freshness=rank_freshness(1),
+            ),
+            candidate_from_entry(
+                entries[1],
+                candidate_id="newer",
+                freshness=rank_freshness(2),
+            ),
+        )
+
+    def translate_selected_inputs(
+        self,
+        profile: SourceProfile,
+        raw_dir: Path,
+        plan: TranslationInputPlan,
+    ) -> SourceTranslationBatch:
+        del profile, raw_dir, plan
+        self.translate_selected_called = True
+        self._events.append("translate_selected_inputs")
+
+        return SourceTranslationBatch(
+            drafts=(),
+            balance_references=(),
+            balance_reference_issues=(),
+            issues=(),
+            reviews=(),
+            location_inventory=(),
+        )
+
+
+class LegacyAdapter(MatchingSourceAdapter):
+    def __init__(self, adapter_id: str) -> None:
+        super().__init__(adapter_id)
+        self.translate_called = False
+
+    @override
+    def translate(
+        self, profile: SourceProfile, raw_dir: Path
+    ) -> SourceTranslationBatch:
+        del profile, raw_dir
+        self.translate_called = True
+
+        return SourceTranslationBatch(
+            drafts=(),
+            balance_references=(),
+            balance_reference_issues=(),
+            issues=(),
+            reviews=(),
+            location_inventory=(),
+        )
+
+
+def test_normalization_writes_planner_artifacts_before_translation(
+    tmp_path: Path,
+) -> None:
+    raw_dir = materialize_capture_root(tmp_path, source="planner_fixture")
+    (raw_dir / "one.csv").write_text(
+        "Timestamp,Amount\n2026-03-23 15:47:00 UTC,1\n",
+        encoding="utf-8",
+    )
+    events: list[str] = []
+    artifacts = TrackingArtifactStore(events)
+    adapter = PlanningAdapter("planner_fixture", candidate_mode="single", events=events)
+    service = build_registry_backed_normalization_service(
+        registry=FakeSourceRegistry(source_adapters=(cast(SourceAdapter, adapter),)),
+        artifacts=artifacts,
+    )
+    output_dir = tmp_path / "normalized"
+
+    response = service.execute(
+        NormalizeRequest(
+            source="planner_fixture",
+            raw_capture_ref=to_resource_ref(raw_dir),
+            normalized_output_ref=to_resource_ref(output_dir),
+        )
+    )
+
+    assert response.translation_planner_used is True
+    assert (output_dir / "translation_input_candidates.json").exists()
+    assert (output_dir / "translation_input_plan.json").exists()
+    assert events.index("translation_input_plan.json") < events.index(
+        "translate_selected_inputs"
+    )
+
+
+def test_normalization_blocks_before_writing_facts_for_blocked_plan(
+    tmp_path: Path,
+) -> None:
+    raw_dir = materialize_capture_root(tmp_path, source="planner_fixture")
+    (raw_dir / "one.csv").write_text(
+        "Timestamp,Amount\n2026-03-23 15:47:00 UTC,1\n",
+        encoding="utf-8",
+    )
+    (raw_dir / "two.csv").write_text(
+        "Timestamp,Amount\n2026-03-24 15:47:00 UTC,2\n",
+        encoding="utf-8",
+    )
+    artifacts = FilesystemArtifactStore()
+    adapter = PlanningAdapter("planner_fixture", candidate_mode="blocked")
+    service = build_registry_backed_normalization_service(
+        registry=FakeSourceRegistry(source_adapters=(cast(SourceAdapter, adapter),)),
+        artifacts=artifacts,
+    )
+    output_dir = tmp_path / "normalized"
+
+    with pytest.raises(
+        ValueError, match="translation input planning blocked normalization"
+    ):
+        service.execute(
+            NormalizeRequest(
+                source="planner_fixture",
+                raw_capture_ref=to_resource_ref(raw_dir),
+                normalized_output_ref=to_resource_ref(output_dir),
+            )
+        )
+
+    issue_rows = artifacts.read_rows(output_dir / "translation_input_issues.csv")
+
+    assert adapter.translate_selected_called is False
+    assert (output_dir / "translation_input_candidates.json").exists()
+    assert (output_dir / "translation_input_plan.json").exists()
+    assert issue_rows[0]["kind"] == "blocked_unknown_coverage"
+    assert not (output_dir / "facts.csv").exists()
+    assert not (output_dir / "balance_snapshots.csv").exists()
+    assert not (output_dir / "balance_references.csv").exists()
+
+
+def test_normalization_uses_legacy_translate_fallback_when_planner_is_absent(
+    tmp_path: Path,
+) -> None:
+    raw_dir = materialize_capture_root(tmp_path, source="legacy_fixture")
+    (raw_dir / "one.csv").write_text(
+        "Timestamp,Amount\n2026-03-23 15:47:00 UTC,1\n",
+        encoding="utf-8",
+    )
+    artifacts = FilesystemArtifactStore()
+    adapter = LegacyAdapter("legacy_fixture")
+    service = build_registry_backed_normalization_service(
+        registry=FakeSourceRegistry(source_adapters=(cast(SourceAdapter, adapter),)),
+        artifacts=artifacts,
+    )
+    output_dir = tmp_path / "normalized"
+
+    response = service.execute(
+        NormalizeRequest(
+            source="legacy_fixture",
+            raw_capture_ref=to_resource_ref(raw_dir),
+            normalized_output_ref=to_resource_ref(output_dir),
+        )
+    )
+
+    assert adapter.translate_called is True
+    assert response.translation_planner_used is False
+    assert response.translation_candidate_count == 0
+    assert not (output_dir / "translation_input_plan.json").exists()
+
+
+def test_normalization_summary_includes_translation_metrics(tmp_path: Path) -> None:
+    raw_dir = materialize_capture_root(tmp_path, source="planner_fixture")
+    (raw_dir / "older.csv").write_text(
+        "Timestamp,Amount\n2026-03-23 15:47:00 UTC,1\n",
+        encoding="utf-8",
+    )
+    (raw_dir / "newer.csv").write_text(
+        "Timestamp,Amount\n2026-03-23 15:47:00 UTC,2\n",
+        encoding="utf-8",
+    )
+    artifacts = FilesystemArtifactStore()
+    adapter = PlanningAdapter("planner_fixture", candidate_mode="superseded")
+    service = build_registry_backed_normalization_service(
+        registry=FakeSourceRegistry(source_adapters=(cast(SourceAdapter, adapter),)),
+        artifacts=artifacts,
+    )
+    output_dir = tmp_path / "normalized"
+
+    response = service.execute(
+        NormalizeRequest(
+            source="planner_fixture",
+            raw_capture_ref=to_resource_ref(raw_dir),
+            normalized_output_ref=to_resource_ref(output_dir),
+        )
+    )
+    summary = json.loads(
+        (output_dir / "normalization_summary.json").read_text(encoding="utf-8")
+    )
+
+    assert response.translation_candidate_count == 2
+    assert response.translation_selected_count == 1
+    assert response.translation_superseded_count == 1
+    assert response.translation_blocked_count == 0
+    assert response.translation_planner_used is True
+    assert summary["translation_candidate_count"] == 2
+    assert summary["translation_selected_count"] == 1
+    assert summary["translation_superseded_count"] == 1
+    assert summary["translation_blocked_count"] == 0
+    assert summary["translation_planner_used"] is True
+
+
+def candidate_from_entry(
+    entry: FileInventoryEntry,
+    *,
+    candidate_id: str,
+    coverage: TranslationCoverageWindow | None = None,
+    freshness: TranslationFreshness | None = None,
+) -> TranslationInputCandidate:
+    selection_mode = TranslationSelectionMode.REPLACEABLE_RANGE
+    return TranslationInputCandidate(
+        candidate_id=candidate_id,
+        selection_group="planner_fixture",
+        family_id="fixture",
+        member_relative_paths=(entry.relative_path,),
+        selection_mode=selection_mode,
+        coverage=coverage or translation_input_coverage_from_inventory_entry(entry),
+        freshness=freshness or rank_freshness(1),
+        content_fingerprint=translation_input_content_fingerprint(
+            member_sha256s=(entry.sha256,),
+            family_id="fixture",
+            selection_group="planner_fixture",
+            selection_mode=selection_mode,
+        ),
+        comparison_key="planner_fixture",
+        description=f"Fixture candidate {candidate_id}",
+        comparable=True,
+    )
+
+
+def unknown_coverage() -> TranslationCoverageWindow:
+    return TranslationCoverageWindow(
+        start_at=None,
+        start_precision=None,
+        end_at=None,
+        end_precision=None,
+        mode=TranslationCoverageMode.UNKNOWN,
+    )
+
+
+def rank_freshness(rank: int) -> TranslationFreshness:
+    return TranslationFreshness(
+        kind=TranslationFreshnessKind.ADAPTER_RANK,
+        timestamp=None,
+        rank=rank,
+    )
+
+
+def unknown_freshness() -> TranslationFreshness:
+    return TranslationFreshness(
+        kind=TranslationFreshnessKind.UNKNOWN,
+        timestamp=None,
+        rank=None,
+    )

--- a/tests/unit/application/normalization/translation_inputs/test_planner.py
+++ b/tests/unit/application/normalization/translation_inputs/test_planner.py
@@ -1,0 +1,437 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from tallylot.application.normalization.translation_inputs import (
+    plan_translation_inputs,
+)
+from tallylot.domain.temporal import TemporalPrecision
+from tallylot.ports.source_profiles import FileInventoryEntry, SourceProfile
+from tallylot.ports.translation_inputs import (
+    TranslationCoverageMode,
+    TranslationCoverageWindow,
+    TranslationFreshness,
+    TranslationFreshnessKind,
+    TranslationInputCandidate,
+    TranslationSelectionMode,
+    translation_input_content_fingerprint,
+)
+from tests.support.services import build_source_profile
+
+
+def test_plan_translation_inputs_selects_single_candidate() -> None:
+    entry = inventory_entry("single.csv", "sha-single")
+    result = plan_translation_inputs(
+        profile=profile_for(entry),
+        candidates=(
+            candidate(
+                candidate_id="single",
+                entry=entry,
+                coverage=unknown_coverage(),
+                freshness=unknown_freshness(),
+            ),
+        ),
+    )
+
+    assert result.plan.selected_candidate_ids == ("single",)
+    assert result.plan.blocked is False
+    assert decision_statuses(result) == {"single": "selected"}
+
+
+def test_plan_translation_inputs_selects_disjoint_appendable_ranges() -> None:
+    first = inventory_entry("2021.csv", "sha-2021")
+    second = inventory_entry("2022.csv", "sha-2022")
+    result = plan_translation_inputs(
+        profile=profile_for(first, second),
+        candidates=(
+            candidate(
+                candidate_id="2022",
+                entry=second,
+                selection_mode=TranslationSelectionMode.APPENDABLE_RANGE,
+                coverage=bounded("2022-01-01 00:00:00", "2022-12-31 23:59:59"),
+                freshness=export_freshness("2023-01-02 00:00:00"),
+            ),
+            candidate(
+                candidate_id="2021",
+                entry=first,
+                selection_mode=TranslationSelectionMode.APPENDABLE_RANGE,
+                coverage=bounded("2021-01-01 00:00:00", "2021-12-31 23:59:59"),
+                freshness=export_freshness("2022-01-02 00:00:00"),
+            ),
+        ),
+    )
+
+    assert result.plan.selected_candidate_ids == ("2021", "2022")
+    assert result.plan.blocked is False
+    assert decision_statuses(result) == {"2021": "selected", "2022": "selected"}
+
+
+def test_plan_translation_inputs_supersedes_older_identical_duplicate() -> None:
+    older = inventory_entry("older.csv", "shared-sha")
+    newer = inventory_entry("newer.csv", "shared-sha")
+    result = plan_translation_inputs(
+        profile=profile_for(older, newer),
+        candidates=(
+            candidate(
+                candidate_id="older",
+                entry=older,
+                coverage=bounded("2021-01-01 00:00:00", "2021-12-31 23:59:59"),
+                freshness=export_freshness("2022-01-01 00:00:00"),
+            ),
+            candidate(
+                candidate_id="newer",
+                entry=newer,
+                coverage=bounded("2021-01-01 00:00:00", "2021-12-31 23:59:59"),
+                freshness=export_freshness("2023-01-01 00:00:00"),
+            ),
+        ),
+    )
+
+    assert result.plan.selected_candidate_ids == ("newer",)
+    assert decision_statuses(result) == {
+        "newer": "selected",
+        "older": "superseded_identical",
+    }
+
+
+def test_plan_translation_inputs_supersedes_replaced_duplicate_for_replaceable_range() -> (
+    None
+):
+    older = inventory_entry("older.csv", "sha-old")
+    newer = inventory_entry("newer.csv", "sha-new")
+    result = plan_translation_inputs(
+        profile=profile_for(older, newer),
+        candidates=(
+            candidate(
+                candidate_id="older",
+                entry=older,
+                coverage=bounded("2021-01-01 00:00:00", "2021-12-31 23:59:59"),
+                freshness=export_freshness("2022-01-01 00:00:00"),
+            ),
+            candidate(
+                candidate_id="newer",
+                entry=newer,
+                coverage=bounded("2021-01-01 00:00:00", "2021-12-31 23:59:59"),
+                freshness=export_freshness("2023-01-01 00:00:00"),
+            ),
+        ),
+    )
+
+    assert result.plan.selected_candidate_ids == ("newer",)
+    assert decision_statuses(result) == {
+        "newer": "selected",
+        "older": "superseded_replaced",
+    }
+
+
+def test_plan_translation_inputs_blocks_replaced_duplicate_for_appendable_range() -> (
+    None
+):
+    older = inventory_entry("older.csv", "sha-old")
+    newer = inventory_entry("newer.csv", "sha-new")
+    result = plan_translation_inputs(
+        profile=profile_for(older, newer),
+        candidates=(
+            candidate(
+                candidate_id="older",
+                entry=older,
+                selection_mode=TranslationSelectionMode.APPENDABLE_RANGE,
+                coverage=bounded("2021-01-01 00:00:00", "2021-12-31 23:59:59"),
+                freshness=export_freshness("2022-01-01 00:00:00"),
+            ),
+            candidate(
+                candidate_id="newer",
+                entry=newer,
+                selection_mode=TranslationSelectionMode.APPENDABLE_RANGE,
+                coverage=bounded("2021-01-01 00:00:00", "2021-12-31 23:59:59"),
+                freshness=export_freshness("2023-01-01 00:00:00"),
+            ),
+        ),
+    )
+
+    assert result.plan.blocked is True
+    assert decision_statuses(result) == {
+        "newer": "blocked_partial_overlap",
+        "older": "blocked_partial_overlap",
+    }
+
+
+def test_plan_translation_inputs_supersedes_subset_with_newer_superset() -> None:
+    subset = inventory_entry("subset.csv", "sha-subset")
+    superset = inventory_entry("superset.csv", "sha-superset")
+    result = plan_translation_inputs(
+        profile=profile_for(subset, superset),
+        candidates=(
+            candidate(
+                candidate_id="subset",
+                entry=subset,
+                coverage=bounded("2021-01-01 00:00:00", "2021-12-31 23:59:59"),
+                freshness=export_freshness("2022-01-01 00:00:00"),
+            ),
+            candidate(
+                candidate_id="superset",
+                entry=superset,
+                coverage=bounded("2021-01-01 00:00:00", "2026-03-23 00:00:00"),
+                freshness=export_freshness("2026-03-23 00:00:00"),
+            ),
+        ),
+    )
+
+    assert result.plan.selected_candidate_ids == ("superset",)
+    assert decision_statuses(result) == {
+        "subset": "superseded_replaced",
+        "superset": "selected",
+    }
+
+
+def test_plan_translation_inputs_blocks_partial_overlap() -> None:
+    first = inventory_entry("first.csv", "sha-first")
+    second = inventory_entry("second.csv", "sha-second")
+    result = plan_translation_inputs(
+        profile=profile_for(first, second),
+        candidates=(
+            candidate(
+                candidate_id="first",
+                entry=first,
+                coverage=bounded("2021-01-01 00:00:00", "2021-12-31 23:59:59"),
+                freshness=export_freshness("2022-01-01 00:00:00"),
+            ),
+            candidate(
+                candidate_id="second",
+                entry=second,
+                coverage=bounded("2021-06-01 00:00:00", "2022-05-31 23:59:59"),
+                freshness=export_freshness("2023-01-01 00:00:00"),
+            ),
+        ),
+    )
+
+    assert result.plan.blocked is True
+    assert decision_statuses(result) == {
+        "first": "blocked_partial_overlap",
+        "second": "blocked_partial_overlap",
+    }
+
+
+def test_plan_translation_inputs_blocks_unknown_coverage_with_multiple_candidates() -> (
+    None
+):
+    unknown = inventory_entry("unknown.csv", "sha-unknown")
+    bounded_entry = inventory_entry("bounded.csv", "sha-bounded")
+    result = plan_translation_inputs(
+        profile=profile_for(unknown, bounded_entry),
+        candidates=(
+            candidate(
+                candidate_id="unknown",
+                entry=unknown,
+                coverage=unknown_coverage(),
+                freshness=unknown_freshness(),
+            ),
+            candidate(
+                candidate_id="bounded",
+                entry=bounded_entry,
+                coverage=bounded("2021-01-01 00:00:00", "2021-12-31 23:59:59"),
+                freshness=export_freshness("2022-01-01 00:00:00"),
+            ),
+        ),
+    )
+
+    assert result.plan.blocked is True
+    assert decision_statuses(result) == {
+        "bounded": "blocked_unknown_coverage",
+        "unknown": "blocked_unknown_coverage",
+    }
+
+
+def test_plan_translation_inputs_blocks_incomparable_overlapping_candidates() -> None:
+    first = inventory_entry("first.csv", "sha-first")
+    second = inventory_entry("second.csv", "sha-second")
+    result = plan_translation_inputs(
+        profile=profile_for(first, second),
+        candidates=(
+            candidate(
+                candidate_id="first",
+                entry=first,
+                comparable=False,
+                coverage=bounded("2021-01-01 00:00:00", "2021-12-31 23:59:59"),
+                freshness=export_freshness("2022-01-01 00:00:00"),
+            ),
+            candidate(
+                candidate_id="second",
+                entry=second,
+                coverage=bounded("2021-01-01 00:00:00", "2026-03-23 00:00:00"),
+                freshness=export_freshness("2023-01-01 00:00:00"),
+            ),
+        ),
+    )
+
+    assert result.plan.blocked is True
+    assert decision_statuses(result) == {
+        "first": "blocked_incomparable_candidates",
+        "second": "blocked_incomparable_candidates",
+    }
+
+
+def test_plan_translation_inputs_blocks_exclusive_snapshot_tie() -> None:
+    first = inventory_entry("first.csv", "sha-first")
+    second = inventory_entry("second.csv", "sha-second")
+    result = plan_translation_inputs(
+        profile=profile_for(first, second),
+        candidates=(
+            candidate(
+                candidate_id="first",
+                entry=first,
+                selection_mode=TranslationSelectionMode.EXCLUSIVE_SNAPSHOT,
+                coverage=bounded("2026-03-23 00:00:00", "2026-03-23 00:00:00"),
+                freshness=export_freshness("2026-03-23 00:00:00"),
+            ),
+            candidate(
+                candidate_id="second",
+                entry=second,
+                selection_mode=TranslationSelectionMode.EXCLUSIVE_SNAPSHOT,
+                coverage=bounded("2026-03-23 00:00:00", "2026-03-23 00:00:00"),
+                freshness=export_freshness("2026-03-23 00:00:00"),
+            ),
+        ),
+    )
+
+    assert result.plan.blocked is True
+    assert decision_statuses(result) == {
+        "first": "blocked_ambiguous_freshness",
+        "second": "blocked_ambiguous_freshness",
+    }
+
+
+def test_plan_translation_inputs_keeps_selected_order_stable_across_repeated_runs() -> (
+    None
+):
+    first = inventory_entry("second.csv", "sha-second")
+    second = inventory_entry("first.csv", "sha-first")
+    third = inventory_entry("third.csv", "sha-third")
+    candidates = (
+        candidate(
+            candidate_id="third",
+            entry=third,
+            selection_mode=TranslationSelectionMode.APPENDABLE_RANGE,
+            coverage=bounded("2023-01-01 00:00:00", "2023-12-31 23:59:59"),
+            freshness=export_freshness("2024-01-01 00:00:00"),
+        ),
+        candidate(
+            candidate_id="first",
+            entry=second,
+            selection_mode=TranslationSelectionMode.APPENDABLE_RANGE,
+            coverage=bounded("2021-01-01 00:00:00", "2021-12-31 23:59:59"),
+            freshness=export_freshness("2022-01-01 00:00:00"),
+        ),
+        candidate(
+            candidate_id="second",
+            entry=first,
+            selection_mode=TranslationSelectionMode.APPENDABLE_RANGE,
+            coverage=bounded("2022-01-01 00:00:00", "2022-12-31 23:59:59"),
+            freshness=export_freshness("2023-01-01 00:00:00"),
+        ),
+    )
+    profile = profile_for(first, second, third)
+
+    first_result = plan_translation_inputs(profile=profile, candidates=candidates)
+    second_result = plan_translation_inputs(
+        profile=profile, candidates=tuple(reversed(candidates))
+    )
+
+    assert first_result.plan.selected_candidate_ids == ("first", "second", "third")
+    assert second_result.plan.selected_candidate_ids == ("first", "second", "third")
+    assert first_result.plan.decisions == second_result.plan.decisions
+
+
+def inventory_entry(relative_path: str, sha256: str) -> FileInventoryEntry:
+    return FileInventoryEntry(
+        relative_path=relative_path,
+        suffix=".csv",
+        size_bytes=1,
+        sha256=sha256,
+        row_count=1,
+    )
+
+
+def profile_for(*entries: FileInventoryEntry) -> SourceProfile:
+    return build_source_profile(
+        adapter_id="planner_fixture",
+        source="planner_fixture",
+        file_inventory=entries,
+    )
+
+
+def candidate(
+    *,
+    candidate_id: str,
+    entry: FileInventoryEntry,
+    coverage: TranslationCoverageWindow,
+    freshness: TranslationFreshness,
+    selection_mode: TranslationSelectionMode = TranslationSelectionMode.REPLACEABLE_RANGE,
+    selection_group: str = "group",
+    comparable: bool = True,
+) -> TranslationInputCandidate:
+    return TranslationInputCandidate(
+        candidate_id=candidate_id,
+        selection_group=selection_group,
+        family_id="family",
+        member_relative_paths=(entry.relative_path,),
+        selection_mode=selection_mode,
+        coverage=coverage,
+        freshness=freshness,
+        content_fingerprint=translation_input_content_fingerprint(
+            member_sha256s=(entry.sha256,),
+            family_id="family",
+            selection_group=selection_group,
+            selection_mode=selection_mode,
+        ),
+        comparison_key="comparison",
+        description=f"Candidate {candidate_id}",
+        comparable=comparable,
+    )
+
+
+def bounded(start_at: str, end_at: str) -> TranslationCoverageWindow:
+    return TranslationCoverageWindow(
+        start_at=timestamp(start_at),
+        start_precision=TemporalPrecision.TIMESTAMP,
+        end_at=timestamp(end_at),
+        end_precision=TemporalPrecision.TIMESTAMP,
+        mode=TranslationCoverageMode.BOUNDED,
+    )
+
+
+def unknown_coverage() -> TranslationCoverageWindow:
+    return TranslationCoverageWindow(
+        start_at=None,
+        start_precision=None,
+        end_at=None,
+        end_precision=None,
+        mode=TranslationCoverageMode.UNKNOWN,
+    )
+
+
+def export_freshness(value: str) -> TranslationFreshness:
+    return TranslationFreshness(
+        kind=TranslationFreshnessKind.EXPORT_TIMESTAMP,
+        timestamp=timestamp(value),
+        rank=None,
+    )
+
+
+def unknown_freshness() -> TranslationFreshness:
+    return TranslationFreshness(
+        kind=TranslationFreshnessKind.UNKNOWN,
+        timestamp=None,
+        rank=None,
+    )
+
+
+def timestamp(value: str) -> datetime:
+    return datetime.strptime(value, "%Y-%m-%d %H:%M:%S").replace(tzinfo=UTC)
+
+
+def decision_statuses(result: object) -> dict[str, str]:
+    return {
+        decision.candidate_id: decision.status
+        for decision in getattr(result, "plan").decisions
+    }

--- a/tests/unit/application/profiling/test_inventory.py
+++ b/tests/unit/application/profiling/test_inventory.py
@@ -33,6 +33,9 @@ def test_inventory_file_details_applies_binance_filename_offset_to_min_and_max(
     assert row_count == 2
     assert details.min_timestamp == "2023-09-21 00:20:55"
     assert details.max_timestamp == "2023-09-21 01:20:55"
+    assert details.observed_period_start == "2023-09-21"
+    assert details.observed_period_end == "2023-09-21"
+    assert details.observed_period_label == "2023-09"
     assert details.timezone_mode == "filename_offset"
     assert details.timezone_value == "UTC-06:00"
 
@@ -57,9 +60,13 @@ def test_inventory_file_details_detects_header_utc_and_date_only_modes(
     assert utc_details.timezone_mode == "header_utc"
     assert utc_details.timezone_value == "UTC"
     assert utc_details.min_timestamp == "2021-07-06 17:37:09"
+    assert utc_details.observed_period_start == "2021-07-06"
+    assert utc_details.observed_period_end == "2021-07-06"
     assert date_only_details.timezone_mode == "date_only"
     assert date_only_details.timestamp_resolution == "date_only"
     assert date_only_details.min_timestamp == "2021-05-09 00:00:00"
+    assert date_only_details.observed_period_start == "2021-05-09"
+    assert date_only_details.observed_period_end == "2021-05-09"
 
 
 def test_inventory_file_details_ignores_placeholder_no_data_rows(
@@ -214,6 +221,9 @@ def test_build_inventory_enriches_rows_from_capture_metadata(tmp_path: Path) -> 
     assert issues == []
     assert inventory[0].capture_uid == "01HV4A5H7VJH7M3Y5A6B7C8D9E"
     assert inventory[0].source == "eth-wallet-fixture"
+    assert inventory[0].observed_period_start == "2026-03-23"
+    assert inventory[0].observed_period_end == "2026-03-23"
+    assert inventory[0].observed_period_label == "2026-03"
 
 
 def test_build_inventory_excludes_capture_control_artifacts(tmp_path: Path) -> None:

--- a/tests/unit/application/profiling/test_inventory.py
+++ b/tests/unit/application/profiling/test_inventory.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from tallylot.application.profiling.artifacts import write_profile_artifacts
+from tallylot.application.profiling.csv_inventory import infer_date_only_format
 from tallylot.application.profiling.inventory import (
     _inventory_file_details,
     build_inventory,
@@ -67,6 +68,156 @@ def test_inventory_file_details_detects_header_utc_and_date_only_modes(
     assert date_only_details.min_timestamp == "2021-05-09 00:00:00"
     assert date_only_details.observed_period_start == "2021-05-09"
     assert date_only_details.observed_period_end == "2021-05-09"
+
+
+def test_inventory_file_details_anchors_day_first_dates_to_matching_filename_date(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "2023-05-06 My_Trading_History_Report.csv"
+    path.write_text(
+        "DATE,PAIR,ADDR,DESCRIPTION,PNL\n06/05/2023,BTCUSD,bb4d,profit,10\n",
+        encoding="utf-8",
+    )
+
+    _, row_count, details = _inventory_file_details(path)
+
+    assert row_count == 1
+    assert details.date_field == "DATE"
+    assert details.timestamp_resolution == "date_only"
+    assert details.timezone_mode == "date_only"
+    assert details.min_timestamp == "2023-05-06 00:00:00"
+    assert details.max_timestamp == "2023-05-06 00:00:00"
+
+
+def test_inventory_file_details_detects_day_first_slash_dates_from_component_bounds(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "trading-history.csv"
+    path.write_text(
+        "DATE,PAIR,ADDR,DESCRIPTION,PNL\n13/05/2023,BTCUSD,bb4d,profit,10\n",
+        encoding="utf-8",
+    )
+
+    _, row_count, details = _inventory_file_details(path)
+
+    assert row_count == 1
+    assert details.timestamp_resolution == "date_only"
+    assert details.timezone_mode == "date_only"
+    assert details.min_timestamp == "2023-05-13 00:00:00"
+
+
+def test_inventory_file_details_detects_month_first_slash_dates_from_component_bounds(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "trading-history.csv"
+    path.write_text(
+        "DATE,PAIR,ADDR,DESCRIPTION,PNL\n05/13/2023,BTCUSD,bb4d,profit,10\n",
+        encoding="utf-8",
+    )
+
+    _, row_count, details = _inventory_file_details(path)
+
+    assert row_count == 1
+    assert details.timestamp_resolution == "date_only"
+    assert details.timezone_mode == "date_only"
+    assert details.min_timestamp == "2023-05-13 00:00:00"
+
+
+def test_inventory_file_details_uses_chronology_when_only_one_slash_format_preserves_order(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "trading-history.csv"
+    path.write_text(
+        "DATE,PAIR,ADDR,DESCRIPTION,PNL\n"
+        "02/03/2023,BTCUSD,bb4d,profit,10\n"
+        "03/02/2023,BTCUSD,bb4d,profit,11\n"
+        "03/03/2023,BTCUSD,bb4d,profit,12\n",
+        encoding="utf-8",
+    )
+
+    _, row_count, details = _inventory_file_details(path)
+
+    assert row_count == 3
+    assert details.timestamp_resolution == "date_only"
+    assert details.timezone_mode == "date_only"
+    assert details.min_timestamp == "2023-02-03 00:00:00"
+    assert details.max_timestamp == "2023-03-03 00:00:00"
+
+
+def test_inventory_file_details_anchors_month_first_dates_to_matching_filename_date(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "2023-12-05 trading-history.csv"
+    path.write_text(
+        "DATE,PAIR,ADDR,DESCRIPTION,PNL\n12/05/2023,BTCUSD,bb4d,profit,10\n",
+        encoding="utf-8",
+    )
+
+    _, row_count, details = _inventory_file_details(path)
+
+    assert row_count == 1
+    assert details.timestamp_resolution == "date_only"
+    assert details.timezone_mode == "date_only"
+    assert details.min_timestamp == "2023-12-05 00:00:00"
+
+
+def test_infer_date_only_format_rejects_monthly_first_of_month_sequence() -> None:
+    assert infer_date_only_format(["01/02/2023", "01/03/2023", "01/04/2023"]) is None
+
+
+def test_infer_date_only_format_rejects_sparse_chronology_with_large_gaps() -> None:
+    assert infer_date_only_format(["02/03/2023", "03/02/2023", "04/02/2023"]) is None
+
+
+def test_infer_date_only_format_rejects_chronology_with_near_year_gap() -> None:
+    assert infer_date_only_format(["02/03/2023", "03/02/2023", "03/02/2024"]) is None
+
+
+def test_infer_date_only_format_rejects_chronology_with_just_over_year_gap() -> None:
+    assert infer_date_only_format(["02/03/2024", "03/02/2024", "03/02/2025"]) is None
+
+
+def test_infer_date_only_format_rejects_ambiguous_slash_sequence_without_decisive_signal() -> (
+    None
+):
+    assert infer_date_only_format(["06/05/2023", "07/05/2023", "08/05/2023"]) is None
+
+
+def test_infer_date_only_format_uses_one_day_witness_to_distinguish_day_and_month() -> (
+    None
+):
+    assert (
+        infer_date_only_format(["01/02/2023", "02/02/2023", "01/03/2023"]) == "%d/%m/%Y"
+    )
+
+
+def test_infer_date_only_format_uses_filename_anchor_for_month_first_dates() -> None:
+    assert (
+        infer_date_only_format(
+            ["12/05/2023"],
+            filename="2023-12-05 trading-history.csv",
+        )
+        == "%m/%d/%Y"
+    )
+
+
+def test_inventory_file_details_leaves_ambiguous_slash_dates_unclassified_without_filename_anchor(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "trading-history.csv"
+    path.write_text(
+        "DATE,PAIR,ADDR,DESCRIPTION,PNL\n06/05/2023,BTCUSD,bb4d,profit,10\n",
+        encoding="utf-8",
+    )
+
+    _, row_count, details = _inventory_file_details(path)
+
+    assert row_count == 1
+    assert details.date_field == "DATE"
+    assert details.timestamp_resolution == "unknown"
+    assert details.timezone_mode == "naive"
+    assert details.min_timestamp == ""
+    assert details.max_timestamp == ""
 
 
 def test_inventory_file_details_ignores_placeholder_no_data_rows(


### PR DESCRIPTION
Why:
- move raw-file winner selection out of adapter-local heuristics and into a deterministic core planning step before translation
- fix the Coinbase live-capture regression where path-ordered retail CSV selection missed the newer all-time export and hid the `2025-10-17` asset migration facts
- prevent generic intake routing and slash-form date inference from blocking or mislabeling planner-ready source captures

What:
- add translation input planning contracts, planner validation and selection logic, planner artifacts, normalization summary metrics, and the adapter opt-in translation path
- migrate Coinbase retail normalization to candidate-based planning, refresh adapter-pack goldens, and harden timezone validation so empty header-only files do not falsely block live verification
- add routing scope tokens so intake matching and generic wallet naming prefer stable identifiers, and extract slash-date inference into a dedicated profiling seam with decisive chronology rules
- document the planner phase, planner artifacts, Coinbase-first rollout, and staged future adapter migration path in the roadmap and normalization docs

Checks:
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.docs_maintenance sync --check`
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run markdownlint ROADMAP.md docs/concepts/reconciliation-tax-architecture.md docs/guides/write-an-adapter.md docs/status/current-state.md`
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pytest tests/unit/application/profiling tests/unit/application/normalization`
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pytest src/tallylot/adapters/sources/platforms/coinbase/tests`
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run pytest tests/e2e/test_cli.py -k "normalize or assemble or coinbase"`
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run python -m tools.run_quality_gates --full-tests`
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run tallylot source normalize --source coinbase --raw-dir /home/user/tallylot-workspace/evidence/raw/source/coinbase/2026-04-11T23-35-12Z --output-dir /home/user/tallylot-workspace/working/supporting_artifacts/translation_planner_verify/coinbase_capture`
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run tallylot source normalize --source coinbase --raw-dir /home/user/tallylot-workspace/evidence/raw/source/coinbase/2026-04-11T23-35-12Z`
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run tallylot source assemble --source coinbase --workspace-root /home/user/tallylot-workspace --output-dir /home/user/tallylot-workspace/working/supporting_artifacts/translation_planner_verify/coinbase_source`
- `UV_PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312" uv run tallylot reconciliation balances check --input-root /home/user/tallylot-workspace/working/supporting_artifacts/translation_planner_verify/coinbase_source --output-root /home/user/tallylot-workspace/working/supporting_artifacts/translation_planner_verify/coinbase_check --as-of 2026-03-22`

Issue linkage:
- None: no existing repo issue matched the translation input planner, Coinbase file-selection regression, and intake follow-up after search

Included checkpoints:
- `refactor(normalization): add translation input planning contracts`
- `feat(normalization): integrate planned adapter translation path`
- `fix(coinbase): select retail exports through core planning`
- `docs(normalization): document translation input planning`
- `fix(intake): prefer stable routing ids and infer slash dates`
