### PR TITLE
chore(licensing): adopt PolyForm and contributor agreement

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,8 @@
 <!-- markdownlint-disable-file MD041 MD032 -->
 <!-- Multi-checkpoint PRs must merge-commit. Single-checkpoint PRs must squash. -->
 <!-- Open PRs as draft first. Mark ready for review only after a clean hardening pass. -->
+<!-- By opening this PR, you confirm that you have read CONTRIBUTING.md and
+agree that the submission is governed by CLA.md. -->
 
 Why:
 - explain the problem or constraint this PR resolves

--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,129 @@
+# TallyLot Contributor License Agreement
+
+This Contributor License Agreement ("Agreement") documents the rights granted by
+contributors to TallyLot. It is adapted from the Harmony contributor agreement
+templates and uses the contributor license model, not copyright assignment.
+
+For this Agreement, "We" or "Us" means Chris Wright as the current maintainer
+of TallyLot, together with any successor maintainer or entity that receives
+stewardship of the project and agrees to the obligations in this Agreement.
+
+This Agreement takes effect on the earlier of:
+
+- the date You first Submit a Contribution to TallyLot
+- the date You otherwise indicate agreement in writing, including through a
+  pull request or similar contribution workflow
+
+Do not Submit a Contribution unless You can agree to these terms.
+
+## 1. Definitions
+
+"You" means the individual copyright owner, or the legal entity authorized by
+the copyright owner, that is making this Agreement with Us. For legal entities,
+all entities that control, are controlled by, or are under common control with
+that entity are considered a single contributor.
+
+"Contribution" means any work of authorship that is intentionally Submitted by
+You to Us for inclusion in, or documentation of, TallyLot, where You own or
+assert ownership of the relevant copyright and other rights needed to grant this
+Agreement.
+
+"Copyright" means all rights protecting works of authorship owned or controlled
+by You, including copyright, moral rights, and neighboring rights to the extent
+applicable.
+
+"Material" means the TallyLot repository and any project materials managed by
+Us to which the Contribution is Submitted.
+
+"Submit" or "Submitted" means any form of electronic, verbal, or written
+communication sent to Us or our representatives for the purpose of discussing,
+reviewing, or improving the Material, including source control systems, pull
+requests, issue trackers, and direct patches, but excluding any communication
+that You clearly mark as "Not a Contribution."
+
+"Submission Date" means the date on which You Submit a Contribution.
+
+## 2. Grant of Rights
+
+### 2.1 Copyright License
+
+You retain ownership of the Copyright in Your Contribution.
+
+To the maximum extent permitted by law, You grant to Us a perpetual, worldwide,
+non-exclusive, transferable, royalty-free, irrevocable license under the
+Copyright covering the Contribution, with the right to sublicense through
+multiple tiers of sublicensees, to reproduce, modify, display, perform,
+distribute, relicense, and otherwise exploit the Contribution as part of the
+Material or derivative works of the Material.
+
+### 2.2 Patent License
+
+For patent claims that You own, control, or have the right to grant, now or in
+the future, You grant to Us a perpetual, worldwide, non-exclusive,
+transferable, royalty-free, irrevocable patent license, with the right to
+sublicense through multiple tiers of sublicensees, to make, have made, use,
+sell, offer for sale, import, and otherwise transfer the Contribution and the
+Contribution in combination with the Material.
+
+This license applies only to the extent that the exercise of the licensed
+rights would otherwise infringe those patent claims.
+
+### 2.3 Outbound Licensing
+
+As a condition on the grants above, if We include Your Contribution in TallyLot,
+We will also make it available under the repository license or licenses in use
+for the relevant material on the Submission Date.
+
+In addition, We may license the Contribution under any other license or
+agreement, including commercial, proprietary, source-available, open-source, or
+documentation licenses.
+
+### 2.4 Moral Rights
+
+If moral rights apply to the Contribution, to the maximum extent permitted by
+law, You waive and agree not to assert them against Us, our successors in
+interest, or our licensees.
+
+### 2.5 No Obligation To Use
+
+We are not obligated to use, merge, distribute, or continue using any
+Contribution.
+
+### 2.6 Reservation of Rights
+
+Any rights not expressly granted under this Agreement are reserved by You.
+
+## 3. Your Representations
+
+You confirm that:
+
+- You have the legal authority to enter into this Agreement.
+- You own or control the rights needed to grant the licenses in Section 2.
+- Granting these rights does not violate any agreement with a third party,
+  including an employer or client.
+- If an employer, client, or other third party may own rights in the
+  Contribution, You have obtained the approvals needed before Submitting it.
+- Each Contribution is Your original creation, or You have fully disclosed the
+  source and any applicable restrictions before Submitting it.
+- You will notify Us if You become aware of facts that make any of these
+  representations inaccurate.
+
+## 4. Disclaimer
+
+Except for the express representations in Section 3, the Contribution is
+provided "AS IS", without warranties or conditions of any kind, express or
+implied, including any warranties of title, non-infringement, merchantability,
+or fitness for a particular purpose.
+
+## 5. Limitation of Liability
+
+To the maximum extent permitted by applicable law, neither party will be liable
+to the other for indirect, special, incidental, consequential, or exemplary
+damages arising out of this Agreement.
+
+## Attribution
+
+This Agreement is adapted from the Harmony contributor agreement templates,
+version 1.0, published by Project Harmony under the Creative Commons
+Attribution 3.0 Unported license:
+[https://www.harmonyagreements.org/](https://www.harmonyagreements.org/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing
+
+Use this file for contributor-facing licensing and submission rules. For repo
+structure, execution, and checkpoint rules, use the standards linked below.
+
+## Before You Start
+
+- Read [docs/standards/engineering.md](docs/standards/engineering.md),
+  [docs/standards/implementation.md](docs/standards/implementation.md), and
+  [docs/standards/commits.md](docs/standards/commits.md).
+- For non-trivial changes, open an issue or draft pull request first so scope,
+  licensing, and fit can be confirmed before You spend time on implementation.
+- Do not submit private workspace data, personal exports, secrets, or
+  third-party material that You are not authorized to contribute.
+
+## Public Project Licenses
+
+- Source code and other source-like material in this repository are
+  source-available under the [PolyForm Noncommercial License 1.0.0](LICENSE).
+- Unless otherwise noted, prose documentation in `README.md` and `docs/` is
+  available under [CC BY-NC-SA 4.0](LICENSE.docs).
+
+## Contributor Agreement
+
+External contributions are accepted only under the
+[TallyLot Contributor License Agreement](CLA.md).
+
+By intentionally Submitting a Contribution for inclusion in TallyLot, You agree
+that the submission is governed by `CLA.md`.
+
+That agreement is designed to preserve a standard contributor workflow while
+ensuring that the maintainer can:
+
+- distribute the project under its public repository licenses
+- offer separate commercial or proprietary licenses
+- relicense or sublicense accepted contributions in future project versions
+
+If Your employer, client, or another third party may own rights in Your work,
+do not Submit until You have the authority required by `CLA.md`.
+
+If You need to share material for discussion without offering it for inclusion,
+mark it clearly as `Not a Contribution`.
+
+## Pull Requests
+
+- Keep pull requests scoped to one reviewable slice when possible.
+- Follow the pull request body template in `.github/pull_request_template.md`.
+- List the checks You actually ran.
+- Only Submit material that You can license under both the repository's public
+  licenses and the contributor agreement.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,114 @@
-MIT License
+Required Notice: Copyright (c) 2026 Chris Wright
+Required Notice: TallyLot source code is published from https://github.com/CrownOpsEng/tallylot
 
-Copyright (c) 2026 Chris Wright
+PolyForm Noncommercial License 1.0.0
+https://polyformproject.org/licenses/noncommercial/1.0.0
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Acceptance
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+In order to get any license under these terms, you must agree to them as both
+strict obligations and conditions to all your licenses.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Copyright License
+
+The licensor grants you a copyright license for the software to do everything
+you might do with the software that would otherwise infringe the licensor's
+copyright in it for any permitted purpose. However, you may only distribute the
+software according to Distribution License and make changes or new works based
+on the software according to Changes and New Works License.
+
+Distribution License
+
+The licensor grants you an additional copyright license to distribute copies of
+the software. Your license to distribute covers distributing the software with
+changes and new works permitted by Changes and New Works License.
+
+Notices
+
+You must ensure that anyone who gets a copy of any part of the software from
+you also gets a copy of these terms or the URL for them above, as well as
+copies of any plain-text lines beginning with "Required Notice:" that the
+licensor provided with the software. For example:
+
+Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+Changes and New Works License
+
+The licensor grants you an additional copyright license to make changes and new
+works based on the software for any permitted purpose.
+
+Patent License
+
+The licensor grants you a patent license for the software that covers patent
+claims the licensor can license, or becomes able to license, that you would
+infringe by using the software.
+
+Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+Personal Uses
+
+Personal use for research, experiment, and testing for the benefit of public
+knowledge, personal study, private entertainment, hobby projects, amateur
+pursuits, or religious observance, without any anticipated commercial
+application, is use for a permitted purpose.
+
+Noncommercial Organizations
+
+Use by any charitable organization, educational institution, public research
+organization, public safety or health organization, environmental protection
+organization, or government institution is use for a permitted purpose
+regardless of the source of funding or obligations resulting from the funding.
+
+Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do
+not limit them.
+
+No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses to
+anyone else, or prevent the licensor from granting licenses to anyone else.
+These terms do not imply any other licenses.
+
+Patent Defense
+
+If you make any written claim that the software infringes or contributes to
+infringement of any patent, your patent license for the software granted under
+these terms ends immediately. If your company makes such a claim, your patent
+license ends immediately for work on behalf of your company.
+
+Violations
+
+The first time you are notified in writing that you have violated any of these
+terms, or done anything with the software not covered by your licenses, your
+licenses can nonetheless continue if you come into full compliance with these
+terms, and take practical steps to correct past violations, within 32 days of
+receiving notice. Otherwise, all your licenses end immediately.
+
+No Liability
+
+As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.
+
+Definitions
+
+The licensor is the individual or entity offering these terms, and the software
+is the software the licensor makes available under these terms.
+
+You refers to the individual or entity agreeing to these terms.
+
+Your company is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that organization.
+Control means ownership of substantially all the assets of an entity, or the
+power to direct its management and policies by vote, contract, or otherwise.
+Control can be direct or indirect.
+
+Your licenses are all the licenses granted to you for the software under these
+terms.
+
+Use means anything you do with the software requiring one of your licenses.

--- a/LICENSE.docs
+++ b/LICENSE.docs
@@ -1,0 +1,15 @@
+Documentation License Notice
+
+Unless otherwise noted, prose documentation in README.md and the docs/
+directory is licensed under the Creative Commons Attribution-NonCommercial-
+ShareAlike 4.0 International license.
+
+License summary:
+https://creativecommons.org/licenses/by-nc-sa/4.0/
+
+Legal code:
+https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode
+
+Code samples, command lines, configuration fragments, and other source-like
+material remain licensed under the PolyForm Noncommercial License 1.0.0 unless
+a different notice is included with that material.

--- a/README.md
+++ b/README.md
@@ -97,16 +97,29 @@ checkpoint rules.
 
 ## Contributing
 
-Use the standards docs for repo rules and [ROADMAP.md](ROADMAP.md) for active
-sequencing:
+Use [CONTRIBUTING.md](CONTRIBUTING.md) for contributor licensing terms and
+submission rules. Use the standards docs and [ROADMAP.md](ROADMAP.md) for repo
+execution and active sequencing:
 
 - [docs/standards/engineering.md](docs/standards/engineering.md)
 - [docs/standards/implementation.md](docs/standards/implementation.md)
 - [docs/standards/commits.md](docs/standards/commits.md)
 
+External contributions are accepted only under
+[CLA.md](CLA.md), which gives the maintainer broad relicensing and commercial
+licensing rights while contributors retain ownership of their work.
+
 ## License
 
-[MIT](LICENSE)
+Source code in this repository is source-available under the
+[PolyForm Noncommercial License 1.0.0](LICENSE).
+
+Unless otherwise noted, prose documentation in `README.md` and `docs/` is
+available under [CC BY-NC-SA 4.0](LICENSE.docs). Code samples and other
+source-like material remain under the PolyForm Noncommercial License 1.0.0.
+
+The maintainer may also offer separate commercial or proprietary licenses for
+some or all of the project outside these public repository terms.
 
 ## Security
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,8 @@ name = "TallyLot"
 version = "0.1.0"
 description = "Typed source-backed transaction tooling with an external workspace architecture."
 readme = "README.md"
-license = "MIT"
-license-files = ["LICENSE"]
+license = { file = "LICENSE" }
+license-files = ["LICENSE", "LICENSE.docs"]
 requires-python = ">=3.12"
 authors = [
     { name = "Chris Wright" },

--- a/repo_support/pr_review_paths.py
+++ b/repo_support/pr_review_paths.py
@@ -48,9 +48,14 @@ PACKAGING_SENSITIVE_PREFIXES = (
 
 
 def is_human_docs(path: str) -> bool:
-    return path in {"README.md", "CHANGELOG.md"} or (
-        path.startswith("docs/") and not path.startswith("docs/standards/")
-    )
+    return path in {
+        "README.md",
+        "CHANGELOG.md",
+        "CONTRIBUTING.md",
+        "CLA.md",
+        "LICENSE",
+        "LICENSE.docs",
+    } or (path.startswith("docs/") and not path.startswith("docs/standards/"))
 
 
 def is_control_plane_text(path: str) -> bool:

--- a/tests/unit/test_audit_pr_review.py
+++ b/tests/unit/test_audit_pr_review.py
@@ -74,6 +74,16 @@ def test_repo_root_conftest_maps_to_repo_code_review_surface() -> None:
     assert plan.unmapped_paths == ()
 
 
+def test_root_licensing_docs_map_to_human_docs() -> None:
+    plan = classify_changed_paths(("CONTRIBUTING.md", "CLA.md", "LICENSE.docs"))
+
+    assert plan.surface_groups == ("human_docs",)
+    assert plan.verification_level == "docs-maintenance"
+    assert plan.requires_full_quality_gates is False
+    assert plan.requires_ci_parity is False
+    assert plan.unmapped_paths == ()
+
+
 def test_packaging_sensitive_repo_code_adds_pre_merge_packaging_verification() -> None:
     plan = classify_changed_paths(("src/tallylot/interfaces/cli/source.py",))
 


### PR DESCRIPTION
Why:
- contributor and submission terms need to be explicit in-repo now that the pull request flow requires CLA acknowledgement
- the rest of the stack should land on top of the final licensing posture instead of mixing policy changes into later delivery PRs

What:
- add the PolyForm licensing files plus CLA and contributing guidance
- update the pull request template, README text, and review-path metadata to reflect the new agreement

Checks:
- `python -m tools.run_pr_review_checks`

Issue linkage:
- None: searched existing repo issues for licensing CLA contributor agreement and found no matching tracked issue

Included checkpoints:
- `chore(licensing): adopt PolyForm and contributor agreement`
