### PR TITLE
docs(architecture): define target pipeline products and ownership

### DIFF
--- a/.agents/skills/adapter-authoring/SKILL.md
+++ b/.agents/skills/adapter-authoring/SKILL.md
@@ -13,6 +13,7 @@ Use this skill for adapter-focused work.
 ## Workflow
 
 1. Read the adapter contract first:
+   - `docs/concepts/unified-adapter-architecture.md`
    - `docs/guides/write-an-adapter.md`
    - `.claude/commands/adapter-authoring.md`
    - `docs/standards/engineering.md`

--- a/.claude/commands/adapter-authoring.md
+++ b/.claude/commands/adapter-authoring.md
@@ -1,10 +1,18 @@
 # Adapter Authoring
 
-Use `docs/guides/write-an-adapter.md` as the primary contract.
+Read `docs/status/adapter-delivery-plan.md` first for the filing-window
+decision rules, then read `docs/concepts/unified-adapter-architecture.md` for
+the forward design target, and use `docs/guides/write-an-adapter.md` as the
+current contract.
 
 When repairing or extending an adapter:
 
 1. keep metadata, code, and tests aligned
-2. keep ambiguous data explicit as issues or review records
-3. keep output rendering and source normalization concerns separated
-4. rerun the full quality gate before considering the adapter ready
+2. keep the adapter work aligned with the core pipeline in
+   `docs/concepts/reconciliation-tax-architecture.md` without turning adapter
+   work into a second architecture center
+3. prefer current-contract hardening for filing-critical adapters over
+   speculative future-contract scaffolding
+4. keep ambiguous data explicit as issues or review records
+5. keep output rendering and source normalization concerns separated
+6. rerun the full quality gate before considering the adapter ready

--- a/.claude/commands/adapter-authoring.md
+++ b/.claude/commands/adapter-authoring.md
@@ -13,6 +13,12 @@ When repairing or extending an adapter:
    work into a second architecture center
 3. prefer current-contract hardening for filing-critical adapters over
    speculative future-contract scaffolding
-4. keep ambiguous data explicit as issues or review records
-5. keep output rendering and source normalization concerns separated
-6. rerun the full quality gate before considering the adapter ready
+4. keep current implementation terms accurate when describing the current
+   bridge, and use final target names only for the forward state
+5. keep ambiguous data explicit as issues or review records
+6. keep output rendering and source normalization concerns separated
+7. do not imply that adapters own reconciliation, checkpoint, accounting, or
+   tax decisions
+8. do not delete adapter tests or silently weaken fixture coverage without
+   explicit human approval
+9. rerun the full quality gate before considering the adapter ready

--- a/.claude/commands/implementation-checkpoint.md
+++ b/.claude/commands/implementation-checkpoint.md
@@ -43,6 +43,13 @@ Use this route before closing any non-trivial coding task.
    - `ROADMAP.md`
    - `docs/concepts/reconciliation-tax-architecture.md`
    - any boundary, matrix, or migration docs affected
+   - if reconciliation, checkpoint, accounting, tax, or canonical pipeline
+     products changed, confirm the narrow routing docs still point to the right
+     architecture and sequencing material:
+     - `AGENTS.md`
+     - `.claude/commands/reconciliation-tax-build.md`
+     - `.claude/commands/adapter-authoring.md` when adapter surfaces are part
+       of the same change
    - if standards, docs placement, doc authoring rules, or agent-default enforcement changed, reload:
      - `AGENTS.md`
      - `docs/README.md`

--- a/.claude/commands/implementation-checkpoint.md
+++ b/.claude/commands/implementation-checkpoint.md
@@ -24,6 +24,9 @@ Use this route before closing any non-trivial coding task.
    - new parser or renderer contracts
    - fixed edge cases
    - meaningful regression prevention rather than trivial coverage
+   - preserved parity when tests moved or consolidated
+   - no silent assertion removal or fixture simplification that weakens
+     coverage
 5. Confirm tracked docs, templates, and control-plane text stayed neutral and
    did not pick up scratch workflow bookkeeping.
 6. Confirm meaningful out-of-scope repo work is not stranded in notes:
@@ -43,7 +46,7 @@ Use this route before closing any non-trivial coding task.
    - `ROADMAP.md`
    - `docs/concepts/reconciliation-tax-architecture.md`
    - any boundary, matrix, or migration docs affected
-   - if reconciliation, checkpoint, accounting, tax, or canonical pipeline
+   - if reconciliation, checkpoint, accounting, tax, or core pipeline
      products changed, confirm the narrow routing docs still point to the right
      architecture and sequencing material:
      - `AGENTS.md`
@@ -71,7 +74,12 @@ Use this route before closing any non-trivial coding task.
    multiple bounded checkpoint commits before closeout. Do not close the task
    first and plan to commit afterward.
 
-11. Confirm branch handling stayed PR-only for protected branches: do not push
+11. Include a short parity note in the checkpoint summary when tests changed:
+    - what old behavior was covered
+    - where that behavior is covered now
+    - whether the assertion became stronger, weaker, or simply moved
+
+12. Confirm branch handling stayed PR-only for protected branches: do not push
     directly to `main`; do not use branch-protection bypass for ordinary
     delivery; do not rewrite a merged `main` commit if the original pull
     request must remain attached to the landing commit and use a new repair

--- a/.claude/commands/reconciliation-tax-build.md
+++ b/.claude/commands/reconciliation-tax-build.md
@@ -13,14 +13,13 @@ reconciliation, checkpoint, accounting, and tax buildout.
    - `docs/concepts/transaction-classification.md`
    - `docs/standards/implementation.md`
 4. Confirm whether the task changes:
-   - evidence or claim products
-   - economic facts
+   - `EvidenceSet` or `ClaimSet`
+   - `EconomicFacts`
    - gap or readiness models
-   - reconciliation rules
-   - checkpoint packages
-   - checkpoint assembly
-   - journal rendering
-   - tax policy
+   - `ReconciliationState`
+   - `Checkpoint`
+   - `Journal`
+   - `TaxInputs` or `TaxOutputs`
    - CoinTracking oracle parsing
 5. If the task changes architecture or sequencing decisions, update
    `docs/concepts/reconciliation-tax-architecture.md` and `ROADMAP.md` in the
@@ -35,6 +34,11 @@ reconciliation, checkpoint, accounting, and tax buildout.
    - keep tax policy behind a policy port
    - keep current facts plus balances as the MVP bridge while landing richer
      pipeline products incrementally
+   - keep tax outputs described as `TaxInputs` plus selected policy, never as
+     direct emissions from reconciled facts
+   - keep the shared readiness slice definition exact: source, location,
+     instrument, subject ref, continuity segment, checkpoint date, and tax
+     year where relevant
    - prefer one bounded stage slice over building a speculative end-state
      framework before the next concrete filing-critical need exists
 7. Keep `pydantic` at boundaries only:
@@ -48,11 +52,14 @@ reconciliation, checkpoint, accounting, and tax buildout.
    - reconciliation behavior
    - journal validation
    - tax outputs
-10. For balance inspection, checking, or reconciliation-date questions, use
+10. Preserve test parity honestly. Do not delete tests without explicit human
+    approval, do not silently remove assertions, and if tests move or
+    consolidate, note what behavior remains covered and where.
+11. For balance inspection, checking, or reconciliation-date questions, use
    `.claude/commands/reconciliation-balance-operations.md` and the runtime
    `reconciliation balances` commands instead of ad hoc shell loops or
    repo-only batch scripts.
-11. Emit explicit issues when the task uncovers unsupported behavior or deferred
+12. Emit explicit issues when the task uncovers unsupported behavior or deferred
    cases.
-12. Refactor obvious shared seams, add tests for new behavior, and commit a
+13. Refactor obvious shared seams, add tests for new behavior, and commit a
     verified checkpoint before closing the task.

--- a/.claude/commands/reconciliation-tax-build.md
+++ b/.claude/commands/reconciliation-tax-build.md
@@ -4,43 +4,55 @@ Use this route for architecture, implementation, or repair work tied to the
 reconciliation, checkpoint, accounting, and tax buildout.
 
 1. Read `docs/concepts/reconciliation-tax-architecture.md` first.
-2. Read these when the task touches boundaries or sequencing:
+2. Read these before shaping any non-trivial slice:
+   - `ROADMAP.md`
+   - `docs/status/migration-sequence.md`
+   - `docs/status/current-state.md`
+3. Read these when the task touches boundaries or sequencing:
    - `docs/concepts/oracle-boundaries.md`
    - `docs/concepts/transaction-classification.md`
-   - `docs/status/migration-sequence.md`
    - `docs/standards/implementation.md`
-3. Confirm whether the task changes:
-   - transaction facts
+4. Confirm whether the task changes:
+   - evidence or claim products
+   - economic facts
+   - gap or readiness models
    - reconciliation rules
+   - checkpoint packages
    - checkpoint assembly
    - journal rendering
    - tax policy
    - CoinTracking oracle parsing
-4. If the task changes architecture or sequencing decisions, update
-   `ROADMAP.md` in the same checkpoint.
-5. Keep these boundaries:
+5. If the task changes architecture or sequencing decisions, update
+   `docs/concepts/reconciliation-tax-architecture.md` and `ROADMAP.md` in the
+   same checkpoint, and update `docs/status/migration-sequence.md` when phase
+   order, bridge rules, or checkpoint criteria changed.
+6. Keep these boundaries:
    - build reconciliation before tax
    - keep facts provider-neutral before rendering compatibility outputs
    - keep CoinTracking-specific parsing and rendering in adapter or oracle code
    - keep CoinTracking tax and accounting reports out of runtime state
    - keep Ledger CLI behind a renderer port
    - keep tax policy behind a policy port
-6. Keep `pydantic` at boundaries only:
+   - keep current facts plus balances as the MVP bridge while landing richer
+     pipeline products incrementally
+   - prefer one bounded stage slice over building a speculative end-state
+     framework before the next concrete filing-critical need exists
+7. Keep `pydantic` at boundaries only:
    - config
    - row parsing
    - request validation
    - artifact schema validation
-7. Preserve strict layer boundaries and `Decimal`-only financial handling.
-8. Add or update tests for:
+8. Preserve strict layer boundaries and `Decimal`-only financial handling.
+9. Add or update tests for:
    - schema and invariants
    - reconciliation behavior
    - journal validation
    - tax outputs
-9. For balance inspection, checking, or reconciliation-date questions, use
+10. For balance inspection, checking, or reconciliation-date questions, use
    `.claude/commands/reconciliation-balance-operations.md` and the runtime
    `reconciliation balances` commands instead of ad hoc shell loops or
    repo-only batch scripts.
-10. Emit explicit issues when the task uncovers unsupported behavior or deferred
+11. Emit explicit issues when the task uncovers unsupported behavior or deferred
    cases.
-11. Refactor obvious shared seams, add tests for new behavior, and commit a
+12. Refactor obvious shared seams, add tests for new behavior, and commit a
     verified checkpoint before closing the task.

--- a/.claude/commands/supporting-artifacts.md
+++ b/.claude/commands/supporting-artifacts.md
@@ -7,7 +7,7 @@ path.
    Shakepay statement PDFs
 2. review the extracted balance rows before using them as evidence
 3. keep the PDF-derived artifacts in supporting or reconciliation review paths;
-   do not treat them as canonical transaction imports
+   do not treat them as transaction-history imports
 
 Use `docs/guides/operator-quickstart.md` for the short surrounding workflow,
 `docs/guides/normalize-screen-stage.md` and `docs/guides/verify-a-round.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,10 @@ workspace as external to the repo.
 - Keep financial values in `Decimal`, never `float`.
 - Surface unsupported or ambiguous data as explicit issues.
 - Keep adapter metadata, implementation, and tests aligned.
+- Preserve current runtime truth in docs while using the final target-doc
+  vocabulary for the future architecture.
+- Preserve or strengthen parity through refactors; do not silently weaken
+  tests.
 - Update `ROADMAP.md` when making decisions that affect later rollout phases.
 
 ## Read Only What You Need
@@ -34,9 +38,10 @@ Do not pre-load every repo doc by default.
 | Delivery guardrails, protected-branch behavior, or agent-assisted Git operations | `docs/standards/delivery-guardrails.md`, `docs/standards/commits.md`, `tools/audit_delivery_guardrails.py` |
 | PR review or review-loop recovery | `docs/standards/delivery-guardrails.md`, `docs/standards/implementation.md`, `docs/standards/commits.md`, `.claude/commands/pr-review.md` |
 | Planning sequence, delivery slices, MVP scope, or rollout checkpoints | `ROADMAP.md`, `docs/status/migration-sequence.md` |
-| Reconciliation, checkpoint, journal, tax-engine implementation, or canonical pipeline products | `docs/concepts/reconciliation-tax-architecture.md`, `ROADMAP.md`, `docs/status/migration-sequence.md`, `docs/concepts/oracle-boundaries.md`, `docs/concepts/transaction-classification.md` |
+| Reconciliation, checkpoint, journal, tax-engine implementation, or core pipeline products | `docs/concepts/reconciliation-tax-architecture.md`, `ROADMAP.md`, `docs/status/migration-sequence.md`, `docs/concepts/oracle-boundaries.md`, `docs/concepts/transaction-classification.md` |
 | Platform-agnostic boundaries, classification mapping, or migration order | `docs/concepts/oracle-boundaries.md`, `docs/concepts/transaction-classification.md`, `docs/status/migration-sequence.md` |
 | Source or output adapter work | `docs/status/adapter-delivery-plan.md`, `docs/concepts/unified-adapter-architecture.md`, `docs/guides/write-an-adapter.md` |
+| High-level architecture orientation | `docs/concepts/architecture-overview.md`, `docs/status/current-state.md`, `docs/concepts/reconciliation-tax-architecture.md` |
 | Docs structure, generated index sections, doc placement, or doc authoring rules | `AGENTS.md`, `docs/README.md`, `tools/docs_maintenance/cli.py`, `tools/docs_maintenance/metadata.py` |
 | External workspace layout and seeded files | `docs/concepts/workspace-model.md`, `docs/workspace/README.md` |
 | Operational state or manual workflow | `docs/status/current-state.md`, `docs/guides/operator-quickstart.md`, `docs/guides/source-intake.md`, `docs/guides/normalize-screen-stage.md`, `docs/guides/verify-a-round.md`, `docs/guides/full-operator-workflow.md` |
@@ -58,6 +63,12 @@ Do not pre-load every repo doc by default.
   the repo-local workflow for the active surface and reload the narrow repo
   guidance listed in this file before editing.
 - Keep tracked docs, templates, and control-plane text neutral and durable.
+- Keep current-state docs accurate to the implemented runtime, and keep
+  forward-looking docs detailed enough to implement from without inventing
+  missing stage structure later.
+- Use final target product names in forward-looking docs after the mapping is
+  established, and keep bridge-era names only where current implementation
+  accuracy requires them.
 - Do not store scratch review notes, hardening ledgers, or temporary process
   bookkeeping in tracked files.
 - Keep repository issues repo-scoped and privacy-safe:
@@ -135,6 +146,13 @@ Do not pre-load every repo doc by default.
   - avoid rhetorical, promotional, or exaggerated wording in repo history
 - Add tests only when they protect meaningful behavior, contracts,
   non-trivial decision logic, or fixed regressions.
+- Do not delete tests, silently remove assertions, or simplify fixtures in a
+  way that weakens coverage without explicit human approval.
+- When tests move or consolidate, record the parity outcome in the checkpoint
+  summary:
+  - what old behavior was covered
+  - where that behavior is covered now
+  - whether the assertion became stronger, weaker, or simply moved
 - Before shaping a non-trivial change, reload the narrow roadmap,
   architecture, migration, or owning-boundary guidance for that surface.
 - Keep public-facing names simple and ergonomic. Prefer short neutral command
@@ -194,18 +212,27 @@ Workspace resolution order:
 - Treat `docs/concepts/reconciliation-tax-architecture.md` as the
   implementation anchor for reconciliation, checkpointing, journaling, and tax
   computation.
+- Treat `docs/concepts/architecture-overview.md` as the concise orientation
+  page and `docs/concepts/reconciliation-tax-architecture.md` as the detailed
+  implementation anchor.
 - Do not treat CoinTracking as the live ledger for new architecture work.
   CoinTracking is now a compatibility and oracle layer.
 - Do not treat CoinTracking tax or accounting reports as normal runtime
   inputs. They are development-only oracle support artifacts unless an
   explicit one-time checkpoint import workflow adopts them with provenance.
-- Do not expand the current canonical event model into the long-term center of
-  the system. Current `EconomicActivityDraft`, `TransactionFact`, and shared
+- Do not expand the current fact-path bridge into the long-term center of the
+  system. Current `EconomicActivityDraft`, `TransactionFact`, and shared
   balance artifacts are the active bridge into the target pipeline, not the
-  final architecture center. New structural work should target the canonical
+  final architecture center. New structural work should target the runtime
   pipeline products and stage contracts described in
   `docs/concepts/reconciliation-tax-architecture.md` and sequenced in
   `ROADMAP.md`.
+- Forward-looking docs use the final target product names:
+  `EvidenceSet`, `ClaimSet`, `EconomicFacts`, `ReconciliationState`,
+  `Checkpoint`, `Journal`, `TaxInputs`, and `TaxOutputs`.
+- Do not push unresolved tax ambiguity downward into earlier stages just to
+  keep facts or reconciliation outputs looking complete. Preserve uncertainty
+  until the owning later stage decides it.
 - Keep `pydantic` at boundaries:
   - config
   - external artifact parsing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,10 +33,10 @@ Do not pre-load every repo doc by default.
 | Issue templates, issue-writing policy, or proactive follow-up issue creation | `AGENTS.md`, `docs/standards/issues.md`, `docs/standards/implementation.md`, `docs/standards/delivery-guardrails.md`, `docs/standards/commits.md`, `.claude/commands/issue-workflow.md` |
 | Delivery guardrails, protected-branch behavior, or agent-assisted Git operations | `docs/standards/delivery-guardrails.md`, `docs/standards/commits.md`, `tools/audit_delivery_guardrails.py` |
 | PR review or review-loop recovery | `docs/standards/delivery-guardrails.md`, `docs/standards/implementation.md`, `docs/standards/commits.md`, `.claude/commands/pr-review.md` |
-| Planning sequence, delivery slices, or rollout checkpoints | `ROADMAP.md` |
-| Reconciliation, checkpoint, journal, or tax-engine implementation | `docs/concepts/reconciliation-tax-architecture.md` |
+| Planning sequence, delivery slices, MVP scope, or rollout checkpoints | `ROADMAP.md`, `docs/status/migration-sequence.md` |
+| Reconciliation, checkpoint, journal, tax-engine implementation, or canonical pipeline products | `docs/concepts/reconciliation-tax-architecture.md`, `ROADMAP.md`, `docs/status/migration-sequence.md`, `docs/concepts/oracle-boundaries.md`, `docs/concepts/transaction-classification.md` |
 | Platform-agnostic boundaries, classification mapping, or migration order | `docs/concepts/oracle-boundaries.md`, `docs/concepts/transaction-classification.md`, `docs/status/migration-sequence.md` |
-| Source or output adapter work | `docs/guides/write-an-adapter.md` |
+| Source or output adapter work | `docs/status/adapter-delivery-plan.md`, `docs/concepts/unified-adapter-architecture.md`, `docs/guides/write-an-adapter.md` |
 | Docs structure, generated index sections, doc placement, or doc authoring rules | `AGENTS.md`, `docs/README.md`, `tools/docs_maintenance/cli.py`, `tools/docs_maintenance/metadata.py` |
 | External workspace layout and seeded files | `docs/concepts/workspace-model.md`, `docs/workspace/README.md` |
 | Operational state or manual workflow | `docs/status/current-state.md`, `docs/guides/operator-quickstart.md`, `docs/guides/source-intake.md`, `docs/guides/normalize-screen-stage.md`, `docs/guides/verify-a-round.md`, `docs/guides/full-operator-workflow.md` |
@@ -200,9 +200,12 @@ Workspace resolution order:
   inputs. They are development-only oracle support artifacts unless an
   explicit one-time checkpoint import workflow adopts them with provenance.
 - Do not expand the current canonical event model into the long-term center of
-  the system. New structural work should target the provider-neutral
-  transaction fact model described in
-  `docs/concepts/reconciliation-tax-architecture.md`.
+  the system. Current `EconomicActivityDraft`, `TransactionFact`, and shared
+  balance artifacts are the active bridge into the target pipeline, not the
+  final architecture center. New structural work should target the canonical
+  pipeline products and stage contracts described in
+  `docs/concepts/reconciliation-tax-architecture.md` and sequenced in
+  `ROADMAP.md`.
 - Keep `pydantic` at boundaries:
   - config
   - external artifact parsing

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -56,18 +56,18 @@ The numbered phases below remain the coarse rollout gates. The detailed plan in
 this section is the implementation reference for the target pipeline products
 and the bounded slices needed to land them without ad hoc design during coding.
 
-Use the exact canonical product names from
+Use the exact target product names from
 `docs/concepts/reconciliation-tax-architecture.md` when shaping the next
 contracts:
 
-1. `EvidenceBundle`
-2. `ClaimBundle`
-3. `EconomicDataset`
-4. `ReconciliationDataset`
-5. `CheckpointPackage`
-6. `JournalDataset`
-7. `TaxDeterminantDataset`
-8. `TaxOutputDataset`
+1. `EvidenceSet`
+2. `ClaimSet`
+3. `EconomicFacts`
+4. `ReconciliationState`
+5. `Checkpoint`
+6. `Journal`
+7. `TaxInputs`
+8. `TaxOutputs`
 
 ### Cross-Cutting Contracts To Land Before Broad Pipeline Expansion
 
@@ -82,8 +82,13 @@ Scope:
   references, candidate interpretations, required evidence, and allowed
   resolution methods
 - one readiness vocabulary reused across all datasets
-- one subject-slice model for readiness and materiality by source, location,
-  instrument, contract or position, continuity segment, and checkpoint date
+- one shared slice model for readiness and materiality
+- one explicit identity seam for instrument, contract, position, location,
+  legal owner, beneficial owner, and counterparty identity
+- `SubjectRef` for shared infrastructure that needs a generic reference without
+  flattening `Contract` and `Position`
+- one typed tax-policy selection seam reused by later `TaxInputs` and
+  `TaxOutputs` work
 - one checkpoint assertion vocabulary reused by reconciliation, checkpoint
   adoption, accounting, and tax
 
@@ -94,6 +99,16 @@ Rules:
   subject-level readiness reducers
 - keep gap ownership explicit so accounting gaps, reconciliation gaps, and
   tax-owned gaps are not conflated operationally
+
+Shared readiness uses this exact slice definition:
+
+- source
+- location
+- instrument
+- subject ref
+- continuity segment
+- checkpoint date
+- tax year where relevant
 
 Exit criteria:
 
@@ -125,6 +140,8 @@ Rules:
   horizontal framework layers with no proven consumer
 - keep crypto filing-critical coverage primary for the MVP while using generic
   runtime names and boundaries that can later absorb other instrument classes
+- keep current-contract adapter stabilization distinct from the later adapter
+  redesign
 
 Exit criteria:
 
@@ -133,7 +150,23 @@ Exit criteria:
 - new reusable seams exist because one real slice needed them, not because the
   repo was trying to pre-build every future variation
 
-### Slice A. Harden `EvidenceBundle`
+### Performance Expectations
+
+Rollout choices must preserve bounded recalculation cost.
+
+Rules:
+
+- expensive reducers must be partitionable by source, location, instrument,
+  subject ref, continuity segment, checkpoint date, and tax year where
+  relevant
+- hot-path calculations should operate on compact typed records instead of
+  repeatedly joining provenance, review, or renderer payloads
+- derived snapshots and reusable state should be introduced where replay cost
+  becomes material
+- tax work should support tax-year partitioning and carry-forward reuse instead
+  of recomputing full acquisition history for every output row
+
+### Slice A. Harden `EvidenceSet`
 
 Goal:
 
@@ -180,11 +213,11 @@ Exit criteria:
 - evidence selection becomes the only supported path into later claim and
   economic compilation work
 
-### Slice B. Introduce `ClaimBundle` Without Breaking The Current Fact Path
+### Slice B. Introduce `ClaimSet` Without Breaking The Current Fact Path
 
 Goal:
 
-- interpose a source-local claim layer between evidence selection and canonical
+- interpose a source-local claim layer between evidence selection and final
   economic facts
 
 Scope:
@@ -225,11 +258,11 @@ Exit criteria:
 - ambiguous source rows can remain claim-complete but economically unresolved
 - the compiler can reject unsafe claims without losing claim provenance
 
-### Slice C. Expand `EconomicDataset` Beyond Today’s Minimal Fact Shape
+### Slice C. Expand `EconomicFacts` Beyond Today’s Minimal Fact Shape
 
 Goal:
 
-- make the canonical economic layer broad enough for obligation-bearing and
+- make the economic-truth layer broad enough for obligation-bearing and
   lifecycle-heavy instruments
 
 Scope:
@@ -272,12 +305,12 @@ Exit criteria:
   representable without a local special-case rewrite
 - valuation requirements are explicit rather than inferred ad hoc downstream
 
-### Slice D. Build `ReconciliationDataset` As Its Own Product
+### Slice D. Build `ReconciliationState` As Its Own Product
 
 Goal:
 
 - make reconciliation more than exact balance assertions by defining the
-  canonical completeness and continuity product
+  completeness and continuity product
 
 Scope:
 
@@ -314,7 +347,7 @@ Exit criteria:
   runtime artifacts
 - reconciliation readiness is sliceable by source and time window
 
-### Slice E. Formalize `CheckpointPackage`
+### Slice E. Formalize `Checkpoint`
 
 Goal:
 
@@ -356,7 +389,7 @@ Exit criteria:
 - checkpoint acceptance basis is explicit and auditable
 - opening-state adoption is intentional, reviewable, and provenance-backed
 
-### Slice F. Build `JournalDataset` As A Validator, Not A Truth Repair Layer
+### Slice F. Build `Journal` As A Validator, Not A Truth Repair Layer
 
 Goal:
 
@@ -396,11 +429,11 @@ Exit criteria:
 - unsupported accounting coverage is visible as stage-owned gaps
 - accounting outputs can be reconciled back to accepted checkpoint state
 
-### Slice G. Introduce `TaxDeterminantDataset`
+### Slice G. Introduce `TaxInputs`
 
 Goal:
 
-- separate policy-ready tax determinants from both raw economics and final
+- separate policy-ready tax inputs from both raw economics and final
   jurisdiction outputs
 
 Scope:
@@ -420,7 +453,7 @@ Primary owners:
 
 Required contracts:
 
-- tax determinant aggregate
+- tax-input aggregate
 - determinant-to-policy application seam
 - tax-owned gap contract
 - year-state and carry-forward intermediate contracts
@@ -440,7 +473,7 @@ Exit criteria:
 - determinant coverage is reproducible from reconciled economics plus accepted
   checkpoint truth
 
-### Slice H. Build `TaxOutputDataset`
+### Slice H. Build `TaxOutputs`
 
 Goal:
 
@@ -467,7 +500,8 @@ Required contracts:
 
 Exit criteria:
 
-- `2023`, `2024`, and `2025` outputs emit from tax determinants
+- `2023`, `2024`, and `2025` outputs emit from `TaxInputs` through selected
+  policy
 - carry-forward state is deterministic and reproducible
 - unresolved unsupported items remain visible instead of disappearing into
   notes
@@ -576,7 +610,7 @@ Scope:
   filing-critical adapters remain on the current contract; use that later
   redesign to replace the bundled source contract only after the active filing
   path is deterministic enough to trust
-- define the target `EvidenceBundle` and `ClaimBundle` contracts and land them
+- define the target `EvidenceSet` and `ClaimSet` contracts and land them
   incrementally without reintroducing normalized-transaction-era wrappers
 - allow source-local ambiguity to survive into claim outputs when forcing one
   final economic meaning would guess
@@ -636,7 +670,7 @@ Scope:
 - checkpoint continuity checks
 - correction and supersession chains
 - reconciliation issue assembly
-- define `ReconciliationDataset` as an explicit product with link decisions,
+- define `ReconciliationState` as an explicit product with link decisions,
   continuity windows, checkpoint candidates, and reconciliation-owned readiness
   slices rather than treating exact balance assertions as the whole product
 - deterministic correction handling for known historical events such as the
@@ -657,9 +691,9 @@ Exit criteria:
 - reconciliation readiness is reducible by source, location, instrument, and
   continuity window instead of only by coarse source summaries
 
-### 4. Checkpoint Packages And Opening State
+### 4. Checkpoint And Opening State
 
-Formalize typed checkpoint packages as the handoff between reconstruction,
+Formalize typed checkpoints as the handoff between reconstruction,
 reconciliation, accounting, and tax.
 
 Scope:
@@ -717,7 +751,7 @@ Scope:
 
 - tax policy port
 - Canada MVP policy
-- tax determinant contracts between reconciled facts and rendered tax outputs
+- tax-input contracts between reconciled economics and rendered tax outputs
 - pooled ACB state
 - disposition outputs
 - income outputs
@@ -728,10 +762,11 @@ Scope:
 
 Exit criteria:
 
-- `2023` to `2025` tax artifacts emit from reconciled facts
+- `2023` to `2025` tax outputs emit from `TaxInputs` built from reconciled
+  economics plus accepted checkpoint truth
 - year-end and carry-forward state is reproducible without tracker tax reports
 - unresolved unsupported tax items are visible rather than hidden in notes
-- tax determinants are reproducible from reconciled economics plus accepted
+- tax inputs are reproducible from reconciled economics plus accepted
   checkpoint truth without depending on CoinTracking or other oracle rows
 
 ### 7. Filing Workflow
@@ -853,6 +888,24 @@ These workstreams continue across the major phases above.
   unsupported-item reporting
 - keep end-to-end smoke workflows for each major slice before removing older
   transition paths
+
+### Test Preservation
+
+- no test deletions without explicit human approval
+- no silent assertion removal
+- no fixture simplification that hides previous edge-case coverage
+- test relocation or renaming is acceptable only when behavior coverage is
+  preserved or improved
+- "updating tests to the new structure" is not acceptable if coverage is
+  weakened
+- every refactor slice that changes tests must state:
+  - what old behavior the tests covered
+  - where that same behavior is covered now
+  - whether the assertion got stronger, weaker, or simply moved
+  - whether any expectation changed because of an intentional product decision
+- require a `test parity note` in checkpoint summaries
+- require manual review of deleted test files, deleted assertions, reduced
+  scenario coverage, and fixture simplifications that remove edge cases
 
 ### Repo And Package Shaping
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -50,6 +50,459 @@ These planning anchors drive phase order and acceptance criteria:
 - normalization is capture-scoped and reconciliation is source-assembly-scoped
 - raw-evidence derivation is the supported semantic parity path
 
+## Detailed Pipeline Delivery Plan
+
+The numbered phases below remain the coarse rollout gates. The detailed plan in
+this section is the implementation reference for the target pipeline products
+and the bounded slices needed to land them without ad hoc design during coding.
+
+Use the exact canonical product names from
+`docs/concepts/reconciliation-tax-architecture.md` when shaping the next
+contracts:
+
+1. `EvidenceBundle`
+2. `ClaimBundle`
+3. `EconomicDataset`
+4. `ReconciliationDataset`
+5. `CheckpointPackage`
+6. `JournalDataset`
+7. `TaxDeterminantDataset`
+8. `TaxOutputDataset`
+
+### Cross-Cutting Contracts To Land Before Broad Pipeline Expansion
+
+These contracts should be treated as blocking shared foundations rather than as
+optional cleanup.
+
+Scope:
+
+- one typed provenance family across evidence, claims, balances, issues,
+  reviews, checkpoints, accounting, and tax artifacts
+- one controlled gap taxonomy with stage ownership, blocking scope, subject
+  references, candidate interpretations, required evidence, and allowed
+  resolution methods
+- one readiness vocabulary reused across all datasets
+- one subject-slice model for readiness and materiality by source, location,
+  instrument, contract or position, continuity segment, and checkpoint date
+- one checkpoint assertion vocabulary reused by reconciliation, checkpoint
+  adoption, accounting, and tax
+
+Rules:
+
+- do not let each new stage invent its own status field or bespoke blocker row
+- do not store whole-dataset readiness as the only truth; derive it from
+  subject-level readiness reducers
+- keep gap ownership explicit so accounting gaps, reconciliation gaps, and
+  tax-owned gaps are not conflated operationally
+
+Exit criteria:
+
+- shared gap and readiness models exist with typed reducers and artifact
+  contracts
+- every new stage can emit stage-owned gaps without inventing one-off issue
+  formats
+- dataset summaries derive from subject-level readiness instead of hand-built
+  status prose
+
+### MVP Scope Guardrails
+
+The MVP should remain filing-capable, provider-neutral where it matters, and
+small enough to implement without a speculative framework buildout.
+
+Rules:
+
+- use the current fact-plus-balances bridge until the next concrete slice needs
+  a richer stage contract
+- do not wait for every target product to exist before improving the active
+  filing path
+- add new stage models, reducers, or ports only when one bounded slice needs
+  them for correctness, determinism, or later-stage reuse
+- avoid plugin systems, manifest families, or broad orchestration abstractions
+  before a second concrete implementation requires them
+- keep unsupported or deferred behavior explicit through gaps instead of
+  low-confidence partial support
+- prefer one end-to-end vertical slice that proves a new stage over several
+  horizontal framework layers with no proven consumer
+- keep crypto filing-critical coverage primary for the MVP while using generic
+  runtime names and boundaries that can later absorb other instrument classes
+
+Exit criteria:
+
+- the active filing path keeps moving while the architecture becomes more
+  explicit
+- new reusable seams exist because one real slice needed them, not because the
+  repo was trying to pre-build every future variation
+
+### Slice A. Harden `EvidenceBundle`
+
+Goal:
+
+- make deterministic evidence selection and source-local observation capture the
+  formal first pipeline product
+
+Scope:
+
+- carry selected, superseded, and blocked raw inputs as explicit evidence-bundle
+  artifacts
+- keep document, statement, and inventory observations source-local
+- preserve capture, assembly, and document provenance without forcing economic
+  meaning
+- keep deterministic evidence selection in core planning services rather than in
+  adapter-local heuristics
+
+Primary owners:
+
+- `application/intake/`
+- `application/profiling/`
+- `application/evidence/`
+- `application/normalization/translation_inputs/`
+
+Required contracts:
+
+- deterministic evidence selection report
+- source-local parsed observation contracts
+- explicit superseded and blocked evidence outputs
+- evidence-bundle summary and issue surfaces
+
+Must not do:
+
+- invent economic meaning at the evidence layer
+- hide raw-selection decisions inside adapter code
+- collapse source-local observations into final facts when the source remains
+  ambiguous
+
+Exit criteria:
+
+- the runtime can explain why every selected source artifact won and why every
+  superseded artifact lost
+- source-local observations and their provenance survive beyond file-selection
+  time
+- evidence selection becomes the only supported path into later claim and
+  economic compilation work
+
+### Slice B. Introduce `ClaimBundle` Without Breaking The Current Fact Path
+
+Goal:
+
+- interpose a source-local claim layer between evidence selection and canonical
+  economic facts
+
+Scope:
+
+- define activity, balance, ownership, location, instrument, contract-term, and
+  valuation claim contracts
+- allow materially unclassified claims when a provider row cannot safely commit
+  to one `EconomicKind`
+- capture candidate interpretations and blocking ambiguity explicitly
+- keep current `EconomicActivityDraft` as a transitional bridge while claim
+  contracts land incrementally
+
+Primary owners:
+
+- `ports/source_translation.py`
+- `application/facts/`
+- source adapters under `adapters/sources/`
+
+Required contracts:
+
+- claim bundle aggregate
+- claim-to-economic compilation seam
+- claim-owned issue and review contracts
+- explicit mapping from transitional draft fields into claim semantics during
+  migration
+
+Must not do:
+
+- require every claim to carry final economic, tax, and accounting semantics
+- bind ambiguous transfers, ownership changes, restructurings, or mixed rows to
+  one interpretation just to stay on the current draft shape
+- let adapters widen policy responsibility beyond source-local meaning
+
+Exit criteria:
+
+- at least one adapter family emits claim-native outputs before economic
+  compilation
+- ambiguous source rows can remain claim-complete but economically unresolved
+- the compiler can reject unsafe claims without losing claim provenance
+
+### Slice C. Expand `EconomicDataset` Beyond Today’s Minimal Fact Shape
+
+Goal:
+
+- make the canonical economic layer broad enough for obligation-bearing and
+  lifecycle-heavy instruments
+
+Scope:
+
+- keep `TransactionFact` as the current row-level bridge while expanding the
+  economic dataset contract around it
+- add first-class seams for contract instance identity, ownership change
+  semantics, settlement state, supersession, collateral, financing, and
+  lifecycle events
+- add valuation attachments with purpose, time, source, precision, and
+  provenance instead of free-form downstream valuation assumptions
+- keep signed-leg structure, precision, and provenance strict
+
+Primary owners:
+
+- `domain/transactions/`
+- `domain/instruments/`
+- `application/facts/`
+
+Required contracts:
+
+- economic dataset aggregate contract
+- contract instance or position identity surface
+- valuation attachment contract
+- correction and supersession chain contract
+
+Must not do:
+
+- assume all activity is spot movement between wallets and exchanges
+- encode loans, margin, shorts, options, futures, repos, or corporate actions
+  as awkward spot-only special cases
+- treat output-adapter projection hints as the long-term driver of core
+  behavior
+
+Exit criteria:
+
+- economic facts preserve the determinants needed for later reconciliation,
+  accounting, and tax work without revisiting raw rows
+- at least one non-trivial obligation or lifecycle-heavy activity family is
+  representable without a local special-case rewrite
+- valuation requirements are explicit rather than inferred ad hoc downstream
+
+### Slice D. Build `ReconciliationDataset` As Its Own Product
+
+Goal:
+
+- make reconciliation more than exact balance assertions by defining the
+  canonical completeness and continuity product
+
+Scope:
+
+- transfer linking across owned venues and wallets
+- funding and settlement completeness checks
+- continuity windows and unresolved ownership transitions
+- cross-source corroboration sidecars
+- reconciliation-owned gaps, readiness, and clean-window summaries
+- checkpoint candidate assembly inputs
+
+Primary owners:
+
+- `application/reconciliation/`
+- `application/balances/`
+
+Required contracts:
+
+- reconciliation dataset aggregate
+- explicit link records and link-decision artifacts
+- continuity-window and clean-window artifacts
+- missing-leg and unresolved-transition artifacts
+
+Must not do:
+
+- rewrite upstream economic facts just to satisfy a check
+- erase valid partial balances because the full source window is not yet clean
+- collapse transfer-link uncertainty into tax or accounting-owned logic
+
+Exit criteria:
+
+- exact balance assertion output becomes one reconciliation surface, not the
+  entire reconciliation product
+- transfer links, continuity gaps, and checkpoint candidates are explicit
+  runtime artifacts
+- reconciliation readiness is sliceable by source and time window
+
+### Slice E. Formalize `CheckpointPackage`
+
+Goal:
+
+- make accepted checkpoint truth a first-class package boundary and not only a
+  derived summary
+
+Scope:
+
+- checkpoint assertion contracts
+- acceptance basis and trust-level contracts
+- intentional opening-state adoption flow with provenance
+- continuity into the adopted checkpoint
+- checkpoint summaries reusable by accounting and tax
+
+Primary owners:
+
+- `application/checkpoints/`
+- `domain/checkpoints/`
+- `application/reconciliation/`
+
+Required contracts:
+
+- accepted checkpoint package
+- opening-state adoption package
+- checkpoint evidence index
+- checkpoint continuity report
+
+Must not do:
+
+- treat operator assertions as equivalent to filing-ready source-backed
+  checkpoint evidence
+- leave accepted checkpoint state implicit in reconciliation notes or balances
+  summaries
+
+Exit criteria:
+
+- one checkpoint package can be referenced directly by later accounting and tax
+  workflows
+- checkpoint acceptance basis is explicit and auditable
+- opening-state adoption is intentional, reviewable, and provenance-backed
+
+### Slice F. Build `JournalDataset` As A Validator, Not A Truth Repair Layer
+
+Goal:
+
+- expand accepted upstream truth into double-entry structure and expose
+  accounting coverage gaps explicitly
+
+Scope:
+
+- posting assembly from reconciled economics and accepted checkpoint state
+- journal validation artifacts
+- unsupported accounting coverage gap reporting
+- checkpoint-aligned accounting summaries
+
+Primary owners:
+
+- `domain/accounting/`
+- `application/accounting/`
+- output renderers under `application/outputs/` and adapter layers
+
+Required contracts:
+
+- journal dataset aggregate
+- posting contract
+- validation result contract
+- accounting coverage gap contract
+
+Must not do:
+
+- patch upstream truth locally to make the ledger balance
+- treat renderer-specific chart choices as the domain model
+- make tax depend on renderer success when the underlying determinants are
+  already known
+
+Exit criteria:
+
+- balanced supported activity renders deterministically
+- unsupported accounting coverage is visible as stage-owned gaps
+- accounting outputs can be reconciled back to accepted checkpoint state
+
+### Slice G. Introduce `TaxDeterminantDataset`
+
+Goal:
+
+- separate policy-ready tax determinants from both raw economics and final
+  jurisdiction outputs
+
+Scope:
+
+- acquisition and disposition determinants
+- income-event determinants
+- internal transfer determinants
+- financing-cost determinants
+- basis or pool state transitions
+- valuation requirements for tax computation
+- tax-owned unresolved gaps
+
+Primary owners:
+
+- `domain/tax/`
+- `application/tax/`
+
+Required contracts:
+
+- tax determinant aggregate
+- determinant-to-policy application seam
+- tax-owned gap contract
+- year-state and carry-forward intermediate contracts
+
+Must not do:
+
+- branch tax logic directly on CoinTracking or other oracle artifact rows
+- use journal output as a hidden prerequisite when the journal only restates
+  already-known truth
+- fill missing valuations or ownership decisions silently
+
+Exit criteria:
+
+- the runtime can explain what was acquired, disposed, earned, transferred
+  internally, or still unresolved before jurisdiction rules render final output
+- tax-owned gaps are distinguishable from reconciliation and accounting gaps
+- determinant coverage is reproducible from reconciled economics plus accepted
+  checkpoint truth
+
+### Slice H. Build `TaxOutputDataset`
+
+Goal:
+
+- render jurisdiction-specific outputs from determinants without contaminating
+  earlier stages with jurisdiction rules
+
+Scope:
+
+- Canada MVP outputs first
+- year summaries
+- carry-forward outputs
+- explicit unsupported and deferred outputs
+
+Primary owners:
+
+- `application/tax/`
+- output renderers under `application/outputs/`
+
+Required contracts:
+
+- tax output aggregate
+- jurisdiction renderer contracts
+- unsupported-output reporting
+
+Exit criteria:
+
+- `2023`, `2024`, and `2025` outputs emit from tax determinants
+- carry-forward state is deterministic and reproducible
+- unresolved unsupported items remain visible instead of disappearing into
+  notes
+
+### Slice I. Cross-Stage Verification And Retirement
+
+Goal:
+
+- replace transition-era behavior only after the new pipeline products prove
+  themselves end to end
+
+Scope:
+
+- raw-evidence semantic parity validation
+- reconciliation artifact parity where meaningful
+- checkpoint continuity regression coverage
+- journal validation coverage
+- tax determinant and output coverage
+- retirement of normalized-transaction-era assumptions after the fact-native
+  path is stable
+
+Rules:
+
+- do not remove an older path until the replacement has stage-appropriate
+  parity, contract, and smoke coverage
+- prefer replacing one active runtime path with a new typed product over adding
+  long-lived wrapper lanes
+
+Exit criteria:
+
+- the supported workflow runs from source evidence through tax output without
+  transition-only assumptions
+- remaining compatibility surfaces are deliberate edges, not hidden core
+  dependencies
+
 ## Roadmap Sequence
 
 ### 1. Oracle Boundary Completion
@@ -80,10 +533,13 @@ reconciliation, accounting, and tax work expands.
 Scope:
 
 - keep direct fact artifacts as the only runtime model
-- add capture-scoped translation input planning as a required fact-path
-  stabilization step so adapters describe valid input candidates and the core
-  planner selects deterministic selected, superseded, or blocked plans from
-  event-time coverage and freshness metadata
+- treat filing-critical adapter work as a stabilization track on the current
+  seams: during the filing window, prioritize deterministic planner, evidence,
+  translation, and output hardening for the adapters actually used by the
+  active filing workflow, and defer the broader unified adapter contract
+  rewrite until after that path is stable; treat
+  `docs/concepts/unified-adapter-architecture.md` as the explicit design
+  target for later adapter-contract replacement
 - center intake on explicit capture identity, capture registries, and
   raw-evidence preservation instead of inferred capture buckets
 - keep inferred period and capture heuristics as report metadata only; they do
@@ -116,6 +572,16 @@ Scope:
 - migrate adapters to the planner path in stages, starting with Coinbase and
   then other adapters that still pick one export by filename or path heuristic
 - add a repo-native semantic parity validator for unchanged raw inputs
+- keep the broad adapter-interface redesign documented and deferred while
+  filing-critical adapters remain on the current contract; use that later
+  redesign to replace the bundled source contract only after the active filing
+  path is deterministic enough to trust
+- define the target `EvidenceBundle` and `ClaimBundle` contracts and land them
+  incrementally without reintroducing normalized-transaction-era wrappers
+- allow source-local ambiguity to survive into claim outputs when forcing one
+  final economic meaning would guess
+- keep `EconomicActivityDraft` and `TransactionFact` as transition seams rather
+  than freezing them as the final architecture center
 
 Exit criteria:
 
@@ -131,6 +597,8 @@ Exit criteria:
 - balance references, issue rows, review rows, and location inventory evidence
   rows share one flattened provenance locator family at artifact boundaries
   while runtime models keep typed provenance
+- at least one adapter family proves the claim-to-economic compilation path
+  without requiring every claim to bind final tax and accounting intent early
 - unchanged raw inputs preserve file completeness, fact counts, snapshot
   counts, reference counts, and issue or review counts unless an
   expected-difference fixture documents the exception
@@ -168,6 +636,9 @@ Scope:
 - checkpoint continuity checks
 - correction and supersession chains
 - reconciliation issue assembly
+- define `ReconciliationDataset` as an explicit product with link decisions,
+  continuity windows, checkpoint candidates, and reconciliation-owned readiness
+  slices rather than treating exact balance assertions as the whole product
 - deterministic correction handling for known historical events such as the
   GALA redistribution
 
@@ -183,6 +654,8 @@ Exit criteria:
 - reconciliation artifacts no longer depend on normalized-transaction-era
   stopgaps
 - material reconciliation issues surface explicitly and reproducibly
+- reconciliation readiness is reducible by source, location, instrument, and
+  continuity window instead of only by coarse source summaries
 
 ### 4. Checkpoint Packages And Opening State
 
@@ -203,6 +676,8 @@ Scope:
   near `2026-03-23`
 - intentional opening-state adoption flow with provenance
 - continuity checks between reconstructed balances and adopted checkpoints
+- keep checkpoint trust level and acceptance basis explicit so later accounting
+  and tax work can reference accepted checkpoint truth directly
 
 Exit criteria:
 
@@ -224,6 +699,8 @@ Scope:
 - Ledger CLI renderer
 - journal validation result artifacts
 - accounting summaries tied to reconciliation and checkpoint outputs
+- keep accounting coverage gaps stage-owned and explicit instead of repairing
+  upstream truth locally
 
 Exit criteria:
 
@@ -240,17 +717,22 @@ Scope:
 
 - tax policy port
 - Canada MVP policy
+- tax determinant contracts between reconciled facts and rendered tax outputs
 - pooled ACB state
 - disposition outputs
 - income outputs
 - unsupported tax item outputs
 - carry-forward and year summary outputs for `2023`, `2024`, and `2025`
+- keep tax-owned unresolved determinants explicit rather than encoding them as
+  generalized reconciliation or accounting failures
 
 Exit criteria:
 
 - `2023` to `2025` tax artifacts emit from reconciled facts
 - year-end and carry-forward state is reproducible without tracker tax reports
 - unresolved unsupported tax items are visible rather than hidden in notes
+- tax determinants are reproducible from reconciled economics plus accepted
+  checkpoint truth without depending on CoinTracking or other oracle rows
 
 ### 7. Filing Workflow
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -5,110 +5,94 @@ This file is the forward planning document for the repo.
 - Completed work belongs in [CHANGELOG.md](CHANGELOG.md).
 - The currently implemented runtime surface belongs in
   [`docs/status/current-state.md`](docs/status/current-state.md).
-- Architectural decisions, schema contracts, and migration rules belong in the
-  architecture docs, especially:
+- Detailed contract ownership lives in:
+  - [`docs/concepts/current-bridge-contracts.md`](docs/concepts/current-bridge-contracts.md)
+  - [`docs/concepts/pipeline-stage-contracts.md`](docs/concepts/pipeline-stage-contracts.md)
+  - [`docs/concepts/domain-ontology.md`](docs/concepts/domain-ontology.md)
+  - [`docs/concepts/gaps-and-readiness.md`](docs/concepts/gaps-and-readiness.md)
   - [`docs/concepts/reconciliation-tax-architecture.md`](docs/concepts/reconciliation-tax-architecture.md)
   - [`docs/status/migration-sequence.md`](docs/status/migration-sequence.md)
-  - [`docs/concepts/oracle-boundaries.md`](docs/concepts/oracle-boundaries.md)
-  - [`docs/concepts/transaction-classification.md`](docs/concepts/transaction-classification.md)
 
-This roadmap assumes the repo stays on the current fact-based architecture. It
-tracks remaining phases, sequencing, and delivery gates. It does not restate
-the detailed architecture contract.
-
-The current runtime now uses `application/balances` as the shared balance
-capability across normalization, reconciliation, and checkpoint submission.
-Inspect, check, and summarize are the operator-facing balance commands.
-Balance state is expressed as derived `balance_snapshots.csv` plus unified
-`balance_references.csv`, where each reference row declares its
-`reference_kind`. Fact-backed checks derive snapshots from facts;
-manual-only checks consume explicit snapshot rows; check runs offline by
-default and hydrates only when requested.
-
-Historical provider hydration is now a first-class balance concern, but the
-current implementation target remains public-ledger balance lookup only. The
-current codebase also ships the separate balance-provider discovery seam with
-discoverable `evm_json_rpc` and `near_rpc` family stubs, plus native and
-contract-backed public-ledger asset ids for the in-scope EVM, NEAR, and Ronin
-adapters. Live network hydration remains deferred behind provider
-implementations.
+This roadmap tracks the implementation program from the current bridge toward
+the target stage-first architecture. The current bridge remains the live runtime
+seam, but it is not the long-term architecture center.
 
 ## Planning Anchors
 
-These planning anchors drive phase order and acceptance criteria:
+These anchors drive sequencing and acceptance criteria:
 
 - the historical CoinTracking export boundary around `2023-08-05` remains an
   oracle boundary, not a trusted opening checkpoint
 - the first source-backed checkpoint target remains near `2026-03-23`
 - the filing-critical output horizon remains `2023` through `2025`
-- reconciliation remains the trust gate before tax
-- accounting validates journal structure and coverage in parallel with
-  reconciliation once the fact path is stable
+- reconciliation remains the trust gate before checkpoint adoption, accounting,
+  and tax
+- checkpoint truth is accepted state with explicit acceptance basis
 - capture identity is metadata, not path
 - typed provenance stays a runtime model and is flattened only when writing
   artifacts
 - normalization is capture-scoped and reconciliation is source-assembly-scoped
 - raw-evidence derivation is the supported semantic parity path
+- current bridge names remain current-state truth until later implementation
+  slices replace them
 
-## Detailed Pipeline Delivery Plan
+## Transition Rules
 
-The numbered phases below remain the coarse rollout gates. The detailed plan in
-this section is the implementation reference for the target pipeline products
-and the bounded slices needed to land them without ad hoc design during coding.
+- preserve current working behavior while new foundations land
+- avoid freezing the current bridge as the long-term architecture center
+- keep adapters and services shippable at every checkpoint
+- keep CoinTracking as one edge projection and oracle family, not a migration
+  anchor
+- preserve current bridge truth while establishing the target stage and
+  ontology ownership model
+- do not rename live bridge symbols or the live repo-only support package as a
+  docs-only side effect; land those as later implementation slices
 
-Use the exact target product names from
-`docs/concepts/reconciliation-tax-architecture.md` when shaping the next
-contracts:
+## Cross-Cutting Foundations
 
-1. `EvidenceSet`
-2. `ClaimSet`
-3. `EconomicFacts`
-4. `ReconciliationState`
-5. `Checkpoint`
-6. `Journal`
-7. `TaxInputs`
-8. `TaxOutputs`
+These are blocking shared foundations for later implementation work:
 
-### Cross-Cutting Contracts To Land Before Broad Pipeline Expansion
+- the live bridge contracts documented in
+  [`docs/concepts/current-bridge-contracts.md`](docs/concepts/current-bridge-contracts.md)
+- the target stage contracts documented in
+  [`docs/concepts/pipeline-stage-contracts.md`](docs/concepts/pipeline-stage-contracts.md)
+- the target ontology and identity seams documented in
+  [`docs/concepts/domain-ontology.md`](docs/concepts/domain-ontology.md)
+- the shared gap, readiness, and `SubjectRef` rules documented in
+  [`docs/concepts/gaps-and-readiness.md`](docs/concepts/gaps-and-readiness.md)
+- bridge-only classification rules documented in
+  [`docs/concepts/transaction-classification.md`](docs/concepts/transaction-classification.md)
+- oracle boundary rules documented in
+  [`docs/concepts/oracle-boundaries.md`](docs/concepts/oracle-boundaries.md)
+- repo-only support boundary direction: the current live package remains
+  `repo_support/`, while later implementation should rename and split that
+  dev-only surface under `dev_support/`
 
-These contracts should be treated as blocking shared foundations rather than as
-optional cleanup.
+Rules:
 
-Scope:
+- do not let new stages invent their own blocker or readiness surface
+- do not let new work recentre the architecture on the current bridge types
+- do not turn repo-only support into a permanent generic catch-all under the
+  current live `repo_support/` name
+- do not rename live bridge symbols or the live repo-only support package as a
+  docs-only side effect; land those as later implementation slices
 
-- one typed provenance family across evidence, claims, balances, issues,
-  reviews, checkpoints, accounting, and tax artifacts
-- one controlled gap taxonomy with stage ownership, blocking scope, subject
-  references, candidate interpretations, required evidence, and allowed
+Shared-foundation deliverables before broad pipeline expansion:
+
+- one typed provenance family across evidence, claims, balances, gaps,
+  readiness, checkpoints, accounting, and tax artifacts
+- one controlled gap taxonomy with stage ownership, blocking scope,
+  `SubjectRef`, candidate interpretations, required evidence, and allowed
   resolution methods
-- one readiness vocabulary reused across all datasets
-- one shared slice model for readiness and materiality
+- one readiness vocabulary reused across all stages
+- one subject-first readiness model with derived projections rather than one
+  mandatory global readiness cube
 - one explicit identity seam for instrument, contract, position, location,
   legal owner, beneficial owner, and counterparty identity
-- `SubjectRef` for shared infrastructure that needs a generic reference without
-  flattening `Contract` and `Position`
 - one typed tax-policy selection seam reused by later `TaxInputs` and
   `TaxOutputs` work
 - one checkpoint assertion vocabulary reused by reconciliation, checkpoint
   adoption, accounting, and tax
-
-Rules:
-
-- do not let each new stage invent its own status field or bespoke blocker row
-- do not store whole-dataset readiness as the only truth; derive it from
-  subject-level readiness reducers
-- keep gap ownership explicit so accounting gaps, reconciliation gaps, and
-  tax-owned gaps are not conflated operationally
-
-Shared readiness uses this exact slice definition:
-
-- source
-- location
-- instrument
-- subject ref
-- continuity segment
-- checkpoint date
-- tax year where relevant
 
 Exit criteria:
 
@@ -119,22 +103,17 @@ Exit criteria:
 - dataset summaries derive from subject-level readiness instead of hand-built
   status prose
 
-### MVP Scope Guardrails
+## MVP Scope Guardrails
 
-The MVP should remain filing-capable, provider-neutral where it matters, and
-small enough to implement without a speculative framework buildout.
-
-Rules:
-
-- use the current fact-plus-balances bridge until the next concrete slice needs
-  a richer stage contract
+- use the current bridge until the next concrete slice needs a richer stage
+  contract
 - do not wait for every target product to exist before improving the active
   filing path
 - add new stage models, reducers, or ports only when one bounded slice needs
   them for correctness, determinism, or later-stage reuse
 - avoid plugin systems, manifest families, or broad orchestration abstractions
   before a second concrete implementation requires them
-- keep unsupported or deferred behavior explicit through gaps instead of
+- keep unsupported or deferred behavior explicit through blockers instead of
   low-confidence partial support
 - prefer one end-to-end vertical slice that proves a new stage over several
   horizontal framework layers with no proven consumer
@@ -143,22 +122,14 @@ Rules:
 - keep current-contract adapter stabilization distinct from the later adapter
   redesign
 
-Exit criteria:
-
-- the active filing path keeps moving while the architecture becomes more
-  explicit
-- new reusable seams exist because one real slice needed them, not because the
-  repo was trying to pre-build every future variation
-
-### Performance Expectations
+## Performance Expectations
 
 Rollout choices must preserve bounded recalculation cost.
 
 Rules:
 
-- expensive reducers must be partitionable by source, location, instrument,
-  subject ref, continuity segment, checkpoint date, and tax year where
-  relevant
+- expensive reducers must be partitionable by the dimensions the owning stage
+  actually uses, with derived reporting projections added only where needed
 - hot-path calculations should operate on compact typed records instead of
   repeatedly joining provenance, review, or renderer payloads
 - derived snapshots and reusable state should be introduced where replay cost
@@ -166,670 +137,212 @@ Rules:
 - tax work should support tax-year partitioning and carry-forward reuse instead
   of recomputing full acquisition history for every output row
 
-### Slice A. Harden `EvidenceSet`
+## Implementation Program
+
+### Phase 0. Shared Foundations And Docs Lock
 
 Goal:
 
-- make deterministic evidence selection and source-local observation capture the
-  formal first pipeline product
+- finish the shared architecture, naming, support-model, and control-plane
+  baseline before broad implementation slices land
 
-Scope:
+Deliver:
 
-- carry selected, superseded, and blocked raw inputs as explicit evidence-bundle
-  artifacts
-- keep document, statement, and inventory observations source-local
-- preserve capture, assembly, and document provenance without forcing economic
-  meaning
-- keep deterministic evidence selection in core planning services rather than in
-  adapter-local heuristics
+- focused ownership docs for the current bridge, target stage contracts,
+  ontology, and gap/readiness contracts
+- aligned roadmap, migration, and architecture anchors
+- target `dev_support/` direction documented while current `repo_support/`
+  remains truth in current-state text
+- explicit trust-gate ownership for reconciliation, checkpoints, accounting,
+  and tax
 
-Primary owners:
+Exit criteria:
 
-- `application/intake/`
-- `application/profiling/`
-- `application/evidence/`
-- `application/normalization/translation_inputs/`
+- a contributor can identify what is current, what is target, who owns each
+  contract, and what the next slice should land without reading the same
+  definition in several conflicting places
 
-Required contracts:
+### Phase 1. Formalize `EvidenceSet`
 
-- deterministic evidence selection report
+Goal:
+
+- make deterministic evidence selection and source-local observation capture
+  the formal first pipeline product
+
+Deliver:
+
+- deterministic evidence selection reports
+- explicit selected, superseded, and blocked evidence outputs
 - source-local parsed observation contracts
-- explicit superseded and blocked evidence outputs
-- evidence-bundle summary and issue surfaces
-
-Must not do:
-
-- invent economic meaning at the evidence layer
-- hide raw-selection decisions inside adapter code
-- collapse source-local observations into final facts when the source remains
-  ambiguous
+- evidence provenance and locator guarantees aligned with the target contract
+- evidence summary and issue surfaces that remain source-local rather than
+  prematurely economic
 
 Exit criteria:
 
 - the runtime can explain why every selected source artifact won and why every
   superseded artifact lost
-- source-local observations and their provenance survive beyond file-selection
-  time
-- evidence selection becomes the only supported path into later claim and
-  economic compilation work
+- source-local observations survive beyond file-selection time
 
-### Slice B. Introduce `ClaimSet` Without Breaking The Current Fact Path
+### Phase 2. Introduce `ClaimSet`
 
 Goal:
 
-- interpose a source-local claim layer between evidence selection and final
-  economic facts
+- interpose a real claim layer between evidence selection and final economic
+  truth
 
-Scope:
+Deliver:
 
-- define activity, balance, ownership, location, instrument, contract-term, and
-  valuation claim contracts
-- allow materially unclassified claims when a provider row cannot safely commit
-  to one `EconomicKind`
-- capture candidate interpretations and blocking ambiguity explicitly
-- keep current `EconomicActivityDraft` as a transitional bridge while claim
-  contracts land incrementally
-
-Primary owners:
-
-- `ports/source_translation.py`
-- `application/facts/`
-- source adapters under `adapters/sources/`
-
-Required contracts:
-
-- claim bundle aggregate
-- claim-to-economic compilation seam
-- claim-owned issue and review contracts
-- explicit mapping from transitional draft fields into claim semantics during
-  migration
-
-Must not do:
-
-- require every claim to carry final economic, tax, and accounting semantics
-- bind ambiguous transfers, ownership changes, restructurings, or mixed rows to
-  one interpretation just to stay on the current draft shape
-- let adapters widen policy responsibility beyond source-local meaning
+- claim-native contracts for activity, balance, ownership, location,
+  instrument, contract, and valuation meaning
+- claim-owned issues and reviews
+- explicit handling for materially unresolved meaning
+- bridge loosening so ambiguous rows can remain claims without being forced
+  into final bridge semantics
+- at least one ambiguous row family that survives as a claim rather than being
+  coerced into a guessed final fact
 
 Exit criteria:
 
 - at least one adapter family emits claim-native outputs before economic
   compilation
 - ambiguous source rows can remain claim-complete but economically unresolved
-- the compiler can reject unsafe claims without losing claim provenance
 
-### Slice C. Expand `EconomicFacts` Beyond Today’s Minimal Fact Shape
-
-Goal:
-
-- make the economic-truth layer broad enough for obligation-bearing and
-  lifecycle-heavy instruments
-
-Scope:
-
-- keep `TransactionFact` as the current row-level bridge while expanding the
-  economic dataset contract around it
-- add first-class seams for contract instance identity, ownership change
-  semantics, settlement state, supersession, collateral, financing, and
-  lifecycle events
-- add valuation attachments with purpose, time, source, precision, and
-  provenance instead of free-form downstream valuation assumptions
-- keep signed-leg structure, precision, and provenance strict
-
-Primary owners:
-
-- `domain/transactions/`
-- `domain/instruments/`
-- `application/facts/`
-
-Required contracts:
-
-- economic dataset aggregate contract
-- contract instance or position identity surface
-- valuation attachment contract
-- correction and supersession chain contract
-
-Must not do:
-
-- assume all activity is spot movement between wallets and exchanges
-- encode loans, margin, shorts, options, futures, repos, or corporate actions
-  as awkward spot-only special cases
-- treat output-adapter projection hints as the long-term driver of core
-  behavior
-
-Exit criteria:
-
-- economic facts preserve the determinants needed for later reconciliation,
-  accounting, and tax work without revisiting raw rows
-- at least one non-trivial obligation or lifecycle-heavy activity family is
-  representable without a local special-case rewrite
-- valuation requirements are explicit rather than inferred ad hoc downstream
-
-### Slice D. Build `ReconciliationState` As Its Own Product
+### Phase 3. Land `EconomicFacts`
 
 Goal:
 
-- make reconciliation more than exact balance assertions by defining the
-  completeness and continuity product
+- move from bridge-first fact shaping toward the target economic layer while
+  preserving parity
 
-Scope:
+Deliver:
 
-- transfer linking across owned venues and wallets
-- funding and settlement completeness checks
-- continuity windows and unresolved ownership transitions
-- cross-source corroboration sidecars
-- reconciliation-owned gaps, readiness, and clean-window summaries
-- checkpoint candidate assembly inputs
-
-Primary owners:
-
-- `application/reconciliation/`
-- `application/balances/`
-
-Required contracts:
-
-- reconciliation dataset aggregate
-- explicit link records and link-decision artifacts
-- continuity-window and clean-window artifacts
-- missing-leg and unresolved-transition artifacts
-
-Must not do:
-
-- rewrite upstream economic facts just to satisfy a check
-- erase valid partial balances because the full source window is not yet clean
-- collapse transfer-link uncertainty into tax or accounting-owned logic
+- claim-to-economic compilation seam
+- target-directed economic models aligned to the target ontology
+- explicit preservation of settlement, lifecycle, valuation, and identity seams
+- bridge retirement rules for the slices that no longer need
+  `EconomicActivityDraft` or `TransactionFact`
+- parity coverage for the first claim-to-economic vertical slice
 
 Exit criteria:
 
-- exact balance assertion output becomes one reconciliation surface, not the
-  entire reconciliation product
-- transfer links, continuity gaps, and checkpoint candidates are explicit
-  runtime artifacts
-- reconciliation readiness is sliceable by source and time window
-
-### Slice E. Formalize `Checkpoint`
-
-Goal:
-
-- make accepted checkpoint truth a first-class package boundary and not only a
-  derived summary
-
-Scope:
-
-- checkpoint assertion contracts
-- acceptance basis and trust-level contracts
-- intentional opening-state adoption flow with provenance
-- continuity into the adopted checkpoint
-- checkpoint summaries reusable by accounting and tax
-
-Primary owners:
-
-- `application/checkpoints/`
-- `domain/checkpoints/`
-- `application/reconciliation/`
-
-Required contracts:
-
-- accepted checkpoint package
-- opening-state adoption package
-- checkpoint evidence index
-- checkpoint continuity report
-
-Must not do:
-
-- treat operator assertions as equivalent to filing-ready source-backed
-  checkpoint evidence
-- leave accepted checkpoint state implicit in reconciliation notes or balances
-  summaries
-
-Exit criteria:
-
-- one checkpoint package can be referenced directly by later accounting and tax
-  workflows
-- checkpoint acceptance basis is explicit and auditable
-- opening-state adoption is intentional, reviewable, and provenance-backed
-
-### Slice F. Build `Journal` As A Validator, Not A Truth Repair Layer
-
-Goal:
-
-- expand accepted upstream truth into double-entry structure and expose
-  accounting coverage gaps explicitly
-
-Scope:
-
-- posting assembly from reconciled economics and accepted checkpoint state
-- journal validation artifacts
-- unsupported accounting coverage gap reporting
-- checkpoint-aligned accounting summaries
-
-Primary owners:
-
-- `domain/accounting/`
-- `application/accounting/`
-- output renderers under `application/outputs/` and adapter layers
-
-Required contracts:
-
-- journal dataset aggregate
-- posting contract
-- validation result contract
-- accounting coverage gap contract
-
-Must not do:
-
-- patch upstream truth locally to make the ledger balance
-- treat renderer-specific chart choices as the domain model
-- make tax depend on renderer success when the underlying determinants are
-  already known
-
-Exit criteria:
-
-- balanced supported activity renders deterministically
-- unsupported accounting coverage is visible as stage-owned gaps
-- accounting outputs can be reconciled back to accepted checkpoint state
-
-### Slice G. Introduce `TaxInputs`
-
-Goal:
-
-- separate policy-ready tax inputs from both raw economics and final
-  jurisdiction outputs
-
-Scope:
-
-- acquisition and disposition determinants
-- income-event determinants
-- internal transfer determinants
-- financing-cost determinants
-- basis or pool state transitions
-- valuation requirements for tax computation
-- tax-owned unresolved gaps
-
-Primary owners:
-
-- `domain/tax/`
-- `application/tax/`
-
-Required contracts:
-
-- tax-input aggregate
-- determinant-to-policy application seam
-- tax-owned gap contract
-- year-state and carry-forward intermediate contracts
-
-Must not do:
-
-- branch tax logic directly on CoinTracking or other oracle artifact rows
-- use journal output as a hidden prerequisite when the journal only restates
-  already-known truth
-- fill missing valuations or ownership decisions silently
-
-Exit criteria:
-
-- the runtime can explain what was acquired, disposed, earned, transferred
-  internally, or still unresolved before jurisdiction rules render final output
-- tax-owned gaps are distinguishable from reconciliation and accounting gaps
-- determinant coverage is reproducible from reconciled economics plus accepted
-  checkpoint truth
-
-### Slice H. Build `TaxOutputs`
-
-Goal:
-
-- render jurisdiction-specific outputs from determinants without contaminating
-  earlier stages with jurisdiction rules
-
-Scope:
-
-- Canada MVP outputs first
-- year summaries
-- carry-forward outputs
-- explicit unsupported and deferred outputs
-
-Primary owners:
-
-- `application/tax/`
-- output renderers under `application/outputs/`
-
-Required contracts:
-
-- tax output aggregate
-- jurisdiction renderer contracts
-- unsupported-output reporting
-
-Exit criteria:
-
-- `2023`, `2024`, and `2025` outputs emit from `TaxInputs` through selected
-  policy
-- carry-forward state is deterministic and reproducible
-- unresolved unsupported items remain visible instead of disappearing into
-  notes
-
-### Slice I. Cross-Stage Verification And Retirement
-
-Goal:
-
-- replace transition-era behavior only after the new pipeline products prove
-  themselves end to end
-
-Scope:
-
-- raw-evidence semantic parity validation
-- reconciliation artifact parity where meaningful
-- checkpoint continuity regression coverage
-- journal validation coverage
-- tax determinant and output coverage
-- retirement of normalized-transaction-era assumptions after the fact-native
-  path is stable
-
-Rules:
-
-- do not remove an older path until the replacement has stage-appropriate
-  parity, contract, and smoke coverage
-- prefer replacing one active runtime path with a new typed product over adding
-  long-lived wrapper lanes
-
-Exit criteria:
-
-- the supported workflow runs from source evidence through tax output without
-  transition-only assumptions
-- remaining compatibility surfaces are deliberate edges, not hidden core
-  dependencies
-
-## Roadmap Sequence
-
-### 1. Oracle Boundary Completion
-
-Finish the remaining dev-only oracle support needed for comparison,
-regression, and filing-close validation.
-
-Scope:
-
-- complete boundary models for the supported CoinTracking oracle artifact
-  families
-- complete deterministic readers and comparison-ready artifact contracts under
-  the dev-only oracle tooling surface
-- finish oracle comparison coverage needed for filing-close validation
-
-Exit criteria:
-
-- supported oracle files parse deterministically
-- oracle comparison workflows are complete enough to support later filing-close
-  validation
-- oracle support remains outside the production runtime surface
-
-### 2. Fact-Path Stabilization Before Deeper Trust Work
-
-Finish the remaining fact-path follow-through required before broad
-reconciliation, accounting, and tax work expands.
-
-Scope:
-
-- keep direct fact artifacts as the only runtime model
-- treat filing-critical adapter work as a stabilization track on the current
-  seams: during the filing window, prioritize deterministic planner, evidence,
-  translation, and output hardening for the adapters actually used by the
-  active filing workflow, and defer the broader unified adapter contract
-  rewrite until after that path is stable; treat
-  `docs/concepts/unified-adapter-architecture.md` as the explicit design
-  target for later adapter-contract replacement
-- center intake on explicit capture identity, capture registries, and
-  raw-evidence preservation instead of inferred capture buckets
-- keep inferred period and capture heuristics as report metadata only; they do
-  not control runtime identity, routing, or normalization ownership
-- finish adapter parity and projection parity coverage on the current fact
-  model
-- keep file-selection policy in `application/normalization/` rather than in
-  adapter-local filename or path-order heuristics
-- keep review and issue outputs explicit for ambiguous direction, precision, or
-  classification decisions
-- persist translation planner artifacts showing candidate descriptions, plan
-  decisions, and blocking issues before translation begins
-- continue tightening overlap heuristics, duplicate detection, file-family
-  signatures, and capture acceptance rules where capture ownership is still
-  ambiguous
-- split capture-scoped normalization from source-scoped assembly before
-  reconciliation expands further
-- centralize statement extraction, document discovery, provenance, and shared
-  issue or review handling behind one evidence seam
-- keep statement selection and portfolio evidence dating owned by typed capture
-  and profile metadata rather than by capture-label conventions or raw-path
-  rescans
-- allow adapter-owned upstream workbook exports to remain raw evidence when the
-  typed intake route classifies them as source originals
-- keep source profile and source normalize strict to one materialized raw
-  capture root and fail explicit on arbitrary directories or mismatched capture
-  metadata
-- make source assembly rerun-safe by rewriting its owned generated artifact
-  surface deterministically on each run
-- migrate adapters to the planner path in stages, starting with Coinbase and
-  then other adapters that still pick one export by filename or path heuristic
-- add a repo-native semantic parity validator for unchanged raw inputs
-- keep the broad adapter-interface redesign documented and deferred while
-  filing-critical adapters remain on the current contract; use that later
-  redesign to replace the bundled source contract only after the active filing
-  path is deterministic enough to trust
-- define the target `EvidenceSet` and `ClaimSet` contracts and land them
-  incrementally without reintroducing normalized-transaction-era wrappers
-- allow source-local ambiguity to survive into claim outputs when forcing one
-  final economic meaning would guess
-- keep `EconomicActivityDraft` and `TransactionFact` as transition seams rather
-  than freezing them as the final architecture center
-
-Exit criteria:
-
-- supported adapters emit facts without normalized-transaction-era wrapper
+- accepted economic meaning is no longer constrained by bridge activity labels
+- at least one bounded slice proves target economic modeling without wrapper
   lanes
-- planner-enabled adapters no longer choose winning translation inputs by path
-  order or lexical filename order
-- selected, superseded, and blocked translation inputs are explicit
-  normalization artifacts before fact translation runs
-- CoinTracking CSV projection remains correct from facts alone
-- remaining normalization ambiguity paths emit explicit reviews or blocking
-  issues instead of silent coercion
-- balance references, issue rows, review rows, and location inventory evidence
-  rows share one flattened provenance locator family at artifact boundaries
-  while runtime models keep typed provenance
-- at least one adapter family proves the claim-to-economic compilation path
-  without requiring every claim to bind final tax and accounting intent early
-- unchanged raw inputs preserve file completeness, fact counts, snapshot
-  counts, reference counts, and issue or review counts unless an
-  expected-difference fixture documents the exception
-- expected-difference fixtures may relax only issue-count or review-count
-  parity and must never excuse raw completeness, fact, snapshot, reference, or
-  reconciliation drift
 
-### 3. Reconciliation
+### Phase 4. Land `ReconciliationState`
 
-Build deterministic reconciliation on top of transaction facts, derived
-balance snapshots, and unified balance references.
+Goal:
 
-Scope:
+- move continuity, linkage, completeness, and checkpoint candidacy onto an
+  explicit reconciliation product
 
-- read only assembled source datasets produced from accepted captures
-- keep target planning, snapshot derivation, reference resolution, inspect and
-  check workflows, hydration, and assertion assembly behind the shared balance
-  capability
-- extend the first exact balance assertion workflow into broader checkpoint and
-  transfer checks
-- keep statement-backed quantity evidence on the normalization path and treat
-  valuation totals as out of scope
-- accept `balance_snapshots.csv` plus unified
-  `balance_references.csv` from normalization, manual submission, or later
-  provider hydration without splitting the downstream reconciliation contracts
-- keep historical API lookup behind separate balance-provider adapters instead
-  of extending source adapters
-- require on-chain asset ids with immutable chain identity before public-ledger
-  provider hydration is considered supported
-- keep symbol-only public-ledger asset ids as explicit unsupported surfaces
-  rather than soft-mapping them into provider hydration
-- add additive cross-source corroboration as a sidecar evidence surface before
-  promoting it into a harder reconciliation gate
-- transfer linking across owned wallets and exchanges
-- checkpoint continuity checks
-- correction and supersession chains
-- reconciliation issue assembly
-- define `ReconciliationState` as an explicit product with link decisions,
-  continuity windows, checkpoint candidates, and reconciliation-owned readiness
-  slices rather than treating exact balance assertions as the whole product
-- deterministic correction handling for known historical events such as the
-  GALA redistribution
+Deliver:
+
+- transfer links, balance targets, continuity, and checkpoint candidacy under
+  `ReconciliationState`
+- target gap and readiness models where the owning stage can support them
+- corroboration sidecars and deterministic correction handling
+- independence from raw capture layout and bridge-only balance assumptions
 
 Exit criteria:
 
-- exact balance assertion artifacts are stable and feed later continuity checks
-- additive cross-source corroboration artifacts exist without redefining the
-  primary clean-date gate and remain dependent on comparable location identity
-- fact history can be reconciled against source-backed evidence or
-  operator-confirmed balance references without manual tracker logic
-- reconciliation inputs no longer depend on raw capture layout or direct
-  multi-capture crawling
-- reconciliation artifacts no longer depend on normalized-transaction-era
-  stopgaps
-- material reconciliation issues surface explicitly and reproducibly
-- reconciliation readiness is reducible by source, location, instrument, and
-  continuity window instead of only by coarse source summaries
+- reconciliation is expressed as explicit completeness and continuity decisions
+- exact balance assertions are one reconciliation surface, not the whole
+  reconciliation product
 
-### 4. Checkpoint And Opening State
+### Phase 5. Land `Checkpoint`
 
-Formalize typed checkpoints as the handoff between reconstruction,
-reconciliation, accounting, and tax.
+Goal:
 
-Scope:
+- make accepted checkpoint truth and acceptance basis explicit
 
-- checkpoint artifact contracts
-- checkpoint provenance and evidence requirements
-- keep manual/operator-authored balance submission packages as a supported
-  checkpoint-owned input path for balance snapshots and operator assertion
-  references
-- keep manual submission row contracts boundary-validated and derive
-  `location_id` values through shared helpers instead of handwritten generic
-  ids
-- source-backed checkpoint builder centered on the best-supported balance date
-  near `2026-03-23`
-- intentional opening-state adoption flow with provenance
-- continuity checks between reconstructed balances and adopted checkpoints
-- keep checkpoint trust level and acceptance basis explicit so later accounting
-  and tax work can reference accepted checkpoint truth directly
+Deliver:
+
+- accepted checkpoint assertions under `Checkpoint`
+- source-backed checkpoint evidence requirements
+- trust level and acceptance basis
+- intentional opening-state adoption with provenance
+- manual balance submission as typed checkpoint-owned input
 
 Exit criteria:
 
-- an operator-authored runtime balance package can be created and reused as a
-  typed input without weakening the later source-backed checkpoint requirement
-- opening-state adoption is explicit, auditable, and not dependent on operator
-  memory
-- checkpoint continuity reports exist as first-class artifacts
+- checkpoint truth is explicit accepted state, not an inferred side effect
 
-### 5. Accounting Validation
+### Phase 6. Land `Journal`
 
-Advance accounting in parallel once reconciliation contracts are stable enough
-to support journal projection.
+Goal:
 
-Scope:
+- make accounting expansion and validation a first-class downstream stage
+
+Deliver:
 
 - internal journal model
-- renderer port
-- Ledger CLI renderer
-- journal validation result artifacts
-- accounting summaries tied to reconciliation and checkpoint outputs
-- keep accounting coverage gaps stage-owned and explicit instead of repairing
-  upstream truth locally
+- posting expansion and validation surfaces
+- accounting-owned blockers
+- renderer orchestration over accepted truth
 
 Exit criteria:
 
-- supported activity renders deterministically in Ledger CLI
-- Ledger CLI parse and balance validation passes for supported activity
-- accounting outputs can be checked against checkpoint balances
+- accounting validates accepted truth without acting as a truth repair layer
 
-### 6. Canadian Tax Policy
+### Phase 7. Land `TaxInputs` And `TaxOutputs`
 
-Implement the first tax policy only after reconciliation establishes a trusted
-fact history and checkpoint basis.
+Goal:
 
-Scope:
+- build policy-ready tax determinants and policy-owned outputs from accepted
+  truth
 
-- tax policy port
+Deliver:
+
+- `TaxInputs` contracts
+- tax-policy selection seam
+- first filing-critical policy implementation
 - Canada MVP policy
-- tax-input contracts between reconciled economics and rendered tax outputs
-- pooled ACB state
-- disposition outputs
-- income outputs
-- unsupported tax item outputs
-- carry-forward and year summary outputs for `2023`, `2024`, and `2025`
-- keep tax-owned unresolved determinants explicit rather than encoding them as
-  generalized reconciliation or accounting failures
+- year partitioning, carry-forward state, and explicit tax-owned blockers
+- `TaxOutputs` derived only from selected tax policies over `TaxInputs`
 
 Exit criteria:
 
-- `2023` to `2025` tax outputs emit from `TaxInputs` built from reconciled
-  economics plus accepted checkpoint truth
-- year-end and carry-forward state is reproducible without tracker tax reports
-- unresolved unsupported tax items are visible rather than hidden in notes
-- tax inputs are reproducible from reconciled economics plus accepted
-  checkpoint truth without depending on CoinTracking or other oracle rows
+- `2023` to `2025` outputs can be produced from reconciled economics plus
+  accepted checkpoint truth without CoinTracking tax reports
 
-### 7. Filing Workflow
+### Phase 8. Repo-Only Support Reset
 
-Assemble the full filing-capable workflow after reconciliation, checkpoints,
-accounting, and tax each have a working typed slice.
+Goal:
 
-Scope:
+- rename and split the dev-only shared support surface cleanly
 
-- end-to-end filing workflow from source evidence to tax outputs
-- checkpoint continuity gate
-- oracle comparison against historical CoinTracking tax outputs
-- explicit deferred-case capture for anything still unsupported
+Deliver:
 
-Exit criteria:
-
-- the forward-computed state from the `2023-08-05` oracle boundary lands on the
-  source-backed checkpoint near `2026-03-23`
-- `2023`, `2024`, and `2025` outputs are reproducible from workspace evidence
-- no unresolved material reconciliation issues remain
-- no unresolved material unsupported tax items remain
-
-### 8. Transition Retirement And Parity Closeout
-
-Retire or demote the remaining normalized-transaction-era transition surfaces
-after the filing-critical path is stable.
-
-Scope:
-
-- remove remaining normalized-transaction-first assumptions from active runtime
-  workflows
-- keep parity coverage in place until older transition surfaces are retired
-- keep CoinTracking output available as an ordinary output adapter after the
-  transition path is removed
+- rename `repo_support/` to `dev_support/`
+- split repo-only support by owned seam such as `quality/`,
+  `review_verification/`, `typecheck/`, `fixtures/`, and environment/path
+  helpers
+- update control-plane automation, docs, and tests to the new dev-only
+  boundary
 
 Exit criteria:
 
-- reconciliation, accounting, and tax all consume fact-native workflows
-- no active runtime slice still depends on normalized-transaction-era
-  assumptions
-- new behavior lands on fact-based services first
+- repo-only support has an explicit dev-only boundary name
+- shared repo-only support no longer reads like a generic support sink
 
-### 9. Public Repo And Agent Hardening
+### Phase 9. Public Repo And Agent Hardening
 
-Finish the post-filing documentation and repository hardening needed for a
-public, agent-usable codebase.
+Goal:
 
-Scope:
+- finish the post-filing documentation and repository hardening needed for a
+  public, agent-usable codebase
 
-- sanitize and maintain publishable fixtures
-- keep provenance and reuse documentation clear
-- keep the docs set navigable by type and concern
-- keep public-facing scope descriptions aligned with the implemented runtime
-- keep delivery guardrails layered across platform settings, repo-native
-  validators, and agent defaults so repo policy does not depend on prose alone
-- keep control-plane ownership routing and default-branch guardrail audits
-  explicit so local repo state and live GitHub protection drift are checked
-  together
-- keep repo-native PR review routing, change-sensitive PR-only review checks,
-  and explicit changed-surface coverage aligned so review loops do not stop
-  early after only inspecting a narrow subset of the touched surfaces
-- keep quality-gate scheduling benchmark-backed and push CI split into explicit
-  lint, type, pylint, test, and build jobs instead of one opaque parity shell
+Deliver:
+
+- publishable fixtures and provenance-safe docs
+- delivery guardrails layered across platform settings, repo-native
+  validators, and agent defaults
+- control-plane ownership routing and default-branch guardrail audits
+- repo-native PR review routing and change-sensitive PR-only review checks
+- benchmark-backed quality-gate scheduling and explicit CI job splits instead
+  of one opaque parity shell
 
 Exit criteria:
 
@@ -837,18 +350,18 @@ Exit criteria:
   assumptions
 - a new contributor or coding agent can find the correct roadmap, status,
   concept, guide, and workspace docs without broad context loading
-- the default-branch delivery path is enforced by platform and repo controls
-  strongly enough that a single agent mistake cannot silently bypass the
-  intended PR-only workflow
+- the default-branch delivery path is enforced strongly enough that a single
+  agent mistake cannot silently bypass the intended PR-only workflow
 - the repo can audit local CODEOWNERS coverage and live GitHub delivery
   settings together without broad context loading or one-off shell repair work
 
-### 10. Post-Core Runtime Expansion
+### Phase 10. Post-Core Runtime Expansion
 
-Only after the filing-critical path is stable should the repo expand runtime
-surfaces and storage choices.
+Goal:
 
-Scope:
+- expand runtime surfaces only after the filing-critical core is stable
+
+Deliver:
 
 - thin HTTP or agent-facing interfaces over the same typed application
   contracts
@@ -856,6 +369,24 @@ Scope:
 - provider-backed AI implementations with explicit audit trails
 - additional productized source and output adapters beyond the current
   high-value evidence sources
+
+Exit criteria:
+
+- post-core expansion layers on top of the filing-capable runtime instead of
+  destabilizing it
+
+## Guardrails
+
+- keep the active filing path moving while the architecture becomes more
+  explicit
+- prefer one end-to-end vertical slice that proves a new stage over horizontal
+  framework buildout with no proven consumer
+- keep unsupported or deferred behavior explicit through blockers instead of
+  low-confidence partial support
+- do not reintroduce wrapper lanes, migration shims, or dual active runtime
+  models once a bounded replacement is ready
+- when work affects architecture, schema, or sequencing, update this file
+  together with the owning concept and migration docs
 
 ## Cross-Cutting Workstreams
 
@@ -870,7 +401,8 @@ These workstreams continue across the major phases above.
 
 ### Adapter Completion
 
-- complete parity coverage for supported source adapters on the fact model
+- complete parity coverage for supported source adapters on the bridge and then
+  on target-stage products as slices land
 - tighten overlap heuristics, duplicate detection, and file-family signatures
   where capture ownership remains ambiguous
 - extend shared adapter support only where it removes repeated provider-local
@@ -883,7 +415,7 @@ These workstreams continue across the major phases above.
 - keep semantic parity, capture-registry, and source-assembly coverage as
   first-class regression surfaces
 - add reconciliation parity and checkpoint continuity tests
-- add Ledger CLI validation coverage
+- add journal validation coverage
 - add Canadian tax policy coverage including fees, income, realized PnL, and
   unsupported-item reporting
 - keep end-to-end smoke workflows for each major slice before removing older
@@ -924,10 +456,66 @@ The system is filing-ready only when all of these are true:
 - a source-backed checkpoint exists near `2026-03-23`
 - no unresolved material reconciliation issues remain
 - no unresolved material unsupported tax items remain
-- Ledger CLI validation passes for supported activity
+- journal validation passes for supported activity
 - the forward-computed state from the `2023-08-05` oracle boundary lands on the
   source-backed checkpoint
 - `2023`, `2024`, and `2025` outputs can be reproduced from workspace evidence
+
+## Tests To Add
+
+### Schema And Parsing
+
+- multi-leg transaction parsing
+- valuation provenance validation
+- CoinTracking alias normalization
+- correction and supersession chains
+
+### Reconciliation
+
+- transfer pairing across owned wallets and exchanges
+- exact balance assertion workflow over unified balance targets with
+  `source_document` precedence, optional `network_api` hydration, and
+  `operator_assertion` fallback
+- redistribution corrections
+- checkpoint balance assertions
+- forward continuity from oracle boundary to checkpoint
+
+### Accounting
+
+- journal posting generation
+- validation parse-and-balance coverage
+- supported commodity balances matching checkpoint outputs
+
+### Tax
+
+- pooled ACB updates
+- crypto-to-crypto dispositions
+- fee treatment in quote, base, and third asset
+- staking and reward income
+- derivatives and margin realized PnL
+- explicit unsupported-item logging
+
+## Initial Refactor Guidance
+
+Perform only the refactors required to support the new architecture:
+
+- split new domain concepts into dedicated packages rather than expanding
+  `domain/transactions/` or sibling domain capability packages
+- promote workflow helper clusters into a package once a third related sibling
+  would otherwise be added
+- introduce target stage products before expanding downstream policy services
+- replace bridge-era or older transitional artifacts directly while migrating
+  downstream services
+- remove superseded transition-first workflows once replacement consumers land
+
+Do not:
+
+- add SQLite first
+- add a web UI
+- add generic workflow engines
+- re-centralize business rules in adapters
+- keep pushing new semantics into one `category` string or equivalent activity
+  label sink
 
 ## Deferred Until Core Rollout Lands
 
@@ -979,3 +567,16 @@ of the following together:
 - `ROADMAP.md`
 - `docs/concepts/reconciliation-tax-architecture.md`
 - `docs/status/migration-sequence.md`
+
+## Time Summary
+
+AI-assisted estimate for the filing-critical path:
+
+- `106` to `164` hours
+
+AI-assisted estimate including open-source hardening:
+
+- `126` to `196` hours
+
+Those ranges assume focused implementation with the current repo standards,
+tests, and documentation discipline preserved.

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,9 @@ model, artifact contracts, and repo standards.
 - [Current state](status/current-state.md)
 - [Operator quickstart](guides/operator-quickstart.md)
 - [Architecture overview](concepts/architecture-overview.md)
+- [Current bridge contracts](concepts/current-bridge-contracts.md)
+- [Pipeline stage contracts](concepts/pipeline-stage-contracts.md)
+- [Domain ontology](concepts/domain-ontology.md)
 - [Reconciliation and tax architecture](concepts/reconciliation-tax-architecture.md)
 - [Engineering standards](standards/engineering.md)
 - [Workspace model](concepts/workspace-model.md)
@@ -34,10 +37,14 @@ Agent-specific routing and repo execution rules live in
 ## Core Concepts
 
 <!-- docs-maintenance:start concepts -->
-- [Architecture Overview](concepts/architecture-overview.md): High-level map of the current bridge, final pipeline, and the documents that own each boundary.
-- [Reconciliation And Tax Architecture](concepts/reconciliation-tax-architecture.md): Design anchor for the current bridge, final pipeline products, performance rules, and filing-critical rollout.
+- [Architecture Overview](concepts/architecture-overview.md): High-level map of the current bridge, the target pipeline, and the focused pages that own each major contract.
+- [Reconciliation And Tax Architecture](concepts/reconciliation-tax-architecture.md): Design anchor for trust gates, performance rules, tax-policy architecture, and filing-critical rollout from the current bridge toward the target pipeline.
+- [Current Bridge Contracts](concepts/current-bridge-contracts.md): Owning concept page for the live bridge contracts, bridge artifacts, and current schema rules.
+- [Pipeline Stage Contracts](concepts/pipeline-stage-contracts.md): Owning contract for the target pipeline products, stage responsibilities, handoff guarantees, and downstream decision boundaries.
 - [Oracle Boundaries](concepts/oracle-boundaries.md): Boundary rules for normal runtime inputs, adapter surfaces, and oracle-only artifacts.
-- [Transaction Classification](concepts/transaction-classification.md): Layered classification vocabulary for the current fact-path bridge and later policy stages.
+- [Domain Ontology](concepts/domain-ontology.md): Owning concept page for the target economic ontology, identity seams, package direction, and bridge-versus-target modeling rules.
+- [Transaction Classification](concepts/transaction-classification.md): Bridge-only classification vocabulary for the current fact-path bridge.
+- [Gaps And Readiness](concepts/gaps-and-readiness.md): Owning concept page for the target gap model, readiness model, sidecar rules, and shared `SubjectRef` contracts.
 - [Workspace Model](concepts/workspace-model.md): Conceptual overview of the external workspace, seeded files, and mirrored repo guidance.
 - [Unified Adapter Architecture](concepts/unified-adapter-architecture.md): First-principles design anchor for the future unified adapter manifest, facets, adapter products, and deterministic verification model.
 <!-- docs-maintenance:end concepts -->
@@ -79,7 +86,7 @@ that follows the external workspace layout.
 
 <!-- docs-maintenance:start status -->
 - [Current State](status/current-state.md): Implemented runtime capabilities, current operational surface, and deferred areas.
-- [Migration Sequence](status/migration-sequence.md): Incremental migration order from the current fact-path bridge to the final pipeline.
+- [Migration Sequence](status/migration-sequence.md): Incremental migration order from the current bridge toward the target stage-first pipeline with parity gates and retirement rules.
 - [Adapter Delivery Plan](status/adapter-delivery-plan.md): Filing-first plan for stabilizing current adapters now and deferring the unified adapter contract rewrite until after filing-critical work.
 <!-- docs-maintenance:end status -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -34,10 +34,10 @@ Agent-specific routing and repo execution rules live in
 ## Core Concepts
 
 <!-- docs-maintenance:start concepts -->
-- [Architecture Overview](concepts/architecture-overview.md): High-level map of the typed application layers, workflow capabilities, and external workspace model.
-- [Reconciliation And Tax Architecture](concepts/reconciliation-tax-architecture.md): Design anchor for the provider-neutral reconciliation, accounting, checkpoint, and tax system.
+- [Architecture Overview](concepts/architecture-overview.md): High-level map of the current bridge, final pipeline, and the documents that own each boundary.
+- [Reconciliation And Tax Architecture](concepts/reconciliation-tax-architecture.md): Design anchor for the current bridge, final pipeline products, performance rules, and filing-critical rollout.
 - [Oracle Boundaries](concepts/oracle-boundaries.md): Boundary rules for normal runtime inputs, adapter surfaces, and oracle-only artifacts.
-- [Transaction Classification](concepts/transaction-classification.md): Canonical layered classification vocabulary for the current fact-path bridge and later policy stages.
+- [Transaction Classification](concepts/transaction-classification.md): Layered classification vocabulary for the current fact-path bridge and later policy stages.
 - [Workspace Model](concepts/workspace-model.md): Conceptual overview of the external workspace, seeded files, and mirrored repo guidance.
 - [Unified Adapter Architecture](concepts/unified-adapter-architecture.md): First-principles design anchor for the future unified adapter manifest, facets, canonical products, and deterministic verification model.
 <!-- docs-maintenance:end concepts -->
@@ -79,7 +79,7 @@ that follows the external workspace layout.
 
 <!-- docs-maintenance:start status -->
 - [Current State](status/current-state.md): Implemented runtime capabilities, current operational surface, and deferred areas.
-- [Migration Sequence](status/migration-sequence.md): Incremental migration order from the current fact-path bridge to the full canonical pipeline.
+- [Migration Sequence](status/migration-sequence.md): Incremental migration order from the current fact-path bridge to the final pipeline.
 - [Adapter Delivery Plan](status/adapter-delivery-plan.md): Filing-first plan for stabilizing current adapters now and deferring the unified adapter contract rewrite until after filing-critical work.
 <!-- docs-maintenance:end status -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,7 +39,7 @@ Agent-specific routing and repo execution rules live in
 - [Oracle Boundaries](concepts/oracle-boundaries.md): Boundary rules for normal runtime inputs, adapter surfaces, and oracle-only artifacts.
 - [Transaction Classification](concepts/transaction-classification.md): Layered classification vocabulary for the current fact-path bridge and later policy stages.
 - [Workspace Model](concepts/workspace-model.md): Conceptual overview of the external workspace, seeded files, and mirrored repo guidance.
-- [Unified Adapter Architecture](concepts/unified-adapter-architecture.md): First-principles design anchor for the future unified adapter manifest, facets, canonical products, and deterministic verification model.
+- [Unified Adapter Architecture](concepts/unified-adapter-architecture.md): First-principles design anchor for the future unified adapter manifest, facets, adapter products, and deterministic verification model.
 <!-- docs-maintenance:end concepts -->
 
 ## Common Tasks

--- a/docs/README.md
+++ b/docs/README.md
@@ -37,8 +37,9 @@ Agent-specific routing and repo execution rules live in
 - [Architecture Overview](concepts/architecture-overview.md): High-level map of the typed application layers, workflow capabilities, and external workspace model.
 - [Reconciliation And Tax Architecture](concepts/reconciliation-tax-architecture.md): Design anchor for the provider-neutral reconciliation, accounting, checkpoint, and tax system.
 - [Oracle Boundaries](concepts/oracle-boundaries.md): Boundary rules for normal runtime inputs, adapter surfaces, and oracle-only artifacts.
-- [Transaction Classification](concepts/transaction-classification.md): Canonical layered classification vocabulary for facts, projections, accounting, and tax.
+- [Transaction Classification](concepts/transaction-classification.md): Canonical layered classification vocabulary for the current fact-path bridge and later policy stages.
 - [Workspace Model](concepts/workspace-model.md): Conceptual overview of the external workspace, seeded files, and mirrored repo guidance.
+- [Unified Adapter Architecture](concepts/unified-adapter-architecture.md): First-principles design anchor for the future unified adapter manifest, facets, canonical products, and deterministic verification model.
 <!-- docs-maintenance:end concepts -->
 
 ## Common Tasks
@@ -78,7 +79,8 @@ that follows the external workspace layout.
 
 <!-- docs-maintenance:start status -->
 - [Current State](status/current-state.md): Implemented runtime capabilities, current operational surface, and deferred areas.
-- [Migration Sequence](status/migration-sequence.md): Incremental migration order from the legacy normalized flow to the provider-neutral fact model.
+- [Migration Sequence](status/migration-sequence.md): Incremental migration order from the current fact-path bridge to the full canonical pipeline.
+- [Adapter Delivery Plan](status/adapter-delivery-plan.md): Filing-first plan for stabilizing current adapters now and deferring the unified adapter contract rewrite until after filing-critical work.
 <!-- docs-maintenance:end status -->
 
 ## Standards

--- a/docs/concepts/architecture-overview.md
+++ b/docs/concepts/architecture-overview.md
@@ -1,6 +1,6 @@
 ---
 title: "Architecture Overview"
-summary: "High-level map of the typed application layers, workflow capabilities, and external workspace model."
+summary: "High-level map of the current bridge, final pipeline, and the documents that own each boundary."
 doc_type: concept
 audience: human
 owner: repo
@@ -8,8 +8,9 @@ status: active
 nav_order: 10
 ---
 
-TallyLot ships a typed Python package and CLI for source-backed transaction
-intake, checkpointing, verification, output rendering, and tax-oriented work.
+TallyLot ships a typed Python package and CLI for source-backed intake,
+reconciliation, checkpointing, accounting validation, output rendering, and
+tax-oriented work.
 
 ## Core Shape
 
@@ -31,16 +32,15 @@ intake, checkpointing, verification, output rendering, and tax-oriented work.
 
 ## Current Direction
 
-- Provider-neutral transaction facts are the current canonical runtime bridge
-  model.
+- `EconomicActivityDraft`, `TransactionFact`, `balance_snapshots.csv`, and
+  `balance_references.csv` are the current runtime bridge.
 - CoinTracking remains an edge output adapter and an oracle family for
   comparison tooling, not the core ledger model.
 - Reconciliation and checkpoint trust gates come before tax policy.
 - The target pipeline now converges on
-  `EvidenceBundle -> ClaimBundle -> EconomicDataset -> ReconciliationDataset -> CheckpointPackage -> JournalDataset -> TaxDeterminantDataset -> TaxOutputDataset`.
-- Current `EconomicActivityDraft`, `TransactionFact`, and shared balance
-  artifacts remain the bridge into that pipeline until the richer products land
-  incrementally.
+  `EvidenceSet -> ClaimSet -> EconomicFacts -> ReconciliationState -> Checkpoint -> Journal -> TaxInputs -> TaxOutputs`.
+- Forward-looking docs use those final product names, while current-state docs
+  keep current implementation terms where accuracy requires them.
 
 ## Read Next
 

--- a/docs/concepts/architecture-overview.md
+++ b/docs/concepts/architecture-overview.md
@@ -31,10 +31,16 @@ intake, checkpointing, verification, output rendering, and tax-oriented work.
 
 ## Current Direction
 
-- Provider-neutral transaction facts are the canonical runtime model.
+- Provider-neutral transaction facts are the current canonical runtime bridge
+  model.
 - CoinTracking remains an edge output adapter and an oracle family for
   comparison tooling, not the core ledger model.
 - Reconciliation and checkpoint trust gates come before tax policy.
+- The target pipeline now converges on
+  `EvidenceBundle -> ClaimBundle -> EconomicDataset -> ReconciliationDataset -> CheckpointPackage -> JournalDataset -> TaxDeterminantDataset -> TaxOutputDataset`.
+- Current `EconomicActivityDraft`, `TransactionFact`, and shared balance
+  artifacts remain the bridge into that pipeline until the richer products land
+  incrementally.
 
 ## Read Next
 

--- a/docs/concepts/architecture-overview.md
+++ b/docs/concepts/architecture-overview.md
@@ -1,6 +1,6 @@
 ---
 title: "Architecture Overview"
-summary: "High-level map of the current bridge, final pipeline, and the documents that own each boundary."
+summary: "High-level map of the current bridge, the target pipeline, and the focused pages that own each major contract."
 doc_type: concept
 audience: human
 owner: repo
@@ -17,35 +17,92 @@ tax-oriented work.
 - `domain/` owns business models, enums, and value objects
 - `application/` owns use-case orchestration over domain models and ports
 - `ports/` defines narrow typed boundaries
-- `infrastructure/` implements filesystem and other operational details
-- `adapters/` translate source and output formats
+- `infrastructure/` implements ports
+- `adapters/` translates source and output formats
 - `interfaces/` exposes CLI entry points over application capabilities
 
 ## Operating Model
 
-- Raw evidence and live operator artifacts live in an external workspace, not
-  in the repo.
-- The repo owns code, tests, docs, templates, automation, and workspace
-  guidance.
-- Financial values stay in `Decimal`.
-- Unsupported or ambiguous facts stay explicit as issues or review artifacts.
+- raw evidence and live operator artifacts live in an external workspace, not
+  in the repo
+- the repo owns code, tests, docs, templates, automation, and workspace
+  guidance
+- financial values stay in `Decimal`
+- unsupported or ambiguous facts stay explicit as issues, reviews, or later
+  stage-owned gaps
 
-## Current Direction
+## Current Bridge
 
-- `EconomicActivityDraft`, `TransactionFact`, `balance_snapshots.csv`, and
-  `balance_references.csv` are the current runtime bridge.
-- CoinTracking remains an edge output adapter and an oracle family for
-  comparison tooling, not the core ledger model.
-- Reconciliation and checkpoint trust gates come before tax policy.
-- The target pipeline now converges on
-  `EvidenceSet -> ClaimSet -> EconomicFacts -> ReconciliationState -> Checkpoint -> Journal -> TaxInputs -> TaxOutputs`.
-- Forward-looking docs use those final product names, while current-state docs
-  keep current implementation terms where accuracy requires them.
+The live runtime bridge currently centers on:
+
+- `EconomicActivityDraft`
+- `TransactionFact`
+- `balance_snapshots.csv`
+- `balance_references.csv`
+
+That bridge is:
+
+- the current implementation seam
+- the current delivery path
+- the current parity baseline
+- not the final architecture center
+
+Current bridge contracts and artifact rules live in
+[Current Bridge Contracts](current-bridge-contracts.md).
+
+## Target Direction
+
+The target runtime pipeline converges on:
+
+`EvidenceSet -> ClaimSet -> EconomicFacts -> ReconciliationState -> Checkpoint -> Journal -> TaxInputs -> TaxOutputs`
+
+The target model is stage-first and ontology-first:
+
+- source evidence and source-backed checkpoints remain first-class
+- reconciliation and checkpoint trust gates come before accounting and tax
+- CoinTracking remains an edge output and oracle surface, not the core ledger
+  model
+- bridge classifications remain current runtime vocabulary, not the long-term
+  ontology center
+
+## System Boundaries
+
+- raw evidence and operator artifacts live in the external workspace
+- the repo owns code, tests, docs, templates, automation, and mirrored
+  workspace guidance
+- source adapters produce source-local observations, bridge outputs today, and
+  later target-stage inputs
+- reconciliation and checkpoints are trust gates, not renderer side effects
+- accounting and tax consume accepted upstream truth; they do not repair source
+  meaning
+- repo-only dev tooling may evolve under a clearer `dev_support/` boundary
+  later, but current live repo-only support remains `repo_support/`
+
+## Contract Owners
+
+Use these pages as the owning contract set:
+
+- [Current Bridge Contracts](current-bridge-contracts.md)
+  Live bridge contracts, bridge artifacts, and current schema rules.
+- [Pipeline Stage Contracts](pipeline-stage-contracts.md)
+  Target stage products, responsibilities, and handoff guarantees.
+- [Domain Ontology](domain-ontology.md)
+  Target ontology, identity seams, and bridge-versus-target modeling rules.
+- [Gaps And Readiness](gaps-and-readiness.md)
+  Target shared blocker model, readiness model, and `SubjectRef` rules.
+- [Transaction Classification](transaction-classification.md)
+  Current bridge classification vocabulary and bridge-only rules.
+- [Oracle Boundaries](oracle-boundaries.md)
+  Runtime-versus-oracle boundary rules.
+- [Reconciliation And Tax Architecture](reconciliation-tax-architecture.md)
+  Trust gates, performance rules, and rollout alignment.
 
 ## Read Next
 
-- `docs/concepts/reconciliation-tax-architecture.md`
-- `docs/concepts/oracle-boundaries.md`
-- `docs/concepts/transaction-classification.md`
-- `docs/concepts/workspace-model.md`
-- `docs/standards/engineering.md`
+- [Current Bridge Contracts](current-bridge-contracts.md)
+- [Reconciliation And Tax Architecture](reconciliation-tax-architecture.md)
+- [Pipeline Stage Contracts](pipeline-stage-contracts.md)
+- [Domain Ontology](domain-ontology.md)
+- [Gaps And Readiness](gaps-and-readiness.md)
+- [Oracle Boundaries](oracle-boundaries.md)
+- [Transaction Classification](transaction-classification.md)

--- a/docs/concepts/current-bridge-contracts.md
+++ b/docs/concepts/current-bridge-contracts.md
@@ -1,0 +1,320 @@
+---
+title: "Current Bridge Contracts"
+summary: "Owning concept page for the live bridge contracts, bridge artifacts, and current schema rules."
+doc_type: concept
+audience: human
+owner: repo
+status: active
+nav_order: 22
+---
+
+Use this page when you need the current runtime truth for the bridge that
+exists today. This document owns the live bridge contracts and artifact rules.
+
+The current bridge is real runtime behavior, not a historical footnote. It is
+the active implementation seam until later bounded slices replace it. At the
+same time, it is not the final architecture center. Future stage contracts live
+in [Pipeline Stage Contracts](pipeline-stage-contracts.md).
+
+## Bridge Purpose And Limits
+
+The live bridge currently centers on:
+
+- `EconomicActivityDraft`
+- `TransactionFact`
+- `balance_snapshots.csv`
+- `balance_references.csv`
+
+That bridge is:
+
+- the live implementation seam
+- the current delivery path
+- the current parity baseline
+- not the final architecture center
+
+## Current Hard Runtime Rules
+
+- raw evidence stays outside the repo
+- normalization and profiling operate on one materialized raw capture root at a
+  time
+- planner-enabled adapters provide translation input candidates and the core
+  selects the winning plan
+- ambiguity blocks fact and balance artifact emission
+- assembled source datasets are the reconciliation input surface
+- provenance stays typed in runtime models and is flattened only at artifact
+  boundaries
+- operator-confirmed balance references may support runtime progress but do not
+  satisfy filing-ready checkpoint requirements alone
+- historical provider hydration remains separate from source adapters
+- runtime balance artifacts are `balance_snapshots.csv` and
+  `balance_references.csv`
+- schema-version mismatch is resolved by regeneration, not compatibility
+  wrappers
+
+## Current Bridge Contracts
+
+### `TransactionFact`
+
+Current bridge contract includes:
+
+- identity:
+  - `fact_id`
+  - `source`
+  - `adapter_id`
+  - `provider_operation_key`
+  - `operation_group_id`
+  - `tx_hash`
+- time:
+  - `timestamp`
+  - optional `effective_at`
+  - optional `effective_precision`
+- participants:
+  - `location_id`
+- semantics:
+  - `economic_kind`
+  - `accounting_intent_hint`
+  - `tax_treatment_hint`
+  - optional `projection_hint`
+- economics:
+  - `legs`
+  - `FactLegPolicy`
+- metadata and status:
+  - `description`
+  - `raw_file`
+  - `raw_row_ref`
+  - `confidence`
+  - `status`
+
+### `EconomicLeg`
+
+Current bridge contract includes:
+
+- `leg_id`
+- `kind`
+- `instrument_id`
+- `quantity`
+- optional `subtype`
+- optional `attributed_to_leg_id`
+- optional `location_id`
+
+### `LegKind`
+
+Current values:
+
+- `primary`
+- `charge`
+- `rebate`
+- `collateral`
+- `settlement`
+- `financing`
+- `withholding`
+- `adjustment`
+
+### `FactLegPolicy`
+
+Current bridge rules to preserve:
+
+- per-kind limits
+- signed-count constraints
+- duplicate kinds prohibited
+- zero-primary support only when intentionally allowed
+- shared policy constants are part of the bridge contract
+
+### Temporal Precision
+
+Current rule to preserve:
+
+- exact time uses UTC-aware `*_at`
+- date-or-time uses `*_at` plus `*_precision`
+
+### Schema Versioning
+
+Current rule to preserve:
+
+- fact artifacts are schema-versioned
+- unknown schema versions fail fast
+- regeneration from evidence is the recovery path
+
+### `EconomicActivityDraft`
+
+Current bridge responsibilities to preserve:
+
+- stable draft identity
+- timestamp and temporal precision
+- location scope
+- `legs`
+- `FactLegPolicy`
+- provider operation key
+- grouped-row support
+- layered hints
+- provenance refs
+- review markers
+- confidence and status
+
+### `SourceTranslationBatch`
+
+Current bridge bundle to preserve:
+
+- drafts
+- balance references
+- balance reference issues
+- issues
+- reviews
+- location inventory
+
+## Current Schema And Artifact Contracts
+
+### Repo-Wide Temporal Precision Contract
+
+- use one timing convention everywhere in the repo:
+  - exact-time fields use UTC-aware `*_at`
+  - fields that may be date-only or exact-time use `*_at` plus `*_precision`
+- `*_precision` uses one shared enum with at least:
+  - `timestamp`
+  - `date`
+- date-only values are stored distinctly from exact timestamps even when an
+  exact timestamp falls at midnight
+- adapters are responsible for preserving this distinction at translation time
+- infer precision from the source contract and parsed field shape, not from the
+  normalized clock value
+
+### Current Fact-Shape Contract
+
+- `TransactionFact` and `EconomicActivityDraft` use one shared `legs` tuple
+- fact construction requires successful identifier resolution to exactly one
+  `InstrumentId`
+- unresolved or ambiguous identity must emit review output and a blocking issue
+  rather than guessing
+- every leg carries:
+  - stable `leg_id`
+  - signed `quantity`
+  - semantic `LegKind`
+  - optional adapter-detail `subtype`
+  - optional `attributed_to_leg_id` metadata
+- signed quantities use one meaning everywhere:
+  - positive increases the balance of the leg location
+  - negative decreases the balance of the leg location
+- `attributed_to_leg_id` is valid only on non-`primary` legs and only when it
+  references one concrete leg in the same fact
+- `FactLegPolicy` is generic and per-kind:
+  - `LegShapeLimit` declares `min_count`, `max_count`, `min_positive_count`,
+    `max_positive_count`, `min_negative_count`, and `max_negative_count`
+  - no duplicate kinds
+  - minimum counts cannot exceed maximum counts
+  - signed-count limits cannot exceed per-kind totals
+  - unspecified kinds are disallowed
+  - zero-`primary` shapes are opt-in through the declared policy
+- current shared policy constants cover:
+  - single-primary activity
+  - two-sided primary exchange
+  - two-sided primary exchange with one `charge`
+- CoinTracking currently supports only:
+  - at least one `primary`
+  - up to one positive `primary`
+  - up to one negative `primary`
+  - up to one negative `charge`
+  - no other non-primary leg kinds
+  - renderers derive inbound and outbound adapter concepts from sign
+
+### Current Normalization Window Contract
+
+- runtime timestamps are timezone-aware UTC in drafts, facts, balance
+  snapshots, and balance references
+- persisted artifact timestamp text remains `YYYY-MM-DD HH:MM:SS` and is
+  interpreted as UTC on read
+- fields that may be date-only or exact-time persist both `*_at` and
+  `*_precision`
+- `facts.csv` is schema-versioned and readers fail fast on unexpected
+  `schema_version` values
+- `balance_snapshots.csv` and `balance_references.csv` persist `instrument_id`
+  values and use `target_at` plus `target_precision`; balance references also
+  persist `observed_at` plus `observed_precision`
+- cross-source balance corroboration is additive in the first release
+- windowed normalization applies to:
+  - `facts.csv`
+  - `fact_annotations.json`
+  - `balance_snapshots.csv`
+  - `exceptions.csv`
+  - `normalization_reviews.csv`
+- windowed normalization does not apply to:
+  - `balance_references.csv`
+  - `location_inventory.csv`
+- source-scope portfolio evidence that does not itself prove wallet ownership
+  may contribute balance evidence only under constrained same-source same-chain
+  rules and must remain explicitly caveated
+- review records carry `context_timestamp`, dataset-level untimed reviews stay
+  visible when a window is active, and summaries report
+  `reviews_outside_normalization_window`
+
+### Capture And Assembly Contract
+
+- raw capture roots use `evidence/raw/source/<source>/<capture_label>/`
+- capture metadata stores the stable `capture_uid`, intake timestamps,
+  manifest fingerprint, and workspace-relative refs
+- untouched upstream originals stay under the raw capture root
+- `working/supporting_artifacts/` is limited to derived or operator-authored
+  helper material
+- capture-normalized outputs live under
+  `working/normalized/captures/<capture_uid>/`
+- assembled source outputs live under `working/normalized/sources/<source>/`
+- source assembly merges accepted captures deterministically, preserves the
+  union of source-backed evidence, collapses exact semantic duplicates, and
+  surfaces semantic conflicts explicitly
+- location inventory and balance evidence provenance reference captures by
+  `capture_uid`, with human-readable labels and roots treated as optional
+  report fields rather than as the key
+
+### Transitional Adapter Draft Seam
+
+Source normalization should translate through `EconomicActivityDraft` until all
+adapters emit `TransactionFact` artifacts directly.
+
+Required draft responsibilities:
+
+- stable identity claims plus evidence references
+- UTC-aware timestamp and provenance
+- optional `effective_at`
+- optional `effective_precision`
+- account and wallet scope
+- one shared `legs` tuple only; no separate fee lane
+- explicit leg semantics per leg:
+  - stable `leg_id`
+  - `LegKind`
+  - optional `subtype`
+  - optional `attributed_to_leg_id` on non-`primary` legs only
+- explicit per-kind leg-shape policy through `FactLegPolicy` and
+  `LegShapeLimit`, including any required minimum counts
+- provider operation key and grouped-row support
+- layered classification hints:
+  - economic kind
+  - projection type
+  - journal intent
+  - tax treatment code
+- explicit review or ambiguity markers
+
+Rules:
+
+- provider modules translate into drafts only; they do not assemble
+  CoinTracking rows or other output-adapter payloads directly
+- shared identifier resolution must succeed to exactly one instrument before
+  fact construction
+- unresolved or ambiguous identifier resolution blocks fact emission for the
+  affected activity and must surface both review output and a blocking issue
+- shared fact builders may derive `TransactionFact` objects from drafts, but
+  that derivation stays in shared support rather than provider-local code
+- shared support stays adapter-agnostic and registry-driven
+- draft-only provenance references and review markers must survive compilation
+  through a fact-keyed sidecar artifact instead of being dropped
+- one shared projection mapper owns the mapping from layered classifications
+  into concrete output-adapter row types
+- grouped operations and provider-local export families must resolve through
+  explicit translation registries, not ad hoc adapter entry-point branching
+
+## Bridge-To-Target Direction
+
+- keep current bridge names in current-state docs and live bridge code until a
+  later implementation slice replaces them
+- document future target products and ontology on their owning pages rather
+  than mutating current bridge pages into a blended current-and-future hybrid
+- treat this bridge as the active runtime seam that later target slices must
+  replace cleanly, not as a structure that should be immortalized

--- a/docs/concepts/domain-ontology.md
+++ b/docs/concepts/domain-ontology.md
@@ -1,0 +1,253 @@
+---
+title: "Domain Ontology"
+summary: "Owning concept page for the target economic ontology, identity seams, package direction, and bridge-versus-target modeling rules."
+doc_type: concept
+audience: human
+owner: repo
+status: active
+nav_order: 35
+---
+
+Use this page when shaping the target domain model. This document owns the
+target ontology and identity seams.
+
+Current bridge note:
+
+- current bridge code still uses `EconomicActivityDraft`, `TransactionFact`,
+  layered bridge classifications, and fact-leg policies
+- those bridge contracts remain current-state runtime truth
+- this page defines the target ontology that later implementation slices should
+  grow toward
+
+## Core Business Concepts
+
+The target model should use these concepts explicitly:
+
+- `Instrument`
+- `Position`
+- `Contract`
+- `Location`
+- `LegalOwner`
+- `BeneficialOwner`
+- `Counterparty`
+- `EconomicEvent`
+- `EconomicLeg`
+- `SettlementState`
+- `LifecycleEvent`
+- `Valuation`
+- `CheckpointAssertion`
+- `Posting`
+- `TaxInput`
+
+These are not interchangeable labels. They represent distinct business
+concepts, and the model should keep them distinct even when one adapter or one
+reporting surface happens to collapse them operationally.
+
+## Generic Core Requirements
+
+The target core should remain:
+
+- instrument-agnostic
+- source-agnostic
+- output-agnostic
+- storage-neutral
+
+Rules:
+
+- crypto is the current filing scope, not the ontology center
+- CoinTracking is an edge import, export, and oracle surface, not a runtime
+  dependency
+- persistence implements the model; it does not define the model
+- no wrapper lanes, compatibility shims, or legacy parallel runtime models
+  should survive after a clean replacement is ready
+- refactors should replace old structures cleanly when the new structure is
+  ready
+- tests and parity must be preserved or strengthened through refactors
+
+## Identity Seams
+
+Keep these seams separate:
+
+- instrument identity
+- contract identity
+- position identity
+- location identity
+- legal owner identity
+- beneficial owner identity
+- counterparty identity
+
+Rules:
+
+- do not collapse these identities into one generic id family
+- resolve only the identity that the current stage can prove safely
+- preserve unresolved identity as explicit blockers instead of guessing across
+  seams
+
+Identity resolution should be incremental and explicit. Earlier stages may know
+less than later stages, and that is acceptable as long as uncertainty stays
+visible.
+
+## `Contract` Versus `Position`
+
+Do not collapse `Contract` and `Position`.
+
+- `Contract` is a specific agreement instance with terms
+- `Position` is an economic exposure or holding state that may arise from one
+  contract, many contracts, or no explicit contract
+
+Implication:
+
+- business logic should model `Contract` and `Position` explicitly where the
+  distinction matters
+- shared infrastructure may reference them generically only through the
+  `SubjectRef` rules owned by
+  [Gaps And Readiness](gaps-and-readiness.md)
+
+## Valuation
+
+Valuation is first-class whenever it changes downstream behavior.
+
+Minimum valuation concerns:
+
+- amount
+- currency
+- purpose
+- timestamp
+- precision
+- source
+- confidence
+- provenance
+
+Rules:
+
+- valuation belongs in the economic model when it changes checkpoint,
+  accounting, or tax behavior
+- valuation should not be hidden only inside renderer metadata or one-off
+  policy blobs
+- missing or uncertain valuation should remain explicit when downstream stages
+  still need to reason about it
+
+## Economic Model
+
+The target economic layer centers on durable economic meaning rather than on
+activity-label expansion.
+
+Modeling rules:
+
+- model accepted economic meaning as `EconomicEvent` plus `EconomicLeg`
+- keep settlement, supersession, and lifecycle state explicit instead of
+  flattening them into activity labels
+- keep valuation first-class when it changes downstream accounting,
+  checkpoint, or tax behavior
+- let ownership and counterparty state remain explicit where known
+
+The target economic layer must be able to express:
+
+- holdings movements
+- cash movements
+- obligations and rights
+- settlements
+- collateral changes
+- financing flows
+- fees, rebates, and withholding
+- corrections and supersession chains
+- corporate actions
+- restructurings
+- lifecycle-heavy activity
+
+Economic facts should describe what happened economically, not what one export
+format calls the row.
+
+## Ownership And Counterparty Modeling
+
+Rules:
+
+- beneficial ownership is not interchangeable with legal ownership
+- counterparty identity is a separate seam, not an ownership alias
+- when an event changes ownership or legal rights in a way that matters later,
+  preserve that explicitly rather than hiding it behind a generic transfer
+  label
+- unresolved ownership transitions should remain visible to reconciliation,
+  checkpoint, accounting, or tax as appropriate
+
+## Settlement And Lifecycle State
+
+Rules:
+
+- settlement state should remain explicit where timing, completeness, or
+  continuity matters
+- lifecycle changes such as restructurings, migrations, contract rolls, and
+  supersession chains should not be flattened into generic trade-like labels
+- corrections should preserve supersession lineage instead of mutating earlier
+  accepted meaning in place
+
+## Bridge Classifications Versus Target Ontology
+
+Current bridge classifications remain real and important, but they are not the
+center of the long-term model.
+
+Rules:
+
+- bridge classifications stay valid for the current bridge and for current
+  renderer hints
+- bridge classifications do not define the full ontology
+- future support for broader financial instruments should be driven by the core
+  ontology, not by endlessly adding new activity labels
+- output hints and policy hints remain downstream aids, not the primary source
+  of economic truth
+
+Bridge-specific classification rules live in
+[Transaction Classification](transaction-classification.md), not here.
+
+## Naming Posture
+
+- keep bridge names in live bridge code until later implementation slices land
+- use target ontology names when defining new target-layer concepts in docs
+  and later implementation work
+- do not force a docs-only bridge rename just to make the target vocabulary
+  appear already implemented
+
+## Package Direction
+
+The target package direction should follow the ontology and stage ownership:
+
+- `domain/claims/` for source-local claim types
+- `domain/economics/` for economic events, legs, valuations, settlement, and
+  lifecycle state
+- `domain/reconciliation/` for continuity, linkage, readiness, and checkpoint
+  candidacy
+- `domain/checkpoints/` for accepted checkpoint truth and checkpoint
+  assertions
+- `domain/accounting/` for journals, entries, postings, and validation outputs
+- `domain/tax/` for tax inputs, policy contracts, carry-forward state, and
+  outputs
+
+Suggested application ownership:
+
+- `application/intake/` for capture planning, apply, and evidence selection
+- `application/evidence/` for shared statement extraction and provenance
+  locator handling
+- `application/profiling/` for capture profile construction, inventory
+  inspection, and timezone review
+- `application/normalization/` for evidence-to-claim translation planning and
+  current bridge artifact production
+- `application/normalization/assembly/` for deterministic merge of accepted
+  capture outputs into assembled source datasets
+- `application/reconciliation/` for links, continuity, readiness reducers, and
+  checkpoint candidates
+- `application/checkpoints/` for checkpoint evidence assembly, manual balance
+  submission validation, and checkpoint acceptance
+- `application/accounting/` for journal expansion, validation, and summaries
+- `application/tax/` for tax-input assembly, policy selection, and tax-output
+  rendering
+- `application/outputs/` for downstream renderer orchestration
+
+Boundary rules:
+
+- `interfaces/` orchestrates services only
+- `infrastructure/` implements ports
+- `application/` depends on domain and ports
+- `domain/` has no infrastructure imports
+
+This is target direction only. It does not claim the current runtime already
+uses that package layout.

--- a/docs/concepts/gaps-and-readiness.md
+++ b/docs/concepts/gaps-and-readiness.md
@@ -1,0 +1,281 @@
+---
+title: "Gaps And Readiness"
+summary: "Owning concept page for the target gap model, readiness model, sidecar rules, and shared `SubjectRef` contracts."
+doc_type: concept
+audience: human
+owner: repo
+status: active
+nav_order: 45
+---
+
+Use this page when defining shared blocker, readiness, or generic
+subject-reference contracts. This document owns the target cross-stage gap and
+readiness model.
+
+Current runtime note:
+
+- the live runtime still uses stage-specific issue and review artifacts such as
+  `IssueRecord` and `NormalizationReviewRecord`
+- those current surfaces remain current-state truth
+- this page defines the target shared support model for later implementation
+  slices
+
+## Design Rules
+
+- shared support types should stay compact and stage-neutral
+- explanation-heavy payloads belong in sidecars, not in the hot-path core
+- stage-owned blockers stay explicit; no stage should invent an incompatible
+  blocker surface
+- dataset summaries are derived from subject-level truth, not stored as the
+  only truth
+- shared support structures should help stages interoperate without erasing
+  stage ownership
+
+## Provenance
+
+Use one typed provenance model across stages.
+
+Rules:
+
+- provenance stays typed in runtime models
+- flattening happens only at artifact and export boundaries
+- file and member identity stay separate from row, page, or anchor identity
+- capture identity stays separate from human-readable labels and file-system
+  paths
+- shared support models should link to provenance rather than embedding large
+  repeated evidence payloads directly
+
+## `SubjectRef`
+
+Use `SubjectRef` only for shared infrastructure that needs a generic pointer.
+
+Minimum fields:
+
+- `subject_kind`
+- `subject_id`
+
+Initial supported `subject_kind` values:
+
+- `position`
+- `contract`
+
+Rules:
+
+- use `Contract` and `Position` explicitly in business logic and modeling
+- use `SubjectRef` only where shared infrastructure needs a generic pointer
+- do not use `SubjectRef` as an excuse to stop modeling the true concept
+
+## Gap Model
+
+The target shared gap model splits compact blocking truth from explanation.
+
+### `GapCore`
+
+Purpose:
+
+- compact shared blocker record used across stages
+
+Minimum fields:
+
+- `gap_id`
+- `owner_stage`
+- `blocking_stages`
+- `subject_ref`
+- `gap_kind`
+- `status`
+- `materiality`
+- `confidence`
+
+Rules:
+
+- `GapCore` is the shared blocking truth
+- it stays compact enough for reducers, indexing, and hot-path references
+- it must not absorb large explanatory text blobs
+- `owner_stage` identifies who owns the gap semantics
+- `blocking_stages` identifies who is blocked by the unresolved condition
+- later stages may add stage-local subtyping, but they should not redefine the
+  shared core out of existence
+
+### `GapExplanation`
+
+Purpose:
+
+- explanation sidecar keyed to one `GapCore`
+
+Minimum fields:
+
+- `gap_id`
+- `known_facts`
+- `missing_inputs`
+- `candidate_interpretations`
+- `required_evidence`
+- `allowed_resolution_methods`
+- `recommended_next_action`
+- `provenance_refs`
+
+Rules:
+
+- explanation belongs in `GapExplanation`, not in `GapCore`
+- explanation may grow richer over time without bloating the compact shared
+  blocker record
+- stages may attach richer explanation or decision history later, but the
+  common explanation shape should stay recognizable across the repo
+
+### Minimum Gap Taxonomy
+
+- `missing_evidence`
+- `unresolved_identity`
+- `unresolved_linkage`
+- `contradiction`
+- `policy_required_determination`
+- `operator_override_required`
+
+Rules:
+
+- gap ownership stays explicit by stage
+- accounting-owned gaps, reconciliation-owned gaps, checkpoint-owned gaps, and
+  tax-owned gaps must not be conflated operationally
+- stages may add stage-local subtyping later, but not by replacing the shared
+  taxonomy completely
+- materiality and confidence should remain first-class attributes on the gap
+  core, not only free-text explanation details
+
+## Readiness Model
+
+Readiness is subject-first, stage-specific, and reducible into reporting
+projections.
+
+### `ReadinessStage`
+
+Shared stage vocabulary:
+
+- `semantic`
+- `reconciliation`
+- `checkpoint`
+- `accounting`
+- `tax`
+
+### `ReadinessStatus`
+
+Shared status vocabulary:
+
+- `ready`
+- `blocked`
+- `partial`
+- `not_applicable`
+
+### `SubjectReadinessRecord`
+
+Purpose:
+
+- stage-specific readiness for one `SubjectRef`
+
+Minimum fields:
+
+- `subject_ref`
+- `stage`
+- `status`
+- `blocking_gap_ids`
+
+Optional derived context may include:
+
+- confidence
+- materiality
+- provenance or explanation references
+
+Rules:
+
+- subject readiness is the base truth
+- reducers should work from subject readiness plus gaps, not from hand-built
+  whole-dataset statuses
+- a subject may be ready for one stage and blocked for another
+- readiness should point to blocking gap ids rather than hiding blockers in
+  summary text
+
+### `ReadinessProjection`
+
+Purpose:
+
+- derived reporting view over subject readiness
+
+Allowed optional projection dimensions:
+
+- source
+- location
+- instrument
+- continuity segment
+- checkpoint date
+- tax year
+
+Rules:
+
+- these are reporting and recalculation dimensions, not mandatory keys on
+  every readiness record
+- a stage should use only the dimensions it actually owns or can derive
+  safely
+- do not turn readiness into a mandatory global cube just to satisfy one
+  report
+
+## Shared Checkpoint Assertions
+
+Use one shared checkpoint-assertion vocabulary across reconciliation,
+checkpoints, accounting, and tax.
+
+Rules:
+
+- checkpoint assertions should stay first-class and referenceable
+- downstream stages may reuse them, but should not redefine them into
+  incompatible local variants
+
+## Anti-Duplication And Sidecar Rules
+
+Copy only when meaning changes.
+
+Meaning:
+
+- one stage owns one semantic payload
+- downstream stages reference upstream records by stable ids
+- downstream stages add stage-owned outputs only
+
+Keep these first-class:
+
+- economic events
+- economic legs
+- identities
+- ownership state
+- settlement and lifecycle state
+- valuations
+- checkpoint assertions
+- postings
+- tax inputs
+
+Use sidecars only for:
+
+- provenance
+- gaps
+- readiness
+- reviews
+- annotations
+- comparison traces
+- policy explanations
+
+Sidecars must never become:
+
+- the only real copy of business meaning
+- a substitute for missing entities
+- a junk drawer of unresolved text
+
+Performance implication:
+
+- avoiding semantic duplication is also a performance rule
+- repeated full payloads increase read amplification, join cost, and drift risk
+- the correct shape is stable ids plus stage-owned deltas
+
+## Current-to-Target Boundary
+
+- current `IssueRecord` and `NormalizationReviewRecord` remain live bridge
+  outputs today
+- later implementation may map current bridge issues and reviews into the
+  target gap/readiness model where the stage ownership and semantics line up
+- current-state docs should keep current issue and review names where accuracy
+  requires them

--- a/docs/concepts/oracle-boundaries.md
+++ b/docs/concepts/oracle-boundaries.md
@@ -18,8 +18,8 @@ depending on any one portfolio tracker.
 
 ## Design Rules
 
-- The current bridge system of record is the provider-neutral transaction fact
-  model, but the target canonical pipeline extends beyond facts alone.
+- The current bridge centers on `TransactionFact` plus shared balance
+  artifacts, but the target pipeline extends beyond facts alone.
 - The internal core should remain asset-class-agnostic even when current
   adapters or policies are crypto-first.
 - Source evidence and source-backed checkpoints are first-class.
@@ -35,10 +35,10 @@ depending on any one portfolio tracker.
 | Class | Examples | Allowed To Create Core Facts | Required In Normal Workflow | Notes |
 | ---- | ---- | ---- | ---- | ---- |
 | Source evidence | exchange exports, wallet exports, statements, explorer exports | Yes | Yes | Primary reconstruction path |
-| Checkpoint evidence | balance statements, wallet snapshots, source-backed checkpoint packages | Yes | Yes | First-class reconciliation input |
+| Checkpoint evidence | balance statements, wallet snapshots, source-backed checkpoint artifacts | Yes | Yes | First-class reconciliation input |
 | Adapter-format inputs | CoinTracking trade imports, CoinTracking CSV shape, future tracker imports | Yes | No | Supported through adapters only |
 | Oracle support artifacts | CoinTracking tax reports, roll-forward reports, average purchase price, double-entry exports | No | No | Development and validation only; never production runtime inputs |
-| Derived outputs | CoinTracking export projection, Ledger journal, tax package, checkpoint package | No | No | Produced by the system |
+| Derived outputs | CoinTracking export projection, Ledger journal, tax outputs package, checkpoint artifacts | No | No | Produced by the system |
 
 ## Normal Runtime Workflow
 
@@ -49,15 +49,15 @@ The normal filing-capable workflow is:
 3. Reconcile transfers, balances, and reconciliation windows.
 4. Build or validate checkpoints.
 5. Render a double-entry journal.
-6. Compute tax state from reconciled facts.
-7. Emit filing artifacts.
+6. Build `TaxInputs` from reconciled economics plus accepted checkpoint truth.
+7. Apply selected tax policies to emit `TaxOutputs`.
 
 This workflow must remain valid even when no CoinTracking tax outputs are
 available.
 
 The detailed target product flow behind that workflow is:
 
-`EvidenceBundle -> ClaimBundle -> EconomicDataset -> ReconciliationDataset -> CheckpointPackage -> JournalDataset -> TaxDeterminantDataset -> TaxOutputDataset`
+`EvidenceSet -> ClaimSet -> EconomicFacts -> ReconciliationState -> Checkpoint -> Journal -> TaxInputs -> TaxOutputs`
 
 Current runtime note:
 
@@ -137,8 +137,8 @@ Those artifacts may support comparison, but not checkpoint existence.
 - Keep domain services unaware of CoinTracking report schemas.
 - Keep crypto-, FX-, and security-specific terms out of shared core abstractions
   unless the concept is inherently specific to that surface.
-- Keep tax policy operating on reconciled economics and accepted checkpoint
-  truth only.
+- Keep tax policy operating on `TaxInputs` built from reconciled economics and
+  accepted checkpoint truth only.
 - Keep journal rendering operating on reconciled economics, accepted checkpoint
   truth, and accounting coverage rules only.
 

--- a/docs/concepts/oracle-boundaries.md
+++ b/docs/concepts/oracle-boundaries.md
@@ -18,7 +18,8 @@ depending on any one portfolio tracker.
 
 ## Design Rules
 
-- The core system of record is the provider-neutral transaction fact model.
+- The current bridge system of record is the provider-neutral transaction fact
+  model, but the target canonical pipeline extends beyond facts alone.
 - The internal core should remain asset-class-agnostic even when current
   adapters or policies are crypto-first.
 - Source evidence and source-backed checkpoints are first-class.
@@ -53,6 +54,17 @@ The normal filing-capable workflow is:
 
 This workflow must remain valid even when no CoinTracking tax outputs are
 available.
+
+The detailed target product flow behind that workflow is:
+
+`EvidenceBundle -> ClaimBundle -> EconomicDataset -> ReconciliationDataset -> CheckpointPackage -> JournalDataset -> TaxDeterminantDataset -> TaxOutputDataset`
+
+Current runtime note:
+
+- today's bridge path still centers on `TransactionFact` plus shared balance
+  artifacts
+- treat that bridge as an incremental delivery seam, not as the long-term
+  endpoint of the architecture
 
 ## CoinTracking-Specific Rules
 
@@ -125,8 +137,10 @@ Those artifacts may support comparison, but not checkpoint existence.
 - Keep domain services unaware of CoinTracking report schemas.
 - Keep crypto-, FX-, and security-specific terms out of shared core abstractions
   unless the concept is inherently specific to that surface.
-- Keep tax policy operating on reconciled facts and checkpoint state only.
-- Keep journal rendering operating on facts and accounting intents only.
+- Keep tax policy operating on reconciled economics and accepted checkpoint
+  truth only.
+- Keep journal rendering operating on reconciled economics, accepted checkpoint
+  truth, and accounting coverage rules only.
 
 ## Failure Test
 

--- a/docs/concepts/pipeline-stage-contracts.md
+++ b/docs/concepts/pipeline-stage-contracts.md
@@ -1,0 +1,400 @@
+---
+title: "Pipeline Stage Contracts"
+summary: "Owning contract for the target pipeline products, stage responsibilities, handoff guarantees, and downstream decision boundaries."
+doc_type: concept
+audience: human
+owner: repo
+status: active
+nav_order: 25
+---
+
+Use this page when defining the target pipeline products or deciding which
+stage owns a decision. This document owns the target stage contracts.
+
+Current runtime note:
+
+- the live runtime still centers on `EconomicActivityDraft`,
+  `TransactionFact`, `balance_snapshots.csv`, and `balance_references.csv`
+- those bridge products remain current-state truth until later implementation
+  slices replace them
+- this page defines the target stage contracts, not the claim that the current
+  code already implements them
+
+The target runtime pipeline is:
+
+`EvidenceSet -> ClaimSet -> EconomicFacts -> ReconciliationState -> Checkpoint -> Journal -> TaxInputs -> TaxOutputs`
+
+## Stage Rules
+
+- upstream stages preserve optionality that they do not own
+- downstream stages force specificity only when they own the decision
+- no stage may guess a later-stage answer
+- no stage may suppress uncertainty that a later stage must still see
+- no stage may duplicate upstream semantic payloads unless the meaning has
+  changed
+
+## Handoff Rules
+
+Every stage contract should answer four questions clearly:
+
+- what comes in
+- what the stage is allowed to decide
+- what comes out
+- what remains explicitly unresolved for later stages
+
+Shared rules:
+
+- every output must preserve stable ids and enough provenance linkage for later
+  audit
+- a later stage may add stage-owned sidecars and summaries, but it should not
+  silently rewrite upstream truth just to make its own outputs look tidy
+- if a stage cannot support a required decision, it should emit explicit
+  blockers or unresolved records rather than inventing a one-off fallback lane
+- stage contracts should stay compact enough for deterministic replay and
+  partitioned recomputation
+
+## `EvidenceSet`
+
+Purpose:
+
+- deterministic intake output before semantic commitment
+
+Owns:
+
+- selected evidence membership
+- superseded and blocked alternatives
+- deterministic evidence selection decisions
+- typed provenance and locator identity for selected evidence
+- source-local parsed observations that do not yet require economic meaning
+
+Carries:
+
+- selected source artifacts
+- source-local parsed observations
+- provenance
+- document, statement, and inventory observations
+- selected, superseded, and blocked alternatives
+- deterministic selection decisions
+
+Must guarantee:
+
+- deterministic selection
+- stable provenance and locators
+- no forced economic meaning
+- no forced reconciliation, accounting, or tax decisions
+
+Must not:
+
+- invent economic or policy meaning
+- hide file-winner logic inside adapter-local heuristics
+
+Handoff to `ClaimSet`:
+
+- `EvidenceSet` provides selected evidence, typed observations, provenance, and
+  selection reasoning
+- it does not provide final economic interpretation, final ownership meaning,
+  checkpoint acceptance, journal logic, or tax treatment
+
+## `ClaimSet`
+
+Purpose:
+
+- source-local meaning layer before economic truth is fixed
+
+Owns:
+
+- source-local semantic assertions derived from evidence
+- explicitly unresolved meaning when one safe final interpretation is not yet
+  available
+- claim-owned issues and reviews
+
+Carries:
+
+- activity claims
+- balance claims
+- ownership claims
+- location claims
+- instrument claims
+- contract claims
+- valuation claims
+- candidate interpretations
+- claim-owned issues and reviews
+
+Must guarantee:
+
+- source-local semantics only
+- preserved ambiguity where one safe final interpretation is unavailable
+- provenance for every claim
+
+Must not:
+
+- force unresolved meaning into final economic or policy interpretations
+- silently discard materially relevant alternative interpretations
+
+Handoff to `EconomicFacts`:
+
+- `ClaimSet` hands off source-local assertions and explicitly unresolved
+  branches
+- the compiler is responsible for deciding which claims can become accepted
+  economic truth and which must remain blocked or unresolved
+
+## `EconomicFacts`
+
+Purpose:
+
+- economic truth the system can safely assert
+
+Owns:
+
+- accepted economic meaning
+- accepted identity resolution needed for economic truth
+- stable economic event and leg structure
+- explicit remaining ambiguity that is still economically safe to preserve
+
+Carries:
+
+- economic events
+- economic legs
+- instrument identity
+- contract identity where relevant
+- position identity where relevant
+- owner and counterparty identity where known
+- temporal precision
+- settlement and supersession links
+- valuations
+- confidence and ambiguity markers
+
+Must support:
+
+- holdings movements
+- cash movements
+- obligations and rights
+- settlements
+- collateral changes
+- financing flows
+- fees, rebates, and withholding
+- corrections and supersession chains
+- corporate actions
+- restructurings
+- lifecycle-heavy activity
+
+Must not:
+
+- collapse to spot-trade assumptions
+- let output hints drive core behavior
+
+Handoff to `ReconciliationState`:
+
+- `EconomicFacts` provides accepted economic events, legs, identity seams,
+  settlement links, lifecycle state, and valuations where they are already safe
+- it does not claim that continuity is complete, transfers are fully linked, or
+  checkpoint truth is accepted
+
+## `ReconciliationState`
+
+Purpose:
+
+- completeness, linkage, continuity, checkpoint candidates, and
+  reconciliation-owned blockers
+
+Owns:
+
+- transfer and settlement linkage
+- continuity decisions
+- balance targets and assertion outcomes
+- reconciliation-owned gaps and readiness
+- checkpoint candidacy derived from reconciled economics plus checkpoint
+  evidence
+
+Carries:
+
+- transfer links
+- balance targets and assertions
+- continuity windows
+- missing funding and settlement legs
+- unresolved ownership transitions
+- corroboration sidecars
+- checkpoint candidates
+- reconciliation-owned gaps
+- readiness records
+
+Must guarantee:
+
+- explicit completeness decisions
+- explicit continuity decisions
+- explicit missing-leg and missing-evidence surfaces
+- preservation of partial truth when the whole window is not yet clean
+- no rewriting of upstream truth to satisfy checks
+
+Must not:
+
+- reclassify upstream economics to make continuity easier
+- bury missing evidence inside whole-dataset summaries
+
+Handoff to `Checkpoint`:
+
+- `ReconciliationState` provides checkpoint candidates, corroboration,
+  continuity outcomes, and reconciliation-owned blockers
+- checkpoint acceptance still belongs to the checkpoint stage
+
+## `Checkpoint`
+
+Purpose:
+
+- accepted checkpoint truth and acceptance basis
+
+Owns:
+
+- accepted checkpoint assertions
+- adopted opening state when intentionally used
+- acceptance basis, trust level, and continuity into accepted state
+
+Carries:
+
+- accepted checkpoint assertions
+- adopted opening state when intentionally used
+- supporting evidence and provenance
+- continuity decisions into accepted state
+- trust level and acceptance basis
+
+Must guarantee:
+
+- accepted checkpoint truth is first-class
+- source-backed evidence remains preferred
+- operator assertions do not silently become filing-ready checkpoint truth
+
+Must not:
+
+- silently elevate operator convenience inputs into filing-ready truth
+- hide the acceptance basis, trust level, or continuity assumptions
+
+Handoff to `Journal` and `TaxInputs`:
+
+- `Checkpoint` provides accepted balances, accepted opening state where used,
+  and the acceptance basis
+- downstream accounting and tax stages must consume that accepted truth rather
+  than re-deciding checkpoint trust locally
+
+## `Journal`
+
+Purpose:
+
+- accounting expansion and validation over accepted truth
+
+Owns:
+
+- journal entry and posting expansion
+- accounting validation results
+- accounting-owned gaps
+
+Carries:
+
+- journal entries and postings
+- provenance back to accepted upstream truth
+- validation results
+- accounting-owned gaps
+
+Must guarantee:
+
+- deterministic posting expansion
+- explicit validation
+- explicit unsupported accounting coverage
+
+Must not:
+
+- become a truth repair layer
+
+Handoff to downstream renderers:
+
+- `Journal` provides accounting-owned postings, validation results, and
+  accounting-owned blockers
+- renderer-specific row shapes stay at output boundaries rather than becoming
+  part of the shared journal contract
+
+## `TaxInputs`
+
+Purpose:
+
+- policy-ready, jurisdiction-neutral tax input surface
+
+Owns:
+
+- tax determinants derived from reconciled economics plus accepted checkpoint
+  truth
+- explicit tax-owned blockers where upstream truth is still not tax-complete
+
+Carries:
+
+- acquisitions
+- dispositions
+- income events
+- financing costs
+- internal transfers
+- corporate actions
+- tax-relevant valuations
+- basis or pool state transitions
+- tax-owned unresolved items
+
+Must guarantee:
+
+- jurisdiction-neutral determinants
+- explicit basis-affecting state changes
+- explicit tax-owned blockers where upstream truth is not tax-complete
+
+Must not:
+
+- embed one jurisdiction's output schema
+- decide source meaning, reconciliation truth, checkpoint truth, or accounting
+  truth
+
+Handoff to `TaxOutputs`:
+
+- `TaxInputs` provides the determinant surface that selected policies operate
+  on
+- the policy layer decides treatment and output shape, not the upstream claim,
+  economic, or reconciliation layers
+
+## `TaxOutputs`
+
+Purpose:
+
+- one selected tax policy's outputs
+
+Owns:
+
+- policy-specific summaries, forms, schedules, and carry-forward state
+- tax-policy explanations, limitations, and unsupported outputs
+- tax-owned blockers that survive policy execution
+
+Carries:
+
+- summaries
+- forms and schedules
+- carry-forward state
+- unsupported or deferred outputs
+- policy-specific notes
+
+Must guarantee:
+
+- outputs are derived from `TaxInputs` through selected tax policies
+- policy selection is explicit
+- unsupported coverage stays explicit instead of being silently omitted
+
+Must not:
+
+- claim to come directly from `EconomicFacts` or `ReconciliationState`
+- backfill earlier-stage semantic gaps by guessing
+
+## Shared Contract References
+
+The pipeline products rely on shared supporting contracts defined elsewhere:
+
+- [Current Bridge Contracts](current-bridge-contracts.md) for the live bridge
+  runtime truth
+- [Domain Ontology](domain-ontology.md) for the target ontology and identity
+  seams
+- [Gaps And Readiness](gaps-and-readiness.md) for `GapCore`,
+  `GapExplanation`, readiness, and `SubjectRef`
+- [Reconciliation And Tax Architecture](reconciliation-tax-architecture.md) for
+  performance rules, tax-policy architecture, and filing-critical acceptance
+  criteria

--- a/docs/concepts/reconciliation-tax-architecture.md
+++ b/docs/concepts/reconciliation-tax-architecture.md
@@ -100,6 +100,12 @@ Every transaction fact should support distinct classification layers:
 - `TaxTreatmentHint`: jurisdiction-neutral tax intent
 - `AccountingIntentHint`: accounting intent
 
+These layered fields are the current fact-bridge contract, not a rule that
+every earlier stage must guess final policy meaning. When a provider row
+cannot safely support one final economic, accounting, or tax reading, the
+target `ClaimBundle` should preserve that ambiguity until one safe canonical
+economic fact or later stage-owned policy decision is available.
+
 ### 5. Keep The Core Runtime Asset-Class Agnostic
 
 The internal runtime should generalize across financial asset classes even when
@@ -348,6 +354,386 @@ Core abstractions added from this point forward must stay neutral enough to
 support multiple asset classes. If a term is only correct for one provider,
 chain, or asset class, keep it adapter-local unless the domain concept itself
 is inherently specific.
+
+### Canonical Pipeline Products
+
+The target runtime should converge on one canonical flow:
+
+`general intake -> surface reconciliation -> checkpoint adoption ->
+journal expansion -> tax expansion`
+
+Each stage narrows truth and then expands the next decision surface. Upstream
+stages preserve optionality. Downstream stages force specificity. No stage may
+guess a later-stage answer or suppress uncertainty that a later stage must
+still see.
+
+The canonical runtime products are:
+
+1. `EvidenceBundle`
+2. `ClaimBundle`
+3. `EconomicDataset`
+4. `ReconciliationDataset`
+5. `CheckpointPackage`
+6. `JournalDataset`
+7. `TaxDeterminantDataset`
+8. `TaxOutputDataset`
+
+Current runtime note:
+
+- today's `EconomicActivityDraft`, `TransactionFact`,
+  `balance_snapshots.csv`, and `balance_references.csv` remain the active
+  runtime center until the richer products land
+- treat those contracts as the current bridge into the target pipeline, not as
+  proof that the final architecture should stop at facts plus balances
+
+### Stage Contracts
+
+#### `EvidenceBundle`
+
+`EvidenceBundle` is the deterministic intake product.
+
+It should contain:
+
+- selected raw source artifacts
+- parsed boundary observations that remain source-local
+- capture and source assembly provenance
+- document, statement, and inventory observations
+- deterministic selection decisions and superseded or blocked alternatives
+
+It must promise:
+
+- deterministic evidence selection
+- stable provenance and locator references
+- no forced economic meaning
+- no forced tax, accounting, or reconciliation policy
+
+It may block only when:
+
+- source selection is nondeterministic
+- parsing cannot produce stable source-local observations
+- provenance is too unresolved to support later review
+
+#### `ClaimBundle`
+
+`ClaimBundle` is the source-local meaning layer.
+
+It should contain claims such as:
+
+- activity claims
+- balance observation claims
+- ownership and control claims
+- location claims
+- instrument identity claims
+- contract term claims
+- valuation claims
+- explicit issues and reviews
+
+It must promise:
+
+- source-local semantics only
+- preserved ambiguity when the source does not support one final reading
+- provenance for every emitted claim
+- candidate interpretations when one safe final meaning is not yet available
+
+Rules:
+
+- adapters may continue populating layered classifications on the current
+  runtime path when they are safe and deterministic
+- the target claim layer must allow unresolved economic, accounting, or tax
+  classification when forcing those fields would guess
+- `ClaimBundle` must be able to express materially unclassified rows instead of
+  coercing everything into one `EconomicKind`
+
+#### `EconomicDataset`
+
+`EconomicDataset` is the first canonical narrowing.
+
+It should contain only what the system can safely say happened economically.
+
+It must preserve enough determinants for later reconciliation, accounting, and
+tax work:
+
+- signed legs
+- instrument identity
+- contract instance identity when applicable
+- location identity
+- legal owner, beneficial owner, and counterparty identity when known
+- effective time and temporal precision
+- settlement and supersession links
+- optional valuation attachments with purpose and provenance
+- provenance, confidence, and ambiguity markers
+
+It must be able to express economically important surfaces beyond simple spot
+flows:
+
+- holdings movements
+- cash movements
+- obligations and rights
+- settlements
+- collateral state changes
+- financing flows
+- fees, rebates, and withholding
+- corrections and supersession chains
+- corporate actions and similar non-trade lifecycle events
+
+It may block only when:
+
+- a canonical fact would be false
+- identity is too unresolved to emit a stable canonical fact
+- the source collapses multiple materially different interpretations and the
+  ambiguity is not representable safely
+
+#### `ReconciliationDataset`
+
+`ReconciliationDataset` is the surface-reconciliation product.
+
+It should contain:
+
+- transfer and linkage decisions
+- balance targets, assertions, and continuity windows
+- missing funding or settlement legs
+- unresolved ownership transitions
+- cross-source corroboration sidecars
+- checkpoint candidates
+- reconciliation-owned issues, gaps, and readiness state
+
+It must promise:
+
+- explicit completeness and continuity decisions
+- explicit missing-leg and missing-evidence surfaces
+- partial truth preservation when full clean-state is not yet available
+- no rewriting of upstream economic truth to make a check pass
+
+Rules:
+
+- transfer linking belongs here, not in adapter translation
+- checkpoint continuity belongs here before checkpoint adoption is accepted
+- reconciliation may declare a subject or window unresolved, but it must not
+  erase a valid partial balance or partial economic fact
+
+#### `CheckpointPackage`
+
+`CheckpointPackage` is the formal handoff between reconstruction and later
+stateful work.
+
+It should contain:
+
+- accepted checkpoint assertions
+- adopted opening state when intentionally imported
+- supporting evidence and provenance
+- continuity decisions into the accepted checkpoint
+- explicit trust level and acceptance basis
+
+Rules:
+
+- keep checkpoint state as a first-class package boundary, not just a flag on
+  reconciliation output
+- source-backed evidence remains the preferred basis
+- operator assertions may support runtime reconciliation but do not satisfy the
+  filing-ready checkpoint requirement by themselves
+
+#### `JournalDataset`
+
+`JournalDataset` is the accounting expansion product.
+
+It should contain:
+
+- journal entries and postings
+- posting provenance back to reconciled economics
+- validation results
+- unsupported accounting coverage gaps
+
+It must promise:
+
+- deterministic posting expansion from accepted upstream truth
+- explicit balanced-versus-unbalanced validation
+- explicit unsupported accounting gaps
+
+Rules:
+
+- accounting is a validator and renderer, not a truth-repair stage
+- journal failures should surface upstream fact or reconciliation gaps instead
+  of inventing local repairs
+
+#### `TaxDeterminantDataset`
+
+`TaxDeterminantDataset` is the policy-ready tax input surface.
+
+It should contain:
+
+- acquisitions
+- dispositions
+- income events
+- financing costs
+- internal transfers
+- corporate actions
+- valuations required for tax computation
+- unresolved tax-owned gaps
+
+It must promise:
+
+- jurisdiction-neutral tax determinants, not final jurisdiction output
+- explicit basis-affecting state changes
+- explicit unresolved tax-specific blockers when reconciliation truth is
+  sufficient operationally but not yet sufficient for tax
+
+Rules:
+
+- tax operates on reconciled economics plus accepted checkpoint truth
+- journal output may corroborate tax readiness, but tax must not depend on a
+  journal renderer succeeding unless the missing accounting information exposes
+  a real upstream determinant gap
+- tax must never invent missing economics
+
+#### `TaxOutputDataset`
+
+`TaxOutputDataset` is the jurisdiction-specific result surface.
+
+It should contain:
+
+- jurisdiction summaries
+- schedules and forms
+- carry-forward state
+- explicit unsupported or deferred outputs
+
+### Shared Sidecars
+
+Every canonical product should reuse the same sidecar families.
+
+#### Provenance
+
+- one typed runtime provenance model
+- flatten only at storage or export boundaries
+- keep evidence locators and row or page anchors distinct
+
+#### Gaps
+
+Use one cross-stage gap contract rather than stage-local ad hoc issue shapes.
+
+Every gap record should declare at least:
+
+- `gap_id`
+- `owner_stage`
+- `blocking_for_stage`
+- `subject_ref`
+- `gap_kind`
+- `known_facts`
+- `missing_determinants`
+- `candidate_interpretations`
+- `required_evidence`
+- `allowed_resolution_methods`
+- `recommended_next_action`
+- `confidence`
+- `materiality`
+- `provenance_refs`
+
+`gap_kind` should stay explicit and closed over a controlled taxonomy such as:
+
+- missing_evidence
+- unresolved_identity
+- unresolved_linkage
+- contradiction
+- policy_required_determination
+- operator_override_required
+
+#### Readiness
+
+Use one readiness vocabulary across the pipeline:
+
+- `semantic_ready`
+- `reconciliation_ready`
+- `checkpoint_ready`
+- `accounting_ready`
+- `tax_ready`
+
+Rules:
+
+- readiness must be sliceable by subject and time window, not just summarized
+  once per whole dataset
+- support at least source, location, instrument, position or contract,
+  continuity segment, and checkpoint date slices
+- dataset-level readiness is a reducer output over subject-level readiness, not
+  the primary stored truth
+
+#### Checkpoints
+
+- one checkpoint assertion vocabulary
+- one accepted checkpoint package surface
+- one trust-level model that distinguishes source-backed, network-backed, and
+  operator-backed support
+
+### MVP Delivery Guardrails
+
+The MVP should be intentionally narrow without painting the system into a
+corner.
+
+Rules:
+
+- keep the current fact-plus-balances bridge as the active delivery path until a
+  richer stage contract is needed by the next concrete slice
+- land new stage products only when they unlock a real filing-critical or
+  architecture-blocking behavior
+- prefer one bounded reducer, compiler, or dataset contract per stage over
+  building a general framework for every future variation up front
+- do not build a full contract-lifecycle or multi-asset engine before an
+  in-scope workflow needs that capability
+- keep unsupported surfaces explicit through gaps instead of speculative partial
+  implementations
+- prioritize the filing-critical `2023` to `2025` reconstruction path even when
+  choosing generic names and seams that can later generalize beyond crypto
+- treat replaceable seams as typed ports and contracts, not as plugin systems
+  that exist before a second concrete implementation needs them
+
+### Generic Core Requirements
+
+The shared core must stay broad enough for crypto, FX, securities, debt,
+options, futures, staking derivatives, loans, funds, and later non-crypto
+instruments without reshaping the engine.
+
+The core should standardize concepts such as:
+
+- `Instrument`
+- `InstrumentTraits`
+- `ContractInstance`
+- `ContractTerms`
+- `PositionState`
+- `OwnershipScope`
+- `Counterparty`
+- `EconomicEvent`
+- `EconomicLeg`
+- `Observation`
+- `Link`
+- `CheckpointAssertion`
+- `Valuation`
+- `Posting`
+- `TaxDeterminant`
+
+The core must not assume the world is only:
+
+- exchanges
+- wallets
+- chain transfers
+- coin categories
+- tracker-specific row types
+
+### Identity Requirements
+
+Cross-stage logic should keep identity layers explicit instead of overloading
+one id field for several concerns.
+
+The target pipeline should keep separate runtime seams for:
+
+- instrument identity
+- contract instance identity
+- location identity
+- legal owner identity
+- beneficial owner identity
+- counterparty identity
+
+Location and instrument identity remain foundational runtime contracts. Later
+reconciliation, checkpoint, accounting, and tax work should add the remaining
+identity layers as first-class seams instead of collapsing them into
+descriptions or adapter-local metadata.
 
 ### Domain Packages
 
@@ -836,17 +1222,21 @@ Estimated effort: `8` to `12` hours
 
 Deliverables:
 
-- final schema and package decisions
+- final schema, package, and stage-boundary decisions
 - roadmap updates
-- migration plan from normalized transactions to transaction facts
+- migration plan from the current fact bridge into the canonical pipeline
+- shared provenance, gap, readiness, and checkpoint-vocabulary decisions
 - provenance policy for external ideas and direct code reuse
 
-### Phase 1. Boundary Models And Dev-Only Oracle Readers
+### Phase 1. Evidence And Claim Foundations Plus Oracle Readers
 
 Estimated effort: `14` to `22` hours
 
 Deliverables:
 
+- deterministic `EvidenceBundle` and `ClaimBundle` contracts for the next
+  pipeline slice
+- claim ambiguity rules and shared gap or readiness foundations
 - Pydantic row models for CoinTracking report families
 - parser services for all oracle exports under `tools/oracles/`
 - projection-type enum and alias normalization for current output adapters
@@ -859,11 +1249,12 @@ Estimated effort: `18` to `28` hours
 Deliverables:
 
 - transaction fact domain package
+- claim-to-economic compilation seam
 - normalization result evolution to emit fact artifacts directly
 - downstream service updates to consume fact artifacts without wrappers
 - parity tests for current adapters
 
-### Phase 3. Deterministic Reconciliation And Checkpointing
+### Phase 3. Reconciliation Dataset And Checkpoint Packages
 
 Estimated effort: `18` to `28` hours
 
@@ -873,11 +1264,13 @@ Deliverables:
   evidence
 - transfer linking
 - balance assertions
+- reconciliation dataset with explicit readiness, link, and continuity outputs
 - checkpoint builder around `2026-03-23`
+- accepted checkpoint package and trust-basis contracts
 - continuity reports
 - deterministic correction handling for events such as the GALA redistribution
 
-### Phase 4. Accounting Layer And Ledger CLI Hard Gate
+### Phase 4. Journal Dataset And Ledger CLI Hard Gate
 
 Estimated effort: `14` to `22` hours
 
@@ -886,14 +1279,16 @@ Deliverables:
 - internal journal model
 - Ledger CLI renderer
 - journal validation results
+- accounting coverage gaps
 - accounting summaries tied to checkpoint and reconciliation outputs
 
-### Phase 5. Canadian Tax MVP
+### Phase 5. Tax Determinants And Canadian Tax MVP
 
 Estimated effort: `24` to `36` hours
 
 Deliverables:
 
+- tax determinant dataset contracts
 - Canadian pooled ACB engine
 - disposition and income outputs
 - unsupported-item and ambiguity reporting

--- a/docs/concepts/reconciliation-tax-architecture.md
+++ b/docs/concepts/reconciliation-tax-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: "Reconciliation And Tax Architecture"
-summary: "Design anchor for the current bridge, final pipeline products, performance rules, and filing-critical rollout."
+summary: "Design anchor for trust gates, performance rules, tax-policy architecture, and filing-critical rollout from the current bridge toward the target pipeline."
 doc_type: concept
 audience: human
 owner: repo
@@ -36,20 +36,10 @@ The system must:
   hard checkpoint
 - compute forward tax state for `2023` to `2025`
 - render a deterministic double-entry journal and require it to validate
-- surface unsupported or ambiguous truth as explicit issues, reviews, and gaps
+- surface unsupported or ambiguous truth as explicit issues, reviews, and
+  later-stage blockers
 - preserve one interface-neutral application surface so future CLI, HTTP, API,
   and agent entrypoints can share the same typed workflows
-
-Normal runtime operation must stay platform-agnostic:
-
-- raw source exports, wallet statements, and checkpoint evidence are the normal
-  reconstruction inputs
-- CoinTracking is one ordinary output adapter and one optional oracle family
-  for dev-only comparison workflows
-- CoinTracking tax and accounting reports are oracle-only support artifacts for
-  comparison and regression, not normal runtime dependencies
-- the internal engine should stay asset-class-agnostic so crypto, FX,
-  securities, and similar surfaces can remain adapter- and policy-driven
 
 ## Active Bridge Note
 
@@ -83,906 +73,46 @@ Current operational surfaces that remain part of runtime truth:
 - replay validation
 - oracle comparison and verification workflows
 
-### Current Hard Runtime Rules
+## Contract Owners
 
-- raw evidence stays outside the repo
-- normalization and profiling operate on one materialized raw capture root at a
-  time
-- planner-enabled adapters provide translation input candidates and the core
-  selects the winning plan
-- ambiguity blocks fact and balance artifact emission
-- assembled source datasets are the reconciliation input surface
-- provenance stays typed in runtime models and is flattened only at artifact
-  boundaries
-- operator-confirmed balance references may support runtime progress but do not
-  satisfy filing-ready checkpoint requirements alone
-- historical provider hydration remains separate from source adapters
-- runtime balance artifacts are `balance_snapshots.csv` and
-  `balance_references.csv`
-- schema-version mismatch is resolved by regeneration, not compatibility
-  wrappers
+This page does not re-own every lower-level contract.
 
-### Current Bridge Contracts
+Use these pages as the detailed contract owners:
 
-#### `TransactionFact`
+- [Current Bridge Contracts](current-bridge-contracts.md)
+- [Pipeline Stage Contracts](pipeline-stage-contracts.md)
+- [Domain Ontology](domain-ontology.md)
+- [Gaps And Readiness](gaps-and-readiness.md)
+- [Transaction Classification](transaction-classification.md)
+- [Oracle Boundaries](oracle-boundaries.md)
 
-Current bridge contract includes:
-
-- identity:
-  - `fact_id`
-  - `source`
-  - `adapter_id`
-  - `provider_operation_key`
-  - `operation_group_id`
-  - `tx_hash`
-- time:
-  - `timestamp`
-  - optional `effective_at`
-  - optional `effective_precision`
-- participants:
-  - `location_id`
-- semantics:
-  - `economic_kind`
-  - `accounting_intent_hint`
-  - `tax_treatment_hint`
-  - optional `projection_hint`
-- economics:
-  - `legs`
-  - `FactLegPolicy`
-- metadata and status:
-  - `description`
-  - `raw_file`
-  - `raw_row_ref`
-  - `confidence`
-  - `status`
-
-#### `EconomicLeg`
-
-Current bridge contract includes:
-
-- `leg_id`
-- `kind`
-- `instrument_id`
-- `quantity`
-- optional `subtype`
-- optional `attributed_to_leg_id`
-- optional `location_id`
-
-#### `LegKind`
-
-Current values:
-
-- `primary`
-- `charge`
-- `rebate`
-- `collateral`
-- `settlement`
-- `financing`
-- `withholding`
-- `adjustment`
-
-#### `FactLegPolicy`
-
-Current bridge rules to preserve:
-
-- per-kind limits
-- signed-count constraints
-- duplicate kinds prohibited
-- zero-primary support only when intentionally allowed
-- shared policy constants are part of the bridge contract
-
-#### Temporal Precision
-
-Current rule to preserve:
-
-- exact time uses UTC-aware `*_at`
-- date-or-time uses `*_at` plus `*_precision`
-
-#### Schema Versioning
-
-Current rule to preserve:
-
-- fact artifacts are schema-versioned
-- unknown schema versions fail fast
-- regeneration from evidence is the recovery path
-
-#### `EconomicActivityDraft`
-
-Current bridge responsibilities to preserve:
-
-- stable draft identity
-- timestamp and temporal precision
-- location scope
-- `legs`
-- `FactLegPolicy`
-- provider operation key
-- grouped-row support
-- layered hints
-- provenance refs
-- review markers
-- confidence and status
-
-#### `SourceTranslationBatch`
-
-Current bridge bundle to preserve:
-
-- drafts
-- balance references
-- balance reference issues
-- issues
-- reviews
-- location inventory
-
-### Current Schema And Artifact Contracts
-
-#### Repo-Wide Temporal Precision Contract
-
-- use one timing convention everywhere in the repo:
-  - exact-time fields use UTC-aware `*_at`
-  - fields that may be date-only or exact-time use `*_at` plus `*_precision`
-- `*_precision` uses one shared enum with at least:
-  - `timestamp`
-  - `date`
-- date-only values are stored distinctly from exact timestamps even when an
-  exact timestamp falls at midnight
-- adapters are responsible for preserving this distinction at translation time
-- infer precision from the source contract and parsed field shape, not from the
-  normalized clock value
-
-#### Current Fact-Shape Contract
-
-- `TransactionFact` and `EconomicActivityDraft` use one shared `legs` tuple
-- fact construction requires successful identifier resolution to exactly one
-  `InstrumentId`
-- unresolved or ambiguous identity must emit review output and a blocking issue
-  rather than guessing
-- every leg carries:
-  - stable `leg_id`
-  - signed `quantity`
-  - semantic `LegKind`
-  - optional adapter-detail `subtype`
-  - optional `attributed_to_leg_id` metadata
-- signed quantities use one meaning everywhere:
-  - positive increases the balance of the leg location
-  - negative decreases the balance of the leg location
-- `attributed_to_leg_id` is valid only on non-`primary` legs and only when it
-  references one concrete leg in the same fact
-- `FactLegPolicy` is generic and per-kind:
-  - `LegShapeLimit` declares `min_count`, `max_count`, `min_positive_count`,
-    `max_positive_count`, `min_negative_count`, and `max_negative_count`
-  - no duplicate kinds
-  - minimum counts cannot exceed maximum counts
-  - signed-count limits cannot exceed per-kind totals
-  - unspecified kinds are disallowed
-  - zero-`primary` shapes are opt-in through the declared policy
-- current shared policy constants cover:
-  - single-primary activity
-  - two-sided primary exchange
-  - two-sided primary exchange with one `charge`
-- CoinTracking currently supports only:
-  - at least one `primary`
-  - up to one positive `primary`
-  - up to one negative `primary`
-  - up to one negative `charge`
-  - no other non-primary leg kinds
-  - renderers derive inbound and outbound adapter concepts from sign
-
-#### Current Normalization Window Contract
-
-- runtime timestamps are timezone-aware UTC in drafts, facts, balance
-  snapshots, and balance references
-- persisted artifact timestamp text remains `YYYY-MM-DD HH:MM:SS` and is
-  interpreted as UTC on read
-- fields that may be date-only or exact-time persist both `*_at` and
-  `*_precision`
-- `facts.csv` is schema-versioned and readers fail fast on unexpected
-  `schema_version` values
-- `balance_snapshots.csv` and `balance_references.csv` persist `instrument_id`
-  values and use `target_at` plus `target_precision`; balance references also
-  persist `observed_at` plus `observed_precision`
-- cross-source balance corroboration is additive in the first release
-- windowed normalization applies to:
-  - `facts.csv`
-  - `fact_annotations.json`
-  - `balance_snapshots.csv`
-  - `exceptions.csv`
-  - `normalization_reviews.csv`
-- windowed normalization does not apply to:
-  - `balance_references.csv`
-  - `location_inventory.csv`
-- source-scope portfolio evidence that does not itself prove wallet ownership
-  may contribute balance evidence only under constrained same-source same-chain
-  rules and must remain explicitly caveated
-- review records carry `context_timestamp`, dataset-level untimed reviews stay
-  visible when a window is active, and summaries report
-  `reviews_outside_normalization_window`
-
-#### Capture And Assembly Contract
-
-- raw capture roots use `evidence/raw/source/<source>/<capture_label>/`
-- capture metadata stores the stable `capture_uid`, intake timestamps,
-  manifest fingerprint, and workspace-relative refs
-- untouched upstream originals stay under the raw capture root
-- `working/supporting_artifacts/` is limited to derived or operator-authored
-  helper material
-- capture-normalized outputs live under
-  `working/normalized/captures/<capture_uid>/`
-- assembled source outputs live under `working/normalized/sources/<source>/`
-- source assembly merges accepted captures deterministically, preserves the
-  union of source-backed evidence, collapses exact semantic duplicates, and
-  surfaces semantic conflicts explicitly
-- location inventory and balance evidence provenance reference captures by
-  `capture_uid`, with human-readable labels and roots treated as optional
-  report fields rather than as the key
-
-#### Transitional Adapter Draft Seam
-
-Source normalization should translate through `EconomicActivityDraft` until all
-adapters emit `TransactionFact` artifacts directly.
-
-Required draft responsibilities:
-
-- stable identity claims plus evidence references
-- UTC-aware timestamp and provenance
-- optional `effective_at`
-- optional `effective_precision`
-- account and wallet scope
-- one shared `legs` tuple only; no separate fee lane
-- explicit leg semantics per leg:
-  - stable `leg_id`
-  - `LegKind`
-  - optional `subtype`
-  - optional `attributed_to_leg_id` on non-`primary` legs only
-- explicit per-kind leg-shape policy through `FactLegPolicy` and
-  `LegShapeLimit`, including any required minimum counts
-- provider operation key and grouped-row support
-- layered classification hints:
-  - economic kind
-  - projection type
-  - journal intent
-  - tax treatment code
-- explicit review or ambiguity markers
-
-Rules:
-
-- provider modules translate into drafts only; they do not assemble
-  CoinTracking rows or other output-adapter payloads directly
-- shared identifier resolution must succeed to exactly one instrument before
-  fact construction
-- unresolved or ambiguous identifier resolution blocks fact emission for the
-  affected activity and must surface both review output and a blocking issue
-- shared fact builders may derive `TransactionFact` objects from drafts, but
-  that derivation stays in shared support rather than provider-local code
-- shared support stays adapter-agnostic and registry-driven
-- draft-only provenance references and review markers must survive compilation
-  through a fact-keyed sidecar artifact instead of being dropped
-- one shared projection mapper owns the mapping from layered classifications
-  into concrete output-adapter row types
-- grouped operations and provider-local export families must resolve through
-  explicit translation registries, not ad hoc adapter entry-point branching
-
-## Final Naming Mapping Note
-
-Forward-looking architecture and rollout docs use these final names:
-
-| Current target-doc term | Final term |
-| --- | --- |
-| `EvidenceBundle` | `EvidenceSet` |
-| `ClaimBundle` | `ClaimSet` |
-| `EconomicDataset` | `EconomicFacts` |
-| `ReconciliationDataset` | `ReconciliationState` |
-| `CheckpointPackage` | `Checkpoint` |
-| `JournalDataset` | `Journal` |
-| `TaxDeterminantDataset` | `TaxInputs` |
-| `TaxOutputDataset` | `TaxOutputs` |
-
-Current bridge and status docs may continue using current implementation terms
-where accuracy requires them. Target architecture docs should use the final
-names after the mapping is established.
-
-Target-direction internal rename guidance:
-
-| Current bridge term | Target-direction name |
-| --- | --- |
-| `EconomicActivityDraft` | `ActivityClaim` |
-| `EconomicLegDraft` | `LegClaim` |
-| `ActivityDraftSeed` | `ActivitySeed` |
-| `TransactionFact` | `EconomicEvent` |
-| `FactSemantics` | `ClassificationHints` |
-| `FactLegPolicy` | `LegPolicy` |
-| `LegShapeLimit` | `LegCountLimit` |
-| `EconomicKind` | `EventKind` |
-| `ProjectionHint` | `OutputHint` |
-| `AccountingIntentHint` | `AccountingHint` |
-| `TaxTreatmentHint` | `TaxHint` |
-| `SourceTranslationBatch` | `TranslationResult` |
-
-These are target-direction names, not claims that the current code already uses
-them.
-
-## Target Pipeline Products And Stage Meanings
+## Trust Gates
 
 The target runtime pipeline is:
 
 `EvidenceSet -> ClaimSet -> EconomicFacts -> ReconciliationState -> Checkpoint -> Journal -> TaxInputs -> TaxOutputs`
 
-Design rules:
-
-- upstream stages preserve optionality
-- downstream stages force specificity only when they own the decision
-- no stage may guess a later-stage answer
-- no stage may suppress uncertainty that a later stage must still see
-- no stage may duplicate upstream semantic payloads unless the meaning has
-  changed
-
-### `EvidenceSet`
-
-Purpose:
-
-- deterministic intake output before semantic commitment
-
-Contains:
-
-- selected source artifacts
-- source-local parsed observations
-- provenance
-- document, statement, and inventory observations
-- selected, superseded, and blocked alternatives
-- deterministic selection decisions
-
-Must guarantee:
-
-- deterministic selection
-- stable provenance and locators
-- no forced economic meaning
-- no forced reconciliation, accounting, or tax decisions
-
-### `ClaimSet`
-
-Purpose:
-
-- source-local meaning layer before economic truth is fixed
-
-Contains:
-
-- activity claims
-- balance claims
-- ownership claims
-- location claims
-- instrument claims
-- contract claims
-- valuation claims
-- candidate interpretations
-- claim-owned issues and reviews
-
-Must guarantee:
-
-- source-local semantics only
-- preserved ambiguity where one safe final interpretation is unavailable
-- provenance for every claim
-
-Must not:
-
-- force unresolved meaning into final economic or policy interpretations
-
-### `EconomicFacts`
-
-Purpose:
-
-- economic truth the system can safely assert
-
-Contains:
-
-- economic events
-- economic legs
-- instrument identity
-- contract identity where relevant
-- position identity where relevant
-- owner and counterparty identity where known
-- temporal precision
-- settlement and supersession links
-- valuations
-- confidence and ambiguity markers
-
-Must support:
-
-- holdings movements
-- cash movements
-- obligations and rights
-- settlements
-- collateral changes
-- financing flows
-- fees, rebates, and withholding
-- corrections and supersession chains
-- corporate actions
-- restructurings
-- lifecycle-heavy activity
-
-Must not:
-
-- collapse to spot-trade assumptions
-- let output hints drive core behavior
-
-### `ReconciliationState`
-
-Purpose:
-
-- completeness, linkage, continuity, checkpoint candidates, and
-  reconciliation-owned gaps
-
-Contains:
-
-- transfer links
-- balance targets and assertions
-- continuity windows
-- missing funding and settlement legs
-- unresolved ownership transitions
-- corroboration sidecars
-- checkpoint candidates
-- reconciliation-owned gaps
-- readiness slices
-
-Must guarantee:
-
-- explicit completeness decisions
-- explicit continuity decisions
-- explicit missing-leg and missing-evidence surfaces
-- preservation of partial truth when the whole window is not yet clean
-- no rewriting of upstream truth to satisfy checks
-
-### `Checkpoint`
-
-Purpose:
-
-- accepted checkpoint truth and acceptance basis
-
-Contains:
-
-- accepted checkpoint assertions
-- adopted opening state when intentionally used
-- supporting evidence and provenance
-- continuity decisions into accepted state
-- trust level and acceptance basis
-
-Must guarantee:
-
-- accepted checkpoint truth is first-class
-- source-backed evidence remains preferred
-- operator assertions do not silently become filing-ready checkpoint truth
-
-### `Journal`
-
-Purpose:
-
-- accounting expansion and validation
-
-Contains:
-
-- journal entries and postings
-- provenance back to accepted upstream truth
-- validation results
-- accounting-owned gaps
-
-Must guarantee:
-
-- deterministic posting expansion
-- explicit validation
-- explicit unsupported accounting coverage
-
-Must not:
-
-- become a truth repair layer
-
-### `TaxInputs`
-
-Purpose:
-
-- policy-ready, jurisdiction-neutral tax input surface
-
-Contains:
-
-- acquisitions
-- dispositions
-- income events
-- financing costs
-- internal transfers
-- corporate actions
-- tax-relevant valuations
-- basis or pool state transitions
-- tax-owned unresolved items
-
-Must guarantee:
-
-- jurisdiction-neutral determinants
-- explicit basis-affecting state changes
-- explicit tax-owned blockers where upstream truth is not tax-complete
-
-### `TaxOutputs`
-
-Purpose:
-
-- one selected tax policy's outputs
-
-Contains:
-
-- summaries
-- forms and schedules
-- carry-forward state
-- unsupported or deferred outputs
-- policy-specific notes
-
-Must guarantee:
-
-- outputs are derived from `TaxInputs` through selected tax policies
-- outputs are never described as coming directly from `EconomicFacts` or
-  `ReconciliationState`
-
-## Shared Cross-Stage Contracts
-
-These contracts should be defined once and reused everywhere.
-
-### Provenance
-
-Use one typed provenance model.
-
-Rules:
-
-- typed in runtime models
-- flattened only at artifact boundaries
-- file and member identity kept separate from row and page anchors
-- capture identity kept separate from display labels and file paths
-
-### Gaps
-
-Use one shared gap model.
-
-Minimum fields:
-
-- `gap_id`
-- `owner_stage`
-- `blocking_for_stage`
-- `subject_ref`
-- `gap_kind`
-- `known_facts`
-- `missing_inputs`
-- `candidate_interpretations`
-- `required_evidence`
-- `allowed_resolution_methods`
-- `recommended_next_action`
-- `confidence`
-- `materiality`
-- `provenance_refs`
-
-Minimum taxonomy:
-
-- `missing_evidence`
-- `unresolved_identity`
-- `unresolved_linkage`
-- `contradiction`
-- `policy_required_determination`
-- `operator_override_required`
-
-### Readiness
-
-Use one exact readiness vocabulary:
-
-- `semantic_ready`
-- `reconciliation_ready`
-- `checkpoint_ready`
-- `accounting_ready`
-- `tax_ready`
-
-Readiness is sliceable by:
-
-- source
-- location
-- instrument
-- subject ref
-- continuity segment
-- checkpoint date
-- tax year where relevant
-
-Rules:
-
-- this exact slice definition must stay identical everywhere it appears
-- when a stage needs to distinguish `Contract` from `Position`, it must do so
-  explicitly through the referenced `SubjectRef`
-- dataset readiness is derived from subject-level reducers, not stored as the
-  only truth
-
-### Identity
-
-Keep these identity seams separate:
-
-- instrument identity
-- contract identity
-- position identity
-- location identity
-- legal owner identity
-- beneficial owner identity
-- counterparty identity
-
-### Valuation
-
-Valuation is first-class.
-
-Fields:
-
-- amount
-- currency
-- purpose
-- timestamp
-- precision
-- source
-- confidence
-- provenance
-
-### Checkpoint Assertions
-
-Use one shared checkpoint-assertion vocabulary across reconciliation,
-checkpoints, accounting, and tax.
-
-## Anti-Duplication And Sidecar Rules
-
-Copy only when meaning changes.
-
-Meaning:
-
-- one stage owns one semantic payload
-- downstream stages reference upstream records by stable ids
-- downstream stages add stage-owned outputs only
-
-Keep these first-class:
-
-- economic events
-- economic legs
-- identities
-- ownership state
-- settlement and lifecycle state
-- valuations
-- checkpoint assertions
-- postings
-- tax inputs
-
-Use sidecars only for:
-
-- provenance
-- gaps
-- readiness
-- reviews
-- annotations
-- comparison traces
-- policy explanations
-
-Sidecars must never become:
-
-- the only real copy of business meaning
-- a substitute for missing entities
-- a junk drawer of unresolved text
-
-Performance implication:
-
-- avoiding semantic duplication is also a performance rule
-- repeated full payloads increase read amplification, join cost, and drift risk
-- the correct shape is stable ids plus stage-owned deltas
-
-Storage implication:
-
-- this structure maps cleanly to future database storage
-- first-class records become base tables
-- sidecars become linked tables keyed by stable ids
-- flattening belongs to storage and export codecs
-- runtime models remain typed and normalized
-
-## Performance And Calculation-Path Rules
-
-The core pipeline must stay auditable, deterministic, replayable, and fast
-enough for large-scale calculation.
-
-### Hot Path
-
-Inner-loop calculations for:
-
-- reconciliation
-- checkpoint continuity
-- journal validation
-- tax computation
-
-must operate on compact typed records only.
-
-Hot-path data should include:
-
-- event ids
-- timestamps and effective times
-- subject refs
-- location refs
-- instrument refs
-- signed quantities
-- explicit link ids
-- explicit state transitions
-- valuations where computation requires them
-- minimal classification hints only where needed
-
-The hot path should not repeatedly join in:
-
-- full provenance detail
-- review records
-- large issue text
-- evidence metadata blobs
-- renderer metadata
-- adapter-local annotations that do not change computation
-
-Those belong in sidecars and explanation layers.
-
-### Deterministic Ordering
-
-Reducers must use stable ordering:
-
-- effective time when present
-- otherwise event timestamp
-- then deterministic tie-break keys such as source sequence, event id, or leg
-  id
-
-Rules:
-
-- reducers must be deterministic
-- replay must be consistent across runs
-- ordering must not depend on incidental file order
-
-### Partitioning
-
-Expensive processing must be partitionable by:
-
-- source
-- location
-- instrument
-- subject ref
-- continuity segment
-- checkpoint date
-- tax year where relevant
-
-These same partition keys are the basis for efficient recalculation. The system
-should rerun affected slices instead of replaying everything.
-
-### Materialized State And Snapshots
-
-Materialized state is allowed and encouraged where replay cost would otherwise
-become too high.
-
-Minimum materialization surfaces:
-
-- checkpoint state snapshots
-- reconciliation continuity summaries
-- position state snapshots where replay cost is material
-- tax pool and carry-forward state by tax year
-- validated posting aggregates where useful
-
-Rules:
-
-- materialized state is derived and replaceable
-- it does not replace source-of-truth history
-- it exists to keep calculation cost bounded
-
-### Reducer Design Rules
-
-Prefer:
-
-- linear or near-linear reducers over sorted subject streams
-- explicit link records instead of repeated inference
-- one-time normalization of ambiguous bridge data into later-stage structures
-- reuse of prior state outputs when valid
-
-Avoid:
-
-- repeated global joins across the full history
-- repeated scanning of unrelated sources or years
-- repeated evidence-level parsing during later-stage calculations
-- dynamic policy dispatch inside tight per-record loops
-
-### Tax Performance Rules
-
-Tax calculation should not recompute full acquisition history from scratch for
-every output row if bounded state is available.
-
-The design should support:
-
-- tax-year partitioning
-- carried-forward pool and state materialization
-- determinant grouping by subject and tax year
-- reuse of prior year-close state as next year-open state
-
-Policy selection should be resolved before execution, not as dynamic branching
-inside the hot loop.
-
-## Generic Core Requirements
-
-The core runtime must remain instrument-agnostic, source-agnostic,
-output-agnostic, and storage-neutral.
-
-Rules:
-
-- CoinTracking is an edge import, export, and oracle surface, not a runtime
-  dependency
-- crypto is the current filing scope, not the ontology center
-- persistence implements the model; it does not define the model
-- no wrapper lanes, compatibility shims, or legacy parallel runtime models
-  should survive after a clean replacement is ready
-- refactors should replace old structures cleanly when the new structure is
-  ready
-- tests and parity must be preserved or strengthened through refactors
-
-## Ontology And Identity Seams
-
-The future model should use this ontology explicitly.
-
-### Core Business Concepts
-
-- `Instrument`
-- `Position`
-- `Contract`
-- `Location`
-- `LegalOwner`
-- `BeneficialOwner`
-- `Counterparty`
-- `EconomicEvent`
-- `EconomicLeg`
-- `SettlementState`
-- `LifecycleEvent`
-- `Valuation`
-- `CheckpointAssertion`
-- `Posting`
-- `TaxInput`
-- `Gap`
-- `Readiness`
-
-### `Contract` Versus `Position`
-
-Do not collapse `Contract` and `Position`.
-
-- `Contract` is a specific agreement instance with terms
-- `Position` is an economic exposure or holding state that may arise from one
-  contract, many contracts, or no explicit contract
-
-### `SubjectRef`
-
-Use `SubjectRef` only for shared cross-stage infrastructure that needs a
-generic pointer.
-
-Minimum fields:
-
-- `subject_kind`
-- `subject_id`
-
-Initial supported `subject_kind` values:
-
-- `position`
-- `contract`
-
-Rules:
-
-- use `Contract` and `Position` explicitly in business logic and modeling
-- use `SubjectRef` only where shared infrastructure needs a generic pointer
-- do not use `SubjectRef` as an excuse to stop modeling the true concept
-
-### Bridge Classifications Versus The Final Ontology
-
-Current bridge classifications remain real and important, but they are not the
-full ontology.
-
-Rules:
-
-- current bridge classifications matter now
-- they remain valid bridge and rendering hints
-- they are not the long-term center of the model
-- future support for broader financial instruments should be driven by the core
-  ontology, not by activity-label expansion alone
+Trust and ownership rules:
+
+- evidence selection is deterministic before semantic commitment
+- claims preserve source-local meaning and explicit ambiguity
+- economic facts assert only economic truth the system can prove safely
+- reconciliation is the trust gate before checkpoint adoption, accounting, and
+  tax
+- checkpoint truth is accepted state with explicit acceptance basis
+- accounting expands and validates accepted truth; it does not repair truth
+- tax inputs assemble determinants from reconciled economics plus accepted
+  checkpoint truth
+- selected tax policies decide treatment in `TaxOutputs`; they do not decide
+  source meaning, reconciliation truth, checkpoint truth, or accounting truth
 
 ## Source, Output, Oracle, And Persistence Boundaries
 
 ### Source Boundaries
 
-- source adapters produce source-local evidence and claims
-- adapters may emit safe bridge hints only
+- source adapters produce source-local evidence and bridge outputs today, and
+  later source-local claims
+- adapters may emit only safe bridge hints and safe source-local meaning
 - adapters do not own reconciliation
 - adapters do not own checkpoint acceptance
 - adapters do not own accounting
@@ -1020,6 +150,123 @@ Rules:
 - repository ports remain the persistence seam
 - active SQLite rollout is deferred until after the filing-critical path is
   stable
+
+## Performance Rules
+
+The core pipeline must stay auditable, deterministic, replayable, and fast
+enough for large-scale calculation.
+
+### Hot Path
+
+Inner-loop calculations for:
+
+- reconciliation
+- checkpoint continuity
+- journal validation
+- tax computation
+
+must operate on compact typed records only.
+
+Hot-path data should include:
+
+- stable ids
+- timestamps and effective times
+- subject refs where the stage actually owns them
+- location refs
+- instrument refs
+- signed quantities
+- explicit link ids
+- explicit state transitions
+- valuations where computation requires them
+- minimal classification hints only where needed
+
+The hot path should not repeatedly join in:
+
+- full provenance detail
+- review records
+- large issue text
+- evidence metadata blobs
+- renderer metadata
+- adapter-local annotations that do not change computation
+
+Those belong in sidecars and explanation layers.
+
+### Deterministic Ordering
+
+Reducers must use stable ordering:
+
+- effective time when present
+- otherwise event timestamp
+- then deterministic tie-break keys such as source sequence, event id, or leg
+  id
+
+Rules:
+
+- reducers must be deterministic
+- replay must be consistent across runs
+- ordering must not depend on incidental file order
+
+### Partitioning
+
+Expensive recalculation must be partitionable by the dimensions the owning
+stage actually uses, including:
+
+- source
+- location
+- instrument
+- subject reference where applicable
+- continuity segment where applicable
+- checkpoint date where applicable
+- tax year where applicable
+
+Use derived reporting projections instead of forcing every stage to key every
+record by every dimension.
+
+### Materialized State
+
+Materialized derived state is allowed where replay cost would otherwise become
+too high.
+
+Typical surfaces include:
+
+- checkpoint state snapshots
+- reconciliation continuity summaries
+- position state snapshots where replay cost is material
+- tax pool and carry-forward state by tax year
+- validated posting aggregates where useful
+
+Derived state remains replaceable and does not replace source-of-truth history.
+
+### Reducer Design Rules
+
+Prefer:
+
+- linear or near-linear reducers over sorted subject streams
+- explicit link records instead of repeated inference
+- one-time normalization of ambiguous bridge data into later-stage structures
+- reuse of prior state outputs when valid
+
+Avoid:
+
+- repeated global joins across the full history
+- repeated scanning of unrelated sources or years
+- repeated evidence-level parsing during later-stage calculations
+- dynamic policy dispatch inside tight per-record loops
+
+### Tax Performance Rules
+
+Tax calculation should not recompute full acquisition history from scratch for
+every output row if bounded state is available.
+
+The design should support:
+
+- tax-year partitioning
+- carried-forward pool and state materialization
+- determinant grouping by subject and tax year
+- reuse of prior year-close state as next year-open state
+
+Policy selection should be resolved before execution, not as dynamic branching
+inside the hot loop.
 
 ## Tax Policy Architecture
 
@@ -1100,212 +347,6 @@ Tax policy may not decide:
 - prioritize the filing path for `2023`, `2024`, and `2025`
 - do not build a plugin platform
 
-## Package Ownership Guidance
-
-Keep package ownership direct and stage-oriented.
-
-Suggested long-term ownership:
-
-- `domain/evidence/`
-  - evidence observations, provenance primitives, and evidence-selection ids
-- `domain/claims/`
-  - source-local claim types and claim-owned ambiguity surfaces
-- `domain/economics/`
-  - economic events, legs, valuations, settlement, and lifecycle state
-- `domain/reconciliation/`
-  - links, continuity, readiness reducers, and checkpoint candidates
-- `domain/checkpoints/`
-  - checkpoint assertions, acceptance basis, and adopted opening state
-- `domain/accounting/`
-  - journals, entries, postings, and validation outputs
-- `domain/tax/`
-  - tax inputs, policy contracts, carry-forward state, and outputs
-
-Application ownership:
-
-- `application/intake/`
-  - capture planning, apply, and evidence selection
-- `application/evidence/`
-  - shared statement extraction and provenance locator handling
-- `application/profiling/`
-  - capture profile construction, inventory inspection, and timezone review
-- `application/normalization/`
-  - evidence-to-claim translation planning and bridge artifact production
-- `application/normalization/assembly/`
-  - deterministic merge of accepted capture outputs into assembled source
-    datasets
-- `application/reconciliation/`
-  - links, continuity, gaps, readiness, and checkpoint candidates
-- `application/checkpoints/`
-  - checkpoint evidence assembly, manual balance submission validation, and
-    checkpoint acceptance
-- `application/accounting/`
-  - journal expansion, validation, and summaries
-- `application/tax/`
-  - tax-input assembly, policy selection, and tax-output rendering
-- `application/outputs/`
-  - downstream renderer orchestration
-
-Boundary rules:
-
-- `interfaces/` orchestrates services only
-- `infrastructure/` implements ports
-- `application/` depends on domain and ports
-- `domain/` has no infrastructure imports
-
-## Rollout Summary Aligned With The Roadmap
-
-### Phase 0. Shared Foundations
-
-Deliver:
-
-- shared provenance family
-- shared gap model and taxonomy
-- shared readiness model and reducers
-- shared checkpoint-assertion vocabulary
-- explicit identity seams
-- `SubjectRef`
-- tax-policy selection contracts
-- alignment across architecture, roadmap, and migration docs
-
-Rules:
-
-- treat these as blocking shared foundations
-- do not let each stage invent its own blocker or status surface
-
-### Phase 1. Evidence And Claims
-
-Deliver:
-
-- formal `EvidenceSet`
-- formal `ClaimSet`
-- deterministic selection outputs
-- explicit selected, superseded, and blocked evidence outputs
-- explicit claim ambiguity rules
-- oracle reader contracts remain outside runtime
-- current output alias normalization where needed
-
-Rules:
-
-- current bridge remains active
-- do not introduce wrapper lanes
-- do not force ambiguous source rows into final facts prematurely
-
-### Phase 2. Fact-Path Follow-Through
-
-Deliver:
-
-- claim-to-economic compilation seam
-- continued use of `TransactionFact` as the row-level bridge until replacement
-  is ready
-- adapter stabilization on current contracts
-- planner artifacts before translation:
-  - candidates
-  - plan
-  - blocking issues
-- shared provenance locator family at artifact boundaries
-- semantic and replay parity checks for unchanged evidence
-
-Rules:
-
-- direct fact artifacts remain the only active runtime model
-- no parallel compatibility models
-- clean schema breaks are allowed when replacement is ready
-- unknown schema versions fail fast and recover by regeneration
-
-### Phase 3. Reconciliation
-
-Deliver:
-
-- exact balance assertion stability
-- transfer links
-- continuity windows
-- reconciliation-owned gaps
-- readiness slices
-- checkpoint candidates
-- corroboration sidecars
-- deterministic correction handling
-- independence from raw capture layout
-
-Rules:
-
-- reconciliation consumes facts plus checkpoint evidence
-- exact balance assertions are one surface, not the whole reconciliation
-  product
-- readiness must use the full shared slice definition
-
-### Phase 4. Checkpoints
-
-Deliver:
-
-- typed checkpoint contracts
-- checkpoint evidence requirements
-- manual balance submission as typed checkpoint-owned input
-- trust level and acceptance basis
-- checkpoint continuity reports
-- intentional opening-state adoption with provenance
-
-Rules:
-
-- operator-confirmed balances may support runtime progress
-- filing-ready checkpoints still require source-backed support
-
-### Phase 5. Accounting
-
-Deliver:
-
-- internal journal model
-- renderer port
-- Ledger CLI renderer
-- validation result artifacts
-- accounting-owned gaps
-- accounting summaries tied to reconciliation and checkpoints
-
-Rules:
-
-- accounting expands and validates accepted truth
-- accounting does not repair truth
-
-### Phase 6. Tax Inputs And First Policy
-
-Deliver:
-
-- `TaxInputs`
-- tax-policy registry and selection
-- Canada MVP policy
-- pooled ACB state
-- disposition outputs
-- income outputs
-- carry-forward and year summaries
-- unsupported tax-item outputs
-- tax-owned unresolved items
-
-Rules:
-
-- tax outputs flow from inputs through policy
-- remove wording that says tax outputs come directly from reconciled facts
-- tax inputs must be reproducible from reconciled economics plus accepted
-  checkpoint truth
-
-### Phase 7. Filing Workflow
-
-Deliver:
-
-- end-to-end filing workflow
-- checkpoint continuity gate
-- oracle comparison against historical CoinTracking outputs
-- explicit deferred-case capture
-- reproducible `2023`, `2024`, and `2025` outputs from workspace evidence
-
-### Phase 8. Transition Retirement And Later Storage
-
-Deliver later:
-
-- retirement of transition-only assumptions
-- broader policy coverage
-- SQLite-backed repositories behind existing ports
-- no semantic-model rewrite as part of storage rollout
-
 ## Filing-Critical Acceptance Criteria
 
 The system is filing-ready only when all of these are true:
@@ -1313,7 +354,7 @@ The system is filing-ready only when all of these are true:
 - a source-backed checkpoint exists near `2026-03-23`
 - no unresolved material reconciliation issues remain
 - no unresolved material unsupported tax items remain
-- Ledger CLI validation passes for supported activity
+- journal validation passes for supported activity
 - the forward-computed state from the `2023-08-05` historical oracle lands on
   the source-backed checkpoint
 - `2023`, `2024`, and `2025` outputs can be reproduced from workspace evidence
@@ -1359,70 +400,25 @@ Do not:
 - lightly rewrite GPL implementations and treat them as original
 - introduce heavy support libraries that fight the current typed architecture
 
-## Tests To Add
+## Rollout Alignment
 
-### Schema And Parsing
+The repo is moving from the current bridge toward the target stage contracts
+incrementally, not through a big-bang rewrite.
 
-- multi-leg transaction parsing
-- valuation provenance validation
-- CoinTracking alias normalization
-- correction and supersession chains
+Rollout rules:
 
-### Reconciliation
+- the current bridge remains the live runtime seam until a bounded slice lands
+  a cleaner replacement
+- no dual active runtime or compatibility-wrapper lane should survive once a
+  clean replacement is ready
+- current-state docs stay accurate about live bridge terms
+- target docs stay explicit about the intended end state without claiming it is
+  already implemented
+- when work affects architecture, sequencing, or trust-gate ownership, update
+  this page together with [ROADMAP.md](../../ROADMAP.md) and
+  [Migration Sequence](../status/migration-sequence.md)
 
-- transfer pairing across owned wallets and exchanges
-- exact balance assertion workflow over unified balance targets with
-  `source_document` precedence, optional `network_api` hydration, and
-  `operator_assertion` fallback
-- redistribution corrections
-- checkpoint balance assertions
-- forward continuity from oracle boundary to checkpoint
+The detailed implementation order lives in:
 
-### Accounting
-
-- journal posting generation
-- Ledger CLI parse and balance
-- supported commodity balances matching checkpoint outputs
-
-### Tax
-
-- pooled ACB updates
-- crypto-to-crypto dispositions
-- fee treatment in quote, base, and third asset
-- staking and reward income
-- derivatives and margin realized PnL
-- explicit unsupported-item logging
-
-## Initial Refactor Guidance
-
-Perform only the refactors required to support the new architecture:
-
-- split new domain concepts into dedicated packages rather than expanding
-  `domain/transactions/` or sibling domain capability packages
-- promote workflow helper clusters into a package once a third related sibling
-  would otherwise be added
-- introduce transaction facts before expanding tax services
-- replace normalized transaction artifacts directly while migrating downstream
-  services
-- remove normalized-transaction-first workflows once fact consumers land
-
-Do not:
-
-- add SQLite first
-- add a web UI
-- add generic workflow engines
-- re-centralize business rules in adapters
-- keep pushing new semantics into one `category` string
-
-## Time Summary
-
-AI-assisted estimate for the filing-critical path:
-
-- `106` to `164` hours
-
-AI-assisted estimate including open-source hardening:
-
-- `126` to `196` hours
-
-Those ranges assume focused implementation with the current repo standards,
-tests, and documentation discipline preserved.
+- [ROADMAP.md](../../ROADMAP.md)
+- [Migration Sequence](../status/migration-sequence.md)

--- a/docs/concepts/reconciliation-tax-architecture.md
+++ b/docs/concepts/reconciliation-tax-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: "Reconciliation And Tax Architecture"
-summary: "Design anchor for the provider-neutral reconciliation, accounting, checkpoint, and tax system."
+summary: "Design anchor for the current bridge, final pipeline products, performance rules, and filing-critical rollout."
 doc_type: concept
 audience: human
 owner: repo
@@ -10,17 +10,24 @@ nav_order: 20
 
 This document is the implementation anchor for evolving the repo away from
 tracker-dependent historical workflows and into an independent reconciliation,
-accounting, and Canadian tax computation system.
+checkpoint, accounting, and tax runtime.
 
-Use this plan when making structural decisions that affect normalization,
-checkpointing, journaling, or tax computation. Treat it as a design contract,
-not as a loose idea list.
+Use it when making structural decisions that affect normalization,
+reconciliation, checkpointing, journaling, or tax computation. Treat it as a
+design contract, not as a loose idea list.
 
-## Objective
+## Current Runtime Note
 
-Deliver a filing-ready `2023` to `2025` workflow without treating CoinTracking
-as a required runtime ledger or organizing model, while preserving the repo's
-current typing, layering, and evidence discipline.
+Current runtime truth remains:
+
+- typed application architecture under `src/tallylot/`
+- CLI and library only
+- filesystem-backed active storage
+- SQLite deferred behind interfaces and ports
+- provider-backed AI deferred behind interfaces and ports
+- raw evidence outside the repo in the external workspace
+
+The filing-critical output horizon remains `2023` through `2025`.
 
 The system must:
 
@@ -29,8 +36,8 @@ The system must:
   hard checkpoint
 - compute forward tax state for `2023` to `2025`
 - render a deterministic double-entry journal and require it to validate
-- surface unsupported or ambiguous facts as explicit issues
-- preserve one interface-neutral application surface so future CLI, HTTP/API,
+- surface unsupported or ambiguous truth as explicit issues, reviews, and gaps
+- preserve one interface-neutral application surface so future CLI, HTTP, API,
   and agent entrypoints can share the same typed workflows
 
 Normal runtime operation must stay platform-agnostic:
@@ -44,883 +51,192 @@ Normal runtime operation must stay platform-agnostic:
 - the internal engine should stay asset-class-agnostic so crypto, FX,
   securities, and similar surfaces can remain adapter- and policy-driven
 
-## Key Decisions
+## Active Bridge Note
+
+The current runtime bridge centers on:
+
+- `EconomicActivityDraft`
+- `TransactionFact`
+- `balance_snapshots.csv`
+- `balance_references.csv`
+
+That bridge is:
+
+- the live implementation seam
+- the current delivery path
+- the current parity baseline
+- not the final architecture center
+
+Current operational surfaces that remain part of runtime truth:
+
+- capture-scoped source profiling
+- capture-scoped normalization
+- planner-enabled normalization
+- translation input candidates, plan, and blocking issues
+- source assembly into `working/normalized/sources/<source>/`
+- shared statement extraction
+- statement-backed balance references
+- checkpoint-owned manual balance submission scaffolding and validation
+- checkpoint location inventory rebuild
+- offline-by-default balance inspection and checking
+- optional provider hydration through separate balance-provider adapters
+- replay validation
+- oracle comparison and verification workflows
+
+### Current Hard Runtime Rules
+
+- raw evidence stays outside the repo
+- normalization and profiling operate on one materialized raw capture root at a
+  time
+- planner-enabled adapters provide translation input candidates and the core
+  selects the winning plan
+- ambiguity blocks fact and balance artifact emission
+- assembled source datasets are the reconciliation input surface
+- provenance stays typed in runtime models and is flattened only at artifact
+  boundaries
+- operator-confirmed balance references may support runtime progress but do not
+  satisfy filing-ready checkpoint requirements alone
+- historical provider hydration remains separate from source adapters
+- runtime balance artifacts are `balance_snapshots.csv` and
+  `balance_references.csv`
+- schema-version mismatch is resolved by regeneration, not compatibility
+  wrappers
+
+### Current Bridge Contracts
+
+#### `TransactionFact`
+
+Current bridge contract includes:
+
+- identity:
+  - `fact_id`
+  - `source`
+  - `adapter_id`
+  - `provider_operation_key`
+  - `operation_group_id`
+  - `tx_hash`
+- time:
+  - `timestamp`
+  - optional `effective_at`
+  - optional `effective_precision`
+- participants:
+  - `location_id`
+- semantics:
+  - `economic_kind`
+  - `accounting_intent_hint`
+  - `tax_treatment_hint`
+  - optional `projection_hint`
+- economics:
+  - `legs`
+  - `FactLegPolicy`
+- metadata and status:
+  - `description`
+  - `raw_file`
+  - `raw_row_ref`
+  - `confidence`
+  - `status`
+
+#### `EconomicLeg`
+
+Current bridge contract includes:
+
+- `leg_id`
+- `kind`
+- `instrument_id`
+- `quantity`
+- optional `subtype`
+- optional `attributed_to_leg_id`
+- optional `location_id`
+
+#### `LegKind`
+
+Current values:
+
+- `primary`
+- `charge`
+- `rebate`
+- `collateral`
+- `settlement`
+- `financing`
+- `withholding`
+- `adjustment`
 
-### 1. Build Reconciliation Before Tax, With Accounting In Parallel
+#### `FactLegPolicy`
 
-The first major milestone after fact-path alignment is deterministic
-reconciliation, not ACB math. Minimal accounting projection should advance in
-parallel on the same shared facts.
+Current bridge rules to preserve:
 
-Reason:
+- per-kind limits
+- signed-count constraints
+- duplicate kinds prohibited
+- zero-primary support only when intentionally allowed
+- shared policy constants are part of the bridge contract
 
-- `2023-08-05` is a transaction cutoff, not a balance-guaranteed checkpoint
-- the best available checkpoint evidence is around `2026-03-23`
-- tax computation is not trustworthy until the fact set lands on a confirmed
-  checkpoint
-- accounting and reconciliation validate different properties of the same fact
-  set and should remain separate capabilities
+#### Temporal Precision
 
-### 2. Keep CoinTracking At The Edge
+Current rule to preserve:
 
-CoinTracking remains supported for:
+- exact time uses UTC-aware `*_at`
+- date-or-time uses `*_at` plus `*_precision`
 
-- one concrete CSV output adapter
-- historical regression through dev-only oracle tooling
+#### Schema Versioning
 
-CoinTracking must not remain the core ledger model, core schema vocabulary, or
-required runtime input surface. Production code may render CoinTracking CSV,
-but report readers, comparison tolerances, and oracle heuristics must stay
-outside `src/tallylot/`.
+Current rule to preserve:
 
-### 3. Replace The Current Transaction Center With A Richer Fact Model
+- fact artifacts are schema-versioned
+- unknown schema versions fail fast
+- regeneration from evidence is the recovery path
 
-The current normalized transaction model is too narrow for:
+#### `EconomicActivityDraft`
 
-- multi-leg transactions
-- collateral, loan, and liquidity flows
-- correction and supersession chains
-- valuation provenance
-- independent journaling
-- jurisdiction-neutral tax policy
+Current bridge responsibilities to preserve:
 
-The repo should introduce a new provider-neutral fact model and replace the
-current normalized transaction model directly. Do not add compatibility
-wrappers, parallel legacy names, or dual-write shims just to preserve the old
-shape.
+- stable draft identity
+- timestamp and temporal precision
+- location scope
+- `legs`
+- `FactLegPolicy`
+- provider operation key
+- grouped-row support
+- layered hints
+- provenance refs
+- review markers
+- confidence and status
 
-### 4. Use Layered Classification
+#### `SourceTranslationBatch`
 
-A single `category` string is not a stable center for the next phase.
+Current bridge bundle to preserve:
 
-Every transaction fact should support distinct classification layers:
+- drafts
+- balance references
+- balance reference issues
+- issues
+- reviews
+- location inventory
 
-- `EconomicKind`: provider-neutral semantics
-- `ProjectionHint`: output projection metadata for external renderers
-- `TaxTreatmentHint`: jurisdiction-neutral tax intent
-- `AccountingIntentHint`: accounting intent
+### Current Schema And Artifact Contracts
 
-These layered fields are the current fact-bridge contract, not a rule that
-every earlier stage must guess final policy meaning. When a provider row
-cannot safely support one final economic, accounting, or tax reading, the
-target `ClaimBundle` should preserve that ambiguity until one safe canonical
-economic fact or later stage-owned policy decision is available.
+#### Repo-Wide Temporal Precision Contract
 
-### 5. Keep The Core Runtime Asset-Class Agnostic
-
-The internal runtime should generalize across financial asset classes even when
-the current adapters and policies are crypto-first.
-
-Rules:
-
-- core facts, checkpoints, accounting, and tax seams should avoid
-  crypto-exclusive semantics unless the concept is truly crypto-specific
-- crypto, FX, securities, and later import or output surfaces should enter
-  through adapters and policy contracts rather than through domain renames or
-  special-case compatibility shims
-- repo, package, and CLI naming may remain stable for now; internal abstractions
-  should still be chosen so later generalization does not require another core
-  rewrite
-
-### 6. Keep The Ledger Replaceable
-
-Use Ledger CLI first because it is permissive, mature, and scriptable, but keep
-all journaling behind a renderer port so later Beancount or hledger adapters do
-not require domain refactors.
-
-### 7. Keep The Tax Layer Replaceable
-
-Implement Canadian capital-account handling first, but keep policy behind a tax
-policy port so future jurisdictions do not require a domain rewrite.
-
-### 8. Expand `pydantic` At Boundaries, Not In The Core Domain
-
-Use `pydantic` for:
-
-- config
-- external artifact parsing
-- manual balance submission row models
-- CoinTracking report row models
-- CLI or API request validation
-- adapter manifest validation
-
-Keep domain models as frozen dataclasses, enums, and value objects so business
-rules remain explicit and tool-friendly.
-
-### 9. Keep On-Chain Identity Identifier-Rooted And Output Labels Separate
-
-On-chain runtime location identity must be identifier-rooted and chain- or
-network-scoped rather than source-label-derived.
-
-Rules:
-
-- EVM-family owned locations use `evm:<network>:<address>`.
-- Native EVM-family assets use `asset:evm:<network>:native`.
-- Native NEAR assets use `asset:near:native`.
-- In-scope public-ledger adapters must emit native asset ids with immutable
-  chain identity directly; symbol-only public-ledger asset ids remain
-  unsupported for provider hydration until immutable asset identity is proven.
-- Non-EVM on-chain locations use their chain namespace such as
-  `near:<account>`, `bitcoin:<address>`, `tron:<address>`, or
-  `solana:<address>`.
-- Derived on-chain sublocations append a stable suffix such as
-  `near:<account>:staking`.
-- Friendly source labels, wallet names, and renderer-facing labels stay in
-  `source`, `location_label`, annotations, and output-adapter display logic.
-- Output adapters such as CoinTracking may render the source label for
-  on-chain facts, but they must not rewrite or own the runtime `location_id`.
-
-### 10. Route Source Families By Content And Block Mixed Captures
-
-Source-family ownership must be established by adapter-declared schema or
-content signatures before filename hints.
-
-Rules:
-
-- profiling records recognized file-family claims per file
-- translation should consume those family claims instead of rediscovering
-  provider filenames
-- path or filename hints are low-confidence tie-breakers only
-- if one raw source directory mixes incompatible adapter families, profiling
-  emits a blocking scan issue and normalization must refuse the capture
-- if a translation-capable adapter recognizes a supported family but emits no
-  facts and no explicit issues or reviews, normalization emits
-  `no_supported_activity` instead of silently succeeding
-
-### 11. Keep Capture Identity In Metadata, Not In Paths
-
-One intake run is one capture, regardless of how many statement months or
-export periods it contains.
-
-Rules:
-
-- use a stable `capture_uid` as the capture identity
-- use a human-readable `capture_label` only for the raw folder name
-- treat inferred periods and any inferred `capture_id` heuristics as metadata,
-  not as the routing key, grouping identity, or capture ownership model
-- keep all untouched upstream originals for the capture under one raw capture
-  root instead of repartitioning them into inferred month or year folders
-- use explicit capture registry records instead of overloading one source row
-  with a single `capture_path`
-
-### 12. Separate Capture Normalization From Source Assembly
-
-Normalization remains capture-scoped. Reconciliation becomes source-assembly
-scoped.
-
-Rules:
-
-- `source profile` and `source normalize` operate on exactly one materialized
-  raw capture root
-- both commands must fail explicitly when the input is not a valid
-  `evidence/raw/source/<source>/<capture_label>/` root with matching
-  `capture.json` metadata
-- capture-normalized outputs live under a capture-owned root
-- `source assemble` is the only supported bridge from accepted captures to the
-  reconciliation-ready source dataset
-- reconciliation reads only assembled source datasets, never raw capture trees
-  or ad hoc multi-capture crawls
-- duplicate, overlap-review, and superseded captures stay explicit in the
-  capture registry and are excluded from source assembly unless accepted
-
-### 13. Use One Shared Statement Extraction Capability
-
-Statement-backed evidence must not fork into separate normalization and
-checkpoint parsers.
-
-Rules:
-
-- add one shared application seam for statement extraction
-- let adapters contribute statement matching, parsing, and instrument-claim
-  resolution hooks through bounded plugin methods
-- use that shared service both when normalization emits source-backed balance
-  evidence and when `checkpoint extract-pdf-balances` is invoked directly
-- let the shared service own capture-inventory-backed document discovery,
-  ambiguity rules, typed provenance locator construction, and shared issue or
-  review handling rather than duplicating that orchestration in providers
-
-### 14. Keep Typed Provenance In Runtime Models
-
-Artifact rows need flattened provenance columns, but runtime models should keep
-one typed locator seam until the storage boundary.
-
-Rules:
-
-- keep capture-scoped provenance as a typed runtime concept
-- flatten provenance only in codecs and artifact writers
-- reuse one flattened locator family across balance evidence, issue rows,
-  review rows, and location inventory evidence rows
-- keep row or page anchors separate from file location rather than collapsing
-  them into one ad hoc string
-
-### 15. Make Source Assembly Deterministic And Rerun-Safe
-
-Source assembly owns one generated output surface per source and should rewrite
-that surface deterministically on rerun.
-
-Rules:
-
-- `source assemble` rewrites only its known generated artifacts under
-  `working/normalized/sources/<source>/`
-- reruns must remove stale generated files that no longer have source data
-- assembly lifecycle and source summary state must be derived by reducers from
-  capture registry state, not by ad hoc latest-write behavior
-
-### 16. Treat Semantic Workspace Validation As A First-Class Repo Capability
-
-The supported validation path is raw-evidence derivation, not migration
-wrappers.
-
-Rules:
-
-- validate semantic parity by deriving typed artifacts from raw evidence into
-  an initialized workspace
-- compare semantic parity, not path identity
-- ignore expected `capture_uid` and `capture_label` differences when two
-  workspaces are otherwise semantically identical
-- compare the semantic registry surface, raw completeness, assembled source
-  metrics, and reconciliation status counts
-- allow expected-difference fixtures only for declared issue-count or
-  review-count drift with an explicit reason
-- keep semantic parity validation in repo-native tooling under `tools/`
-- do not add one-off migration utilities or compatibility wrappers just to
-  preserve a superseded capture layout
-
-### 17. Keep Manual Balance Submission Checkpoint-Owned And Boundary-Validated
-
-Manual balance submission is a supported operational path for producing
-`balance_snapshots.csv` and `balance_references.csv`, but it is not an
-adapter-owned schema.
-
-Rules:
-
-- the user-facing package under
-  `working/supporting_artifacts/balance_submissions/<source>/` is a
-  checkpoint-owned pre-reconciliation input surface
-- `checkpoint scaffold-balance-submission` and `checkpoint submit-balances`
-  own that validation and materialization path inside
-  `application/checkpoints/`
-- the shared reconciliation schema still lives under the chosen output root,
-  normally `working/normalized/sources/<source>/`
-- `balance_snapshots.csv` and `balance_references.csv` are the only runtime
-  balance inputs; `balances.csv` and `balance_evidence.csv` are superseded
-  generated outputs and are not read at runtime, and no compatibility wrappers
-  or dual-read logic should keep them alive
-- manual submission records `operator_assertion` runtime references and must
-  not fabricate or widen source-backed `source_document` references
-- runtime reconciliation resolves references through one unified
-  `balance_references.csv` artifact with precedence
-  `source_document`, `network_api`, then `operator_assertion`
-- filing-ready checkpoint status still requires source-backed or otherwise
-  acceptable first-party references under the shared model
-- optional submitted `location_inventory.csv` improves cross-source
-  corroboration, but omitting it does not block source-local balance checks
-- manual submission must preserve explicit user-provided `instrument_id`
-  values and derive `location_id` values through shared runtime helpers rather
-  than hand-authored location identifiers
-- checkpoint submission row models stay validated at the boundary with
-  `pydantic` so malformed or unsupported rows fail with explicit issues
-
-### 18. Plan Translation Inputs In Core Before Adapter Translation
-
-Capture-scoped normalization must decide which raw source files are translated
-before adapter row translation runs.
-
-Rules:
-
-- adapters describe every valid translation input candidate for the capture,
-  including coverage, freshness, grouping, replaceability, and comparability
-  metadata
-- the core planner in `application/normalization/` selects the deterministic
-  candidate plan and records selected, superseded, and blocked outcomes before
-  translation begins
-- event-time coverage outranks path order, filename order, and discovery order
-- ambiguous overlap, incomparable candidates, unknown coverage, or unresolved
-  freshness ties are blocking normalization concerns, not adapter-local
-  heuristics
-- planner artifacts must preserve raw-input provenance explicitly through
-  candidate and decision outputs rather than hiding file selection inside
-  adapter code
-- migrated adapters translate only the selected plan; legacy adapters may stay
-  on the fallback `translate(...)` path until their candidate semantics are
-  modeled accurately
-- Coinbase is the first migrated adapter and future migrations should proceed
-  in stages from path-order or filename-order adapters toward richer grouped
-  multi-file inputs
-
-## Target Architecture
-
-Core abstractions added from this point forward must stay neutral enough to
-support multiple asset classes. If a term is only correct for one provider,
-chain, or asset class, keep it adapter-local unless the domain concept itself
-is inherently specific.
-
-### Canonical Pipeline Products
-
-The target runtime should converge on one canonical flow:
-
-`general intake -> surface reconciliation -> checkpoint adoption ->
-journal expansion -> tax expansion`
-
-Each stage narrows truth and then expands the next decision surface. Upstream
-stages preserve optionality. Downstream stages force specificity. No stage may
-guess a later-stage answer or suppress uncertainty that a later stage must
-still see.
-
-The canonical runtime products are:
-
-1. `EvidenceBundle`
-2. `ClaimBundle`
-3. `EconomicDataset`
-4. `ReconciliationDataset`
-5. `CheckpointPackage`
-6. `JournalDataset`
-7. `TaxDeterminantDataset`
-8. `TaxOutputDataset`
-
-Current runtime note:
-
-- today's `EconomicActivityDraft`, `TransactionFact`,
-  `balance_snapshots.csv`, and `balance_references.csv` remain the active
-  runtime center until the richer products land
-- treat those contracts as the current bridge into the target pipeline, not as
-  proof that the final architecture should stop at facts plus balances
-
-### Stage Contracts
-
-#### `EvidenceBundle`
-
-`EvidenceBundle` is the deterministic intake product.
-
-It should contain:
-
-- selected raw source artifacts
-- parsed boundary observations that remain source-local
-- capture and source assembly provenance
-- document, statement, and inventory observations
-- deterministic selection decisions and superseded or blocked alternatives
-
-It must promise:
-
-- deterministic evidence selection
-- stable provenance and locator references
-- no forced economic meaning
-- no forced tax, accounting, or reconciliation policy
-
-It may block only when:
-
-- source selection is nondeterministic
-- parsing cannot produce stable source-local observations
-- provenance is too unresolved to support later review
-
-#### `ClaimBundle`
-
-`ClaimBundle` is the source-local meaning layer.
-
-It should contain claims such as:
-
-- activity claims
-- balance observation claims
-- ownership and control claims
-- location claims
-- instrument identity claims
-- contract term claims
-- valuation claims
-- explicit issues and reviews
-
-It must promise:
-
-- source-local semantics only
-- preserved ambiguity when the source does not support one final reading
-- provenance for every emitted claim
-- candidate interpretations when one safe final meaning is not yet available
-
-Rules:
-
-- adapters may continue populating layered classifications on the current
-  runtime path when they are safe and deterministic
-- the target claim layer must allow unresolved economic, accounting, or tax
-  classification when forcing those fields would guess
-- `ClaimBundle` must be able to express materially unclassified rows instead of
-  coercing everything into one `EconomicKind`
-
-#### `EconomicDataset`
-
-`EconomicDataset` is the first canonical narrowing.
-
-It should contain only what the system can safely say happened economically.
-
-It must preserve enough determinants for later reconciliation, accounting, and
-tax work:
-
-- signed legs
-- instrument identity
-- contract instance identity when applicable
-- location identity
-- legal owner, beneficial owner, and counterparty identity when known
-- effective time and temporal precision
-- settlement and supersession links
-- optional valuation attachments with purpose and provenance
-- provenance, confidence, and ambiguity markers
-
-It must be able to express economically important surfaces beyond simple spot
-flows:
-
-- holdings movements
-- cash movements
-- obligations and rights
-- settlements
-- collateral state changes
-- financing flows
-- fees, rebates, and withholding
-- corrections and supersession chains
-- corporate actions and similar non-trade lifecycle events
-
-It may block only when:
-
-- a canonical fact would be false
-- identity is too unresolved to emit a stable canonical fact
-- the source collapses multiple materially different interpretations and the
-  ambiguity is not representable safely
-
-#### `ReconciliationDataset`
-
-`ReconciliationDataset` is the surface-reconciliation product.
-
-It should contain:
-
-- transfer and linkage decisions
-- balance targets, assertions, and continuity windows
-- missing funding or settlement legs
-- unresolved ownership transitions
-- cross-source corroboration sidecars
-- checkpoint candidates
-- reconciliation-owned issues, gaps, and readiness state
-
-It must promise:
-
-- explicit completeness and continuity decisions
-- explicit missing-leg and missing-evidence surfaces
-- partial truth preservation when full clean-state is not yet available
-- no rewriting of upstream economic truth to make a check pass
-
-Rules:
-
-- transfer linking belongs here, not in adapter translation
-- checkpoint continuity belongs here before checkpoint adoption is accepted
-- reconciliation may declare a subject or window unresolved, but it must not
-  erase a valid partial balance or partial economic fact
-
-#### `CheckpointPackage`
-
-`CheckpointPackage` is the formal handoff between reconstruction and later
-stateful work.
-
-It should contain:
-
-- accepted checkpoint assertions
-- adopted opening state when intentionally imported
-- supporting evidence and provenance
-- continuity decisions into the accepted checkpoint
-- explicit trust level and acceptance basis
-
-Rules:
-
-- keep checkpoint state as a first-class package boundary, not just a flag on
-  reconciliation output
-- source-backed evidence remains the preferred basis
-- operator assertions may support runtime reconciliation but do not satisfy the
-  filing-ready checkpoint requirement by themselves
-
-#### `JournalDataset`
-
-`JournalDataset` is the accounting expansion product.
-
-It should contain:
-
-- journal entries and postings
-- posting provenance back to reconciled economics
-- validation results
-- unsupported accounting coverage gaps
-
-It must promise:
-
-- deterministic posting expansion from accepted upstream truth
-- explicit balanced-versus-unbalanced validation
-- explicit unsupported accounting gaps
-
-Rules:
-
-- accounting is a validator and renderer, not a truth-repair stage
-- journal failures should surface upstream fact or reconciliation gaps instead
-  of inventing local repairs
-
-#### `TaxDeterminantDataset`
-
-`TaxDeterminantDataset` is the policy-ready tax input surface.
-
-It should contain:
-
-- acquisitions
-- dispositions
-- income events
-- financing costs
-- internal transfers
-- corporate actions
-- valuations required for tax computation
-- unresolved tax-owned gaps
-
-It must promise:
-
-- jurisdiction-neutral tax determinants, not final jurisdiction output
-- explicit basis-affecting state changes
-- explicit unresolved tax-specific blockers when reconciliation truth is
-  sufficient operationally but not yet sufficient for tax
-
-Rules:
-
-- tax operates on reconciled economics plus accepted checkpoint truth
-- journal output may corroborate tax readiness, but tax must not depend on a
-  journal renderer succeeding unless the missing accounting information exposes
-  a real upstream determinant gap
-- tax must never invent missing economics
-
-#### `TaxOutputDataset`
-
-`TaxOutputDataset` is the jurisdiction-specific result surface.
-
-It should contain:
-
-- jurisdiction summaries
-- schedules and forms
-- carry-forward state
-- explicit unsupported or deferred outputs
-
-### Shared Sidecars
-
-Every canonical product should reuse the same sidecar families.
-
-#### Provenance
-
-- one typed runtime provenance model
-- flatten only at storage or export boundaries
-- keep evidence locators and row or page anchors distinct
-
-#### Gaps
-
-Use one cross-stage gap contract rather than stage-local ad hoc issue shapes.
-
-Every gap record should declare at least:
-
-- `gap_id`
-- `owner_stage`
-- `blocking_for_stage`
-- `subject_ref`
-- `gap_kind`
-- `known_facts`
-- `missing_determinants`
-- `candidate_interpretations`
-- `required_evidence`
-- `allowed_resolution_methods`
-- `recommended_next_action`
-- `confidence`
-- `materiality`
-- `provenance_refs`
-
-`gap_kind` should stay explicit and closed over a controlled taxonomy such as:
-
-- missing_evidence
-- unresolved_identity
-- unresolved_linkage
-- contradiction
-- policy_required_determination
-- operator_override_required
-
-#### Readiness
-
-Use one readiness vocabulary across the pipeline:
-
-- `semantic_ready`
-- `reconciliation_ready`
-- `checkpoint_ready`
-- `accounting_ready`
-- `tax_ready`
-
-Rules:
-
-- readiness must be sliceable by subject and time window, not just summarized
-  once per whole dataset
-- support at least source, location, instrument, position or contract,
-  continuity segment, and checkpoint date slices
-- dataset-level readiness is a reducer output over subject-level readiness, not
-  the primary stored truth
-
-#### Checkpoints
-
-- one checkpoint assertion vocabulary
-- one accepted checkpoint package surface
-- one trust-level model that distinguishes source-backed, network-backed, and
-  operator-backed support
-
-### MVP Delivery Guardrails
-
-The MVP should be intentionally narrow without painting the system into a
-corner.
-
-Rules:
-
-- keep the current fact-plus-balances bridge as the active delivery path until a
-  richer stage contract is needed by the next concrete slice
-- land new stage products only when they unlock a real filing-critical or
-  architecture-blocking behavior
-- prefer one bounded reducer, compiler, or dataset contract per stage over
-  building a general framework for every future variation up front
-- do not build a full contract-lifecycle or multi-asset engine before an
-  in-scope workflow needs that capability
-- keep unsupported surfaces explicit through gaps instead of speculative partial
-  implementations
-- prioritize the filing-critical `2023` to `2025` reconstruction path even when
-  choosing generic names and seams that can later generalize beyond crypto
-- treat replaceable seams as typed ports and contracts, not as plugin systems
-  that exist before a second concrete implementation needs them
-
-### Generic Core Requirements
-
-The shared core must stay broad enough for crypto, FX, securities, debt,
-options, futures, staking derivatives, loans, funds, and later non-crypto
-instruments without reshaping the engine.
-
-The core should standardize concepts such as:
-
-- `Instrument`
-- `InstrumentTraits`
-- `ContractInstance`
-- `ContractTerms`
-- `PositionState`
-- `OwnershipScope`
-- `Counterparty`
-- `EconomicEvent`
-- `EconomicLeg`
-- `Observation`
-- `Link`
-- `CheckpointAssertion`
-- `Valuation`
-- `Posting`
-- `TaxDeterminant`
-
-The core must not assume the world is only:
-
-- exchanges
-- wallets
-- chain transfers
-- coin categories
-- tracker-specific row types
-
-### Identity Requirements
-
-Cross-stage logic should keep identity layers explicit instead of overloading
-one id field for several concerns.
-
-The target pipeline should keep separate runtime seams for:
-
-- instrument identity
-- contract instance identity
-- location identity
-- legal owner identity
-- beneficial owner identity
-- counterparty identity
-
-Location and instrument identity remain foundational runtime contracts. Later
-reconciliation, checkpoint, accounting, and tax work should add the remaining
-identity layers as first-class seams instead of collapsing them into
-descriptions or adapter-local metadata.
-
-### Domain Packages
-
-- `domain/transactions/`
-  - transaction facts, legs, valuations, ids, corrections, projection enums
-- `domain/balances/`
-  - balance targets, snapshots, references, assertions, and selection rules
-- `domain/accounting/`
-  - journal entries, postings, balance checks, journal intents
-- `domain/tax/`
-  - tax records, pool state, policy contracts, unsupported tax items
-
-### Application Capabilities
-
-- `application/intake/`
-  - manifest generation plus capture-scoped intake planning and apply
-    workflows
-- `application/evidence/`
-  - shared statement extraction, provenance locators, and document-family
-    recognition
-- `application/profiling/`
-  - capture profile construction, inventory inspection, and timezone review
-- `application/normalization/`
-  - orchestrate one capture's translation-input planning, translation into fact
-    artifacts, source-backed evidence, and fact-backed balance packages through
-    `application/balances`
-- `application/balances/`
-  - target planning, snapshot derivation, reference resolution, exact-balance
-    inspection and check workflows, cross-source corroboration, summary and
-    blocker assembly, and deterministic merge policy
-- `application/normalization/assembly/`
-  - deterministic merge of accepted capture outputs into assembled
-    source-scoped normalization datasets
-- `application/reconciliation/`
-  - reserve for transfer linking, checkpoint continuity, correction and
-    supersession chains, and higher-order reconciliation beyond exact balance
-    assertions over assembled source datasets
-- `application/checkpoints/`
-  - build source-backed checkpoint evidence, validate manual balance
-    submission packages, and assemble checkpoint-supporting wallet aggregates
-- `application/accounting/`
-  - journal assembly, ledger validation, and accounting summaries
-- `application/tax/`
-  - policy application, ACB updates, and disposition or income outputs
-- `application/outputs/`
-  - render external artifacts from facts, journals, or tax results
-
-### Interfaces
-
-- `interfaces/cli/`
-  - current operator-facing entry points over application capabilities
-- `interfaces/api/`
-  - reserve for a future thin HTTP or agent-facing surface over the same typed
-    application workflows
-
-Rules:
-
-- CLI, API, and agent entrypoints should share use-case contracts instead of
-  growing separate orchestration logic.
-- Application request and response DTOs should trend toward transport-safe
-  resource references so a future API does not inherit raw filesystem `Path`
-  assumptions as its public contract.
-- Long-running workflows should expose explicit job or artifact references at
-  the interface boundary rather than relying on shell-owned temporary paths.
-
-### Ports
-
-- typed source translation contracts under `ports/source_translation.py`
-- typed fact and evidence repositories under `ports/facts.py` and
-  `ports/evidence.py`
-- typed adapter contracts under `ports/source_adapters.py`,
-  `ports/output_adapters.py`, and `ports/adapter_contracts.py`
-- future journal, checkpoint, and tax ports by capability instead of generic
-  catch-all storage contracts
-
-### Adapter Responsibilities
-
-- source adapters translate raw exports into the shared adapter draft model and
-  surface explicit issues or reviews
-- output adapters render facts into CoinTracking, Ledger CLI, and report
-  artifacts
-- source adapters return `SourceTranslationBatch`; they do not emit output
-  rows, checkpoint decisions, or tax policy decisions directly
-- planner-enabled source adapters describe translation input candidates and
-  translate only the selected plan; they do not choose winning files
-  independently once they opt into the planner contract
-- CoinTracking-specific column defaults, `Tx-ID` behavior, and row-shape
-  metadata stay inside the CoinTracking output adapter package rather than in
-  provider-local source code
-- CoinTracking rendering must validate that a fact stays within the adapter's
-  published render policy rather than truncating richer legs silently
-- adapters do not own tax logic, checkpoint policy, or reconciliation rules
-- adapters should stay focused on source/output translation. Core data
-  manipulation, verification, and workflow policy belong in application and
-  domain code.
-- application services own derived-balance assembly. Adapters return balance
-  references only when the source actually provides them.
-- normalization owns production statement-backed `source_document` references
-  for supported providers through the shared statement extraction seam.
-  Adapters may publish quantity evidence through
-  `SourceTranslationBatch.balance_references`, but market-value totals and
-  other valuation-only rows are not balance assertions.
-- adapters may declare numeric precision expectations for source fields when
-  decimal scale is part of the source contract. Shared adapter support should
-  validate displayed raw-text fractional digits and support exact or minimum
-  scale checks so rounded export values are surfaced explicitly rather than
-  normalized silently.
-
-## Input And Oracle Boundaries
-
-The platform-agnostic core must distinguish between operational inputs and
-optional support artifacts.
-
-### Normal Runtime Inputs
-
-These are valid operational inputs for reconstruction, reconciliation, and tax
-computation:
-
-- source-platform exports
-- wallet and explorer exports
-- statements and balance evidence
-- deterministic checkpoint packages intentionally created by this system
-- opening-state imports intentionally adopted as checkpoints
-
-### Optional External Input Formats
-
-These may be supported through adapters, but the system must not require them
-for normal operation:
-
-- CoinTracking trade-table style imports
-- CoinTracking CSV import/export shapes
-- other portfolio-tracker import formats added later through adapters
-
-### Oracle-Only Support Artifacts
-
-These are comparison inputs only:
-
-- CoinTracking `Roll Forward in CAD`
-- CoinTracking `Realized Gain or Loss in CAD`
-- CoinTracking `Average Purchase Price`
-- CoinTracking `Double-entry`
-- historical CoinTracking tax reports
-
-Do not wire business logic so these artifacts are required to reconstruct facts,
-balances, journal entries, or tax state. Keep oracle code outside
-`src/tallylot/`, preferably under `tools/oracles/`.
-
-### Boundary Rule
-
-If every CoinTracking tax report disappeared, the system should still be able
-to:
-
-- normalize source evidence
-- build checkpoints
-- reconcile balances
-- compute tax state
-- render journal output
-
-The only lost capability should be comparison against the external oracle.
-
-## Schema Contract
-
-### Repo-Wide Temporal Precision Contract
-
-- Use one timing convention everywhere in the repo:
-  - exact-time fields use UTC-aware `*_at` values
-  - fields that may be date-only or exact-time use `*_at` plus
-    `*_precision`
+- use one timing convention everywhere in the repo:
+  - exact-time fields use UTC-aware `*_at`
+  - fields that may be date-only or exact-time use `*_at` plus `*_precision`
 - `*_precision` uses one shared enum with at least:
   - `timestamp`
   - `date`
-- Date-only values are stored distinctly from exact timestamps even when an
-  exact timestamp falls at midnight.
-- Adapters are responsible for preserving this distinction at translation time.
-- Infer precision from the source contract and parsed field shape, not from the
-  normalized clock value. An exact midnight timestamp remains `timestamp`
-  precision; a date-only source value remains `date` precision.
-- New domain and port fields must adopt this convention instead of introducing
-  provider-local date flags, boolean precision markers, or mixed string shapes.
+- date-only values are stored distinctly from exact timestamps even when an
+  exact timestamp falls at midnight
+- adapters are responsible for preserving this distinction at translation time
+- infer precision from the source contract and parsed field shape, not from the
+  normalized clock value
 
-### Current Fact-Shape Contract
+#### Current Fact-Shape Contract
 
-- `TransactionFact` and `EconomicActivityDraft` use one shared `legs` tuple.
-- Fact construction requires successful identifier resolution to exactly one
-  `InstrumentId`. Unresolved or ambiguous identity must emit review output and a
-  blocking issue rather than guessing.
-- Every leg carries:
+- `TransactionFact` and `EconomicActivityDraft` use one shared `legs` tuple
+- fact construction requires successful identifier resolution to exactly one
+  `InstrumentId`
+- unresolved or ambiguous identity must emit review output and a blocking issue
+  rather than guessing
+- every leg carries:
   - stable `leg_id`
   - signed `quantity`
   - semantic `LegKind`
@@ -929,8 +245,8 @@ The only lost capability should be comparison against the external oracle.
 - signed quantities use one meaning everywhere:
   - positive increases the balance of the leg location
   - negative decreases the balance of the leg location
-- `attributed_to_leg_id` is valid only on non-`primary` legs and only when
-  it references one concrete leg in the same fact.
+- `attributed_to_leg_id` is valid only on non-`primary` legs and only when it
+  references one concrete leg in the same fact
 - `FactLegPolicy` is generic and per-kind:
   - `LegShapeLimit` declares `min_count`, `max_count`, `min_positive_count`,
     `max_positive_count`, `min_negative_count`, and `max_negative_count`
@@ -939,7 +255,7 @@ The only lost capability should be comparison against the external oracle.
   - signed-count limits cannot exceed per-kind totals
   - unspecified kinds are disallowed
   - zero-`primary` shapes are opt-in through the declared policy
-- Current shared policy constants cover:
+- current shared policy constants cover:
   - single-primary activity
   - two-sided primary exchange
   - two-sided primary exchange with one `charge`
@@ -951,48 +267,42 @@ The only lost capability should be comparison against the external oracle.
   - no other non-primary leg kinds
   - renderers derive inbound and outbound adapter concepts from sign
 
-### Current Normalization Window Contract
+#### Current Normalization Window Contract
 
-- Runtime timestamps are timezone-aware UTC in drafts, facts, balance
-  snapshots, and balance references. Persisted artifact timestamp text remains
-  `YYYY-MM-DD HH:MM:SS` and is interpreted as UTC on read.
-- Fields that may be date-only or exact-time persist both `*_at` and
-  `*_precision` so exact midnight timestamps remain distinguishable from
-  date-only values.
+- runtime timestamps are timezone-aware UTC in drafts, facts, balance
+  snapshots, and balance references
+- persisted artifact timestamp text remains `YYYY-MM-DD HH:MM:SS` and is
+  interpreted as UTC on read
+- fields that may be date-only or exact-time persist both `*_at` and
+  `*_precision`
 - `facts.csv` is schema-versioned and readers fail fast on unexpected
-  `schema_version` values; re-deriving artifacts from raw evidence is the
-  supported recovery path after fact-shape breaks.
+  `schema_version` values
 - `balance_snapshots.csv` and `balance_references.csv` persist `instrument_id`
   values and use `target_at` plus `target_precision`; balance references also
-  persist `observed_at` plus `observed_precision`.
-- cross-source balance corroboration is additive in the first release. It
-  consumes normalized balance snapshots plus `location_inventory.csv`, writes
-  sidecar corroboration artifacts, and does not redefine the primary
-  source-local clean-date gate yet.
-- Windowed normalization applies to:
+  persist `observed_at` plus `observed_precision`
+- cross-source balance corroboration is additive in the first release
+- windowed normalization applies to:
   - `facts.csv`
   - `fact_annotations.json`
   - `balance_snapshots.csv`
   - `exceptions.csv`
   - `normalization_reviews.csv`
-- Windowed normalization does not apply to:
+- windowed normalization does not apply to:
   - `balance_references.csv`
   - `location_inventory.csv`
-- source-scope portfolio evidence that does not itself prove wallet ownership,
-  such as MetaMask portfolio CSV rows, may contribute balance evidence only for
-  same-source same-chain rows and must remain explicitly caveated as
-  source-folder-scoped rather than globally authoritative identity proof.
-- Review records carry `context_timestamp`, dataset-level untimed reviews stay
+- source-scope portfolio evidence that does not itself prove wallet ownership
+  may contribute balance evidence only under constrained same-source same-chain
+  rules and must remain explicitly caveated
+- review records carry `context_timestamp`, dataset-level untimed reviews stay
   visible when a window is active, and summaries report
-  `reviews_outside_normalization_window`.
+  `reviews_outside_normalization_window`
 
-### Capture And Assembly Contract
+#### Capture And Assembly Contract
 
 - raw capture roots use `evidence/raw/source/<source>/<capture_label>/`
 - capture metadata stores the stable `capture_uid`, intake timestamps,
   manifest fingerprint, and workspace-relative refs
-- untouched upstream originals stay under the raw capture root even when they
-  are statements, HTML exports, ZIP archives, or required sidecars
+- untouched upstream originals stay under the raw capture root
 - `working/supporting_artifacts/` is limited to derived or operator-authored
   helper material
 - capture-normalized outputs live under
@@ -1005,7 +315,7 @@ The only lost capability should be comparison against the external oracle.
   `capture_uid`, with human-readable labels and roots treated as optional
   report fields rather than as the key
 
-### Transitional Adapter Draft Seam
+#### Transitional Adapter Draft Seam
 
 Source normalization should translate through `EconomicActivityDraft` until all
 adapters emit `TransactionFact` artifacts directly.
@@ -1043,278 +353,958 @@ Rules:
   affected activity and must surface both review output and a blocking issue
 - shared fact builders may derive `TransactionFact` objects from drafts, but
   that derivation stays in shared support rather than provider-local code
-- shared support stays adapter-agnostic and registry-driven; adapters publish
-  manifests, translation registries, and provider-local coverage metadata
-- one shared fact builder owns draft-to-fact conversion
+- shared support stays adapter-agnostic and registry-driven
 - draft-only provenance references and review markers must survive compilation
   through a fact-keyed sidecar artifact instead of being dropped
 - one shared projection mapper owns the mapping from layered classifications
   into concrete output-adapter row types
-- one shared projection mapper owns CoinTracking CSV row construction
 - grouped operations and provider-local export families must resolve through
   explicit translation registries, not ad hoc adapter entry-point branching
 
-### Core Fact Model
+## Final Naming Mapping Note
 
-Add `TransactionFact` as the new system-of-record object.
+Forward-looking architecture and rollout docs use these final names:
 
-Required fields:
+| Current target-doc term | Final term |
+| --- | --- |
+| `EvidenceBundle` | `EvidenceSet` |
+| `ClaimBundle` | `ClaimSet` |
+| `EconomicDataset` | `EconomicFacts` |
+| `ReconciliationDataset` | `ReconciliationState` |
+| `CheckpointPackage` | `Checkpoint` |
+| `JournalDataset` | `Journal` |
+| `TaxDeterminantDataset` | `TaxInputs` |
+| `TaxOutputDataset` | `TaxOutputs` |
 
-- identity
-  - internal id
-  - source id
-  - adapter id
-  - external ids
-  - tx hash
-- time
-  - event timestamp
-  - optional `effective_at`
-  - optional `effective_precision`
-  - timestamp provenance
-  - timestamp precision
-- participants
-  - account
-  - wallet
-  - optional counterparty hints
-  - ownership scope
-- economics
-  - `tuple[EconomicLeg, ...]`
-  - legs use `InstrumentId`
-  - legs carry stable `leg_id`
-  - legs use signed `quantity: Decimal`
-  - explicit per-kind leg-shape policy
-  - optional grouped correction or bundle links
-  - beneficial ownership change classification
-- valuation
-  - `tuple[Valuation, ...]`
-  - currency, amount, method, provenance, confidence
-- projection and policy hints
-  - optional `ProjectionHint`
-  - optional `TaxTreatmentHint`
-  - optional `AccountingIntentHint`
+Current bridge and status docs may continue using current implementation terms
+where accuracy requires them. Target architecture docs should use the final
+names after the mapping is established.
+
+Target-direction internal rename guidance:
+
+| Current bridge term | Target-direction name |
+| --- | --- |
+| `EconomicActivityDraft` | `ActivityClaim` |
+| `EconomicLegDraft` | `LegClaim` |
+| `ActivityDraftSeed` | `ActivitySeed` |
+| `TransactionFact` | `EconomicEvent` |
+| `FactSemantics` | `ClassificationHints` |
+| `FactLegPolicy` | `LegPolicy` |
+| `LegShapeLimit` | `LegCountLimit` |
+| `EconomicKind` | `EventKind` |
+| `ProjectionHint` | `OutputHint` |
+| `AccountingIntentHint` | `AccountingHint` |
+| `TaxTreatmentHint` | `TaxHint` |
+| `SourceTranslationBatch` | `TranslationResult` |
+
+These are target-direction names, not claims that the current code already uses
+them.
+
+## Target Pipeline Products And Stage Meanings
+
+The target runtime pipeline is:
+
+`EvidenceSet -> ClaimSet -> EconomicFacts -> ReconciliationState -> Checkpoint -> Journal -> TaxInputs -> TaxOutputs`
+
+Design rules:
+
+- upstream stages preserve optionality
+- downstream stages force specificity only when they own the decision
+- no stage may guess a later-stage answer
+- no stage may suppress uncertainty that a later stage must still see
+- no stage may duplicate upstream semantic payloads unless the meaning has
+  changed
+
+### `EvidenceSet`
+
+Purpose:
+
+- deterministic intake output before semantic commitment
+
+Contains:
+
+- selected source artifacts
+- source-local parsed observations
+- provenance
+- document, statement, and inventory observations
+- selected, superseded, and blocked alternatives
+- deterministic selection decisions
+
+Must guarantee:
+
+- deterministic selection
+- stable provenance and locators
+- no forced economic meaning
+- no forced reconciliation, accounting, or tax decisions
+
+### `ClaimSet`
+
+Purpose:
+
+- source-local meaning layer before economic truth is fixed
+
+Contains:
+
+- activity claims
+- balance claims
+- ownership claims
+- location claims
+- instrument claims
+- contract claims
+- valuation claims
+- candidate interpretations
+- claim-owned issues and reviews
+
+Must guarantee:
+
+- source-local semantics only
+- preserved ambiguity where one safe final interpretation is unavailable
+- provenance for every claim
+
+Must not:
+
+- force unresolved meaning into final economic or policy interpretations
+
+### `EconomicFacts`
+
+Purpose:
+
+- economic truth the system can safely assert
+
+Contains:
+
+- economic events
+- economic legs
+- instrument identity
+- contract identity where relevant
+- position identity where relevant
+- owner and counterparty identity where known
+- temporal precision
+- settlement and supersession links
+- valuations
+- confidence and ambiguity markers
+
+Must support:
+
+- holdings movements
+- cash movements
+- obligations and rights
+- settlements
+- collateral changes
+- financing flows
+- fees, rebates, and withholding
+- corrections and supersession chains
+- corporate actions
+- restructurings
+- lifecycle-heavy activity
+
+Must not:
+
+- collapse to spot-trade assumptions
+- let output hints drive core behavior
+
+### `ReconciliationState`
+
+Purpose:
+
+- completeness, linkage, continuity, checkpoint candidates, and
+  reconciliation-owned gaps
+
+Contains:
+
+- transfer links
+- balance targets and assertions
+- continuity windows
+- missing funding and settlement legs
+- unresolved ownership transitions
+- corroboration sidecars
+- checkpoint candidates
+- reconciliation-owned gaps
+- readiness slices
+
+Must guarantee:
+
+- explicit completeness decisions
+- explicit continuity decisions
+- explicit missing-leg and missing-evidence surfaces
+- preservation of partial truth when the whole window is not yet clean
+- no rewriting of upstream truth to satisfy checks
+
+### `Checkpoint`
+
+Purpose:
+
+- accepted checkpoint truth and acceptance basis
+
+Contains:
+
+- accepted checkpoint assertions
+- adopted opening state when intentionally used
+- supporting evidence and provenance
+- continuity decisions into accepted state
+- trust level and acceptance basis
+
+Must guarantee:
+
+- accepted checkpoint truth is first-class
+- source-backed evidence remains preferred
+- operator assertions do not silently become filing-ready checkpoint truth
+
+### `Journal`
+
+Purpose:
+
+- accounting expansion and validation
+
+Contains:
+
+- journal entries and postings
+- provenance back to accepted upstream truth
+- validation results
+- accounting-owned gaps
+
+Must guarantee:
+
+- deterministic posting expansion
+- explicit validation
+- explicit unsupported accounting coverage
+
+Must not:
+
+- become a truth repair layer
+
+### `TaxInputs`
+
+Purpose:
+
+- policy-ready, jurisdiction-neutral tax input surface
+
+Contains:
+
+- acquisitions
+- dispositions
+- income events
+- financing costs
+- internal transfers
+- corporate actions
+- tax-relevant valuations
+- basis or pool state transitions
+- tax-owned unresolved items
+
+Must guarantee:
+
+- jurisdiction-neutral determinants
+- explicit basis-affecting state changes
+- explicit tax-owned blockers where upstream truth is not tax-complete
+
+### `TaxOutputs`
+
+Purpose:
+
+- one selected tax policy's outputs
+
+Contains:
+
+- summaries
+- forms and schedules
+- carry-forward state
+- unsupported or deferred outputs
+- policy-specific notes
+
+Must guarantee:
+
+- outputs are derived from `TaxInputs` through selected tax policies
+- outputs are never described as coming directly from `EconomicFacts` or
+  `ReconciliationState`
+
+## Shared Cross-Stage Contracts
+
+These contracts should be defined once and reused everywhere.
+
+### Provenance
+
+Use one typed provenance model.
+
+Rules:
+
+- typed in runtime models
+- flattened only at artifact boundaries
+- file and member identity kept separate from row and page anchors
+- capture identity kept separate from display labels and file paths
+
+### Gaps
+
+Use one shared gap model.
+
+Minimum fields:
+
+- `gap_id`
+- `owner_stage`
+- `blocking_for_stage`
+- `subject_ref`
+- `gap_kind`
+- `known_facts`
+- `missing_inputs`
+- `candidate_interpretations`
+- `required_evidence`
+- `allowed_resolution_methods`
+- `recommended_next_action`
+- `confidence`
+- `materiality`
+- `provenance_refs`
+
+Minimum taxonomy:
+
+- `missing_evidence`
+- `unresolved_identity`
+- `unresolved_linkage`
+- `contradiction`
+- `policy_required_determination`
+- `operator_override_required`
+
+### Readiness
+
+Use one exact readiness vocabulary:
+
+- `semantic_ready`
+- `reconciliation_ready`
+- `checkpoint_ready`
+- `accounting_ready`
+- `tax_ready`
+
+Readiness is sliceable by:
+
+- source
+- location
+- instrument
+- subject ref
+- continuity segment
+- checkpoint date
+- tax year where relevant
+
+Rules:
+
+- this exact slice definition must stay identical everywhere it appears
+- when a stage needs to distinguish `Contract` from `Position`, it must do so
+  explicitly through the referenced `SubjectRef`
+- dataset readiness is derived from subject-level reducers, not stored as the
+  only truth
+
+### Identity
+
+Keep these identity seams separate:
+
+- instrument identity
+- contract identity
+- position identity
+- location identity
+- legal owner identity
+- beneficial owner identity
+- counterparty identity
+
+### Valuation
+
+Valuation is first-class.
+
+Fields:
+
+- amount
+- currency
+- purpose
+- timestamp
+- precision
+- source
+- confidence
+- provenance
+
+### Checkpoint Assertions
+
+Use one shared checkpoint-assertion vocabulary across reconciliation,
+checkpoints, accounting, and tax.
+
+## Anti-Duplication And Sidecar Rules
+
+Copy only when meaning changes.
+
+Meaning:
+
+- one stage owns one semantic payload
+- downstream stages reference upstream records by stable ids
+- downstream stages add stage-owned outputs only
+
+Keep these first-class:
+
+- economic events
+- economic legs
+- identities
+- ownership state
+- settlement and lifecycle state
+- valuations
+- checkpoint assertions
+- postings
+- tax inputs
+
+Use sidecars only for:
+
+- provenance
+- gaps
+- readiness
+- reviews
 - annotations
-  - fact-keyed provenance and review-marker sidecar for draft-only metadata
-- status
-  - unsupported flag
-  - ambiguity flag
-  - review-required flag
+- comparison traces
+- policy explanations
 
-### Supporting Types
+Sidecars must never become:
 
+- the only real copy of business meaning
+- a substitute for missing entities
+- a junk drawer of unresolved text
+
+Performance implication:
+
+- avoiding semantic duplication is also a performance rule
+- repeated full payloads increase read amplification, join cost, and drift risk
+- the correct shape is stable ids plus stage-owned deltas
+
+Storage implication:
+
+- this structure maps cleanly to future database storage
+- first-class records become base tables
+- sidecars become linked tables keyed by stable ids
+- flattening belongs to storage and export codecs
+- runtime models remain typed and normalized
+
+## Performance And Calculation-Path Rules
+
+The core pipeline must stay auditable, deterministic, replayable, and fast
+enough for large-scale calculation.
+
+### Hot Path
+
+Inner-loop calculations for:
+
+- reconciliation
+- checkpoint continuity
+- journal validation
+- tax computation
+
+must operate on compact typed records only.
+
+Hot-path data should include:
+
+- event ids
+- timestamps and effective times
+- subject refs
+- location refs
+- instrument refs
+- signed quantities
+- explicit link ids
+- explicit state transitions
+- valuations where computation requires them
+- minimal classification hints only where needed
+
+The hot path should not repeatedly join in:
+
+- full provenance detail
+- review records
+- large issue text
+- evidence metadata blobs
+- renderer metadata
+- adapter-local annotations that do not change computation
+
+Those belong in sidecars and explanation layers.
+
+### Deterministic Ordering
+
+Reducers must use stable ordering:
+
+- effective time when present
+- otherwise event timestamp
+- then deterministic tie-break keys such as source sequence, event id, or leg
+  id
+
+Rules:
+
+- reducers must be deterministic
+- replay must be consistent across runs
+- ordering must not depend on incidental file order
+
+### Partitioning
+
+Expensive processing must be partitionable by:
+
+- source
+- location
+- instrument
+- subject ref
+- continuity segment
+- checkpoint date
+- tax year where relevant
+
+These same partition keys are the basis for efficient recalculation. The system
+should rerun affected slices instead of replaying everything.
+
+### Materialized State And Snapshots
+
+Materialized state is allowed and encouraged where replay cost would otherwise
+become too high.
+
+Minimum materialization surfaces:
+
+- checkpoint state snapshots
+- reconciliation continuity summaries
+- position state snapshots where replay cost is material
+- tax pool and carry-forward state by tax year
+- validated posting aggregates where useful
+
+Rules:
+
+- materialized state is derived and replaceable
+- it does not replace source-of-truth history
+- it exists to keep calculation cost bounded
+
+### Reducer Design Rules
+
+Prefer:
+
+- linear or near-linear reducers over sorted subject streams
+- explicit link records instead of repeated inference
+- one-time normalization of ambiguous bridge data into later-stage structures
+- reuse of prior state outputs when valid
+
+Avoid:
+
+- repeated global joins across the full history
+- repeated scanning of unrelated sources or years
+- repeated evidence-level parsing during later-stage calculations
+- dynamic policy dispatch inside tight per-record loops
+
+### Tax Performance Rules
+
+Tax calculation should not recompute full acquisition history from scratch for
+every output row if bounded state is available.
+
+The design should support:
+
+- tax-year partitioning
+- carried-forward pool and state materialization
+- determinant grouping by subject and tax year
+- reuse of prior year-close state as next year-open state
+
+Policy selection should be resolved before execution, not as dynamic branching
+inside the hot loop.
+
+## Generic Core Requirements
+
+The core runtime must remain instrument-agnostic, source-agnostic,
+output-agnostic, and storage-neutral.
+
+Rules:
+
+- CoinTracking is an edge import, export, and oracle surface, not a runtime
+  dependency
+- crypto is the current filing scope, not the ontology center
+- persistence implements the model; it does not define the model
+- no wrapper lanes, compatibility shims, or legacy parallel runtime models
+  should survive after a clean replacement is ready
+- refactors should replace old structures cleanly when the new structure is
+  ready
+- tests and parity must be preserved or strengthened through refactors
+
+## Ontology And Identity Seams
+
+The future model should use this ontology explicitly.
+
+### Core Business Concepts
+
+- `Instrument`
+- `Position`
+- `Contract`
+- `Location`
+- `LegalOwner`
+- `BeneficialOwner`
+- `Counterparty`
+- `EconomicEvent`
 - `EconomicLeg`
-- `InstrumentIdentityClaim`
-- `EffectiveTime`
-- `TemporalPrecision`
+- `SettlementState`
+- `LifecycleEvent`
 - `Valuation`
-- `TransferLink`
-- `BalanceAssertion`
-- `CorrectionRecord`
 - `CheckpointAssertion`
-- `JournalEntryModel`
 - `Posting`
-- `TaxComputationRecord`
-- `UnsupportedTaxItem`
+- `TaxInput`
+- `Gap`
+- `Readiness`
 
-### Required Enums
+### `Contract` Versus `Position`
 
-Lock these early:
+Do not collapse `Contract` and `Position`.
 
-- `EconomicKind`
-- `LegKind`
-- `OwnershipChange`
-- `ValuationMethod`
-- `CorrectionReason`
-- `ProjectionHint`
-- `TaxTreatmentHint`
-- `AccountingIntentHint`
+- `Contract` is a specific agreement instance with terms
+- `Position` is an economic exposure or holding state that may arise from one
+  contract, many contracts, or no explicit contract
 
-## Current CoinTracking Adapter Contract
+### `SubjectRef`
 
-### Full Type Surface
+Use `SubjectRef` only for shared cross-stage infrastructure that needs a
+generic pointer.
 
-Lock the current CoinTracking output taxonomy now so the projection metadata
-used by that adapter does not churn later.
+Minimum fields:
 
-Trade types:
+- `subject_kind`
+- `subject_id`
 
-- `Trade`
-- `Margin Trade`
-- `Derivatives / Futures Trade`
+Initial supported `subject_kind` values:
 
-Incoming types:
+- `position`
+- `contract`
 
-- `Deposit`
-- `Income`
-- `Gift / Tip`
-- `Reward / Bonus`
-- `Mining`
-- `Airdrop`
-- `Staking`
-- `Masternode`
-- `Minting`
-- `Mining (commercial)`
-- `Dividends Income`
-- `Lending Income`
-- `Interest Income`
-- `Derivatives / Futures Profit`
-- `Margin Profit`
-- `LP Rewards`
-- `Airdrop (non taxable)`
-- `Receive Loan`
-- `Remove Collateral`
-- `Remove Liquidity`
-- `Receive LP Token`
-- `Other Income`
-- `Income (non taxable)`
+Rules:
 
-Outgoing types:
+- use `Contract` and `Position` explicitly in business logic and modeling
+- use `SubjectRef` only where shared infrastructure needs a generic pointer
+- do not use `SubjectRef` as an excuse to stop modeling the true concept
 
-- `Withdrawal`
-- `Spend`
-- `Donation`
-- `Gift`
-- `Stolen`
-- `Lost`
-- `Borrowing Fee`
-- `Settlement Fee`
-- `Margin Loss`
-- `Margin Fee`
-- `Derivatives / Futures Loss`
-- `Provide Liquidity`
-- `Return LP Token`
-- `Other Fee`
-- `Other Expense`
-- `Expense (non taxable)`
-- `Add Collateral`
-- `Repay Loan`
-- `Liquidation`
+### Bridge Classifications Versus The Final Ontology
 
-### Oracle And Projection Notes
+Current bridge classifications remain real and important, but they are not the
+full ontology.
 
-- normalize label aliases such as `Gift / Tip` and `Gift/Tip`
-- treat Double-entry report labels such as `Deposit (IN)` as report-only labels,
-  not core transaction labels
-- preserve optional CoinTracking valuation and `Tx-ID` fields inside
-  CoinTracking-only projection adapters
+Rules:
 
-### Oracle Inputs To Support
+- current bridge classifications matter now
+- they remain valid bridge and rendering hints
+- they are not the long-term center of the model
+- future support for broader financial instruments should be driven by the core
+  ontology, not by activity-label expansion alone
 
-Add dedicated readers for:
+## Source, Output, Oracle, And Persistence Boundaries
 
-- `Trade Table`
-- `Trade List`
-- `Double-entry`
-- `Roll Forward in CAD`
-- `Realized Gain or Loss in CAD`
-- `Average Purchase Price`
+### Source Boundaries
 
-Use these for comparison and regression only. Do not normalize them into the
-same source-fact path as exchange and wallet exports.
+- source adapters produce source-local evidence and claims
+- adapters may emit safe bridge hints only
+- adapters do not own reconciliation
+- adapters do not own checkpoint acceptance
+- adapters do not own accounting
+- adapters do not own tax policy
 
-Keep them in dev-only tooling under `tools/oracles/` so production state does
-not depend on their presence.
+### Output Boundaries
 
-## Delivery Sequence
+- renderers consume downstream-owned products
+- renderer-specific constraints stay at the edge
+- CoinTracking row rules remain output-adapter concerns only
 
-### Phase 0. Design Lock And Migration Plan
+### Oracle Boundaries
 
-Estimated effort: `8` to `12` hours
+- CoinTracking import and export shapes may be supported at the edge
+- CoinTracking reports remain oracle-only
+- oracle parsing remains outside `src/tallylot/`
+- the system must still reconstruct, reconcile, checkpoint, journal, and
+  compute taxes if CoinTracking tax reports disappear
 
-Deliverables:
+### Crypto Boundaries
 
-- final schema, package, and stage-boundary decisions
-- roadmap updates
-- migration plan from the current fact bridge into the canonical pipeline
-- shared provenance, gap, readiness, and checkpoint-vocabulary decisions
-- provenance policy for external ideas and direct code reuse
+- crypto is the current filing scope
+- crypto is not the ontology center
+- crypto-specific language belongs at adapter, policy, or output edges unless
+  fundamentally required
+- the core remains broad enough for non-crypto support later
 
-### Phase 1. Evidence And Claim Foundations Plus Oracle Readers
+### Persistence Boundaries
 
-Estimated effort: `14` to `22` hours
+- persistence implements the model
+- persistence does not define the model
+- no core runtime type relies on filesystem path, CSV row order, or export
+  shape as identity
+- raw evidence remains file-backed even after future database adoption
+- repository ports remain the persistence seam
+- active SQLite rollout is deferred until after the filing-critical path is
+  stable
 
-Deliverables:
+## Tax Policy Architecture
 
-- deterministic `EvidenceBundle` and `ClaimBundle` contracts for the next
-  pipeline slice
-- claim ambiguity rules and shared gap or readiness foundations
-- Pydantic row models for CoinTracking report families
-- parser services for all oracle exports under `tools/oracles/`
-- projection-type enum and alias normalization for current output adapters
-- comparison-ready artifact contracts
+Typed tax-policy selection is a foundation seam, not an afterthought.
 
-### Phase 2. Core Fact Model And Direct Normalization Replacement
+### Required Contracts
 
-Estimated effort: `18` to `28` hours
+- `TaxPolicyId`
+- `TaxPolicyDescriptor`
+- `TaxPolicy`
+- `TaxPolicyRegistry`
+- `ApplyTaxPoliciesRequest`
+- `ApplyTaxPoliciesResponse`
 
-Deliverables:
+### `TaxPolicyDescriptor`
 
-- transaction fact domain package
+Must include:
+
+- stable id
+- display name
+- jurisdiction or regime code
+- supported years or periods
+- supported output families
+- version
+- limitations
+- status:
+  - `supported`
+  - `partial`
+  - `experimental`
+  - `deferred`
+
+### `TaxPolicy`
+
+Consumes:
+
+- one `TaxInputs`
+- one execution context
+
+Produces:
+
+- one `TaxOutputs`
+- tax-owned gaps
+- unsupported or deferred outputs
+
+### Selection Semantics
+
+- one run may select one or more policy ids
+- all selected policies run independently against the same input set
+- one policy's unsupported coverage does not invalidate another's results
+- unknown policy ids fail request validation immediately
+- missing explicit selection and missing configured default also fail
+  validation
+- configured defaults live only at application, config, and interface
+  boundaries
+- the core must not assume one default jurisdiction
+
+### Tax-Stage Ownership
+
+Tax policy may decide:
+
+- jurisdiction-specific treatment
+- basis rules
+- carry-forward rules
+- output structure
+
+Tax policy may not decide:
+
+- source meaning
+- economic truth
+- reconciliation truth
+- checkpoint truth
+- accounting truth
+
+### MVP Tax Scope
+
+- keep the seam general
+- implement Canada MVP first
+- prioritize the filing path for `2023`, `2024`, and `2025`
+- do not build a plugin platform
+
+## Package Ownership Guidance
+
+Keep package ownership direct and stage-oriented.
+
+Suggested long-term ownership:
+
+- `domain/evidence/`
+  - evidence observations, provenance primitives, and evidence-selection ids
+- `domain/claims/`
+  - source-local claim types and claim-owned ambiguity surfaces
+- `domain/economics/`
+  - economic events, legs, valuations, settlement, and lifecycle state
+- `domain/reconciliation/`
+  - links, continuity, readiness reducers, and checkpoint candidates
+- `domain/checkpoints/`
+  - checkpoint assertions, acceptance basis, and adopted opening state
+- `domain/accounting/`
+  - journals, entries, postings, and validation outputs
+- `domain/tax/`
+  - tax inputs, policy contracts, carry-forward state, and outputs
+
+Application ownership:
+
+- `application/intake/`
+  - capture planning, apply, and evidence selection
+- `application/evidence/`
+  - shared statement extraction and provenance locator handling
+- `application/profiling/`
+  - capture profile construction, inventory inspection, and timezone review
+- `application/normalization/`
+  - evidence-to-claim translation planning and bridge artifact production
+- `application/normalization/assembly/`
+  - deterministic merge of accepted capture outputs into assembled source
+    datasets
+- `application/reconciliation/`
+  - links, continuity, gaps, readiness, and checkpoint candidates
+- `application/checkpoints/`
+  - checkpoint evidence assembly, manual balance submission validation, and
+    checkpoint acceptance
+- `application/accounting/`
+  - journal expansion, validation, and summaries
+- `application/tax/`
+  - tax-input assembly, policy selection, and tax-output rendering
+- `application/outputs/`
+  - downstream renderer orchestration
+
+Boundary rules:
+
+- `interfaces/` orchestrates services only
+- `infrastructure/` implements ports
+- `application/` depends on domain and ports
+- `domain/` has no infrastructure imports
+
+## Rollout Summary Aligned With The Roadmap
+
+### Phase 0. Shared Foundations
+
+Deliver:
+
+- shared provenance family
+- shared gap model and taxonomy
+- shared readiness model and reducers
+- shared checkpoint-assertion vocabulary
+- explicit identity seams
+- `SubjectRef`
+- tax-policy selection contracts
+- alignment across architecture, roadmap, and migration docs
+
+Rules:
+
+- treat these as blocking shared foundations
+- do not let each stage invent its own blocker or status surface
+
+### Phase 1. Evidence And Claims
+
+Deliver:
+
+- formal `EvidenceSet`
+- formal `ClaimSet`
+- deterministic selection outputs
+- explicit selected, superseded, and blocked evidence outputs
+- explicit claim ambiguity rules
+- oracle reader contracts remain outside runtime
+- current output alias normalization where needed
+
+Rules:
+
+- current bridge remains active
+- do not introduce wrapper lanes
+- do not force ambiguous source rows into final facts prematurely
+
+### Phase 2. Fact-Path Follow-Through
+
+Deliver:
+
 - claim-to-economic compilation seam
-- normalization result evolution to emit fact artifacts directly
-- downstream service updates to consume fact artifacts without wrappers
-- parity tests for current adapters
+- continued use of `TransactionFact` as the row-level bridge until replacement
+  is ready
+- adapter stabilization on current contracts
+- planner artifacts before translation:
+  - candidates
+  - plan
+  - blocking issues
+- shared provenance locator family at artifact boundaries
+- semantic and replay parity checks for unchanged evidence
 
-### Phase 3. Reconciliation Dataset And Checkpoint Packages
+Rules:
 
-Estimated effort: `18` to `28` hours
+- direct fact artifacts remain the only active runtime model
+- no parallel compatibility models
+- clean schema breaks are allowed when replacement is ready
+- unknown schema versions fail fast and recover by regeneration
 
-Deliverables:
+### Phase 3. Reconciliation
 
-- exact balance assertion artifacts comparing derived snapshots to source-backed
-  evidence
-- transfer linking
-- balance assertions
-- reconciliation dataset with explicit readiness, link, and continuity outputs
-- checkpoint builder around `2026-03-23`
-- accepted checkpoint package and trust-basis contracts
-- continuity reports
-- deterministic correction handling for events such as the GALA redistribution
+Deliver:
 
-### Phase 4. Journal Dataset And Ledger CLI Hard Gate
+- exact balance assertion stability
+- transfer links
+- continuity windows
+- reconciliation-owned gaps
+- readiness slices
+- checkpoint candidates
+- corroboration sidecars
+- deterministic correction handling
+- independence from raw capture layout
 
-Estimated effort: `14` to `22` hours
+Rules:
 
-Deliverables:
+- reconciliation consumes facts plus checkpoint evidence
+- exact balance assertions are one surface, not the whole reconciliation
+  product
+- readiness must use the full shared slice definition
+
+### Phase 4. Checkpoints
+
+Deliver:
+
+- typed checkpoint contracts
+- checkpoint evidence requirements
+- manual balance submission as typed checkpoint-owned input
+- trust level and acceptance basis
+- checkpoint continuity reports
+- intentional opening-state adoption with provenance
+
+Rules:
+
+- operator-confirmed balances may support runtime progress
+- filing-ready checkpoints still require source-backed support
+
+### Phase 5. Accounting
+
+Deliver:
 
 - internal journal model
+- renderer port
 - Ledger CLI renderer
-- journal validation results
-- accounting coverage gaps
-- accounting summaries tied to checkpoint and reconciliation outputs
+- validation result artifacts
+- accounting-owned gaps
+- accounting summaries tied to reconciliation and checkpoints
 
-### Phase 5. Tax Determinants And Canadian Tax MVP
+Rules:
 
-Estimated effort: `24` to `36` hours
+- accounting expands and validates accepted truth
+- accounting does not repair truth
 
-Deliverables:
+### Phase 6. Tax Inputs And First Policy
 
-- tax determinant dataset contracts
-- Canadian pooled ACB engine
-- disposition and income outputs
-- unsupported-item and ambiguity reporting
-- carry-forward and year summary outputs for `2023`, `2024`, and `2025`
+Deliver:
 
-### Phase 6. Filing Workflow And Closeout
+- `TaxInputs`
+- tax-policy registry and selection
+- Canada MVP policy
+- pooled ACB state
+- disposition outputs
+- income outputs
+- carry-forward and year summaries
+- unsupported tax-item outputs
+- tax-owned unresolved items
 
-Estimated effort: `10` to `16` hours
+Rules:
 
-Deliverables:
+- tax outputs flow from inputs through policy
+- remove wording that says tax outputs come directly from reconciled facts
+- tax inputs must be reproducible from reconciled economics plus accepted
+  checkpoint truth
 
-- filing-ready workflow
+### Phase 7. Filing Workflow
+
+Deliver:
+
+- end-to-end filing workflow
 - checkpoint continuity gate
-- CoinTracking oracle comparison for tax outputs
-- roadmap capture for deferred cases
+- oracle comparison against historical CoinTracking outputs
+- explicit deferred-case capture
+- reproducible `2023`, `2024`, and `2025` outputs from workspace evidence
 
-### Phase 7. Open-Source Hardening
+### Phase 8. Transition Retirement And Later Storage
 
-Estimated effort: `20` to `32` hours
+Deliver later:
 
-Deliverables:
-
-- sanitized fixtures
-- clearer licensing and provenance docs
-- public-facing scope description
-- generalized docs for non-personal use
+- retirement of transition-only assumptions
+- broader policy coverage
+- SQLite-backed repositories behind existing ports
+- no semantic-model rewrite as part of storage rollout
 
 ## Filing-Critical Acceptance Criteria
 
@@ -1339,7 +1329,7 @@ Default materiality rules:
   aggregate
 - do not auto-waive `CAD`, `BTC`, `ETH`, or stablecoins
 
-Unsupported or ambiguous facts must produce explicit outputs and roadmap items.
+Unsupported or ambiguous truth must produce explicit outputs and roadmap items.
 Do not guess on:
 
 - superficial loss treatment
@@ -1410,8 +1400,7 @@ Perform only the refactors required to support the new architecture:
 - split new domain concepts into dedicated packages rather than expanding
   `domain/transactions/` or sibling domain capability packages
 - promote workflow helper clusters into a package once a third related sibling
-  would otherwise be added; do not let facts, checkpoints, or tax policy land
-  in new flat prefix piles
+  would otherwise be added
 - introduce transaction facts before expanding tax services
 - replace normalized transaction artifacts directly while migrating downstream
   services

--- a/docs/concepts/transaction-classification.md
+++ b/docs/concepts/transaction-classification.md
@@ -1,6 +1,6 @@
 ---
 title: "Transaction Classification"
-summary: "Canonical layered classification vocabulary for facts, projections, accounting, and tax."
+summary: "Canonical layered classification vocabulary for the current fact-path bridge and later policy stages."
 doc_type: concept
 audience: human
 owner: repo
@@ -8,13 +8,26 @@ status: active
 nav_order: 40
 ---
 
-Use this document to lock the current canonical classification vocabulary
-before deeper fact, checkpoint, accounting, and tax work lands.
+Use this document to lock the current layered classification vocabulary on the
+fact-path bridge before deeper claim, checkpoint, accounting, and tax work
+lands.
 
 The current runtime now writes `TransactionFact` artifacts, and the canonical
 layered terms live in `domain/transactions/classification.py`. Adapters should
-populate layered classifications first. Output adapters own any mapping from
-fact metadata into external row types such as the CoinTracking `Type` column.
+populate layered classifications first on the current fact-path bridge when
+those classifications are safe and deterministic. Output adapters own any
+mapping from fact metadata into external row types such as the CoinTracking
+`Type` column.
+
+Target-pipeline note:
+
+- layered classifications belong to canonical economic facts, not to raw
+  evidence selection
+- the target `ClaimBundle` layer may remain materially unclassified when
+  forcing one final `EconomicKind`, `TaxTreatmentHint`, or
+  `AccountingIntentHint` would guess
+- when that target claim layer lands, keep the unresolved meaning explicit in
+  claims until one safe canonical economic fact can be emitted
 
 Naming convention:
 
@@ -25,8 +38,10 @@ Naming convention:
 ## Classification Layers
 
 - `EconomicKind`: provider-neutral semantic meaning
-- `TaxTreatmentHint`: default tax intent used by later policy layers
-- `AccountingIntentHint`: default accounting intent used by later journal renderers
+- `TaxTreatmentHint`: default tax intent used by later policy layers when it is
+  already safe to say on the current fact bridge
+- `AccountingIntentHint`: default accounting intent used by later journal
+  expansion when it is already safe to say on the current fact bridge
 - `ProjectionHint`: output projection metadata for concrete renderers
 
 Core behavior should not key primarily on the legacy normalized `category`
@@ -69,7 +84,13 @@ aligned on these values exactly.
 
 ## Runtime Rules
 
-- Adapters populate layered classifications first.
+- Adapters populate layered classifications first on the current bridge path
+  only when the classification is safe and deterministic.
+- The target claim layer may preserve unresolved meaning instead of forcing a
+  final fact classification too early.
+- Missing tax or accounting intent must not force lower layers to guess.
+  Preserve unresolved meaning in claims and let later accounting- or tax-owned
+  gaps carry the remaining policy blockers.
 - Runtime consumers operate on canonical `legs` only; there is no split
   `fee_legs` lane and no first-leg compatibility view on `TransactionFact`.
 - Leg-level semantics live on the leg through `LegKind`; fact classification
@@ -80,8 +101,12 @@ aligned on these values exactly.
   business behavior.
 - Machine-oriented runtime values should stay lowercase snake_case even when an
   output adapter renders them as title-style labels.
-- If an adapter cannot determine a safe layered classification, it must emit an
-  explicit issue instead of guessing.
+- If an adapter cannot determine a safe layered classification on the current
+  fact bridge, it must emit an explicit blocking issue or review instead of
+  guessing.
+- When the target claim layer lands, that same unresolved meaning should remain
+  explicit in `ClaimBundle` until one safe canonical economic fact or later
+  stage-owned policy decision is available.
 
 ## Review Triggers
 
@@ -89,6 +114,8 @@ Require explicit review when:
 
 - the fact could be either a transfer or a taxable disposition
 - the fact changes beneficial ownership but not obvious tax treatment
+- the economic meaning is safe enough for reconciliation, but tax treatment
+  still depends on later policy-owned determinants
 - a provider row collapses financing, trading, and fee semantics into one record
 - a future activity type would require a new classification value rather than a
   safe mapping into the current canonical set

--- a/docs/concepts/transaction-classification.md
+++ b/docs/concepts/transaction-classification.md
@@ -1,6 +1,6 @@
 ---
 title: "Transaction Classification"
-summary: "Canonical layered classification vocabulary for the current fact-path bridge and later policy stages."
+summary: "Layered classification vocabulary for the current fact-path bridge and later policy stages."
 doc_type: concept
 audience: human
 owner: repo
@@ -12,8 +12,8 @@ Use this document to lock the current layered classification vocabulary on the
 fact-path bridge before deeper claim, checkpoint, accounting, and tax work
 lands.
 
-The current runtime now writes `TransactionFact` artifacts, and the canonical
-layered terms live in `domain/transactions/classification.py`. Adapters should
+The current runtime now writes `TransactionFact` artifacts, and the layered
+bridge terms live in `domain/transactions/classification.py`. Adapters should
 populate layered classifications first on the current fact-path bridge when
 those classifications are safe and deterministic. Output adapters own any
 mapping from fact metadata into external row types such as the CoinTracking
@@ -21,13 +21,24 @@ mapping from fact metadata into external row types such as the CoinTracking
 
 Target-pipeline note:
 
-- layered classifications belong to canonical economic facts, not to raw
-  evidence selection
-- the target `ClaimBundle` layer may remain materially unclassified when
-  forcing one final `EconomicKind`, `TaxTreatmentHint`, or
-  `AccountingIntentHint` would guess
-- when that target claim layer lands, keep the unresolved meaning explicit in
-  claims until one safe canonical economic fact can be emitted
+- layered classifications belong to bridge facts today, not to raw evidence
+  selection
+- the future `ClaimSet` layer may remain materially unclassified when forcing
+  one final `EconomicKind`, `TaxTreatmentHint`, or `AccountingIntentHint`
+  would guess
+- bridge classifications remain important now, but they are not the whole
+  future ontology
+- when the future claim layer lands, keep unresolved meaning explicit until one
+  safe final economic fact can be emitted or a later stage owns the decision
+
+Target-direction naming note:
+
+- current code still uses `EconomicKind`, `ProjectionHint`,
+  `AccountingIntentHint`, and `TaxTreatmentHint`
+- forward-looking docs point toward the future names `EventKind`,
+  `OutputHint`, `AccountingHint`, and `TaxHint`
+- use the current names when describing the live bridge contract and the future
+  names only when describing the target architecture beyond the bridge
 
 Naming convention:
 
@@ -50,12 +61,12 @@ string.
 ## Support Tiers
 
 - `T1`: implemented and supported in the current runtime
-- `T2`: explicitly planned, but not yet part of the canonical runtime enum set
+- `T2`: explicitly planned, but not yet part of the current runtime enum set
 - `T3`: output-specific or future-policy work
 
-## Current Canonical Mapping
+## Current Runtime Mapping
 
-These are the currently implemented canonical mappings. Code and docs must stay
+These are the currently implemented bridge mappings. Code and docs must stay
 aligned on these values exactly.
 
 | Normalized Category | ProjectionHint | EconomicKind | TaxTreatmentHint | AccountingIntentHint | Tier | Notes |
@@ -91,7 +102,7 @@ aligned on these values exactly.
 - Missing tax or accounting intent must not force lower layers to guess.
   Preserve unresolved meaning in claims and let later accounting- or tax-owned
   gaps carry the remaining policy blockers.
-- Runtime consumers operate on canonical `legs` only; there is no split
+- Runtime consumers operate on bridge `legs` only; there is no split
   `fee_legs` lane and no first-leg compatibility view on `TransactionFact`.
 - Leg-level semantics live on the leg through `LegKind`; fact classification
   remains a separate fact-level layer.
@@ -105,7 +116,7 @@ aligned on these values exactly.
   fact bridge, it must emit an explicit blocking issue or review instead of
   guessing.
 - When the target claim layer lands, that same unresolved meaning should remain
-  explicit in `ClaimBundle` until one safe canonical economic fact or later
+  explicit in `ClaimSet` until one safe economic fact or later
   stage-owned policy decision is available.
 
 ## Review Triggers
@@ -118,4 +129,4 @@ Require explicit review when:
   still depends on later policy-owned determinants
 - a provider row collapses financing, trading, and fee semantics into one record
 - a future activity type would require a new classification value rather than a
-  safe mapping into the current canonical set
+  safe mapping into the current bridge set

--- a/docs/concepts/transaction-classification.md
+++ b/docs/concepts/transaction-classification.md
@@ -1,6 +1,6 @@
 ---
 title: "Transaction Classification"
-summary: "Layered classification vocabulary for the current fact-path bridge and later policy stages."
+summary: "Bridge-only classification vocabulary for the current fact-path bridge."
 doc_type: concept
 audience: human
 owner: repo
@@ -12,47 +12,39 @@ Use this document to lock the current layered classification vocabulary on the
 fact-path bridge before deeper claim, checkpoint, accounting, and tax work
 lands.
 
-The current runtime now writes `TransactionFact` artifacts, and the layered
-bridge terms live in `domain/transactions/classification.py`. Adapters should
-populate layered classifications first on the current fact-path bridge when
-those classifications are safe and deterministic. Output adapters own any
-mapping from fact metadata into external row types such as the CoinTracking
-`Type` column.
+This page owns the current bridge classification vocabulary only.
 
-Target-pipeline note:
+Current runtime note:
 
-- layered classifications belong to bridge facts today, not to raw evidence
-  selection
-- the future `ClaimSet` layer may remain materially unclassified when forcing
-  one final `EconomicKind`, `TaxTreatmentHint`, or `AccountingIntentHint`
-  would guess
-- bridge classifications remain important now, but they are not the whole
-  future ontology
-- when the future claim layer lands, keep unresolved meaning explicit until one
-  safe final economic fact can be emitted or a later stage owns the decision
+- the current runtime writes `TransactionFact` artifacts
+- the layered bridge terms live in `domain/transactions/classification.py`
+- adapters should populate bridge classifications only when those
+  classifications are safe and deterministic
+- output adapters own the mapping from bridge metadata into external row types
+  such as the CoinTracking `Type` column
 
-Target-direction naming note:
+Target-direction note:
 
-- current code still uses `EconomicKind`, `ProjectionHint`,
-  `AccountingIntentHint`, and `TaxTreatmentHint`
-- forward-looking docs point toward the future names `EventKind`,
-  `OutputHint`, `AccountingHint`, and `TaxHint`
-- use the current names when describing the live bridge contract and the future
-  names only when describing the target architecture beyond the bridge
+- bridge classifications remain important now, but they are not the full
+  long-term ontology
+- future target-layer naming and ontology rules belong in
+  [Domain Ontology](domain-ontology.md), not here
+- this docs-only slice does not rename the live bridge symbols
 
 Naming convention:
 
 - enum members such as `ProjectionHint.TRADE` stay Python-style uppercase names
-- stored/runtime values such as `trade` stay lowercase snake_case machine identifiers
+- stored/runtime values such as `trade` stay lowercase snake_case machine
+  identifiers
 - renderer labels such as `Trade` stay adapter-local presentation strings
 
 ## Classification Layers
 
-- `EconomicKind`: provider-neutral semantic meaning
-- `TaxTreatmentHint`: default tax intent used by later policy layers when it is
-  already safe to say on the current fact bridge
-- `AccountingIntentHint`: default accounting intent used by later journal
-  expansion when it is already safe to say on the current fact bridge
+- `EconomicKind`: provider-neutral bridge semantic meaning
+- `TaxTreatmentHint`: bridge tax intent used only when it is already safe to
+  say on the current fact path
+- `AccountingIntentHint`: bridge accounting intent used only when it is already
+  safe to say on the current fact path
 - `ProjectionHint`: output projection metadata for concrete renderers
 
 Core behavior should not key primarily on the legacy normalized `category`
@@ -70,7 +62,7 @@ These are the currently implemented bridge mappings. Code and docs must stay
 aligned on these values exactly.
 
 | Normalized Category | ProjectionHint | EconomicKind | TaxTreatmentHint | AccountingIntentHint | Tier | Notes |
-| ---- | ---- | ---- | ---- | ---- | ---- | ---- |
+| --- | --- | --- | --- | --- | --- | --- |
 | `trade` | `trade` | `spot_trade` | `capital_exchange` | `asset_exchange` | `T1` | Main spot trade path |
 | `deposit` | `deposit` | `asset_deposit` | `non_taxable_transfer_in` | `funding_inflow` | `T1` | Compatibility deposit before later transfer-linking |
 | `withdrawal` | `withdrawal` | `asset_withdrawal` | `non_taxable_transfer_out` | `funding_outflow` | `T1` | Compatibility withdrawal before later transfer-linking |
@@ -82,42 +74,21 @@ aligned on these values exactly.
 | `derivatives_profit` | `derivatives_futures_profit` | `derivative_realized_profit` | `derivative_realized_gain` | `income_recognition` | `T1` | Current realized profit bridge path |
 | `derivatives_loss` | `derivatives_futures_loss` | `derivative_realized_loss` | `derivative_realized_loss` | `expense_recognition` | `T1` | Current realized loss bridge path |
 
-## Future Expansion Rules
-
-- Do not add near-duplicate names for the same concept.
-- Add new enum values only when the behavior, tests, and adapter mappings land
-  together.
-- Keep future unsupported or planned semantics explicit in docs or roadmap
-  notes rather than preloading duplicate enum names into the runtime.
-- When later fact, accounting, or tax work needs a richer classification set,
-  update this document and `domain/transactions/classification.py` in the same
-  checkpoint.
-
 ## Runtime Rules
 
-- Adapters populate layered classifications first on the current bridge path
-  only when the classification is safe and deterministic.
-- The target claim layer may preserve unresolved meaning instead of forcing a
-  final fact classification too early.
-- Missing tax or accounting intent must not force lower layers to guess.
-  Preserve unresolved meaning in claims and let later accounting- or tax-owned
-  gaps carry the remaining policy blockers.
-- Runtime consumers operate on bridge `legs` only; there is no split
-  `fee_legs` lane and no first-leg compatibility view on `TransactionFact`.
-- Leg-level semantics live on the leg through `LegKind`; fact classification
-  remains a separate fact-level layer.
-- Output adapters map layered classifications into concrete external row
-  families when they need them.
+- adapters populate layered classifications on the current bridge path only
+  when the classification is safe and deterministic
+- if an adapter cannot determine a safe bridge classification, it must emit an
+  explicit blocking issue or review instead of guessing
+- missing tax or accounting intent must not force lower layers to guess
+- runtime consumers operate on bridge `legs` only; there is no split
+  `fee_legs` lane and no first-leg compatibility view on `TransactionFact`
+- leg-level semantics live on the leg through `LegKind`; fact classification
+  remains a separate fact-level layer
 - `ProjectionHint` is output metadata, not the long-term core driver of
-  business behavior.
-- Machine-oriented runtime values should stay lowercase snake_case even when an
-  output adapter renders them as title-style labels.
-- If an adapter cannot determine a safe layered classification on the current
-  fact bridge, it must emit an explicit blocking issue or review instead of
-  guessing.
-- When the target claim layer lands, that same unresolved meaning should remain
-  explicit in `ClaimSet` until one safe economic fact or later
-  stage-owned policy decision is available.
+  business behavior
+- output adapters map bridge classifications into concrete external row
+  families when they need them
 
 ## Review Triggers
 
@@ -127,6 +98,17 @@ Require explicit review when:
 - the fact changes beneficial ownership but not obvious tax treatment
 - the economic meaning is safe enough for reconciliation, but tax treatment
   still depends on later policy-owned determinants
-- a provider row collapses financing, trading, and fee semantics into one record
-- a future activity type would require a new classification value rather than a
-  safe mapping into the current bridge set
+- a provider row collapses financing, trading, and fee semantics into one
+  record
+- a future activity type would require a new bridge classification value
+  instead of a safe mapping into the current bridge set
+
+## Future Expansion Rules
+
+- do not add near-duplicate names for the same concept
+- add new bridge enum values only when the behavior, tests, and adapter
+  mappings land together
+- keep future unsupported or planned semantics explicit in docs or roadmap
+  notes rather than preloading duplicate bridge enum names into the runtime
+- when later bridge work needs a richer bridge classification set, update this
+  document and `domain/transactions/classification.py` in the same checkpoint

--- a/docs/concepts/unified-adapter-architecture.md
+++ b/docs/concepts/unified-adapter-architecture.md
@@ -10,6 +10,8 @@ related:
   - ROADMAP.md
   - docs/status/adapter-delivery-plan.md
   - docs/guides/write-an-adapter.md
+  - docs/concepts/pipeline-stage-contracts.md
+  - docs/concepts/domain-ontology.md
   - docs/concepts/reconciliation-tax-architecture.md
   - docs/concepts/oracle-boundaries.md
   - docs/concepts/transaction-classification.md
@@ -21,6 +23,13 @@ repo still runs on the older bundled adapter contracts.
 
 This document is intentionally explicit. It is meant to be scrutinized,
 challenged, and used as a design reference during later migration work.
+
+Detailed target stage contracts are owned by
+[`docs/concepts/pipeline-stage-contracts.md`](pipeline-stage-contracts.md), and
+target ontology rules are owned by
+[`docs/concepts/domain-ontology.md`](domain-ontology.md). This page focuses on
+adapter responsibilities, adapter handoffs, and adapter-local implications of
+those target contracts.
 
 ## Objective
 

--- a/docs/concepts/unified-adapter-architecture.md
+++ b/docs/concepts/unified-adapter-architecture.md
@@ -1,0 +1,1102 @@
+---
+title: "Unified Adapter Architecture"
+summary: "First-principles design anchor for the future unified adapter manifest, facets, canonical products, and deterministic verification model."
+doc_type: concept
+audience: human
+owner: repo
+status: active
+nav_order: 60
+related:
+  - ROADMAP.md
+  - docs/status/adapter-delivery-plan.md
+  - docs/guides/write-an-adapter.md
+  - docs/concepts/reconciliation-tax-architecture.md
+  - docs/concepts/oracle-boundaries.md
+  - docs/concepts/transaction-classification.md
+---
+
+Read this document before shaping adapter changes. Use it as the forward design
+anchor for source, portfolio, and output adapter work, even while the current
+repo still runs on the older bundled adapter contracts.
+
+This document is intentionally explicit. It is meant to be scrutinized,
+challenged, and used as a design reference during later migration work.
+
+## Objective
+
+Design one future adapter architecture that:
+
+- makes adapters easier to build and reason about
+- removes avoidable behavior drift between adapters
+- centralizes deterministic workflow logic in shared services
+- keeps provider-local code focused on provider-local semantics
+- supports source, portfolio-style, and output surfaces without forcing them
+  through unrelated responsibilities
+- scales to reconciliation, checkpoint, accounting, and tax work without
+  re-centering on a tracker-specific model
+
+The future design must not be shaped by the current repo layout beyond the
+actual jobs the repo must accomplish.
+
+## Why The Current Shape Is Not The End State
+
+The current runtime already contains valuable components:
+
+- shared draft compilation
+- translation-input planning
+- shared statement extraction
+- shared output-policy validation
+- shared evidence and provenance artifacts
+
+However, the current adapter shape still has one central flaw:
+
+- the source-side contract bundles too many unrelated jobs into one plugin
+  surface
+
+Today a source adapter may be expected to do all of the following:
+
+- match a source during profiling
+- classify file families
+- match and route intake files
+- validate timezone policy
+- extract location inventory
+- recognize and parse statement PDFs
+- resolve statement instrument claims
+- describe translation candidates
+- translate selected inputs or fallback inputs
+
+That bundling creates three problems:
+
+1. Adapters do too much.
+2. Capability flags do not fully narrow the actual implementation burden.
+3. Workflow behavior can drift because shared orchestration concerns stay
+   scattered across provider-local entry points.
+
+The future architecture should unify the model without creating another giant
+"do everything" interface.
+
+## Core Design Decision
+
+The future system should unify adapters around four things:
+
+- one universal manifest model
+- a small set of purpose-defined facets
+- one shared canonical product pipeline
+- one deterministic verifier model
+
+It should not unify adapters around one monolithic method surface.
+
+This means:
+
+- portfolio is not a special third adapter species
+- portfolio is a reader surface that emits balance, position, or statement
+  claims instead of only activity claims
+- output is not a source adapter with inverted arrows
+- output is a writer surface that consumes canonical semantic data and emits
+  target-specific artifacts
+
+## First-Principles Basis
+
+This design follows durable architecture ideas rather than repo-local
+convenience.
+
+### 1. Purpose-Defined Ports Beat Technology-Defined Layers
+
+Ports should represent a meaningful job boundary, not a technology or folder
+boundary.
+
+Implication:
+
+- "source adapter" is too broad if it means discovery, routing, parsing,
+  planning, translation, statement extraction, and location extraction
+
+### 2. Shared Intermediate Representations Reduce Drift
+
+Complex ingestion and rendering systems stay simpler when adapters do not
+translate directly from raw input to final output in one jump.
+
+Implication:
+
+- the system needs a canonical sequence of intermediate products with explicit
+  invariants and verification points
+
+### 3. Determinism Must Be A Contract, Not A Hope
+
+Any surface that depends on unordered iteration, filename order, path order, or
+ hidden heuristics is not trustworthy enough for reconciliation and tax work.
+
+Implication:
+
+- canonical ordering, fingerprints, replacement rules, and blocking ambiguity
+  must be explicit
+
+### 4. Provenance Is A First-Class Runtime Concern
+
+Financial reconstruction requires trust in where each fact and balance
+reference came from.
+
+Implication:
+
+- provenance must remain typed in runtime models and must not be reduced to an
+  ad hoc string until artifact boundaries
+
+### 5. Assertions And Annotations Must Stay Separate
+
+Systems become fragile when structural facts, advisory notes, and review hints
+share one loose payload.
+
+Implication:
+
+- hard assertions, soft annotations, blocking issues, and review records need
+  distinct types and distinct rules
+
+### 6. Schema Evolution Needs Canonical Identity
+
+Schema compatibility is simpler when every canonical product has versioned
+identity and canonical fingerprints.
+
+Implication:
+
+- manifests and canonical product schemas need explicit versioning and
+  fingerprint rules
+
+## Non-Goals
+
+This architecture is not trying to:
+
+- preserve the current bundled source contract under new names
+- make every provider look identical at the semantic level
+- turn adapters into giant declarative config files with no provider-local code
+- hide unsupported behavior behind coercion or defaults
+- keep compatibility wrappers alive indefinitely
+- center the architecture on CoinTracking or any other tracker shape
+
+## Design Goals
+
+- Adapters should be thin at their entry points.
+- Provider-local code should focus on provider-local evidence and semantics.
+- Shared orchestration should live in the core planner, compiler, verifier, and
+  artifact writers.
+- Input, portfolio, and output surfaces should use one manifest family and one
+  shared terminology.
+- Every major handoff should have a deterministic fingerprint.
+- Unsupported or ambiguous data should become explicit issues or reviews.
+- Future migration should be incremental and family-based, not big-bang.
+
+## Terminology
+
+### Evidence
+
+Untouched or boundary-parsed provider material such as CSV exports, workbook
+tabs, PDFs, HTML reports, explorer exports, or future API payloads.
+
+### Claim
+
+A provider-local semantic assertion derived from evidence but not yet accepted
+as canonical runtime data.
+
+Examples:
+
+- "this row describes a trade-like activity"
+- "this statement row reports a quantity balance as of a date"
+- "this wallet export proves ownership of this chain-scoped identifier"
+
+### Semantic Data
+
+Canonical provider-neutral runtime objects such as transaction facts, balance
+references, location inventory, issues, and reviews.
+
+### Projection
+
+A target-specific but still structured representation derived from semantic
+data, such as a CoinTracking row model or a future journal posting set.
+
+### Artifact
+
+A serialized file, directory, or byte-oriented output written for operators,
+tools, or external systems.
+
+## Canonical Product Pipeline
+
+The future adapter system should revolve around five canonical products.
+
+Boundary note:
+
+- this document defines the adapter-scoped handoff products only
+- `docs/concepts/reconciliation-tax-architecture.md` remains the core runtime
+  architecture anchor for `EconomicDataset`, `ReconciliationDataset`,
+  `CheckpointPackage`, `JournalDataset`, `TaxDeterminantDataset`, and
+  `TaxOutputDataset`
+- adapter work should map into that runtime pipeline rather than creating a
+  second competing core architecture
+
+### 1. EvidenceBundle
+
+Purpose:
+
+- represent the evidence selected for one adapter-owned read operation
+- preserve discovery results, family classification, provenance, and typed
+  parse outputs without making semantic commitments too early
+
+Owned by:
+
+- reader facets and shared evidence orchestration
+
+Must include:
+
+- adapter id
+- capture or input identity
+- manifest version and fingerprint
+- evidence members with typed provenance
+- evidence family ids
+- parse diagnostics
+- deterministic member ordering
+- bundle fingerprint
+
+Must not include:
+
+- canonical transaction facts
+- target-specific output rows
+
+Typical contents:
+
+- typed CSV rows
+- workbook sheets
+- PDF-extracted balance rows
+- discovered document metadata
+- recognized evidence families
+
+### 2. ClaimBundle
+
+Purpose:
+
+- hold provider-local semantic claims before canonical compilation
+
+Owned by:
+
+- reader and translation facets
+
+Claim types may include:
+
+- `ActivityClaim`
+- `BalanceObservationClaim`
+- `OwnershipClaim`
+- `LocationClaim`
+- `StatementClaim`
+- `InstrumentIdentityClaim`
+- `ContractTermClaim`
+- `ValuationClaim`
+- `ProjectionAnnotation`
+- `EvidenceIssue`
+- `EvidenceReview`
+
+Must include:
+
+- deterministic claim ids
+- typed provenance references back to the evidence bundle
+- structural status for each claim
+- blocking versus advisory distinction
+- bundle fingerprint
+
+Must not include:
+
+- inferred canonical identities that have not been resolved
+- writer-specific rows
+
+### 3. EconomicDataset
+
+Purpose:
+
+- hold canonical provider-neutral economic outputs accepted by the core system
+  at the adapter-to-core boundary
+
+Owned by:
+
+- shared compiler, identity resolver, and verifier
+
+May include:
+
+- `TransactionFact`
+- `BalanceReference`
+- `BalanceSnapshot` when derived by shared services
+- `LocationInventoryRecord`
+- `IssueRecord`
+- `NormalizationReviewRecord`
+
+Must include:
+
+- canonical ordering
+- schema version
+- dataset fingerprint
+- deterministic derivation metadata
+
+Boundary mapping:
+
+- this adapter-scoped `EconomicDataset` maps onto the core runtime
+  `EconomicDataset`
+- later downstream runtime products such as reconciliation datasets,
+  checkpoint packages, journals, tax determinants, and tax outputs are defined
+  in the reconciliation and tax architecture doc rather than here
+
+### 4. ProjectionBundle
+
+Purpose:
+
+- hold target-specific structured outputs before serialization
+
+Owned by:
+
+- writer facets and shared projection validation
+
+Examples:
+
+- CoinTracking CSV row models
+- Ledger posting sets
+- future tax package rows
+
+Must include:
+
+- target id
+- target version
+- source economic dataset fingerprint
+- projection fingerprint
+- target constraint validation results
+
+### 5. ArtifactBundle
+
+Purpose:
+
+- represent serialized outputs written to disk or another delivery boundary
+
+Owned by:
+
+- shared artifact writers plus writer facets
+
+Examples:
+
+- CSV files
+- JSON plan files
+- Markdown summaries
+- future API payload packages
+
+Must include:
+
+- artifact paths or identifiers
+- media type or artifact kind
+- byte or row counts
+- artifact fingerprint
+- manifest and source fingerprint references
+
+## Why These Products Matter
+
+This pipeline gives the architecture explicit checkpoints:
+
+- evidence can be verified independently of semantics
+- claims can be verified independently of canonical compilation
+- canonical data can be verified independently of target projections
+- target projections can be validated independently of final serialization
+
+That separation is the main mechanism for reducing adapter drift.
+
+## Adapter Model
+
+The future adapter system should have one universal manifest and a small set of
+optional facets.
+
+### Universal Manifest
+
+Every adapter should publish one `AdapterManifest`.
+
+The manifest is the durable contract. Facets are executable behaviors attached
+to that contract.
+
+### Manifest Responsibilities
+
+The manifest should answer:
+
+- what evidence kinds this adapter can read or write
+- what canonical products it can emit or consume
+- what facets it implements
+- which determinism guarantees it provides
+- which schema versions it supports
+- what constraints or unsupported surfaces it declares
+
+### Manifest Shape
+
+The exact field list may change, but the manifest should eventually cover at
+least the following areas.
+
+| Category | Representative fields | Purpose |
+| --- | --- | --- |
+| Identity | `adapter_id`, `display_name`, `version`, `family`, `status` | Stable adapter identity and support posture. |
+| Direction | `implemented_facets`, `reads`, `writes` | Declares whether the adapter probes, reads, translates, writes, or combines those jobs. |
+| Evidence | `accepted_evidence_kinds`, `recognized_family_ids`, `statement_kinds` | Declares what raw or parsed evidence the adapter understands. |
+| Canonical products | `emits_claim_types`, `emits_semantic_types`, `consumes_semantic_types`, `emits_projection_types` | Defines product flow explicitly. |
+| Determinism | `ordering_contract`, `fingerprint_contract`, `planner_support`, `selection_modes` | Makes determinism a contract surface. |
+| Identity | `supported_identifier_schemes`, `location_identity_rules`, `instrument_claim_rules` | Declares identity expectations. |
+| Temporal and numeric policy | `timezone_policy`, `effective_time_policy`, `precision_policy` | Makes interpretation rules explicit. |
+| Constraints | `unsupported_surfaces`, `hard_requirements`, `review_triggers` | Distinguishes unsupported from merely advisory. |
+| Compatibility | `schema_version`, `compatibility_window`, `manifest_fingerprint` | Supports evolution and migration discipline. |
+
+### Facets
+
+The architecture should avoid one large interface and instead define a small
+set of purpose-defined facets.
+
+Recommended facets:
+
+| Facet | Purpose | Typical users |
+| --- | --- | --- |
+| `ProbeFacet` | Recognize evidence and describe confidence, families, and route hints. | Source, portfolio, and statement-capable adapters. |
+| `ReadFacet` | Read selected evidence and emit evidence bundles or claim bundles. | Source, portfolio, wallet, and explorer adapters. |
+| `StatementFacet` | Recognize and parse statement documents plus statement-specific identity claims. | Statement-capable platform and wallet adapters. |
+| `TranslateFacet` | Convert provider-local claims into canonical semantic datasets when provider-local semantic mapping is required. | Source adapters with activity semantics. |
+| `WriteFacet` | Convert canonical semantic or projection data into target artifacts. | Output adapters. |
+
+Additional rule:
+
+- portfolio is not a dedicated facet
+- portfolio behavior is expressed through `ReadFacet` and possibly
+  `StatementFacet`, because portfolio inputs are evidence readers that emit
+  balance or position claims instead of activity-heavy claims
+
+## Responsibilities By Layer
+
+### Adapter-Owned Responsibilities
+
+Adapters should own only the responsibilities that truly require provider-local
+knowledge.
+
+Reader-side examples:
+
+- identifying provider-specific evidence families
+- parsing provider-specific evidence structures
+- mapping provider fields into provider-local claims
+- declaring provider-specific ambiguity, precision, or semantic constraints
+- rendering provider-specific output labels or row shapes
+
+Writer-side examples:
+
+- mapping canonical semantics into target-specific row models
+- handling target-specific formatting or required field population
+
+### Shared Core Responsibilities
+
+The shared core should own responsibilities that must be consistent across
+providers.
+
+Examples:
+
+- evidence selection and planning
+- deterministic candidate comparison and replacement rules
+- canonical ordering and fingerprint creation
+- provenance flattening at artifact boundaries
+- instrument identity resolution
+- issue and review severity conventions
+- fact compilation
+- projection validation
+- artifact writing
+- replay and parity verification
+
+### Explicit Rule
+
+If two adapters would need the same workflow rule and that rule is not
+provider-specific, it belongs in shared core services, not in duplicated
+adapter logic.
+
+## ProbeFacet Design
+
+`ProbeFacet` should answer three questions:
+
+1. Does this adapter recognize the evidence?
+2. What evidence families or statement kinds are present?
+3. What confidence and caveats apply?
+
+It should not:
+
+- parse the entire provider semantic model
+- choose winning translation candidates
+- perform full translation
+
+The probe output should be declarative.
+
+Recommended output fields:
+
+- `recognized`
+- `confidence_score`
+- `recognized_families`
+- `statement_kinds`
+- `route_hints`
+- `blocking_issues`
+- `advisory_reviews`
+
+This facet should replace the current spread of:
+
+- source matching
+- file-family classification
+- intake matching hints
+- statement-document detection
+
+while still allowing those current jobs to be implemented incrementally.
+
+## ReadFacet Design
+
+`ReadFacet` is the future home for provider-local evidence reading.
+
+Its job is to:
+
+- accept selected evidence members
+- parse them into typed evidence structures
+- emit evidence bundles and claim bundles
+
+It should not:
+
+- own cross-provider selection policy
+- infer canonical instrument identity beyond provider-local claims
+- write final runtime artifacts directly
+
+Reader outputs should be deterministic for unchanged inputs.
+
+Reader ordering rules:
+
+- evidence members sorted by canonical evidence ordering
+- claims sorted by stable claim key
+- diagnostics sorted by provenance plus claim or evidence id
+
+## StatementFacet Design
+
+Statements are important enough to deserve a specialized facet because they
+have distinct evidence semantics:
+
+- document recognition
+- document parsing
+- row-level balance evidence
+- row-level instrument identity claims
+
+`StatementFacet` should:
+
+- recognize statement documents
+- parse statement rows into typed statement claims
+- preserve document-level and row-level provenance
+- declare statement-specific ambiguity when quantity evidence is insufficient
+
+It should not:
+
+- silently promote valuation-only rows into quantity-backed balance references
+- bypass the shared statement extraction orchestration
+
+## TranslateFacet Design
+
+`TranslateFacet` exists because provider-local semantics still matter even
+after parsing.
+
+Its job is to:
+
+- convert provider-local claims into canonical semantic data or
+  semantic-compiler-ready claims
+- express provider-local semantic ambiguity explicitly
+
+It should not:
+
+- choose evidence members by itself
+- resolve canonical identities through provider-local lookup tables when shared
+  resolution should own the final choice
+- write output artifacts directly
+
+This facet is closest to the current source translation behavior, but it should
+operate on claims and evidence bundles rather than on raw file-path heuristics.
+
+## WriteFacet Design
+
+`WriteFacet` is the future unified writer surface for output adapters.
+
+Its job is to:
+
+- declare what semantic or projection data it accepts
+- declare target-specific constraints
+- emit projection bundles and artifact bundles
+
+It should not:
+
+- reinterpret canonical facts semantically
+- invent missing projection metadata silently
+- coerce unsupported fact shapes into target rows
+
+This is a stricter version of the current output adapter model.
+
+## Planner And Selection Model
+
+Selection is one of the most important shared behaviors and must not remain
+adapter-local.
+
+### Design Rule
+
+The core planner owns evidence selection. Adapters describe candidates.
+
+### Candidate Model
+
+Every reader capable of overlapping or replaceable evidence should be able to
+describe candidates with:
+
+- candidate id
+- selection group
+- family id
+- member list
+- coverage window
+- freshness
+- selection mode
+- comparability
+- content fingerprint
+- description
+- notes
+
+### Selection Modes
+
+The future model should preserve the useful ideas already present:
+
+- appendable range
+- replaceable range
+- exclusive snapshot
+
+Additional rules:
+
+- candidate comparison rules must be deterministic
+- unknown coverage must block selection when it could change semantics
+- incomparable candidates must block selection unless an explicit human choice
+  exists
+- replacement must leave an auditable chain
+
+### Why Selection Must Be Shared
+
+If adapters choose winners internally:
+
+- behavior becomes non-uniform
+- replacement semantics drift
+- test coverage becomes fragmented
+- replay confidence falls
+
+## Claim Taxonomy
+
+The future architecture should separate provider-local claims by job.
+
+Recommended claim families:
+
+| Claim family | Purpose |
+| --- | --- |
+| `ActivityClaim` | A provider-local economic activity candidate with raw semantic details. |
+| `BalanceObservationClaim` | A quantity-backed balance or position observation tied to evidence. |
+| `OwnershipClaim` | A claim that a location identifier is controlled or owned. |
+| `LocationClaim` | A provider-local claim about where activity, balances, or positions are held. |
+| `StatementClaim` | A parsed statement row or document-level claim. |
+| `InstrumentIdentityClaim` | One provider-local identity assertion for an asset or instrument. |
+| `ContractTermClaim` | A provider-local claim about instrument or position terms that later economic compilation may need. |
+| `ValuationClaim` | A provider-local valuation observation with purpose, time, and provenance. |
+| `ProjectionAnnotation` | Output-oriented metadata that is not itself a canonical fact. |
+| `IssueCandidate` | A blocking or informational problem requiring canonical issue assembly. |
+| `ReviewCandidate` | A review-needed case requiring canonical review assembly. |
+
+These claim families let the core compiler distinguish:
+
+- hard semantic assertions
+- evidence observations
+- identity claims
+- output hints
+- workflow diagnostics
+
+## Canonical Compilation Rules
+
+The compiler from claims to canonical semantic data should be shared.
+
+### Compiler Responsibilities
+
+- resolve instrument identity from claims
+- validate temporal conventions
+- validate leg shape rules
+- validate required location identity
+- separate blocking issues from advisory reviews
+- create canonical facts, balance references, and location inventory
+
+### Compiler Rules
+
+- no canonical fact may be created when identity remains unresolved
+- no quantity-backed balance reference may be created from valuation-only
+  evidence
+- no location inventory record may be created without identifier-rooted
+  canonical location identity
+- no output hint may become a semantic fact just because a writer can use it
+
+### Why This Must Be Shared
+
+If each adapter compiles canonical facts differently:
+
+- semantic correctness becomes adapter-dependent
+- output parity becomes unstable
+- reconciliation trust is reduced
+
+## Determinism Contract
+
+Determinism must be explicit across all canonical products.
+
+### Deterministic Inputs
+
+For unchanged evidence, unchanged manifest versions, and unchanged shared-core
+versions:
+
+- selected evidence members must be identical
+- candidate and plan fingerprints must be identical
+- claim bundle fingerprints must be identical
+- semantic dataset fingerprints must be identical
+- projection bundle fingerprints must be identical
+- artifact fingerprints must be identical unless the target format includes a
+  documented nondeterministic field that is intentionally excluded
+
+### Canonical Ordering Rules
+
+Every canonical product must declare a sort key.
+
+Examples:
+
+- evidence members sorted by canonical provenance key
+- candidates sorted by selection group, coverage, freshness, and candidate id
+- claims sorted by claim family, timestamp, stable claim id, and provenance
+- facts sorted by timestamp, effective time, source, fact id
+- issues and reviews sorted by severity, kind, timestamp, provenance, id
+- projection rows sorted by target-defined canonical row order
+
+### Fingerprint Rules
+
+Every canonical product should have:
+
+- a schema version
+- a canonical serialization form
+- a stable fingerprint
+
+Canonical serialization rules should:
+
+- sort object keys
+- avoid implicit ordering from language runtime containers
+- exclude presentation-only noise
+- include semantically relevant fields only
+
+## Assertions, Issues, And Reviews
+
+The future design should treat diagnostic surfaces as first-class contracts.
+
+### Hard Assertions
+
+Hard assertions are required for canonical semantic acceptance.
+
+Examples:
+
+- one resolved instrument identity
+- valid timezone semantics
+- valid quantity precision where required
+- acceptable leg shape
+
+### Blocking Issues
+
+Blocking issues stop canonical acceptance or later workflow progress.
+
+Examples:
+
+- ambiguous identity
+- unsupported precision loss
+- unknown coverage during candidate selection
+- incompatible evidence bundles in one selection group
+
+### Reviews
+
+Reviews are explicit human attention requests that do not always block the
+entire workflow.
+
+Examples:
+
+- lower-confidence fee precision on a known provider edge
+- advisory same-source same-chain portfolio evidence
+- low-confidence ownership inference
+
+### Rule
+
+Adapters must not downgrade a hard semantic failure into a review just to keep
+facts flowing.
+
+## Provenance Model
+
+Provenance is central enough to deserve explicit rules.
+
+### Runtime Rule
+
+Provenance stays typed in runtime models until artifact boundaries.
+
+### Provenance Levels
+
+The future model should distinguish:
+
+- evidence member provenance
+- parsed row or page provenance
+- claim provenance
+- canonical semantic derivation provenance
+- artifact derivation provenance
+
+### Why Product Boundaries Matter
+
+The repo needs to answer:
+
+- which file, sheet, row, or page caused this fact
+- which evidence item supports this balance reference
+- which candidate was selected and why
+- which target row came from which fact or claim
+
+Ad hoc string fields are not enough for that.
+
+## Identity Model
+
+Identity rules should remain shared and identifier-rooted.
+
+### Instrument Identity
+
+Adapters should emit identity claims, not final canonical instrument choices.
+
+The shared identity resolver should:
+
+- accept multiple claims
+- resolve exactly one canonical instrument or fail explicitly
+- preserve review context when ambiguity remains
+
+### Location Identity
+
+Adapters should emit identifier-rooted canonical locations.
+
+Rules:
+
+- friendly labels stay out of canonical ids
+- chain or network identity must be explicit
+- sublocations must be stable derivations of parent identity
+
+### Ownership
+
+Ownership claims should be their own claim family, not hidden in translation
+helpers.
+
+## Temporal And Numeric Policy
+
+Time and quantity interpretation must be explicit at the adapter edge, but the
+policy model should be shared.
+
+### Temporal Rules
+
+- timestamps must be timezone-aware before entering canonical semantic data
+- date-only and timestamp precision must remain distinct
+- exact midnight timestamps are still timestamps if the source contract says so
+- unknown or conflicting timezone interpretation must block or review
+  explicitly based on declared policy
+
+### Numeric Rules
+
+- financial quantities remain `Decimal`
+- precision expectations may be declared by manifest or provider-local code
+- silent rounding or truncation is not acceptable on semantically important
+  quantities
+- known provider precision defects must be modeled as explicit review or issue
+  behavior
+
+## Input, Portfolio, And Output Under One Model
+
+The future design should stop treating input, portfolio, and output as
+fundamentally different architecture categories.
+
+### Input
+
+An input adapter is an adapter whose facets read evidence and emit claims or
+semantic data.
+
+### Portfolio
+
+A portfolio adapter is an input adapter whose primary claim types are balance,
+position, statement, or ownership claims instead of activity-heavy claims.
+
+### Output
+
+An output adapter is an adapter whose primary facet writes projection or
+artifact bundles from semantic data.
+
+### Why One Adapter Model Matters
+
+The architecture stays smaller if:
+
+- one manifest model describes all adapters
+- one verifier model checks their products
+- one canonical vocabulary describes the flow
+
+## Migration Of Current Jobs Into Future Facets
+
+The current repo jobs should map into the future architecture as follows.
+
+| Current job | Future owner |
+| --- | --- |
+| profile matching | `ProbeFacet` plus shared selection service |
+| file-family classification | `ProbeFacet` plus manifest-declared evidence families |
+| intake matching and route hints | `ProbeFacet` plus shared intake router |
+| timezone summary | shared temporal policy service with manifest-declared expectations |
+| location inventory extraction | `ReadFacet` or `TranslateFacet` producing `OwnershipClaim` and canonical inventory through shared compilation |
+| statement matching and parsing | `StatementFacet` plus shared statement orchestration |
+| translation-input planning | shared planner using manifest and candidate descriptions |
+| activity translation | `ReadFacet` and `TranslateFacet` producing `ActivityClaim` |
+| draft compilation | shared compiler to `EconomicDataset` |
+| output policy validation | shared projection validator |
+| rendering | `WriteFacet` |
+
+This mapping is the main path for shrinking adapter entry points.
+
+## Testing And Verification Model
+
+The future adapter system needs a stronger and more uniform verification model
+than the current contract-by-contract mixture.
+
+### Required Test Layers
+
+| Layer | Purpose |
+| --- | --- |
+| Unit tests | Provider-local parsing, semantic mapping, and edge-case decisions. |
+| Contract tests | Manifest validity, facet declarations, and product schema conformance. |
+| Golden tests | Stable evidence, claim, economic, and projection outputs on known packs. |
+| Replay tests | Re-run unchanged inputs and verify identical canonical fingerprints. |
+| Negative tests | Assert blocking behavior for unsupported or ambiguous evidence. |
+
+### Mandatory Determinism Checks
+
+- shuffled file order must not change selected candidates
+- equivalent archive extraction order must not change claim order
+- repeated runs must preserve canonical fingerprints
+- rendered writer outputs must remain stable for unchanged economic datasets
+
+### Compatibility Checks
+
+The future verifier should check:
+
+- manifest schema compatibility
+- canonical product schema compatibility
+- adapter support-window declarations
+- intentional breaking changes via explicit version increments
+
+## Scaffolding And Authoring Rules
+
+Once the future model lands, scaffolds should create:
+
+- one manifest
+- only the facets the adapter actually implements
+- provider-local modules split by real concern
+- local tests for each implemented facet
+
+Scaffolds should not create:
+
+- no-op method surfaces for unrelated jobs
+- fake fallback methods just to satisfy a bundled protocol
+- generic helper dumps
+
+## Performance And Operational Rules
+
+The future system should optimize for determinism first and performance second,
+but performance still matters.
+
+Rules:
+
+- bundle products should be stream-friendly where possible
+- large evidence collections should avoid materializing unnecessary duplicate
+  structures
+- fingerprints should be cheap enough to run in ordinary workflows
+- shared planning should avoid repeated provider-local rescans when profile
+  artifacts already contain the needed evidence facts
+
+## Security And Safety Posture
+
+The adapter system should remain safe-by-default.
+
+Rules:
+
+- adapters may read only selected evidence provided by the core workflow
+- adapters should not perform unrestricted workspace scans outside their
+  assigned evidence roots
+- network calls should remain outside ordinary adapter reading unless a
+  separate provider family explicitly owns them
+- ambiguity should never be hidden for convenience
+
+## Open Questions
+
+These questions are intentionally left open for later design review:
+
+- Should `ReadFacet` emit evidence bundles and claim bundles separately, or may
+  some adapters emit claims directly when parsing is trivial?
+- Should writer adapters consume `EconomicDataset` directly, or should all
+  writers consume a target-neutral `ProjectionBundle` first?
+- Which manifest fields should be purely declarative versus code-generated?
+- How much of current timezone and precision policy belongs in manifest data
+  versus provider-local code?
+- Should claim and product fingerprints include manifest fingerprints
+  directly, or reference them externally?
+
+These are implementation questions, not reasons to keep the bundled current
+contract.
+
+## Migration Principles
+
+When this architecture is implemented later, migration should follow these
+rules:
+
+- migrate by adapter family, not all at once
+- do not preserve permanent dual contracts
+- keep each checkpoint reviewable
+- let filing-critical adapters migrate first only after the filing path is
+  stable
+- remove obsolete seams once the new family path is verified
+
+## Practical Near-Term Guidance
+
+Until the future architecture lands:
+
+- keep current adapter changes moving toward these product and facet
+  boundaries
+- extract shared workflow logic when it is clearly cross-provider
+- avoid adding new adapter-local orchestration that the future shared planner,
+  compiler, or verifier should own
+- keep current fixes filing-first while still using this document as the
+  direction of travel
+
+## Design Summary
+
+The future adapter architecture should be:
+
+- manifest-centered
+- facet-based
+- intermediate-representation driven
+- deterministic by contract
+- provenance-rich
+- issue-forward
+- migration-friendly
+
+It should not be:
+
+- monolithic
+- filename-order driven
+- tracker-centered
+- adapter-local workflow heavy
+- tolerant of hidden ambiguity
+
+## External Design References
+
+These references support the design posture in this document.
+
+- Alistair Cockburn, Hexagonal Architecture:
+  <https://alistair.cockburn.us/hexagonal-architecture>
+- MLIR Dialect Conversion:
+  <https://mlir.llvm.org/docs/DialectConversion/>
+- Apache Avro Specification:
+  <https://avro.apache.org/docs/1.12.0/specification/>
+- Apache Beam coder determinism:
+  <https://beam.apache.org/releases/pydoc/2.10.0/apache_beam.coders.coders.html>
+- RFC 8785 JSON Canonicalization Scheme:
+  <https://www.rfc-editor.org/rfc/rfc8785>
+- W3C PROV-DM:
+  <https://www.w3.org/standards/history/prov-dm/>
+- JSON Schema Draft 2020-12:
+  <https://json-schema.org/draft/2020-12>

--- a/docs/concepts/unified-adapter-architecture.md
+++ b/docs/concepts/unified-adapter-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: "Unified Adapter Architecture"
-summary: "First-principles design anchor for the future unified adapter manifest, facets, canonical products, and deterministic verification model."
+summary: "First-principles design anchor for the future unified adapter manifest, facets, adapter products, and deterministic verification model."
 doc_type: concept
 audience: human
 owner: repo
@@ -81,7 +81,7 @@ The future system should unify adapters around four things:
 
 - one universal manifest model
 - a small set of purpose-defined facets
-- one shared canonical product pipeline
+- one shared adapter product pipeline
 - one deterministic verifier model
 
 It should not unify adapters around one monolithic method surface.
@@ -92,7 +92,7 @@ This means:
 - portfolio is a reader surface that emits balance, position, or statement
   claims instead of only activity claims
 - output is not a source adapter with inverted arrows
-- output is a writer surface that consumes canonical semantic data and emits
+- output is a writer surface that consumes runtime or projection data and emits
   target-specific artifacts
 
 ## First-Principles Basis
@@ -117,7 +117,7 @@ translate directly from raw input to final output in one jump.
 
 Implication:
 
-- the system needs a canonical sequence of intermediate products with explicit
+- the system needs a stable sequence of intermediate products with explicit
   invariants and verification points
 
 ### 3. Determinism Must Be A Contract, Not A Hope
@@ -127,7 +127,7 @@ Any surface that depends on unordered iteration, filename order, path order, or
 
 Implication:
 
-- canonical ordering, fingerprints, replacement rules, and blocking ambiguity
+- stable ordering, fingerprints, replacement rules, and blocking ambiguity
   must be explicit
 
 ### 4. Provenance Is A First-Class Runtime Concern
@@ -150,14 +150,14 @@ Implication:
 - hard assertions, soft annotations, blocking issues, and review records need
   distinct types and distinct rules
 
-### 6. Schema Evolution Needs Canonical Identity
+### 6. Schema Evolution Needs Stable Identity
 
-Schema compatibility is simpler when every canonical product has versioned
-identity and canonical fingerprints.
+Schema compatibility is simpler when every adapter product has versioned
+identity and stable fingerprints.
 
 Implication:
 
-- manifests and canonical product schemas need explicit versioning and
+- manifests and adapter product schemas need explicit versioning and
   fingerprint rules
 
 ## Non-Goals
@@ -193,7 +193,7 @@ tabs, PDFs, HTML reports, explorer exports, or future API payloads.
 ### Claim
 
 A provider-local semantic assertion derived from evidence but not yet accepted
-as canonical runtime data.
+as bridge or downstream runtime data.
 
 Examples:
 
@@ -201,10 +201,11 @@ Examples:
 - "this statement row reports a quantity balance as of a date"
 - "this wallet export proves ownership of this chain-scoped identifier"
 
-### Semantic Data
+### Runtime Data
 
-Canonical provider-neutral runtime objects such as transaction facts, balance
-references, location inventory, issues, and reviews.
+Downstream-owned runtime products such as `EconomicFacts`,
+`ReconciliationState`, `Checkpoint`, `Journal`, `TaxInputs`, and
+`TaxOutputs`.
 
 ### Projection
 
@@ -216,21 +217,22 @@ data, such as a CoinTracking row model or a future journal posting set.
 A serialized file, directory, or byte-oriented output written for operators,
 tools, or external systems.
 
-## Canonical Product Pipeline
+## Adapter Product Pipeline
 
-The future adapter system should revolve around five canonical products.
+The future adapter system should revolve around evidence, claims, explicit
+bridge outputs while the migration remains active, and target-local rendering.
 
 Boundary note:
 
 - this document defines the adapter-scoped handoff products only
 - `docs/concepts/reconciliation-tax-architecture.md` remains the core runtime
-  architecture anchor for `EconomicDataset`, `ReconciliationDataset`,
-  `CheckpointPackage`, `JournalDataset`, `TaxDeterminantDataset`, and
-  `TaxOutputDataset`
+  architecture anchor for `EconomicFacts`, `ReconciliationState`,
+  `Checkpoint`, `Journal`, `TaxInputs`, and
+  `TaxOutputs`
 - adapter work should map into that runtime pipeline rather than creating a
   second competing core architecture
 
-### 1. EvidenceBundle
+### 1. EvidenceSet
 
 Purpose:
 
@@ -251,11 +253,11 @@ Must include:
 - evidence family ids
 - parse diagnostics
 - deterministic member ordering
-- bundle fingerprint
+- evidence fingerprint
 
 Must not include:
 
-- canonical transaction facts
+- current bridge facts or downstream runtime products
 - target-specific output rows
 
 Typical contents:
@@ -266,11 +268,11 @@ Typical contents:
 - discovered document metadata
 - recognized evidence families
 
-### 2. ClaimBundle
+### 2. ClaimSet
 
 Purpose:
 
-- hold provider-local semantic claims before canonical compilation
+- hold provider-local semantic claims before shared compilation
 
 Owned by:
 
@@ -293,50 +295,43 @@ Claim types may include:
 Must include:
 
 - deterministic claim ids
-- typed provenance references back to the evidence bundle
+- typed provenance references back to the evidence set
 - structural status for each claim
 - blocking versus advisory distinction
-- bundle fingerprint
+- claim-set fingerprint
 
 Must not include:
 
-- inferred canonical identities that have not been resolved
+- inferred final identities that have not been resolved
 - writer-specific rows
 
-### 3. EconomicDataset
+### 3. Bridge Result While The Current Path Remains Active
 
 Purpose:
 
-- hold canonical provider-neutral economic outputs accepted by the core system
-  at the adapter-to-core boundary
+- describe the current bridge bundle honestly while adapter migration is still
+  landing
 
-Owned by:
+Current truth:
 
-- shared compiler, identity resolver, and verifier
+- source adapters still return `SourceTranslationBatch`
+- that bridge bundle currently carries drafts, balance references, balance
+  reference issues, issues, reviews, and location inventory
 
-May include:
+Rules:
 
-- `TransactionFact`
-- `BalanceReference`
-- `BalanceSnapshot` when derived by shared services
-- `LocationInventoryRecord`
-- `IssueRecord`
-- `NormalizationReviewRecord`
+- this is a migration seam, not the future adapter architecture center
+- do not describe this bundle as if it owns `EconomicFacts`
+- adapter-side bundles must not overload "economic output" with
+  balance snapshots, balance references, issues, reviews, and location
+  inventory as if they shared one semantic meaning
+- the main runtime architecture doc owns the meaning of downstream products
 
-Must include:
+Target-direction naming note:
 
-- canonical ordering
-- schema version
-- dataset fingerprint
-- deterministic derivation metadata
-
-Boundary mapping:
-
-- this adapter-scoped `EconomicDataset` maps onto the core runtime
-  `EconomicDataset`
-- later downstream runtime products such as reconciliation datasets,
-  checkpoint packages, journals, tax determinants, and tax outputs are defined
-  in the reconciliation and tax architecture doc rather than here
+- future code may move toward the name `TranslationResult`
+- current-state docs must continue using `SourceTranslationBatch` until code
+  changes land
 
 ### 4. ProjectionBundle
 
@@ -358,7 +353,7 @@ Must include:
 
 - target id
 - target version
-- source economic dataset fingerprint
+- source fingerprint
 - projection fingerprint
 - target constraint validation results
 
@@ -392,8 +387,8 @@ Must include:
 This pipeline gives the architecture explicit checkpoints:
 
 - evidence can be verified independently of semantics
-- claims can be verified independently of canonical compilation
-- canonical data can be verified independently of target projections
+- claims can be verified independently of shared compilation
+- bridge or runtime data can be verified independently of target projections
 - target projections can be validated independently of final serialization
 
 That separation is the main mechanism for reducing adapter drift.
@@ -415,7 +410,7 @@ to that contract.
 The manifest should answer:
 
 - what evidence kinds this adapter can read or write
-- what canonical products it can emit or consume
+- what adapter or runtime products it can emit or consume
 - what facets it implements
 - which determinism guarantees it provides
 - which schema versions it supports
@@ -431,7 +426,7 @@ least the following areas.
 | Identity | `adapter_id`, `display_name`, `version`, `family`, `status` | Stable adapter identity and support posture. |
 | Direction | `implemented_facets`, `reads`, `writes` | Declares whether the adapter probes, reads, translates, writes, or combines those jobs. |
 | Evidence | `accepted_evidence_kinds`, `recognized_family_ids`, `statement_kinds` | Declares what raw or parsed evidence the adapter understands. |
-| Canonical products | `emits_claim_types`, `emits_semantic_types`, `consumes_semantic_types`, `emits_projection_types` | Defines product flow explicitly. |
+| Product flow | `emits_claim_types`, `emits_bridge_types`, `consumes_runtime_types`, `emits_projection_types` | Defines product flow explicitly. |
 | Determinism | `ordering_contract`, `fingerprint_contract`, `planner_support`, `selection_modes` | Makes determinism a contract surface. |
 | Identity | `supported_identifier_schemes`, `location_identity_rules`, `instrument_claim_rules` | Declares identity expectations. |
 | Temporal and numeric policy | `timezone_policy`, `effective_time_policy`, `precision_policy` | Makes interpretation rules explicit. |
@@ -450,8 +445,8 @@ Recommended facets:
 | `ProbeFacet` | Recognize evidence and describe confidence, families, and route hints. | Source, portfolio, and statement-capable adapters. |
 | `ReadFacet` | Read selected evidence and emit evidence bundles or claim bundles. | Source, portfolio, wallet, and explorer adapters. |
 | `StatementFacet` | Recognize and parse statement documents plus statement-specific identity claims. | Statement-capable platform and wallet adapters. |
-| `TranslateFacet` | Convert provider-local claims into canonical semantic datasets when provider-local semantic mapping is required. | Source adapters with activity semantics. |
-| `WriteFacet` | Convert canonical semantic or projection data into target artifacts. | Output adapters. |
+| `TranslateFacet` | Convert provider-local claims into bridge-ready outputs or compiler-ready claims when provider-local semantic mapping is required. | Source adapters with activity semantics. |
+| `WriteFacet` | Convert runtime or projection data into target artifacts. | Output adapters. |
 
 Additional rule:
 
@@ -477,7 +472,7 @@ Reader-side examples:
 
 Writer-side examples:
 
-- mapping canonical semantics into target-specific row models
+- mapping runtime semantics into target-specific row models
 - handling target-specific formatting or required field population
 
 ### Shared Core Responsibilities
@@ -489,7 +484,7 @@ Examples:
 
 - evidence selection and planning
 - deterministic candidate comparison and replacement rules
-- canonical ordering and fingerprint creation
+- stable ordering and fingerprint creation
 - provenance flattening at artifact boundaries
 - instrument identity resolution
 - issue and review severity conventions
@@ -552,14 +547,14 @@ Its job is to:
 It should not:
 
 - own cross-provider selection policy
-- infer canonical instrument identity beyond provider-local claims
+- infer resolved runtime instrument identity beyond provider-local claims
 - write final runtime artifacts directly
 
 Reader outputs should be deterministic for unchanged inputs.
 
 Reader ordering rules:
 
-- evidence members sorted by canonical evidence ordering
+- evidence members sorted by stable evidence ordering
 - claims sorted by stable claim key
 - diagnostics sorted by provenance plus claim or evidence id
 
@@ -592,14 +587,14 @@ after parsing.
 
 Its job is to:
 
-- convert provider-local claims into canonical semantic data or
+- convert provider-local claims into bridge-ready data or
   semantic-compiler-ready claims
 - express provider-local semantic ambiguity explicitly
 
 It should not:
 
 - choose evidence members by itself
-- resolve canonical identities through provider-local lookup tables when shared
+- resolve final runtime identities through provider-local lookup tables when shared
   resolution should own the final choice
 - write output artifacts directly
 
@@ -618,7 +613,7 @@ Its job is to:
 
 It should not:
 
-- reinterpret canonical facts semantically
+- reinterpret runtime facts semantically
 - invent missing projection metadata silently
 - coerce unsupported fact shapes into target rows
 
@@ -691,9 +686,9 @@ Recommended claim families:
 | `InstrumentIdentityClaim` | One provider-local identity assertion for an asset or instrument. |
 | `ContractTermClaim` | A provider-local claim about instrument or position terms that later economic compilation may need. |
 | `ValuationClaim` | A provider-local valuation observation with purpose, time, and provenance. |
-| `ProjectionAnnotation` | Output-oriented metadata that is not itself a canonical fact. |
-| `IssueCandidate` | A blocking or informational problem requiring canonical issue assembly. |
-| `ReviewCandidate` | A review-needed case requiring canonical review assembly. |
+| `ProjectionAnnotation` | Output-oriented metadata that is not itself a bridge or downstream runtime fact. |
+| `IssueCandidate` | A blocking or informational problem requiring shared issue assembly. |
+| `ReviewCandidate` | A review-needed case requiring shared review assembly. |
 
 These claim families let the core compiler distinguish:
 
@@ -703,9 +698,9 @@ These claim families let the core compiler distinguish:
 - output hints
 - workflow diagnostics
 
-## Canonical Compilation Rules
+## Shared Compilation Rules
 
-The compiler from claims to canonical semantic data should be shared.
+The compiler from claims to bridge or downstream runtime data should be shared.
 
 ### Compiler Responsibilities
 
@@ -714,20 +709,20 @@ The compiler from claims to canonical semantic data should be shared.
 - validate leg shape rules
 - validate required location identity
 - separate blocking issues from advisory reviews
-- create canonical facts, balance references, and location inventory
+- create current bridge facts, balance references, and location inventory
 
 ### Compiler Rules
 
-- no canonical fact may be created when identity remains unresolved
+- no bridge fact may be created when identity remains unresolved
 - no quantity-backed balance reference may be created from valuation-only
   evidence
 - no location inventory record may be created without identifier-rooted
-  canonical location identity
+  runtime location identity
 - no output hint may become a semantic fact just because a writer can use it
 
 ### Why This Must Be Shared
 
-If each adapter compiles canonical facts differently:
+If each adapter compiles bridge facts differently:
 
 - semantic correctness becomes adapter-dependent
 - output parity becomes unstable
@@ -735,7 +730,7 @@ If each adapter compiles canonical facts differently:
 
 ## Determinism Contract
 
-Determinism must be explicit across all canonical products.
+Determinism must be explicit across all adapter products.
 
 ### Deterministic Inputs
 
@@ -745,33 +740,33 @@ versions:
 - selected evidence members must be identical
 - candidate and plan fingerprints must be identical
 - claim bundle fingerprints must be identical
-- semantic dataset fingerprints must be identical
+- bridge or runtime dataset fingerprints must be identical
 - projection bundle fingerprints must be identical
 - artifact fingerprints must be identical unless the target format includes a
   documented nondeterministic field that is intentionally excluded
 
-### Canonical Ordering Rules
+### Deterministic Ordering Rules
 
-Every canonical product must declare a sort key.
+Every adapter product must declare a sort key.
 
 Examples:
 
-- evidence members sorted by canonical provenance key
+- evidence members sorted by stable provenance key
 - candidates sorted by selection group, coverage, freshness, and candidate id
 - claims sorted by claim family, timestamp, stable claim id, and provenance
 - facts sorted by timestamp, effective time, source, fact id
 - issues and reviews sorted by severity, kind, timestamp, provenance, id
-- projection rows sorted by target-defined canonical row order
+- projection rows sorted by target-defined stable row order
 
 ### Fingerprint Rules
 
-Every canonical product should have:
+Every adapter product should have:
 
 - a schema version
-- a canonical serialization form
+- a stable serialization form
 - a stable fingerprint
 
-Canonical serialization rules should:
+Serialization rules should:
 
 - sort object keys
 - avoid implicit ordering from language runtime containers
@@ -784,7 +779,7 @@ The future design should treat diagnostic surfaces as first-class contracts.
 
 ### Hard Assertions
 
-Hard assertions are required for canonical semantic acceptance.
+Hard assertions are required for bridge or runtime acceptance.
 
 Examples:
 
@@ -795,7 +790,7 @@ Examples:
 
 ### Blocking Issues
 
-Blocking issues stop canonical acceptance or later workflow progress.
+Blocking issues stop bridge acceptance or later workflow progress.
 
 Examples:
 
@@ -835,7 +830,7 @@ The future model should distinguish:
 - evidence member provenance
 - parsed row or page provenance
 - claim provenance
-- canonical semantic derivation provenance
+- bridge or runtime derivation provenance
 - artifact derivation provenance
 
 ### Why Product Boundaries Matter
@@ -855,21 +850,22 @@ Identity rules should remain shared and identifier-rooted.
 
 ### Instrument Identity
 
-Adapters should emit identity claims, not final canonical instrument choices.
+Adapters should emit identity claims, not final resolved runtime instrument
+choices.
 
 The shared identity resolver should:
 
 - accept multiple claims
-- resolve exactly one canonical instrument or fail explicitly
+- resolve exactly one runtime instrument or fail explicitly
 - preserve review context when ambiguity remains
 
 ### Location Identity
 
-Adapters should emit identifier-rooted canonical locations.
+Adapters should emit identifier-rooted runtime locations.
 
 Rules:
 
-- friendly labels stay out of canonical ids
+- friendly labels stay out of runtime ids
 - chain or network identity must be explicit
 - sublocations must be stable derivations of parent identity
 
@@ -885,7 +881,8 @@ policy model should be shared.
 
 ### Temporal Rules
 
-- timestamps must be timezone-aware before entering canonical semantic data
+- timestamps must be timezone-aware before entering bridge or downstream
+  runtime data
 - date-only and timestamp precision must remain distinct
 - exact midnight timestamps are still timestamps if the source contract says so
 - unknown or conflicting timezone interpretation must block or review
@@ -907,8 +904,8 @@ fundamentally different architecture categories.
 
 ### Input
 
-An input adapter is an adapter whose facets read evidence and emit claims or
-semantic data.
+An input adapter is an adapter whose facets read evidence and emit claims,
+bridge-ready outputs, or downstream runtime data.
 
 ### Portfolio
 
@@ -918,7 +915,7 @@ position, statement, or ownership claims instead of activity-heavy claims.
 ### Output
 
 An output adapter is an adapter whose primary facet writes projection or
-artifact bundles from semantic data.
+artifact bundles from runtime or projection data.
 
 ### Why One Adapter Model Matters
 
@@ -926,7 +923,7 @@ The architecture stays smaller if:
 
 - one manifest model describes all adapters
 - one verifier model checks their products
-- one canonical vocabulary describes the flow
+- one shared adapter vocabulary describes the flow
 
 ## Migration Of Current Jobs Into Future Facets
 
@@ -938,11 +935,11 @@ The current repo jobs should map into the future architecture as follows.
 | file-family classification | `ProbeFacet` plus manifest-declared evidence families |
 | intake matching and route hints | `ProbeFacet` plus shared intake router |
 | timezone summary | shared temporal policy service with manifest-declared expectations |
-| location inventory extraction | `ReadFacet` or `TranslateFacet` producing `OwnershipClaim` and canonical inventory through shared compilation |
+| location inventory extraction | `ReadFacet` or `TranslateFacet` producing `OwnershipClaim` and runtime inventory through shared compilation |
 | statement matching and parsing | `StatementFacet` plus shared statement orchestration |
 | translation-input planning | shared planner using manifest and candidate descriptions |
 | activity translation | `ReadFacet` and `TranslateFacet` producing `ActivityClaim` |
-| draft compilation | shared compiler to `EconomicDataset` |
+| draft compilation | shared compiler to current bridge outputs first, then `EconomicFacts` once the bridge is retired |
 | output policy validation | shared projection validator |
 | rendering | `WriteFacet` |
 
@@ -960,14 +957,14 @@ than the current contract-by-contract mixture.
 | Unit tests | Provider-local parsing, semantic mapping, and edge-case decisions. |
 | Contract tests | Manifest validity, facet declarations, and product schema conformance. |
 | Golden tests | Stable evidence, claim, economic, and projection outputs on known packs. |
-| Replay tests | Re-run unchanged inputs and verify identical canonical fingerprints. |
+| Replay tests | Re-run unchanged inputs and verify identical stable fingerprints. |
 | Negative tests | Assert blocking behavior for unsupported or ambiguous evidence. |
 
 ### Mandatory Determinism Checks
 
 - shuffled file order must not change selected candidates
 - equivalent archive extraction order must not change claim order
-- repeated runs must preserve canonical fingerprints
+- repeated runs must preserve stable fingerprints
 - rendered writer outputs must remain stable for unchanged economic datasets
 
 ### Compatibility Checks
@@ -975,7 +972,7 @@ than the current contract-by-contract mixture.
 The future verifier should check:
 
 - manifest schema compatibility
-- canonical product schema compatibility
+- adapter product schema compatibility
 - adapter support-window declarations
 - intentional breaking changes via explicit version increments
 
@@ -1027,7 +1024,7 @@ These questions are intentionally left open for later design review:
 
 - Should `ReadFacet` emit evidence bundles and claim bundles separately, or may
   some adapters emit claims directly when parsing is trivial?
-- Should writer adapters consume `EconomicDataset` directly, or should all
+- Should writer adapters consume `EconomicFacts` directly, or should all
   writers consume a target-neutral `ProjectionBundle` first?
 - Which manifest fields should be purely declarative versus code-generated?
 - How much of current timezone and precision policy belongs in manifest data

--- a/docs/guides/write-an-adapter.md
+++ b/docs/guides/write-an-adapter.md
@@ -67,24 +67,24 @@ current repo-facing implementation rules.
   export provides actual balance evidence.
 - Statement-backed balance evidence must stay quantity-based. Normalize only
   rows that prove per-instrument quantities; do not promote market-value totals,
-  net-worth summaries, or other valuation-only rows into canonical balance
+  net-worth summaries, or other valuation-only rows into runtime balance
   evidence.
 - Normalize source-specific sign conventions at the adapter edge into signed
-  canonical quantities. If the provider sign or direction signal is ambiguous,
+  shared quantities. If the provider sign or direction signal is ambiguous,
   surface an issue or review instead of guessing.
 - Treat symbols, venue codes, and chain contracts as identifier inputs.
-  Adapters should target canonical instrument references through the shared
+  Adapters should target shared instrument references through the shared
   identifier-resolution seam rather than treating raw symbols as stable
   identity.
 - Emit identifier claims that are sufficient for shared resolution to one
-  canonical instrument. If resolution is unresolved or ambiguous, emit a review
+  runtime instrument. If resolution is unresolved or ambiguous, emit a review
   record plus a blocking issue and do not produce a fact for that activity.
-- Use identifier-rooted canonical on-chain location ids:
+- Use identifier-rooted on-chain location ids:
   - EVM-family locations use `evm:<network>:<address>`
   - non-EVM chains use their own namespace such as `near:<account>` or
     `bitcoin:<address>`
   - derived sublocations append a stable suffix such as `:staking`
-- Keep source labels, wallet names, and other friendly labels out of canonical
+- Keep source labels, wallet names, and other friendly labels out of
   runtime `location_id` values. Those labels belong in `source`,
   `location_label`, annotations, and output-adapter display logic.
 - Normalize runtime timestamps at the adapter edge. Draft, fact, balance, and
@@ -157,7 +157,7 @@ families in one raw source directory, the adapter should rely on the shared
 blocking scan issue instead of attempting a best-effort normalization pass.
 
 Wallet-state adapters must treat UI identity maps and friendly labels as labels
-only. Emit canonical wallet inventory only when the export proves authoritative
+only. Emit runtime wallet inventory only when the export proves authoritative
 chain-scoped or chain-specific ownership.
 
 When a wallet or explorer source also includes portfolio-style balance views
@@ -215,6 +215,9 @@ Known current adapter workaround:
   assert transaction facts, balances, issues, and rendered outputs.
 - Adapters must continue to pass both strict type checkers. Do not rely on
   runtime tests as a substitute for `mypy` and `pyright`.
+- Do not delete adapter tests, silently remove assertions, or simplify
+  fixtures in a way that weakens coverage without explicit human approval.
+- If tests move or consolidate, state what behavior is still covered and where.
 
 ## Tooling
 

--- a/docs/guides/write-an-adapter.md
+++ b/docs/guides/write-an-adapter.md
@@ -11,8 +11,24 @@ nav_order: 60
 Adapters are first-class modules inside the repo and are discovered
 automatically.
 
+Read [`../status/adapter-delivery-plan.md`](../status/adapter-delivery-plan.md)
+first when deciding whether adapter work belongs in the filing-critical `now`
+track or the later contract rewrite.
+
+Read [`../concepts/unified-adapter-architecture.md`](../concepts/unified-adapter-architecture.md)
+before shaping adapter changes. That concept document is the forward design
+anchor for adapter work. This guide describes the current contract and the
+current repo-facing implementation rules.
+
 ## Rules
 
+- Keep the future unified adapter architecture in view when changing current
+  adapters. Prefer shared seams and deterministic contracts that move toward
+  the target design instead of adding new adapter-local workflow logic.
+- Keep the core runtime pipeline in
+  [`../concepts/reconciliation-tax-architecture.md`](../concepts/reconciliation-tax-architecture.md)
+  as the system architecture center. Adapter docs define adapter responsibilities
+  and migration shape, not a second core runtime center.
 - Keep adapter metadata, code, and tests together.
 - Implement the `SourceAdapter` or `OutputAdapter` port only.
 - Keep the concrete adapter implementation class private inside `adapter.py` or

--- a/docs/standards/delivery-guardrails.md
+++ b/docs/standards/delivery-guardrails.md
@@ -109,6 +109,13 @@ Control-plane files include:
 - `tools/run_quality_gates.py`
 - `tools/verify_built_wheel.py`
 
+Current-state note:
+
+- these `repo_support/**` paths are current live control-plane surfaces today
+- later implementation may rename that dev-only shared support boundary under
+  `dev_support/`, but until that slice lands the current live paths remain the
+  enforcement truth
+
 If a repo policy depends on a platform-native control that is not enabled, call
 that out as a real enforcement gap rather than assuming documentation is
 enough.
@@ -158,8 +165,9 @@ the changed surface groups in the current PR diff:
     delivery behavior, compaction and context-loss recovery, issue and privacy
     handling
 - `repo_code_or_tooling`
-  - paths: `src/**`, Python under `tools/**`, `repo_support/**`, `tests/**`,
-    and repo-root test support such as `conftest.py`
+  - paths: `src/**`, Python under `tools/**`, current live repo-only support
+    code under `repo_support/**`, `tests/**`, and repo-root test support such
+    as `conftest.py`
   - review domains: design and ownership, correctness and behavior, complexity
     and over-engineering, tests and regression value, naming and public
     terminology, documentation and control-plane alignment

--- a/docs/standards/engineering.md
+++ b/docs/standards/engineering.md
@@ -26,9 +26,9 @@ Place code by responsibility, not by convenience:
 - `adapters/`: source and output adapters plus their adapter-local helpers.
 - `interfaces/`: thin entry points such as the CLI. Interfaces orchestrate
   services; they do not own business rules.
-- `repo_support/`: shared support seams for repo-native tooling and repo-side
-  tests. Keep this outside `src/tallylot/` because it is not production/runtime
-  code.
+- `repo_support/`: the current live shared support seam for repo-native tooling
+  and repo-side tests. Keep this outside `src/tallylot/` because it is not
+  production/runtime code.
 
 If a change crosses layer boundaries, refactor the boundary instead of
 importing through it.
@@ -38,10 +38,14 @@ Repo-native support boundaries:
 - `src/tallylot/` remains production/runtime code only.
 - `tools/` remains the home for repo-native entry points and task-specific
   dev-only modules.
-- `repo_support/` is the shared support seam for repo-native tooling and
+- `repo_support/` is the current live shared seam for repo-native tooling and
   repo-side tests.
-- `repo_support/` must stay narrow, typed, stdlib-first, and named by concept.
-- `repo_support/` must not become a generic catch-all.
+- later implementation should rename that dev-only surface to `dev_support/`
+  so the boundary is explicit.
+- until that rename lands, `repo_support/` must stay narrow, typed,
+  stdlib-first, and named by concept.
+- do not let `repo_support/` become a generic catch-all while the repo is
+  still on the current live name.
 
 ## Typing Rules
 
@@ -85,8 +89,9 @@ Default to one responsibility per module.
   `misc.py`, or another catch-all `common.py`.
 - Existing generic modules should shrink over time, not absorb more unrelated
   behavior.
-- Apply the same rule to `repo_support/`. Shared repo-only support must be
-  split by named seam, not collected under generic support modules.
+- Apply the same rule to the current live `repo_support/` surface and the later
+  target `dev_support/` surface. Shared repo-only support must be split by
+  named seam, not collected under generic support modules.
 
 When a capability grows, split by stable seams:
 
@@ -107,7 +112,8 @@ When a capability grows, split by stable seams:
   persistence, or composition-root wiring. Do not push application policy down
   here just to share code.
 - `repo_support/`: host reusable repo-only support only when it is shared by
-  multiple repo-native surfaces such as `tools/` and `tests/`. Do not move
+  multiple repo-native surfaces such as `tools/` and `tests/`. This is the
+  current live name for a later `dev_support/` target. Do not move
   production/runtime concerns here.
 
 Mirror that structure in tests:

--- a/docs/standards/implementation.md
+++ b/docs/standards/implementation.md
@@ -117,7 +117,7 @@ otherwise:
 
 - keep the architecture aligned with
   `docs/concepts/reconciliation-tax-architecture.md`
-- for reconciliation, checkpoint, accounting, tax, or canonical pipeline work,
+- for reconciliation, checkpoint, accounting, tax, or core pipeline work,
   reload the owning roadmap and migration docs before shaping the slice:
   `ROADMAP.md` and `docs/status/migration-sequence.md`
 - read the narrow forward-looking roadmap, architecture, migration, or owning
@@ -148,7 +148,7 @@ Before shaping a non-trivial fix, reload the narrow forward-looking guidance
 that owns the change surface. Prefer the intended end-state seam over a local
 temporary patch when the repo already documents the target ownership model.
 
-For reconciliation, checkpoint, accounting, tax, and canonical pipeline work,
+For reconciliation, checkpoint, accounting, tax, and core pipeline work,
 the normal minimum routing set is:
 
 - `docs/concepts/reconciliation-tax-architecture.md`

--- a/docs/standards/implementation.md
+++ b/docs/standards/implementation.md
@@ -117,6 +117,9 @@ otherwise:
 
 - keep the architecture aligned with
   `docs/concepts/reconciliation-tax-architecture.md`
+- for reconciliation, checkpoint, accounting, tax, or canonical pipeline work,
+  reload the owning roadmap and migration docs before shaping the slice:
+  `ROADMAP.md` and `docs/status/migration-sequence.md`
 - read the narrow forward-looking roadmap, architecture, migration, or owning
   boundary guidance before shaping a non-trivial change
 - refactor when a clearer shared seam is already visible
@@ -144,6 +147,17 @@ the right structure.
 Before shaping a non-trivial fix, reload the narrow forward-looking guidance
 that owns the change surface. Prefer the intended end-state seam over a local
 temporary patch when the repo already documents the target ownership model.
+
+For reconciliation, checkpoint, accounting, tax, and canonical pipeline work,
+the normal minimum routing set is:
+
+- `docs/concepts/reconciliation-tax-architecture.md`
+- `ROADMAP.md`
+- `docs/status/migration-sequence.md`
+
+Add `docs/concepts/oracle-boundaries.md` and
+`docs/concepts/transaction-classification.md` when the slice changes
+boundaries or semantic classification.
 
 ## Refactor Expectations
 

--- a/docs/status/adapter-delivery-plan.md
+++ b/docs/status/adapter-delivery-plan.md
@@ -9,6 +9,8 @@ nav_order: 30
 related:
   - ROADMAP.md
   - docs/guides/write-an-adapter.md
+  - docs/concepts/pipeline-stage-contracts.md
+  - docs/concepts/domain-ontology.md
   - docs/concepts/reconciliation-tax-architecture.md
   - docs/status/current-state.md
 ---
@@ -36,9 +38,11 @@ This plan treats adapter work as two tracks:
 - `roadmap`: the post-filing unified adapter interface and migration
 
 Forward-looking adapter work must map into the main runtime pipeline in
+`docs/concepts/pipeline-stage-contracts.md` and the trust-gate rules in
 `docs/concepts/reconciliation-tax-architecture.md`. Adapter docs do not define
-their own competing meaning for `EconomicFacts`, `ReconciliationState`,
-`Checkpoint`, `Journal`, `TaxInputs`, or `TaxOutputs`.
+their own competing meaning for `EvidenceSet`, `ClaimSet`, `EconomicFacts`,
+`ReconciliationState`, `Checkpoint`, `Journal`, `TaxInputs`, or
+`TaxOutputs`.
 
 ## Why This Plan Exists
 

--- a/docs/status/adapter-delivery-plan.md
+++ b/docs/status/adapter-delivery-plan.md
@@ -1,0 +1,528 @@
+---
+title: "Adapter Delivery Plan"
+summary: "Filing-first plan for stabilizing current adapters now and deferring the unified adapter contract rewrite until after filing-critical work."
+doc_type: status
+audience: human
+owner: repo
+status: active
+nav_order: 30
+related:
+  - ROADMAP.md
+  - docs/guides/write-an-adapter.md
+  - docs/concepts/reconciliation-tax-architecture.md
+  - docs/status/current-state.md
+---
+
+Use this plan when deciding whether adapter work belongs in the current
+filing-critical window or in the later adapter-contract rewrite.
+
+The intent is to keep tax delivery primary. The repo should harden the current
+adapter path where it directly improves filing confidence, determinism, and
+repeatability, but it should defer the full unified adapter redesign until the
+filing path is stable enough to trust.
+
+## Decision
+
+The repo should use a filing-first adapter strategy:
+
+- harden the current adapter layer where it directly reduces filing risk
+- avoid a broad source and output adapter contract rewrite before filing
+- extract only those shared seams that remove current drift on the filing path
+- write down the future unified adapter design now, but migrate to it later
+
+This plan treats adapter work as two tracks:
+
+- `now`: filing-critical hardening on the current seams
+- `roadmap`: the post-filing unified adapter interface and migration
+
+## Why This Plan Exists
+
+The current adapter layer already carries much more responsibility than a
+single translation interface suggests.
+
+Today a source adapter may be responsible for:
+
+- source matching during profile selection
+- file-family classification during profile analysis
+- intake file matching and route selection
+- timezone validation policy
+- location inventory extraction
+- statement PDF recognition and parsing
+- statement instrument claim resolution
+- translation input planning in planner-enabled adapters
+- translation from raw evidence into shared activity drafts, issues, reviews,
+  balance references, and location inventory
+
+Today an output adapter is responsible for:
+
+- declaring supported render policy and fact-shape requirements
+- rendering facts into an external artifact
+
+This mismatch matters because the current source contract is effectively a
+bundle of unrelated jobs. That makes it easy for behavior drift to accumulate
+between adapters and makes every contract cleanup larger than it needs to be.
+
+The repo still needs a broad redesign, but taxes depend on deterministic
+current behavior sooner than they depend on a perfect future contract.
+
+## Current Adapter Scope
+
+### Current Source-Side Jobs
+
+| Job | Current seam | Why it matters |
+| --- | --- | --- |
+| Source selection | `match(...)` | Chooses the owning adapter for profiling and normalization. |
+| File-family recognition | `classify_profile_families(...)` | Drives deterministic family ownership before translation. |
+| Intake classification | `match_intake(...)`, `route_intake(...)` | Controls where inbound files land in the workspace. |
+| Timezone policy | `validate_profile_timezones(...)` | Prevents silent timestamp drift. |
+| Location evidence | `extract_location_inventory(...)` | Supplies owned location identity and evidence. |
+| Statement parsing | `match_statement_document(...)`, `parse_statement_document(...)` | Converts statements into quantity-backed balance evidence. |
+| Statement identity claims | `resolve_statement_instrument_claims(...)` | Resolves statement rows to canonical instruments. |
+| Translation planning | `describe_translation_inputs(...)`, `translate_selected_inputs(...)` | Prevents adapter-local file winner heuristics. |
+| Translation | `translate(...)` | Produces activity drafts and evidence artifacts. |
+
+### Current Output-Side Jobs
+
+| Job | Current seam | Why it matters |
+| --- | --- | --- |
+| Output policy declaration | `render_policy` | Rejects facts that the target format cannot represent safely. |
+| Rendering | `render(...)` | Produces deterministic external output artifacts. |
+
+### Current Adapters
+
+| Adapter | Kind | Current role | Default filing priority |
+| --- | --- | --- | --- |
+| `coinbase` | source platform | retail export translation, planner path, statement parsing | Tier A when the filing workspace uses Coinbase |
+| `binance` | source platform | multifamily CSV translation, intake routing, statement parsing | Tier A when the filing workspace uses Binance |
+| `shakepay` | source platform | translation, statement parsing, statement evidence | Tier A when the filing workspace uses Shakepay |
+| `wealthsimple` | source platform | translation, intake routing | Tier A when the filing workspace uses Wealthsimple |
+| `ledger_live` | source wallet | grouped-operation translation, wallet inventory | Tier A when the filing workspace uses Ledger Live |
+| `evm_explorer` | source explorer | translation, address extraction, portfolio evidence | Tier A only when explorer evidence is needed for filing |
+| `near` | source explorer | translation, location inventory | Tier A only when NEAR activity is part of filing |
+| `ronin` | source explorer | translation, location inventory | Tier A only when Ronin activity is part of filing |
+| `evm_wallet` | source wallet | wallet inventory, transaction translation | Tier A only when wallet-state evidence is needed |
+| `crypto_com` | source platform | translation, intake routing | Tier B unless required in the filing workspace |
+| `gtrade` | source platform | translation, intake routing, location inventory | Tier B unless required in the filing workspace |
+| `structured_csv` | generic source | generic structured import surface | Tier B unless the filing workspace depends on it |
+| `cointracking_portfolio` | portfolio intake | intake-only routing of portfolio exports | Tier B for intake stability, not for translation |
+| `cointracking_csv` | output | filing-oriented CSV projection | Tier A because output determinism directly affects filing |
+| `cointracking_api` | output stub | reserved edge surface | Tier C |
+| `generic_http_output` | output stub | reserved edge surface | Tier C |
+| `platform_api_stub` | source stub | reserved non-runtime surface | Tier C |
+| `blockchain_stub` | source stub | reserved non-runtime surface | Tier C |
+
+### Priority Tiers
+
+| Tier | Meaning | Action in this plan |
+| --- | --- | --- |
+| Tier A | Required for the current filing workspace or filing output path | Harden now. |
+| Tier B | Supported but not required for the current filing window | Only touch if a shared fix naturally improves it at low cost. |
+| Tier C | Stubbed, reserved, or clearly non-filing | Do not expand now. Roadmap only. |
+
+The actual Tier A set must be driven by the active filing workspace, not by a
+desire for repo-wide completeness.
+
+## Filing-First Principles
+
+- Prefer deterministic current behavior over ambitious interface redesign.
+- Prefer shared support extraction over copy-paste repairs when the shared seam
+  is already visible.
+- Prefer explicit issues and reviews over adapter-local guesswork.
+- Prefer content signatures, coverage metadata, and fingerprints over filename
+  or lexical path order.
+- Prefer one shared statement extraction path over adapter-local statement
+  orchestration.
+- Prefer one shared output-policy gate over format-specific silent coercion.
+- Do not widen the current source adapter contract during the filing window.
+- Do not introduce dual contracts, migration wrappers, or adapter-local
+  compatibility shims for the future design.
+
+## Work To Do Now
+
+The `now` track is the work that should land before or during filing as long as
+the active filing path benefits directly.
+
+### 1. Lock The Filing-Critical Adapter Set
+
+Before additional adapter work begins, determine which current adapters are
+actually in the filing path for the active workspace.
+
+Required actions:
+
+- list every source used by the current filing workspace for `2023` to `2025`
+- map each source to one current adapter id
+- identify which outputs are filing-critical, beginning with
+  `cointracking_csv`
+- mark all other adapters as non-blocking for the current filing window
+
+Deliverables:
+
+- one repo-safe filing adapter set recorded in the active delivery notes or
+  issue thread
+- one explicit decision on whether each non-filing adapter is Tier B or Tier C
+
+Out of scope now:
+
+- broad parity work for adapters not used in the current filing path
+- redesigning discovery to support future adapter kinds
+
+Exit criteria:
+
+- the team can say exactly which adapters must be stable before filing
+
+### 2. Harden Shared Determinism Surfaces
+
+These shared surfaces reduce drift across multiple adapters and are worth
+changing during the filing window.
+
+| Work item | Why now | Concrete work | Explicitly out of scope | Exit criteria |
+| --- | --- | --- | --- | --- |
+| Translation input selection | File winner logic is one of the biggest drift sources. | Finish planner migration for filing-critical adapters, remove path-order and filename-order winning logic, keep selected, superseded, and blocked candidates explicit. | A new global adapter DSL. | Unchanged raw inputs pick the same candidates every run and emit the same plan artifacts. |
+| Deterministic ordering | Output drift can come from unordered iteration even when facts are correct. | Canonicalize ordering for candidates, selected files, drafts, issues, reviews, balance references, and rendered rows where the target format permits it. | New storage formats. | Repeated normalization and rendering runs are byte-stable or field-stable on unchanged inputs. |
+| Shared file-family recognition | Family ownership drift creates downstream translation drift. | Prefer content and schema signatures, publish stable family ids, and keep family claims in profile artifacts authoritative for translation. | Rewriting discovery around the future facet model. | Filing-critical adapters translate only recognized families and surface unmatched files explicitly. |
+| Timezone handling | Silent timestamp drift directly changes tax outcomes. | Keep timezone policy explicit, centralize common timezone summaries and review patterns, and reject ambiguous timestamp interpretation. | A universal temporal framework rewrite. | Filing-critical adapters no longer silently coerce naive timestamps into facts. |
+| Statement extraction | Statement evidence is needed for checkpoint and balance trust. | Keep one shared PDF extraction path, align statement matching and instrument-claim resolution, and fail explicitly on recognized-but-empty parses. | A new statement plugin system. | Statement-backed balance evidence is deterministic across repeated runs. |
+| Identity resolution feedback | Instrument ambiguity must block fact creation consistently. | Keep draft compilation as the shared gate, standardize blocking issue and review paths, and remove adapter-local special cases where possible. | New identity domains or taxonomy expansion. | All unresolved identity paths fail the same way across filing-critical adapters. |
+| Output projection validation | Filing outputs cannot rely on renderer guesswork. | Strengthen render-policy checks and keep unsupported fact shapes explicit before rendering. | New output-contract architecture. | The renderer rejects unsupported fact shapes before writing the artifact. |
+
+### 3. Finish Planner Migration Only Where It Reduces Filing Risk
+
+Planner migration is worth doing now only when the adapter still performs
+winner-selection internally.
+
+Now:
+
+- finish planner migration for every Tier A adapter that still chooses one file
+  by filename, path order, or provider-local winner heuristics
+- keep plan artifacts mandatory before translation starts
+- ensure candidate description, coverage, freshness, selection mode, and
+  comparability are explicit
+- block ambiguous overlap instead of selecting implicitly
+
+Later:
+
+- generalize planner support into the future unified adapter contract
+- add declarative candidate schemas for every adapter kind
+
+Exit criteria:
+
+- every Tier A adapter uses either a safe planner path or an explicitly
+  accepted fallback path with no hidden winner logic
+
+### 4. Reduce Adapter-Local Orchestration In Tier A Adapters
+
+Tier A adapters should stay responsible for provider-local semantics only.
+They should not own their own mini workflow engines when a shared seam already
+exists.
+
+Allowed extractions now:
+
+- shared file-family dispatch helpers
+- shared timezone summary builders
+- shared issue and review builders
+- shared statement extraction orchestration
+- shared draft compilation
+- shared location-id and identifier helpers
+- shared deterministic ordering helpers
+
+Avoid now:
+
+- creating another broad `helpers.py` or generic adapter utility sink
+- extracting abstractions that are only preparing for the future redesign
+- moving provider-local economic semantics into generic support too early
+
+Exit criteria:
+
+- the average Tier A adapter entry point becomes thinner without changing the
+  external contract
+
+### 5. Add Replay-Grade Verification For Tier A Adapters
+
+The filing path needs deterministic verification more than it needs a new
+contract.
+
+Required verification work:
+
+- maintain golden packs for Tier A adapters with meaningful provider cases
+- add or refresh expected fact, balance, issue, and review coverage for
+  observed row families
+- add parity checks for unchanged raw inputs
+- verify that repeated runs preserve:
+  - file completeness
+  - fact counts
+  - balance reference counts
+  - issue and review behavior unless a documented expected difference applies
+- verify that rendered filing outputs are stable on unchanged facts
+
+Recommended verification focus:
+
+- planner artifacts for planner-enabled adapters
+- statement-backed evidence for adapters with PDF support
+- grouped or multi-leg operations for complex platform and wallet adapters
+- explorer and wallet inventory behavior when location identity is filing
+  relevant
+
+Out of scope now:
+
+- repo-wide parity goldens for non-filing adapters
+- exhaustive perfection for every unsupported provider edge case
+
+Exit criteria:
+
+- unchanged filing inputs can be rerun with confidence that output drift is a
+  real signal, not adapter noise
+
+### 6. Tier A Adapter Work Matrix
+
+This matrix defines what should happen now for each likely filing-relevant
+adapter.
+
+| Adapter | Do now | Defer |
+| --- | --- | --- |
+| `coinbase` | Keep planner path authoritative, harden statement PDF extraction, ensure retail export family claims stay stable, refresh deterministic goldens. | Future facet split and declarative manifest redesign. |
+| `binance` | Keep multifamily family recognition explicit, remove hidden winner logic, harden timezone review behavior, verify statement evidence, expand row and family coverage only for observed filing inputs. | Broad cleanup for unsupported export families not in the filing workspace. |
+| `shakepay` | Keep statement-backed balances deterministic, ensure translation and statement parsers agree on instrument claims, refresh goldens for observed filing rows. | Contract redesign for statement parsing hooks. |
+| `wealthsimple` | Verify deterministic translation and intake behavior for actual filing exports, add missing edge coverage only when observed in the workspace. | Broader portfolio-style abstraction work. |
+| `ledger_live` | Harden grouped-operation translation and wallet inventory only if the filing workspace depends on it, especially for swaps and grouped operations. | General wallet-adapter redesign. |
+| `evm_explorer` | Keep address extraction, transaction translation, and same-source same-chain portfolio evidence explicit if explorer evidence is needed for filing. | General public-ledger adapter unification and provider-hydration integration. |
+| `near` | Harden only if the filing workspace includes NEAR activity. | Family-wide explorer contract redesign. |
+| `ronin` | Harden only if the filing workspace includes Ronin activity, including known fee-precision review behavior. | Family-wide explorer contract redesign. |
+| `evm_wallet` | Harden only if wallet-state or wallet inventory evidence is needed for filing. | Wallet-state contract redesign. |
+| `cointracking_csv` | Keep render-policy validation strict, verify deterministic row ordering and projection coverage for filing facts. | New writer contract or multi-target artifact pipeline. |
+
+### 7. Tier B And Tier C Handling During The Filing Window
+
+Tier B and Tier C adapters are not ignored, but they should not drive the
+shape of filing-period work.
+
+Tier B rule:
+
+- accept low-cost shared improvements when they naturally benefit Tier B
+  adapters
+- avoid adapter-specific surgery unless that adapter becomes part of the
+  current filing workspace
+
+Tier C rule:
+
+- keep stubs and reserved surfaces minimal
+- do not expand stub capabilities during the filing window
+
+### 8. Explicitly Deferred Work
+
+The following work should be roadmapped, not pulled into the filing window:
+
+- replacing the monolithic `SourceAdapter` contract with a new multi-facet
+  interface
+- unifying input, portfolio, and output adapters under one new runtime
+  contract
+- redesigning discovery around future adapter kinds
+- introducing adapter migration wrappers, compatibility shims, or dual-write
+  flows
+- creating a fully declarative adapter specification language
+- broad parity work for non-filing adapters
+- generalized balance-provider integration work beyond filing-critical needs
+
+### 9. Filing-Window Exit Criteria
+
+The `now` track is complete when all of the following are true for the active
+filing workspace:
+
+- every filing-critical source is mapped to one supported adapter
+- planner-enabled Tier A adapters emit stable planning artifacts before
+  translation
+- Tier A adapters no longer depend on hidden lexical winner selection
+- timestamp interpretation is explicit and stable
+- statement-backed balance evidence is deterministic where used
+- unchanged raw inputs preserve expected fact and evidence behavior
+- `cointracking_csv` rendering is stable and rejects unsupported fact shapes
+- remaining unsupported or ambiguous cases surface as explicit issues or
+  reviews
+
+The filing window does not require every adapter to be elegant. It requires
+the filing path to be trustworthy.
+
+## Work To Roadmap
+
+The `roadmap` track is the full unified adapter redesign that should happen
+after filing-critical work no longer depends on current seam stability.
+
+### Roadmap Objective
+
+Replace the current bundled source contract and separate output contract with a
+smaller, purpose-defined adapter architecture built around shared canonical
+products, deterministic verification, and provider-local semantics only.
+
+### Roadmap Principles
+
+- unify around canonical products, not around one giant method surface
+- keep manifests declarative and authoritative
+- separate hard assertions from soft annotations
+- treat provenance as a first-class runtime concept
+- require canonical ordering and fingerprints at artifact boundaries
+- keep the compiler and verifier shared
+- keep provider-local code focused on parsing, semantic mapping, and rendering
+
+### Roadmap Phase R1. Define Canonical Products
+
+Design and write the future canonical products:
+
+- `EvidenceBundle`
+- `ClaimBundle`
+- `EconomicDataset`
+- `ProjectionBundle`
+- `ArtifactBundle`
+
+Boundary rule:
+
+- these adapter-scoped products must map explicitly into the core runtime
+  pipeline in `docs/concepts/reconciliation-tax-architecture.md`
+- adapter planning must not become a second architecture center with competing
+  names or stage ownership
+
+Deliverables:
+
+- written contracts for each product
+- declared ordering and fingerprint rules
+- rules for which layers may create or transform each product
+
+Entry criteria:
+
+- filing-critical path is stable enough that the team can change contracts
+  without risking the tax deadline
+
+### Roadmap Phase R2. Split The Contract Into Facets
+
+Replace the current bundled source adapter interface with a small set of
+purpose-defined facets.
+
+Planned facets:
+
+- probe or discovery facet
+- evidence reader facet
+- statement facet
+- semantic translator facet
+- artifact writer facet
+
+Goals:
+
+- allow intake-only adapters to stay intake-only
+- allow statement-capable adapters to declare only statement work
+- keep writer adapters separate from semantic readers without duplicating the
+  manifest model
+
+Non-goals:
+
+- preserving the current monolithic shape under new names
+- adding wrappers that keep both contract systems alive indefinitely
+
+### Roadmap Phase R3. Make Manifests Declarative
+
+Move more behavior description into manifests instead of open-coded adapter
+methods where the behavior is structural rather than semantic.
+
+Candidate manifest-owned data:
+
+- evidence family signatures
+- accepted artifact kinds
+- planner support and selection modes
+- statement kinds
+- canonicalization rules
+- determinism guarantees
+- schema version and compatibility rules
+- supported claim and artifact types
+
+Exit criteria:
+
+- a reader can understand what an adapter can do from its manifest and small
+  provider-local modules, not from a large composite entry point
+
+### Roadmap Phase R4. Unify Verification Around Canonical Products
+
+Build one verifier that checks the canonical products instead of relying on a
+mix of adapter-local conventions.
+
+Verifier goals:
+
+- replay stability on unchanged inputs
+- canonical fingerprint stability
+- no unordered output surfaces
+- explicit unsupported or ambiguous cases
+- artifact parity where projections exist
+
+Exit criteria:
+
+- adapter verification is centered on canonical products and deterministic
+  compiler behavior
+
+### Roadmap Phase R5. Migrate Adapter Families In Priority Order
+
+Once the future contracts exist, migrate adapter families in bounded phases.
+
+Recommended order:
+
+1. filing-critical platform adapters
+2. filing-critical writer adapters
+3. wallet and explorer adapters needed for checkpoint confidence
+4. remaining supported platform adapters
+5. generic and reserved surfaces
+
+Rules:
+
+- migrate one family at a time
+- keep each migration checkpoint reviewable
+- remove obsolete seams once the new family path is stable
+- avoid a giant umbrella migration
+
+### Roadmap Phase R6. Retire The Bundled Current Contract
+
+Only after migrated families are stable should the repo remove the current
+bundled contract shape.
+
+Retirement conditions:
+
+- no filing-critical adapter depends on the old contract
+- verification has moved to canonical products
+- docs, scaffolds, and tests all describe the new model
+
+## Decision Rules While Filing Work Is Active
+
+Use these rules to decide whether an adapter change belongs in `now` or
+`roadmap`.
+
+Choose `now` when:
+
+- the change directly improves a filing-critical adapter or output
+- the change removes a current source of nondeterminism
+- the change moves duplicated workflow logic into an already visible shared
+  seam
+- the change improves replay confidence on unchanged inputs
+- the change makes unsupported or ambiguous behavior explicit
+
+Choose `roadmap` when:
+
+- the change exists mainly to prepare a future interface
+- the change introduces a new abstraction layer with no filing benefit
+- the change requires dual-contract support or migration wrappers
+- the change primarily benefits non-filing adapters
+- the change expands stubs, reserved surfaces, or speculative future adapter
+  kinds
+
+When in doubt:
+
+- prefer the smaller current-contract hardening change
+- record the future design pressure in roadmap notes instead of solving it
+  prematurely in code
+
+## Relationship To The Roadmap
+
+This plan does not replace `ROADMAP.md`.
+
+`ROADMAP.md` should continue to track the long-range architecture sequence.
+This document narrows one immediate execution question that the main roadmap
+does not need to carry in detail:
+
+- what adapter work should happen before taxes
+- what adapter work should wait until after filing
+
+The broad unified adapter redesign remains a roadmap item. The current filing
+window should stabilize the path, not perfect the architecture.

--- a/docs/status/adapter-delivery-plan.md
+++ b/docs/status/adapter-delivery-plan.md
@@ -35,6 +35,11 @@ This plan treats adapter work as two tracks:
 - `now`: filing-critical hardening on the current seams
 - `roadmap`: the post-filing unified adapter interface and migration
 
+Forward-looking adapter work must map into the main runtime pipeline in
+`docs/concepts/reconciliation-tax-architecture.md`. Adapter docs do not define
+their own competing meaning for `EconomicFacts`, `ReconciliationState`,
+`Checkpoint`, `Journal`, `TaxInputs`, or `TaxOutputs`.
+
 ## Why This Plan Exists
 
 The current adapter layer already carries much more responsibility than a
@@ -77,7 +82,7 @@ current behavior sooner than they depend on a perfect future contract.
 | Timezone policy | `validate_profile_timezones(...)` | Prevents silent timestamp drift. |
 | Location evidence | `extract_location_inventory(...)` | Supplies owned location identity and evidence. |
 | Statement parsing | `match_statement_document(...)`, `parse_statement_document(...)` | Converts statements into quantity-backed balance evidence. |
-| Statement identity claims | `resolve_statement_instrument_claims(...)` | Resolves statement rows to canonical instruments. |
+| Statement identity claims | `resolve_statement_instrument_claims(...)` | Resolves statement rows to shared instrument identities. |
 | Translation planning | `describe_translation_inputs(...)`, `translate_selected_inputs(...)` | Prevents adapter-local file winner heuristics. |
 | Translation | `translate(...)` | Produces activity drafts and evidence artifacts. |
 
@@ -349,26 +354,28 @@ after filing-critical work no longer depends on current seam stability.
 ### Roadmap Objective
 
 Replace the current bundled source contract and separate output contract with a
-smaller, purpose-defined adapter architecture built around shared canonical
-products, deterministic verification, and provider-local semantics only.
+smaller, purpose-defined adapter architecture built around evidence, claims,
+explicit bridge seams during migration, deterministic verification, and
+provider-local semantics only.
 
 ### Roadmap Principles
 
-- unify around canonical products, not around one giant method surface
+- unify around explicit adapter products, not around one giant method surface
 - keep manifests declarative and authoritative
 - separate hard assertions from soft annotations
 - treat provenance as a first-class runtime concept
-- require canonical ordering and fingerprints at artifact boundaries
+- require explicit ordering and fingerprints at artifact boundaries
 - keep the compiler and verifier shared
 - keep provider-local code focused on parsing, semantic mapping, and rendering
 
-### Roadmap Phase R1. Define Canonical Products
+### Roadmap Phase R1. Define Adapter Products
 
-Design and write the future canonical products:
+Design and write the future adapter-scoped products:
 
-- `EvidenceBundle`
-- `ClaimBundle`
-- `EconomicDataset`
+- `EvidenceSet`
+- `ClaimSet`
+- `SourceTranslationBatch` as the current bridge seam, with a target-direction
+  move toward `TranslationResult` only when code changes land
 - `ProjectionBundle`
 - `ArtifactBundle`
 
@@ -426,7 +433,7 @@ Candidate manifest-owned data:
 - accepted artifact kinds
 - planner support and selection modes
 - statement kinds
-- canonicalization rules
+- ordering and serialization rules
 - determinism guarantees
 - schema version and compatibility rules
 - supported claim and artifact types
@@ -436,22 +443,22 @@ Exit criteria:
 - a reader can understand what an adapter can do from its manifest and small
   provider-local modules, not from a large composite entry point
 
-### Roadmap Phase R4. Unify Verification Around Canonical Products
+### Roadmap Phase R4. Unify Verification Around Adapter Products
 
-Build one verifier that checks the canonical products instead of relying on a
+Build one verifier that checks the adapter products instead of relying on a
 mix of adapter-local conventions.
 
 Verifier goals:
 
 - replay stability on unchanged inputs
-- canonical fingerprint stability
+- product fingerprint stability
 - no unordered output surfaces
 - explicit unsupported or ambiguous cases
 - artifact parity where projections exist
 
 Exit criteria:
 
-- adapter verification is centered on canonical products and deterministic
+- adapter verification is centered on adapter products and deterministic
   compiler behavior
 
 ### Roadmap Phase R5. Migrate Adapter Families In Priority Order
@@ -481,7 +488,7 @@ bundled contract shape.
 Retirement conditions:
 
 - no filing-critical adapter depends on the old contract
-- verification has moved to canonical products
+- verification has moved to adapter products
 - docs, scaffolds, and tests all describe the new model
 
 ## Decision Rules While Filing Work Is Active

--- a/docs/status/current-state.md
+++ b/docs/status/current-state.md
@@ -26,6 +26,19 @@ nav_order: 10
 - Platform API expansion, SQLite, and provider-backed AI remain stubbed behind
   typed boundaries
 
+## Current Bridge To The Target Pipeline
+
+- The implemented bridge currently centers on `EconomicActivityDraft`,
+  `TransactionFact`, `balance_snapshots.csv`, and `balance_references.csv`.
+- Treat that bridge as the current delivery seam, not as the final architecture
+  center.
+- The target pipeline products and stage contracts live in
+  `docs/concepts/reconciliation-tax-architecture.md` and are sequenced in
+  `ROADMAP.md`.
+- MVP work should extend the current bridge incrementally where it protects the
+  filing path, while landing richer pipeline products only when a concrete next
+  stage needs them.
+
 ## Current Operational Surface
 
 The repo currently ships typed replacements for the core workflow capabilities:

--- a/docs/status/current-state.md
+++ b/docs/status/current-state.md
@@ -39,8 +39,9 @@ product names `EvidenceSet`, `ClaimSet`, `EconomicFacts`,
 - Treat that bridge as the current delivery seam, not as the final architecture
   center.
 - The target pipeline products and stage contracts live in
-  `docs/concepts/reconciliation-tax-architecture.md` and are sequenced in
-  `ROADMAP.md`.
+  `docs/concepts/pipeline-stage-contracts.md`; system-level trust gates and
+  rollout alignment live in
+  `docs/concepts/reconciliation-tax-architecture.md` and `ROADMAP.md`.
 - MVP work should extend the current bridge incrementally where it protects the
   filing path, while landing richer pipeline products only when a concrete next
   stage needs them.

--- a/docs/status/current-state.md
+++ b/docs/status/current-state.md
@@ -8,6 +8,12 @@ status: active
 nav_order: 10
 ---
 
+This status page uses current implementation terms where accuracy requires
+them. Forward-looking architecture and roadmap docs use the final target
+product names `EvidenceSet`, `ClaimSet`, `EconomicFacts`,
+`ReconciliationState`, `Checkpoint`, `Journal`, `TaxInputs`, and
+`TaxOutputs`.
+
 ## Current Runtime
 
 - Typed single-package architecture under `src/tallylot/`

--- a/docs/status/migration-sequence.md
+++ b/docs/status/migration-sequence.md
@@ -1,6 +1,6 @@
 ---
 title: "Migration Sequence"
-summary: "Incremental migration order from the current fact-path bridge to the final pipeline."
+summary: "Incremental migration order from the current bridge toward the target stage-first pipeline with parity gates and retirement rules."
 doc_type: status
 audience: human
 owner: repo
@@ -9,22 +9,42 @@ nav_order: 20
 ---
 
 Use this document to implement the next phase without a big-bang refactor. The
-goal is to move from the current normalized-transaction flow and current
-fact-path bridge into the final pipeline with explicit parity gates and clean
-retirement rules.
+goal is to move from the current bridge into the target pipeline with explicit
+parity gates, clean retirement rules, and no wrapper-lane sprawl.
 
 ## Migration Objectives
 
 - preserve current working behavior while new foundations land
-- avoid pushing more semantics into the current normalized transaction model
+- avoid freezing the current bridge as the long-term architecture center
 - keep adapters and services shippable at every checkpoint
-- keep CoinTracking as one edge projection, not a migration anchor
-- preserve current bridge truth while establishing the final vocabulary for the
-  future architecture
+- keep CoinTracking as one edge projection and oracle family, not a migration
+  anchor
+- preserve current bridge truth while establishing the target stage and
+  ontology ownership model
 
-## Target Pipeline Landings
+## Current Bridge
 
-The target architecture should land as these final products:
+Current bridge truth:
+
+- `EconomicActivityDraft`, `TransactionFact`, and the shared balance artifacts
+  are the live implementation seam
+- that seam is the current parity baseline
+- that seam is not the final architecture center
+
+Bridge naming rule:
+
+- keep current bridge names in live bridge code until later implementation
+  slices replace them
+- do not perform large bridge renames as a prerequisite for the next bounded
+  architecture slice
+
+Current live bridge contract owner:
+
+- [`docs/concepts/current-bridge-contracts.md`](../concepts/current-bridge-contracts.md)
+
+## Target Pipeline
+
+The target architecture lands as these final products:
 
 1. `EvidenceSet`
 2. `ClaimSet`
@@ -35,361 +55,196 @@ The target architecture should land as these final products:
 7. `TaxInputs`
 8. `TaxOutputs`
 
-Migration rule:
+Owning contract pages:
 
-- current `EconomicActivityDraft`, `TransactionFact`, and shared balance
-  artifacts remain the active bridge into this pipeline
-- do not freeze that bridge as the final architecture center
-- land the richer pipeline products incrementally without restoring
-  normalized-transaction-era wrapper lanes
+- [`docs/concepts/current-bridge-contracts.md`](../concepts/current-bridge-contracts.md)
+- [`docs/concepts/pipeline-stage-contracts.md`](../concepts/pipeline-stage-contracts.md)
+- [`docs/concepts/domain-ontology.md`](../concepts/domain-ontology.md)
+- [`docs/concepts/gaps-and-readiness.md`](../concepts/gaps-and-readiness.md)
 
-## Current Bridge And Old-To-New Mapping
-
-Current bridge truth:
-
-- `EconomicActivityDraft`, `TransactionFact`, and shared balance artifacts are
-  the live implementation seam
-- that seam is the migration input and current parity baseline
-- that seam is not the final architecture center
-
-Final target-doc vocabulary:
-
-| Current target-doc term | Final term |
-| --- | --- |
-| `EvidenceBundle` | `EvidenceSet` |
-| `ClaimBundle` | `ClaimSet` |
-| `EconomicDataset` | `EconomicFacts` |
-| `ReconciliationDataset` | `ReconciliationState` |
-| `CheckpointPackage` | `Checkpoint` |
-| `JournalDataset` | `Journal` |
-| `TaxDeterminantDataset` | `TaxInputs` |
-| `TaxOutputDataset` | `TaxOutputs` |
-
-Rules:
-
-- current-state sections keep live implementation names where accuracy
-  requires them
-- target-state sections use the final names after this mapping is established
-- do not keep dual active vocabularies once the mapping is clear
-
-## Shared Foundations First
+## Shared Foundations
 
 These foundations are prerequisites, not later cleanup:
 
-- shared provenance family
-- shared gap model and taxonomy
-- shared readiness model and reducers
-- shared checkpoint-assertion vocabulary
-- explicit identity seams
-- `SubjectRef`
-- tax-policy selection contracts
-
-Shared readiness uses this exact vocabulary:
-
-- `semantic_ready`
-- `reconciliation_ready`
-- `checkpoint_ready`
-- `accounting_ready`
-- `tax_ready`
-
-Readiness is sliceable by:
-
-- source
-- location
-- instrument
-- subject ref
-- continuity segment
-- checkpoint date
-- tax year where relevant
+- shared stage contracts
+- shared ontology and identity seams
+- shared gap and readiness model
+- shared `SubjectRef` rules
+- shared checkpoint-assertion direction
+- typed tax-policy selection seam
 
 Rules:
 
-- this exact slice definition must stay identical everywhere it appears
-- dataset readiness is derived from subject-level reducers
 - no stage should invent an incompatible blocker or readiness surface
+- no stage should use `SubjectRef` as a substitute for real domain modeling
+- no stage should restate the target contracts in a competing document when an
+  owning contract page already exists
 
-## Phase 0. Shared Foundations And Schema Lock
+## Bridge-To-Target Landing Rules
+
+- `EvidenceSet` formalizes deterministic evidence selection and source-local
+  observations now spread across intake, profiling, and translation-input
+  planning
+- `ClaimSet` becomes the place where `EconomicActivityDraft` responsibilities
+  can split into source-local meaning plus preserved ambiguity
+- `EconomicFacts` becomes the accepted economic truth that the current
+  `TransactionFact` bridge only approximates today
+- `ReconciliationState` and `Checkpoint` absorb the trust-gate work currently
+  expressed through bridge-era balances, links, and checkpoint scaffolding
+- `Journal`, `TaxInputs`, and `TaxOutputs` replace the remaining bridge-era
+  tendency to push accounting or tax meaning downward too early
+
+## Phase Order
+
+### Phase 0. Shared Foundations And Schema Lock
 
 Deliver before broad code changes:
 
-- `TransactionFact` and supporting value objects
-- layered classification enums
-- runtime input and oracle boundaries
-- migration acceptance criteria
+- aligned bridge, target, ontology, and support-model docs
 - shared provenance, gaps, readiness, checkpoint assertions, identity seams,
   `SubjectRef`, and tax-policy selection contracts
-
-Do not start tax-engine work before these contracts are written down.
-
-## Phase 1. Boundary Models And Dev-Only Oracle Readers
-
-Introduce boundary-only models for:
-
-- CoinTracking trade exports
-- CoinTracking accounting exports
-- CoinTracking tax or roll-forward exports
-- checkpoint artifact contracts
-- journal validation contracts
+- clear bridge-versus-target ownership so later code slices do not re-decide
+  naming or stage boundaries
 
 Rules:
 
-- use `pydantic` here
-- keep these models out of the core domain
-- do not let oracle readers create production facts automatically
-- keep CoinTracking-specific metadata out of the transaction fact core while
-  this phase lands
+- do not start broad tax-engine work before these contracts are written down
+- do not let the bridge contract masquerade as the target ontology
 
-Exit criteria:
+### Phase 1. Formalize `EvidenceSet`
 
-- oracle files parse deterministically
-- no domain layer depends on CoinTracking row schemas
+Deliver:
 
-## Phase 2. Introduce Transaction Facts
-
-Add the new domain packages and services for facts without adding compatibility
-wrappers around the current normalized transaction path.
-
-Implementation rule:
-
-- first land a fact-aligned adapter draft seam so working adapters stop
-  constructing the temporary normalized artifact directly
-- normalization writes transaction facts first
-- introduce instrument identity, signed legs, stable leg ids, and the repo-wide
-  `*_at` plus `*_precision` temporal convention as part of the shared fact
-  contract
-- replace the normalized transaction artifact set directly once the fact path is
-  ready
-- replace the current fact artifact schema directly for this branch rather than
-  preserving a second active runtime model
-- CoinTracking output remains an adapter projection, not a second core model
-- until fact services land, keep CoinTracking candidate rendering as an
-  explicit projection step rather than a normalization side effect
-
-Bridge rule for the current branch:
-
-- source adapters translate provider exports into `EconomicActivityDraft`
-- introduce `ClaimSet` incrementally between evidence selection and final
-  fact compilation when a source row cannot safely commit to one
-  final economic meaning
-- adapter resolution remains registry-driven; shared support must not depend on
-  concrete adapter ids or hand-maintained provider lists
-- shared compiler code produces transaction facts
-- shared projection code produces CoinTracking CSV rows
-- application services, not adapters, derive runtime balances from translated
-  activity unless the source provides real balance evidence
-- unresolved or ambiguous identifier resolution blocks fact emission for the
-  affected activity and must surface both review output and a blocking issue
-- ambiguous transfer, ownership, lifecycle, or mixed-purpose rows must be able
-  to survive as source-local claims until one safe economic meaning
-  is available
-- no parallel runtime, wrapper lane, or runtime artifact translators
-- a clean fact artifact schema break is allowed in this branch when the
-  replacement is ready
-- fact artifact readers must reject unknown `schema_version` values and the
-  operational recovery path is full regeneration from raw evidence
-
-Exit criteria:
-
-- at least one adapter writes fact artifacts end to end
-- fact artifacts fail fast when the schema version does not match the current
-  reader
-- projection tests prove the CoinTracking adapter still renders the expected
-  external shape from the new facts
-
-## Phase 3. Migrate Reconciliation To Facts
-
-Move these capabilities off normalized transactions:
-
-- transfer linking
-- balance assertions
-- checkpoint continuity
-- correction chains
-- reconciliation issue assembly
-- reconciliation dataset and readiness reducers
+- deterministic selection outputs
+- explicit selected, superseded, and blocked evidence outputs
+- source-local parsed observation contracts
 
 Rules:
 
-- reconciliation consumes facts plus checkpoint evidence only
-- keep balance orchestration behind one shared balance capability for target
-  planning, snapshot derivation, reference resolution, inspect and check
-  workflows, hydration, corroboration, and assertion assembly
-- treat exact balance assertions as one reconciliation input surface, not as the
-  whole reconciliation product
-- replace split balance evidence or confirmation artifacts directly with
-  unified `balance_references.csv`
-- fact-backed balance checks derive snapshots from facts; manual-only balance
-  checks consume explicit snapshot rows
-- check defaults to offline resolution; provider hydration is opt-in
-- keep historical API lookup in separate balance-provider adapters rather than
-  in source adapters
-- require immutable on-chain asset ids before public-ledger provider hydration
-  is treated as supported runtime behavior
-- keep symbol-only public-ledger asset ids as explicit unsupported outputs
-  until immutable on-chain identity is available
-- CoinTracking tax outputs stay in oracle comparison services
-- deterministic corrections such as redistributions must live in typed rules or
-  fact metadata, not operator notes
-- row-level candidate-versus-reference CSV comparison is a `source diff`
-  utility, not the reconciliation service surface
-- reconciliation advances in parallel with the accounting slice once the
-  shared fact shape is stable
-- reconciliation remains the gate before tax and before treating rebuilt fact
-  history as trusted
-- readiness must be reducible by source, location, instrument, and continuity
-  segment rather than only by whole-source summaries
-- readiness must use the shared slice definition exactly:
-  - source
-  - location
-  - instrument
-  - subject ref
-  - continuity segment
-  - checkpoint date
-  - tax year where relevant
+- evidence selection remains deterministic
+- evidence does not force economic meaning
+- evidence selection reasoning must survive beyond intake-time heuristics
 
-Exit criteria:
+### Phase 2. Introduce `ClaimSet`
 
-- checkpoint assembly works from facts and source-backed evidence
-- reconciliation resolves explicit balance targets from facts and unified
-  references rather than from a latest-only balance artifact assumption
-- reconciliation artifacts no longer depend on normalized-transaction-specific
-  stopgaps
+Deliver:
 
-## Phase 4. Add Accounting Layer
+- claim-native contracts
+- claim-owned issues and reviews
+- explicit materially unresolved meaning
+- claim-to-economic compilation seam boundaries
 
-Implement:
+Rules:
+
+- ambiguous rows may remain claims without being forced into final economic,
+  accounting, or tax meaning
+- adapters own source-local meaning only
+- the current bridge may remain as a bounded seam during migration, but it must
+  stop forcing final semantics too early
+
+### Phase 3. Land `EconomicFacts`
+
+Deliver:
+
+- claim-to-economic compilation seam
+- target-directed economic models aligned to the target ontology
+- explicit identity, settlement, lifecycle, and valuation handling
+
+Rules:
+
+- no wrapper lane beside the active runtime path
+- no bridge rename is required before the first target economic slice lands
+- accepted economic meaning should move away from bridge activity-label
+  centrality
+
+### Phase 4. Land `ReconciliationState`
+
+Deliver:
+
+- explicit reconciliation completeness and continuity outputs
+- target gap and readiness adoption where the owning stage can support it
+- transfer linkage, balance targets, and checkpoint candidacy under one
+  reconciliation-owned product
+
+Rules:
+
+- reconciliation consumes accepted economic truth plus checkpoint evidence
+- exact balance assertions are one reconciliation input surface, not the whole
+  reconciliation product
+
+### Phase 5. Land `Checkpoint`
+
+Deliver:
+
+- explicit checkpoint truth and acceptance basis
+- source-backed checkpoint evidence requirements
+- trust level and adopted opening-state handling
+- checkpoint continuity reports
+
+Rules:
+
+- checkpoint truth remains source-backed where filing readiness requires it
+- operator-confirmed balances may support runtime progress but do not become
+  filing-ready checkpoint truth by default
+
+### Phase 6. Land `Journal`
+
+Deliver:
 
 - internal journal model
-- renderer port
-- Ledger CLI renderer
-- journal validation result artifacts
+- posting expansion and validation
+- accounting-owned blockers
 
 Rules:
 
-- accounting consumes reconciled economics plus accepted checkpoint state
-- CoinTracking double-entry is comparison-only
-- unsupported activity must surface as explicit journal coverage gaps
-- accounting advances in parallel with reconciliation once the shared fact
-  shape is stable
-- accounting is the journal structure and coverage validator, not the evidence
-  truth gate
-- accounting must not become a local repair layer for upstream fact or
-  reconciliation gaps
+- accounting validates accepted truth
+- accounting does not repair truth
 
-Exit criteria:
+### Phase 7. Land `TaxInputs` And `TaxOutputs`
 
-- supported activity renders and validates in Ledger CLI
-- accounting balance checks line up with checkpoint outputs
+Deliver:
 
-## Phase 5. Add Tax Policy Layer
-
-Implement:
-
-- tax policy port
-- `TaxInputs` contracts
-- Canada MVP policy
-- pooled ACB state
-- disposition and income outputs
-- unsupported tax item outputs
+- `TaxInputs`
+- selected tax-policy execution
+- year-partitioned carry-forward state
+- policy-owned `TaxOutputs`
 
 Rules:
 
-- tax computation consumes reconciled economics plus accepted checkpoint truth,
-  including intentional opening-state adoption when that checkpoint path is
-  used
-- CoinTracking tax outputs are oracle-only
-- no tax logic branches directly on CoinTracking report rows
-- journal validation may corroborate tax readiness, but tax must not depend on
-  renderer success when the required determinants are already known
-- tax-owned unresolved determinants must remain explicit instead of being pushed
-  back into reconciliation or adapter logic
+- tax outputs flow from `TaxInputs` through selected tax policies
+- tax policy does not decide source meaning, reconciliation truth, or
+  checkpoint truth
 
-Exit criteria:
+### Phase 8. Retire Superseded Bridge Surfaces
 
-- `2023` to `2025` tax outputs emit from `TaxInputs` built from reconciled
-  economics plus accepted checkpoint truth
-- internal year-end and carry-forward logic is reproducible without CoinTracking
-  tax reports
+Retire or demote bridge surfaces only after:
 
-## Phase 6. Retire The Current Normalized Workflow
-
-Retire or demote the current normalized-transaction-first path only after:
-
-- adapter parity tests exist
-- reconciliation no longer depends on normalized-transaction-specific
-  assumptions
-- accounting and tax consume facts directly
-- CoinTracking output remains available as an ordinary output adapter
-
-After this phase, new behavior must land in fact-based services first and the
-temporary normalized transaction shape should not continue as a second active
-runtime model.
+- parity tests exist for the affected slice
+- the replacement slice has one active runtime path
+- downstream stages no longer depend on the superseded bridge-only assumptions
+- current-state docs are updated to reflect the new live truth
 
 ## Parity Gates
 
 Do not remove an older path until all relevant gates pass:
 
-- parser or adapter contract tests
+- adapter or parser contract tests
 - projection parity tests
-- reconciliation artifact parity where applicable
+- reconciliation or checkpoint artifact parity where applicable
 - end-to-end smoke workflow for the affected slice
+- explicit docs updates so current-state truth and target-state planning remain
+  aligned
 
-## Test Preservation
+## Docs And Control-Plane Migration
 
-- no test deletions without explicit human approval
-- no silent assertion removal
-- no fixture simplification that hides previous edge-case coverage
-- test relocation or renaming is acceptable only when behavior coverage is
-  preserved or improved
-- "updating tests to the new structure" is not acceptable if coverage is
-  weakened
+The docs and control-plane baseline for this migration is:
 
-Every refactor slice that changes tests must state:
-
-- what old behavior the tests covered
-- where that same behavior is covered now
-- whether the assertion got stronger, weaker, or simply moved
-- whether any expectation changed because of an intentional product decision
-
-Manual anti-drift review is required for:
-
-- deleted test files
-- deleted assertions
-- reduced scenario coverage
-- fixture simplifications that remove edge cases
-- behavior assertions weakened into smoke checks
-
-## Retirement Rules
-
-- retire bridge-era seams only after the replacement path passes the relevant
-  parity gates
-- remove obsolete structures cleanly instead of leaving wrapper lanes,
-  compatibility shims, or parallel runtime models behind
-- keep schema-version failures fast and explicit; recover by regeneration from
-  evidence rather than compatibility backfills
-- retire the current normalized workflow only after facts, reconciliation,
-  checkpointing, accounting, and tax inputs or outputs cover the filing path
-- when a replacement is ready, update the owning architecture, roadmap, and
-  migration docs in the same checkpoint so the repo keeps one active direction
-
-## What Must Not Happen
-
-- no big-bang rewrite
-- no temporary wrappers that become permanent
-- no provider-local adapter glue for compilation, projection, or synthetic
-  balance assembly
-- no new tax logic in adapters
-- no new checkpoint logic in CoinTracking-specific code
-- no direct use of CoinTracking tax reports as production state
-- no weakening of the shared readiness slice definition
-- no collapse of `Contract` and `Position`
-- no use of `SubjectRef` as a substitute for real domain modeling
-- no wording that says tax outputs come directly from reconciled facts
-- no silent test weakening or deletion
-
-## Required Follow-Through
-
-When a task changes architecture, schema, or migration order:
-
-- update `docs/concepts/reconciliation-tax-architecture.md`
-- update `ROADMAP.md`
-- update this migration sequence if the checkpoint order changed
+- target stage contracts, ontology, and gap/readiness ownership are already
+  separated into focused concept pages
+- current-state docs keep current bridge terms where accuracy requires them
+- later implementation should rename the dev-only shared repo support surface
+  from `repo_support/` to `dev_support/`, but this remains future work until
+  the corresponding implementation slice lands
+- roadmap, migration, and architecture anchors must be updated together when a
+  slice changes stage ownership, trust-gate sequencing, or shared support
+  contracts

--- a/docs/status/migration-sequence.md
+++ b/docs/status/migration-sequence.md
@@ -1,6 +1,6 @@
 ---
 title: "Migration Sequence"
-summary: "Incremental migration order from the current fact-path bridge to the full canonical pipeline."
+summary: "Incremental migration order from the current fact-path bridge to the final pipeline."
 doc_type: status
 audience: human
 owner: repo
@@ -10,7 +10,8 @@ nav_order: 20
 
 Use this document to implement the next phase without a big-bang refactor. The
 goal is to move from the current normalized-transaction flow and current
-fact-path bridge into the full canonical pipeline with explicit parity gates.
+fact-path bridge into the final pipeline with explicit parity gates and clean
+retirement rules.
 
 ## Migration Objectives
 
@@ -18,19 +19,21 @@ fact-path bridge into the full canonical pipeline with explicit parity gates.
 - avoid pushing more semantics into the current normalized transaction model
 - keep adapters and services shippable at every checkpoint
 - keep CoinTracking as one edge projection, not a migration anchor
+- preserve current bridge truth while establishing the final vocabulary for the
+  future architecture
 
 ## Target Pipeline Landings
 
-The target architecture should land as these canonical products:
+The target architecture should land as these final products:
 
-1. `EvidenceBundle`
-2. `ClaimBundle`
-3. `EconomicDataset`
-4. `ReconciliationDataset`
-5. `CheckpointPackage`
-6. `JournalDataset`
-7. `TaxDeterminantDataset`
-8. `TaxOutputDataset`
+1. `EvidenceSet`
+2. `ClaimSet`
+3. `EconomicFacts`
+4. `ReconciliationState`
+5. `Checkpoint`
+6. `Journal`
+7. `TaxInputs`
+8. `TaxOutputs`
 
 Migration rule:
 
@@ -40,7 +43,72 @@ Migration rule:
 - land the richer pipeline products incrementally without restoring
   normalized-transaction-era wrapper lanes
 
-## Phase 0. Schema Lock
+## Current Bridge And Old-To-New Mapping
+
+Current bridge truth:
+
+- `EconomicActivityDraft`, `TransactionFact`, and shared balance artifacts are
+  the live implementation seam
+- that seam is the migration input and current parity baseline
+- that seam is not the final architecture center
+
+Final target-doc vocabulary:
+
+| Current target-doc term | Final term |
+| --- | --- |
+| `EvidenceBundle` | `EvidenceSet` |
+| `ClaimBundle` | `ClaimSet` |
+| `EconomicDataset` | `EconomicFacts` |
+| `ReconciliationDataset` | `ReconciliationState` |
+| `CheckpointPackage` | `Checkpoint` |
+| `JournalDataset` | `Journal` |
+| `TaxDeterminantDataset` | `TaxInputs` |
+| `TaxOutputDataset` | `TaxOutputs` |
+
+Rules:
+
+- current-state sections keep live implementation names where accuracy
+  requires them
+- target-state sections use the final names after this mapping is established
+- do not keep dual active vocabularies once the mapping is clear
+
+## Shared Foundations First
+
+These foundations are prerequisites, not later cleanup:
+
+- shared provenance family
+- shared gap model and taxonomy
+- shared readiness model and reducers
+- shared checkpoint-assertion vocabulary
+- explicit identity seams
+- `SubjectRef`
+- tax-policy selection contracts
+
+Shared readiness uses this exact vocabulary:
+
+- `semantic_ready`
+- `reconciliation_ready`
+- `checkpoint_ready`
+- `accounting_ready`
+- `tax_ready`
+
+Readiness is sliceable by:
+
+- source
+- location
+- instrument
+- subject ref
+- continuity segment
+- checkpoint date
+- tax year where relevant
+
+Rules:
+
+- this exact slice definition must stay identical everywhere it appears
+- dataset readiness is derived from subject-level reducers
+- no stage should invent an incompatible blocker or readiness surface
+
+## Phase 0. Shared Foundations And Schema Lock
 
 Deliver before broad code changes:
 
@@ -48,6 +116,8 @@ Deliver before broad code changes:
 - layered classification enums
 - runtime input and oracle boundaries
 - migration acceptance criteria
+- shared provenance, gaps, readiness, checkpoint assertions, identity seams,
+  `SubjectRef`, and tax-policy selection contracts
 
 Do not start tax-engine work before these contracts are written down.
 
@@ -98,8 +168,8 @@ Implementation rule:
 Bridge rule for the current branch:
 
 - source adapters translate provider exports into `EconomicActivityDraft`
-- introduce `ClaimBundle` incrementally between evidence selection and
-  canonical fact compilation when a source row cannot safely commit to one
+- introduce `ClaimSet` incrementally between evidence selection and final
+  fact compilation when a source row cannot safely commit to one
   final economic meaning
 - adapter resolution remains registry-driven; shared support must not depend on
   concrete adapter ids or hand-maintained provider lists
@@ -110,7 +180,7 @@ Bridge rule for the current branch:
 - unresolved or ambiguous identifier resolution blocks fact emission for the
   affected activity and must surface both review output and a blocking issue
 - ambiguous transfer, ownership, lifecycle, or mixed-purpose rows must be able
-  to survive as source-local claims until one safe canonical economic meaning
+  to survive as source-local claims until one safe economic meaning
   is available
 - no parallel runtime, wrapper lane, or runtime artifact translators
 - a clean fact artifact schema break is allowed in this branch when the
@@ -167,6 +237,14 @@ Rules:
   history as trusted
 - readiness must be reducible by source, location, instrument, and continuity
   segment rather than only by whole-source summaries
+- readiness must use the shared slice definition exactly:
+  - source
+  - location
+  - instrument
+  - subject ref
+  - continuity segment
+  - checkpoint date
+  - tax year where relevant
 
 Exit criteria:
 
@@ -207,7 +285,7 @@ Exit criteria:
 Implement:
 
 - tax policy port
-- tax determinant dataset contracts
+- `TaxInputs` contracts
 - Canada MVP policy
 - pooled ACB state
 - disposition and income outputs
@@ -227,7 +305,8 @@ Rules:
 
 Exit criteria:
 
-- `2023` to `2025` tax artifacts emit from reconciled facts
+- `2023` to `2025` tax outputs emit from `TaxInputs` built from reconciled
+  economics plus accepted checkpoint truth
 - internal year-end and carry-forward logic is reproducible without CoinTracking
   tax reports
 
@@ -254,6 +333,44 @@ Do not remove an older path until all relevant gates pass:
 - reconciliation artifact parity where applicable
 - end-to-end smoke workflow for the affected slice
 
+## Test Preservation
+
+- no test deletions without explicit human approval
+- no silent assertion removal
+- no fixture simplification that hides previous edge-case coverage
+- test relocation or renaming is acceptable only when behavior coverage is
+  preserved or improved
+- "updating tests to the new structure" is not acceptable if coverage is
+  weakened
+
+Every refactor slice that changes tests must state:
+
+- what old behavior the tests covered
+- where that same behavior is covered now
+- whether the assertion got stronger, weaker, or simply moved
+- whether any expectation changed because of an intentional product decision
+
+Manual anti-drift review is required for:
+
+- deleted test files
+- deleted assertions
+- reduced scenario coverage
+- fixture simplifications that remove edge cases
+- behavior assertions weakened into smoke checks
+
+## Retirement Rules
+
+- retire bridge-era seams only after the replacement path passes the relevant
+  parity gates
+- remove obsolete structures cleanly instead of leaving wrapper lanes,
+  compatibility shims, or parallel runtime models behind
+- keep schema-version failures fast and explicit; recover by regeneration from
+  evidence rather than compatibility backfills
+- retire the current normalized workflow only after facts, reconciliation,
+  checkpointing, accounting, and tax inputs or outputs cover the filing path
+- when a replacement is ready, update the owning architecture, roadmap, and
+  migration docs in the same checkpoint so the repo keeps one active direction
+
 ## What Must Not Happen
 
 - no big-bang rewrite
@@ -263,6 +380,11 @@ Do not remove an older path until all relevant gates pass:
 - no new tax logic in adapters
 - no new checkpoint logic in CoinTracking-specific code
 - no direct use of CoinTracking tax reports as production state
+- no weakening of the shared readiness slice definition
+- no collapse of `Contract` and `Position`
+- no use of `SubjectRef` as a substitute for real domain modeling
+- no wording that says tax outputs come directly from reconciled facts
+- no silent test weakening or deletion
 
 ## Required Follow-Through
 

--- a/docs/status/migration-sequence.md
+++ b/docs/status/migration-sequence.md
@@ -1,6 +1,6 @@
 ---
 title: "Migration Sequence"
-summary: "Incremental migration order from the legacy normalized flow to the provider-neutral fact model."
+summary: "Incremental migration order from the current fact-path bridge to the full canonical pipeline."
 doc_type: status
 audience: human
 owner: repo
@@ -9,8 +9,8 @@ nav_order: 20
 ---
 
 Use this document to implement the next phase without a big-bang refactor. The
-goal is to move from the current normalized-transaction flow to a
-provider-neutral fact model with explicit parity gates.
+goal is to move from the current normalized-transaction flow and current
+fact-path bridge into the full canonical pipeline with explicit parity gates.
 
 ## Migration Objectives
 
@@ -18,6 +18,27 @@ provider-neutral fact model with explicit parity gates.
 - avoid pushing more semantics into the current normalized transaction model
 - keep adapters and services shippable at every checkpoint
 - keep CoinTracking as one edge projection, not a migration anchor
+
+## Target Pipeline Landings
+
+The target architecture should land as these canonical products:
+
+1. `EvidenceBundle`
+2. `ClaimBundle`
+3. `EconomicDataset`
+4. `ReconciliationDataset`
+5. `CheckpointPackage`
+6. `JournalDataset`
+7. `TaxDeterminantDataset`
+8. `TaxOutputDataset`
+
+Migration rule:
+
+- current `EconomicActivityDraft`, `TransactionFact`, and shared balance
+  artifacts remain the active bridge into this pipeline
+- do not freeze that bridge as the final architecture center
+- land the richer pipeline products incrementally without restoring
+  normalized-transaction-era wrapper lanes
 
 ## Phase 0. Schema Lock
 
@@ -77,6 +98,9 @@ Implementation rule:
 Bridge rule for the current branch:
 
 - source adapters translate provider exports into `EconomicActivityDraft`
+- introduce `ClaimBundle` incrementally between evidence selection and
+  canonical fact compilation when a source row cannot safely commit to one
+  final economic meaning
 - adapter resolution remains registry-driven; shared support must not depend on
   concrete adapter ids or hand-maintained provider lists
 - shared compiler code produces transaction facts
@@ -85,6 +109,9 @@ Bridge rule for the current branch:
   activity unless the source provides real balance evidence
 - unresolved or ambiguous identifier resolution blocks fact emission for the
   affected activity and must surface both review output and a blocking issue
+- ambiguous transfer, ownership, lifecycle, or mixed-purpose rows must be able
+  to survive as source-local claims until one safe canonical economic meaning
+  is available
 - no parallel runtime, wrapper lane, or runtime artifact translators
 - a clean fact artifact schema break is allowed in this branch when the
   replacement is ready
@@ -108,6 +135,7 @@ Move these capabilities off normalized transactions:
 - checkpoint continuity
 - correction chains
 - reconciliation issue assembly
+- reconciliation dataset and readiness reducers
 
 Rules:
 
@@ -115,6 +143,8 @@ Rules:
 - keep balance orchestration behind one shared balance capability for target
   planning, snapshot derivation, reference resolution, inspect and check
   workflows, hydration, corroboration, and assertion assembly
+- treat exact balance assertions as one reconciliation input surface, not as the
+  whole reconciliation product
 - replace split balance evidence or confirmation artifacts directly with
   unified `balance_references.csv`
 - fact-backed balance checks derive snapshots from facts; manual-only balance
@@ -135,6 +165,8 @@ Rules:
   shared fact shape is stable
 - reconciliation remains the gate before tax and before treating rebuilt fact
   history as trusted
+- readiness must be reducible by source, location, instrument, and continuity
+  segment rather than only by whole-source summaries
 
 Exit criteria:
 
@@ -155,13 +187,15 @@ Implement:
 
 Rules:
 
-- accounting consumes facts plus journal intents
+- accounting consumes reconciled economics plus accepted checkpoint state
 - CoinTracking double-entry is comparison-only
 - unsupported activity must surface as explicit journal coverage gaps
 - accounting advances in parallel with reconciliation once the shared fact
   shape is stable
 - accounting is the journal structure and coverage validator, not the evidence
   truth gate
+- accounting must not become a local repair layer for upstream fact or
+  reconciliation gaps
 
 Exit criteria:
 
@@ -173,6 +207,7 @@ Exit criteria:
 Implement:
 
 - tax policy port
+- tax determinant dataset contracts
 - Canada MVP policy
 - pooled ACB state
 - disposition and income outputs
@@ -180,9 +215,15 @@ Implement:
 
 Rules:
 
-- tax computation consumes reconciled facts and intentional opening state only
+- tax computation consumes reconciled economics plus accepted checkpoint truth,
+  including intentional opening-state adoption when that checkpoint path is
+  used
 - CoinTracking tax outputs are oracle-only
 - no tax logic branches directly on CoinTracking report rows
+- journal validation may corroborate tax readiness, but tax must not depend on
+  renderer success when the required determinants are already known
+- tax-owned unresolved determinants must remain explicit instead of being pushed
+  back into reconciliation or adapter logic
 
 Exit criteria:
 

--- a/docs/workspace/outputs/checkpoints/2025-12-31-final/README.md
+++ b/docs/workspace/outputs/checkpoints/2025-12-31-final/README.md
@@ -1,16 +1,16 @@
 ---
 title: "Final 2025 Checkpoint"
-summary: "Expected target for the frozen 2025 year-end checkpoint package."
+summary: "Expected target for the frozen 2025 year-end checkpoint."
 doc_type: reference
 audience: both
 owner: repo
 status: active
 ---
 
-Place the frozen `2025-12-31` checkpoint package here when that milestone is
+Place the frozen `2025-12-31` checkpoint here when that milestone is
 ready.
 
-The package should be defined by source-backed balances, continuity evidence,
+The checkpoint should be defined by source-backed balances, continuity evidence,
 and internal checkpoint artifacts. If CoinTracking or other portfolio-tracker
 exports are kept here for comparison, keep them as sidecar oracle material,
 not as the checkpoint definition.

--- a/docs/workspace/outputs/checkpoints/README.md
+++ b/docs/workspace/outputs/checkpoints/README.md
@@ -1,15 +1,15 @@
 ---
 title: "Checkpoints"
-summary: "Rules for frozen source-backed checkpoint packages and related sidecar artifacts."
+summary: "Rules for frozen source-backed checkpoints and related sidecar artifacts."
 doc_type: reference
 audience: both
 owner: repo
 status: active
 ---
 
-Store frozen checkpoint packages here.
+Store frozen checkpoints here.
 
-Checkpoint packages should be system-native and source-backed. Sidecar oracle
+Checkpoint artifacts should be system-native and source-backed. Sidecar oracle
 or comparison exports may live beside them when useful, but those support
 artifacts do not define the checkpoint.
 


### PR DESCRIPTION
Why:
- the target pipeline rewrite needed one coherent architecture baseline before contract freeze and naming work could proceed safely
- product ownership, adapter boundaries, and control-plane routing were still split across older rewrite notes and partially overlapping docs

What:
- define the target pipeline product set, ownership model, and migration sequence across roadmap, concept, status, and workspace docs
- separate adapter ownership from core runtime boundaries and align AGENTS and command routes with the rewritten architecture

Checks:
- `make pr-review`

Issue linkage:
- None: searched existing repo issues for target pipeline architecture ownership docs and found no matching tracked issue

Included checkpoints:
- `docs(architecture): define target pipeline products`
- `docs(architecture): align core pipeline rewrite`
- `docs(adapters): separate adapter ownership from core runtime`
- `docs(routing): align control-plane guidance with the rewrite`
- `docs(architecture): split target pipeline ownership`
