### PR TITLE
docs(contracts): freeze phase 0 target pipeline contracts

### DIFF
--- a/.agents/skills/adapter-authoring/SKILL.md
+++ b/.agents/skills/adapter-authoring/SKILL.md
@@ -18,12 +18,13 @@ Use this skill for adapter-focused work.
    - `.claude/commands/adapter-authoring.md`
    - `docs/standards/engineering.md`
    - `docs/standards/implementation.md`
-2. Keep adapter metadata, implementation, and tests aligned in one slice.
+2. Keep adapter metadata, implementation, and tests aligned in one reviewable
+   change.
 3. Keep normalization, rendering, and oracle-only behavior separated.
 4. Prefer the scaffold path for new adapters:
    - `make scaffold-adapter ARGS='...'`
 5. Add or update adapter tests beside the adapter package while implementing.
-6. Run the standard quality gate before closing the adapter slice:
+6. Run the standard quality gate before finishing the adapter change:
    - `make quality`
    - reserve `make quality-full`
      for the explicit full-suite override when a specific task needs it

--- a/.agents/skills/balance-submission-operations/SKILL.md
+++ b/.agents/skills/balance-submission-operations/SKILL.md
@@ -17,8 +17,8 @@ Use this skill for the manual balance submission path.
    matching route checklist.
 2. Scaffold the package first with
    `.agents/skills/balance-submission-operations/scripts/balance_submission_operations.py`.
-3. Inspect the filled files before submit so missing required values surface
-   explicitly.
+3. Inspect the filled files before submit so missing required values are called
+   out explicitly.
 4. Submit only when the package is ready; do not guess `instrument_id`,
    timestamps, quantities, support refs, or identity values.
 5. Use `$reconciliation-balance-operations` only after balance artifacts

--- a/.agents/skills/docs-authoring/SKILL.md
+++ b/.agents/skills/docs-authoring/SKILL.md
@@ -16,7 +16,7 @@ proactive follow-up issue handling.
 
 ## Workflow
 
-1. Read the narrow authoring surface first:
+1. Read the narrow authoring guidance first:
    - `AGENTS.md`
    - `docs/README.md`
    - `docs/status/current-state.md`

--- a/.agents/skills/implementation-workflow/SKILL.md
+++ b/.agents/skills/implementation-workflow/SKILL.md
@@ -26,7 +26,8 @@ work that should be captured as a follow-up issue.
    architecture guidance before editing.
 3. Add or update only the tests that define meaningful behavior, contracts, or
    regressions.
-4. Implement the change and refactor obvious shared seams while the seam is open.
+4. Implement the change and refactor obvious shared boundaries while the code
+   area is already in motion.
 5. Use fresh editor diagnostics first when available, then targeted tests while
    iterating.
 6. Before closing substantial work, run:
@@ -44,5 +45,5 @@ work that should be captured as a follow-up issue.
 
 - keep strict typed layer boundaries
 - keep `Decimal` for monetary values
-- surface ambiguity as explicit issues
+- record ambiguity as explicit issues
 - update `ROADMAP.md` with architecture or sequencing changes

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -12,7 +12,7 @@ Use this skill for repeatable review passes on an active branch or draft PR.
 
 ## Workflow
 
-1. Read the narrow PR review surface first:
+1. Read the narrow PR review guidance first:
    - `docs/standards/delivery-guardrails.md`
    - `docs/standards/implementation.md`
    - `docs/standards/commits.md`
@@ -20,10 +20,10 @@ Use this skill for repeatable review passes on an active branch or draft PR.
 2. Start from deterministic branch and PR facts rather than scratch notes.
 3. Use
    `make audit-pr-review`
-   to identify the applicable surface groups, review domains, and required
+   to identify the applicable file groups, review domains, and required
    verification before choosing the next issue-finding pass.
-4. Repair findings in bounded slices, rerun the required checks for the
-   repaired slice, and keep the PR draft until a full applicable-surface pass
+4. Repair findings in bounded changes, rerun the required checks for the
+   repaired change, and keep the PR draft until a full review cycle
    yields no new meaningful findings.
    Do not describe an upcoming pass as clean, final, or publish-ready; every
    pass is issue-finding with open outcome.
@@ -31,11 +31,11 @@ Use this skill for repeatable review passes on an active branch or draft PR.
    decision by itself; it is only verification evidence for the current
    red-team pass.
 5. Use `issue-workflow`, `docs-authoring`, or `implementation-workflow` when
-   the repair surface moves into those repo-local workflows.
+   the repair work moves into those repo-local workflows.
 
 ## Focus
 
-- cover every applicable changed surface group
+- cover every applicable changed file group
 - keep findings evidence-backed
 - use the strongest broad verification family without skipping declared
-  surface-specific checks
+  file-group-specific checks

--- a/.agents/skills/reconciliation-tax-build/SKILL.md
+++ b/.agents/skills/reconciliation-tax-build/SKILL.md
@@ -23,7 +23,7 @@ Use this skill for architecture-sensitive core workflow work.
 2. Confirm whether the task changes facts, reconciliation, checkpoints,
    accounting, tax policy, or oracle-only compatibility code.
 3. Keep provider-neutral facts at the center and keep CoinTracking-specific
-   behavior in compatibility or oracle surfaces.
+   behavior in compatibility or oracle paths.
 4. Add or update schema, invariant, reconciliation, or tax tests before
    implementing behavior.
 5. Update `ROADMAP.md` in the same checkpoint when architecture or sequencing

--- a/.agents/skills/round-verification-operations/SKILL.md
+++ b/.agents/skills/round-verification-operations/SKILL.md
@@ -19,8 +19,8 @@ Use this skill for round verification workflow execution.
 2. Use the documented oracle CLI commands:
    - `make oracle ARGS='round scaffold'`
    - `make oracle ARGS='verification compare'`
-3. Review the round artifacts and comparison outputs before answering closeout
-   questions.
+3. Review the round artifacts and comparison outputs before answering final
+   review questions.
 4. Use `source diff` only when the verification path needs source-level repair
    context.
 

--- a/.claude/commands/implementation-checkpoint.md
+++ b/.claude/commands/implementation-checkpoint.md
@@ -18,7 +18,7 @@ Use this route before closing any non-trivial coding task.
    - duplicate logic appeared
    - a second responsibility was added to a module
    - a hotspot module absorbed more behavior
-   - tests became repetitive because the seam is wrong
+   - tests became repetitive because the boundary is wrong
 4. Confirm tests were added or updated for:
    - new decision logic
    - new parser or renderer contracts
@@ -41,7 +41,7 @@ Use this route before closing any non-trivial coding task.
    - reserve `make quality-full`
      for the explicit full-suite override when a specific task needs it
    - `make pr-review-full` when the change touches CI,
-     packaging, release, or other workflow surfaces and you want the final non-draft PR suite locally
+     packaging, release, or other workflow areas and you want the final non-draft PR suite locally
 8. If architecture, schema, or sequencing changed, update:
    - `ROADMAP.md`
    - `docs/concepts/reconciliation-tax-architecture.md`
@@ -51,7 +51,7 @@ Use this route before closing any non-trivial coding task.
      architecture and sequencing material:
      - `AGENTS.md`
      - `.claude/commands/reconciliation-tax-build.md`
-     - `.claude/commands/adapter-authoring.md` when adapter surfaces are part
+     - `.claude/commands/adapter-authoring.md` when adapter areas are part
        of the same change
    - if standards, docs placement, doc authoring rules, or agent-default enforcement changed, reload:
      - `AGENTS.md`
@@ -63,15 +63,15 @@ Use this route before closing any non-trivial coding task.
      and confirm any new material belongs in human docs rather than agent-only
      routing and still follows the docs-maintenance scaffold and metadata rules
 9. After compaction or context loss, reload the narrow standards for the active
-   surface before more edits or commits:
+   area before more edits or commits:
 
    - `docs/standards/implementation.md`
    - `docs/standards/commits.md`
    - `docs/standards/delivery-guardrails.md` when delivery work is active
 
-10. Create the stable checkpoint commit when the slice is coherent and verified.
-   If the task contains more than one separable reviewable slice, split it into
-   multiple bounded checkpoint commits before closeout. Do not close the task
+10. Create the stable checkpoint commit when the change is coherent and verified.
+   If the task contains more than one separable reviewable change, split it into
+   multiple bounded checkpoint commits before finishing. Do not close the task
    first and plan to commit afterward.
 
 11. Include a short parity note in the checkpoint summary when tests changed:
@@ -82,11 +82,11 @@ Use this route before closing any non-trivial coding task.
 12. Confirm branch handling stayed PR-only for protected branches: do not push
     directly to `main`; do not use branch-protection bypass for ordinary
     delivery; do not rewrite a merged `main` commit if the original pull
-    request must remain attached to the landing commit and use a new repair
+    request must remain attached to the merged commit and use a new repair
     pull request instead; for multi-checkpoint PR merges, use
     `<pr title> (#<pr number>)` as the merge subject; if a repair PR replaces
     an older PR, apply the repo's neutral duplicate/superseded label before
-    closing the repair loop; if the user explicitly requested a one-time
+    closing the older PR; if the user explicitly requested a one-time
     protected-branch repair, verify the remote branch tip afterward and return
     to PR-only flow.
 

--- a/.claude/commands/normalization-exceptions.md
+++ b/.claude/commands/normalization-exceptions.md
@@ -3,7 +3,7 @@
 Review these artifacts after `source normalize`:
 
 - `exceptions.csv` for blocking or unsupported rows
-- `normalization_reviews.csv` for explicit assumptions and canonicalizations
+- `normalization_reviews.csv` for explicit assumptions and normalization choices
 - `facts.csv` for the internal fact artifact set
 
 If the issue is a candidate-shape or overlap problem, render a candidate with

--- a/.claude/commands/pr-review.md
+++ b/.claude/commands/pr-review.md
@@ -13,42 +13,42 @@ Use this route for repeatable review passes on an active branch or draft PR.
    - latest targeted verification results
 2. Use
    `make audit-pr-review`
-   to identify the current diff's applicable surface groups, review domains,
+   to identify the current diff's applicable file groups, review domains,
    selected verification mode, selected and suppressed checks, and any
    unmapped paths before deciding the current pass found no new meaningful
    findings.
-3. Re-check every prior fix surface first, then inspect the next applicable
-   changed surface group that has not yet been re-checked in the current full
-   loop.
+3. Re-check every prior fix first, then inspect the next applicable changed
+   file group that has not yet been re-checked in the current full review
+   cycle.
 4. Repair every finding from that pass before starting the next pass.
-   - reload the narrow repo guidance for each repair surface using `AGENTS.md`,
+   - reload the narrow repo guidance for each repaired area using `AGENTS.md`,
      its task-routing table, and the owning roadmap, architecture, migration,
-     or delivery docs surfaced by that route or by repo search hints
+     or delivery docs identified by that route or by repo search hints
    - add or tighten tests, docs, automation, and validation where the fix
      belongs instead of leaving the repair in prose alone
    - when a meaningful finding should stay out of the active PR, search for an
      existing issue first and open or link the follow-up issue immediately
-5. Rerun the required review checks for the repaired slice with
+5. Rerun the required review checks for the repaired change with
    `make pr-review`
    or, for CI, packaging, release, or workflow-sensitive repairs, with
    `make pr-review-full`,
-   then create a bounded checkpoint commit before starting the next pass. Do not start another red-team pass with
+   then create a bounded checkpoint commit before starting the next pass. Do not start another review pass with
    uncommitted repaired findings unless the pass is still in a very small
-   in-progress slice.
+   in-progress change.
    Do not describe an upcoming pass as clean, final, or publish-ready; every
    pass is issue-finding with open outcome.
    Do not treat a green `tools.run_pr_review_checks` result as a no-findings
    decision by itself; it is only the verification evidence for the current
    red-team pass.
-6. Continue steps 1 through 5 until every applicable changed surface group has
-   been revisited and a full applicable-surface loop yields no new meaningful
+6. Continue steps 1 through 5 until every applicable changed file group has
+   been revisited and a full review cycle yields no new meaningful
    findings. When a pass finds fewer than 5 findings, report only those
    findings. Do not invent findings to hit a quota.
 7. If the only remaining item is a very minor finishing touch, repair it and
-   finish once no other meaningful issues surface.
+   finish once no other meaningful issues appear.
 8. Keep scratch notes untracked. Do not create tracked issue ledgers, review
    logs, or temporary bookkeeping files.
-9. Keep the PR draft until the full applicable-surface issue-finding loop
+9. Keep the PR draft until the full issue-finding review cycle
    yields no new meaningful findings. Before updating the PR state or marking
    it ready for review, finish with a clean working tree and reload the
    relevant delivery guidance or skills. Ensure any remaining out-of-scope repo

--- a/.claude/commands/reconciliation-tax-build.md
+++ b/.claude/commands/reconciliation-tax-build.md
@@ -4,7 +4,7 @@ Use this route for architecture, implementation, or repair work tied to the
 reconciliation, checkpoint, accounting, and tax buildout.
 
 1. Read `docs/concepts/reconciliation-tax-architecture.md` first.
-2. Read these before shaping any non-trivial slice:
+2. Read these before shaping any non-trivial increment:
    - `ROADMAP.md`
    - `docs/status/migration-sequence.md`
    - `docs/status/current-state.md`
@@ -32,14 +32,14 @@ reconciliation, checkpoint, accounting, and tax buildout.
    - keep CoinTracking tax and accounting reports out of runtime state
    - keep Ledger CLI behind a renderer port
    - keep tax policy behind a policy port
-   - keep current facts plus balances as the MVP bridge while landing richer
+   - keep current facts plus balances as the MVP bridge while adding richer
      pipeline products incrementally
    - keep tax outputs described as `TaxInputs` plus selected policy, never as
      direct emissions from reconciled facts
-   - keep the shared readiness slice definition exact: source, location,
+   - keep the shared readiness definition exact: source, location,
      instrument, subject ref, continuity segment, checkpoint date, and tax
      year where relevant
-   - prefer one bounded stage slice over building a speculative end-state
+   - prefer one bounded stage increment over building a speculative end-state
      framework before the next concrete filing-critical need exists
 7. Keep `pydantic` at boundaries only:
    - config
@@ -61,5 +61,5 @@ reconciliation, checkpoint, accounting, and tax buildout.
    repo-only batch scripts.
 12. Emit explicit issues when the task uncovers unsupported behavior or deferred
    cases.
-13. Refactor obvious shared seams, add tests for new behavior, and commit a
+13. Refactor obvious shared boundaries, add tests for new behavior, and commit a
     verified checkpoint before closing the task.

--- a/.claude/commands/source-diff.md
+++ b/.claude/commands/source-diff.md
@@ -1,6 +1,6 @@
 # Source Diff
 
-Use this route when a rendered candidate or fact-derived slice needs a direct
+Use this route when a rendered candidate or fact-derived output set needs a direct
 row comparison against a reference ledger extract.
 
 1. run `make oracle ARGS='source diff'`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Do not pre-load every repo doc by default.
 | Delivery guardrails, protected-branch behavior, or agent-assisted Git operations | `docs/standards/delivery-guardrails.md`, `docs/standards/commits.md`, `tools/audit_delivery_guardrails.py` |
 | PR review or review-loop recovery | `docs/standards/delivery-guardrails.md`, `docs/standards/implementation.md`, `docs/standards/commits.md`, `.claude/commands/pr-review.md` |
 | Planning sequence, phased delivery steps, MVP scope, or rollout checkpoints | `ROADMAP.md`, `docs/status/migration-sequence.md` |
-| Reconciliation, checkpoint, journal, tax-engine implementation, or core pipeline products | `docs/concepts/reconciliation-tax-architecture.md`, `ROADMAP.md`, `docs/status/migration-sequence.md`, `docs/concepts/oracle-boundaries.md`, `docs/concepts/transaction-classification.md` |
+| Reconciliation, checkpoint, journal, tax-engine implementation, or core pipeline products | `docs/concepts/reconciliation-tax-architecture.md`, `docs/reference/target-contract-primitives.md`, `docs/reference/target-product-artifacts.md`, `ROADMAP.md`, `docs/status/migration-sequence.md`, `docs/concepts/oracle-boundaries.md`, `docs/concepts/transaction-classification.md` |
 | Platform-agnostic boundaries, classification mapping, or migration order | `docs/concepts/oracle-boundaries.md`, `docs/concepts/transaction-classification.md`, `docs/status/migration-sequence.md` |
 | Source or output adapter work | `docs/status/adapter-delivery-plan.md`, `docs/concepts/unified-adapter-architecture.md`, `docs/guides/write-an-adapter.md` |
 | High-level architecture orientation | `docs/concepts/architecture-overview.md`, `docs/status/current-state.md`, `docs/concepts/reconciliation-tax-architecture.md` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ Do not pre-load every repo doc by default.
 | Issue templates, issue-writing policy, or proactive follow-up issue creation | `AGENTS.md`, `docs/standards/issues.md`, `docs/standards/implementation.md`, `docs/standards/delivery-guardrails.md`, `docs/standards/commits.md`, `.claude/commands/issue-workflow.md` |
 | Delivery guardrails, protected-branch behavior, or agent-assisted Git operations | `docs/standards/delivery-guardrails.md`, `docs/standards/commits.md`, `tools/audit_delivery_guardrails.py` |
 | PR review or review-loop recovery | `docs/standards/delivery-guardrails.md`, `docs/standards/implementation.md`, `docs/standards/commits.md`, `.claude/commands/pr-review.md` |
-| Planning sequence, delivery slices, MVP scope, or rollout checkpoints | `ROADMAP.md`, `docs/status/migration-sequence.md` |
+| Planning sequence, phased delivery steps, MVP scope, or rollout checkpoints | `ROADMAP.md`, `docs/status/migration-sequence.md` |
 | Reconciliation, checkpoint, journal, tax-engine implementation, or core pipeline products | `docs/concepts/reconciliation-tax-architecture.md`, `ROADMAP.md`, `docs/status/migration-sequence.md`, `docs/concepts/oracle-boundaries.md`, `docs/concepts/transaction-classification.md` |
 | Platform-agnostic boundaries, classification mapping, or migration order | `docs/concepts/oracle-boundaries.md`, `docs/concepts/transaction-classification.md`, `docs/status/migration-sequence.md` |
 | Source or output adapter work | `docs/status/adapter-delivery-plan.md`, `docs/concepts/unified-adapter-architecture.md`, `docs/guides/write-an-adapter.md` |
@@ -60,7 +60,7 @@ Do not pre-load every repo doc by default.
   `.claude/commands/`.
 - When editing repo docs or Markdown, use the `markdown` skill if available.
 - When editing repo standards, automation, or other control-plane files, use
-  the repo-local workflow for the active surface and reload the narrow repo
+  the repo-local workflow for the active area and reload the narrow repo
   guidance listed in this file before editing.
 - Keep tracked docs, templates, and control-plane text neutral and durable.
 - Keep current-state docs accurate to the implemented runtime, and keep
@@ -82,14 +82,14 @@ Do not pre-load every repo doc by default.
 - Avoid duplicate routing pages. Prefer `README.md`, `docs/README.md`, and
   this file over adding another switchboard.
 - Broad docs or repo-structure reshapes should land as checkpoint commits at
-  stable slices, not as one giant umbrella commit unless the slice cannot be
-  validated incrementally.
+  stable stopping points, not as one giant umbrella commit unless the change
+  cannot be validated incrementally.
 
 ## Execution Rules
 
 - This repo intentionally uses the external uv environment at
   `$HOME/.venvs/tallylot-py312`.
-- Use the root `Makefile` as the standard local command surface. It prepends
+- Use the root `Makefile` as the standard local command interface. It prepends
   `$(HOME)/.venvs/tallylot-py312/bin` to `PATH`, which keeps repo commands
   machine-neutral and sandbox-safe without inline environment prefixes.
 - Bootstrap each clone before doing stable work. This refreshes the shared
@@ -98,7 +98,7 @@ Do not pre-load every repo doc by default.
   history rebuilds:
   - `make install-hooks`
 - Do not consider work ready until the repo's selected verification for the
-  changed surfaces passes. For agent-default local verification, use the
+  changed files passes. For agent-default local verification, use the
   standard `tools.run_quality_gates` path rather than forcing the explicit
   full-suite override.
 - Do not consider non-trivial work ready until the verified checkpoint commit
@@ -110,7 +110,7 @@ Do not pre-load every repo doc by default.
   - `make quality`
   - `make pr-review-full`
   - `make quality-full`
-- Benchmark quality-gate scheduling or test-slice changes before changing the
+- Benchmark quality-gate scheduling or test-bundle changes before changing the
   default verification path:
   - `make benchmark-quality`
   - `make benchmark-tests`
@@ -119,7 +119,7 @@ Do not pre-load every repo doc by default.
 - Use `tools.run_quality_gates` as the normal final local verification
   command.
 - Use `tools.run_pr_review_checks --mode full` when changes touch CI,
-  packaging, release, or other workflow surfaces where the local verification
+  packaging, release, or other workflow areas where the local verification
   pass should mirror the final non-draft PR suite before handoff.
 - `tools.run_quality_gates --full-tests` is not the standard agent close-out
   path. Avoid it unless there is a specific reason to reach for the explicit
@@ -134,7 +134,7 @@ Do not pre-load every repo doc by default.
   - do not turn the hook path into a second full-suite verification pass
 - Treat commits as stable checkpoints by default:
   - prefer small cohesive commits
-  - keep every authored commit bounded to one reviewable slice
+  - keep every authored commit bounded to one reviewable change
   - avoid micro-commits with no rollback or review value
   - split large but separable work into multiple bounded checkpoint commits
     instead of one umbrella commit
@@ -154,11 +154,11 @@ Do not pre-load every repo doc by default.
   - where that behavior is covered now
   - whether the assertion became stronger, weaker, or simply moved
 - Before shaping a non-trivial change, reload the narrow roadmap,
-  architecture, migration, or owning-boundary guidance for that surface.
+  architecture, migration, or owning-boundary guidance for that area.
 - Keep public-facing names simple and ergonomic. Prefer short neutral command
   and API names over long implementation labels, and only add qualifiers when
   a real ambiguity exists.
-- Treat protected branches as PR-only landing surfaces:
+- Treat protected branches as PR-only branches:
   - do not push directly to `main`
   - do not bypass branch protection for ordinary delivery
   - do not rewrite a merged `main` commit when preserving the original pull
@@ -243,7 +243,7 @@ Workspace resolution order:
 - Follow `docs/standards/implementation.md` during coding:
   - structure first
   - tests alongside behavior, but only when they add real regression value
-  - refactor obvious shared seams during the task
+  - refactor obvious shared boundaries during the task
   - commit at stable checkpoints without waiting to be reminded
 - When work affects architecture, schema, or execution sequencing, update
   `ROADMAP.md` and `docs/concepts/reconciliation-tax-architecture.md`

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ implemented surface.
 - deterministic artifact generation for manifests, normalization output,
   checkpoint output, and validation packages
 - explicit issues for unsupported or ambiguous data
-- provider-neutral transaction facts as the canonical runtime model
+- provider-neutral transaction facts as the only runtime model
 - adapter-driven source and output boundaries, with mirrored workspace guidance
   under [docs/workspace/README.md](docs/workspace/README.md)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -85,33 +85,11 @@ Rules:
 
 Shared-foundation deliverables before broad pipeline expansion:
 
-- one typed provenance family across evidence, claims, balances, gaps,
-  readiness, checkpoints, accounting, and tax artifacts
-- one target-product versioning, compatibility, canonical-serialization, and
-  fingerprint rule
-- one controlled gap taxonomy with stage ownership, blocking scope,
-  `SubjectRef`, candidate interpretations, required evidence, and allowed
-  resolution methods
-- one gap-attachment rule that covers subject, group, and dataset scopes
-- one readiness vocabulary reused across all stages
-- one subject-first readiness model with derived projections rather than one
-  mandatory global readiness cube
-- one kernel-and-envelope rule with stable rehydration joins
-- one explicit identity seam for instrument, contract, position, location,
-  legal owner, beneficial owner, and counterparty identity
-- one minimum `ClaimSet` taxonomy shared across adapters and later compilation
-- one minimum `EconomicFacts` invariant grammar
-- one typed tax-policy selection seam reused by later `TaxInputs` and
-  `TaxOutputs` work
-- one minimum `TaxInputs` determinant grammar
-- one checkpoint assertion vocabulary reused by reconciliation, checkpoint
-  adoption, accounting, and tax
-- one checkpoint acceptance vocabulary for trust level, acceptance basis,
-  evidence class, continuity proof, and minimum admissibility rules
-- one bridge-to-target mapping for how current planner and
-  translation seams become the first proto-`EvidenceSet` and proto-`ClaimSet`
-  slices
-- one named first vertical slice with parity and replay gates
+- freeze the Phase 0 contract details on the owner pages listed above
+- keep roadmap text focused on readiness, sequencing, and exit criteria instead
+  of restating family lists, kernel makeup, or bridge landing rules
+- use the bounded first-slice owner page for Coinbase-first replay and parity
+  instead of redefining that contract here
 
 Exit criteria:
 
@@ -194,14 +172,9 @@ Deliver:
   remains truth in current-state text
 - explicit trust-gate ownership for reconciliation, checkpoints, accounting,
   and tax
-- target-product versioning, serialization, and fingerprint rules
-- kernel-and-envelope rules with stable rehydration joins
-- shared gap scope, `SubjectRef`, and evidence-readiness rules
-- minimum `ClaimSet`, `EconomicFacts`, `Checkpoint`, and `TaxInputs`
-  vocabularies
-- one bridge-to-target mapping for how current planner and
-  translation seams land the first proto-`EvidenceSet` and proto-`ClaimSet`
-  slices
+- freeze the detailed product, taxonomy, id, ordering, fingerprint, temporal,
+  and bridge-mapping contracts on the owner pages instead of restating them
+  here
 - unified adapter product and facet prep where it removes first-slice drift,
   without broad family migration or wrapper lanes
 - one named first vertical slice with parity and replay gates

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,6 +9,8 @@ This file is the forward planning document for the repo.
   - [`docs/concepts/current-bridge-contracts.md`](docs/concepts/current-bridge-contracts.md)
   - [`docs/concepts/bridge-to-target-mapping.md`](docs/concepts/bridge-to-target-mapping.md)
   - [`docs/concepts/pipeline-stage-contracts.md`](docs/concepts/pipeline-stage-contracts.md)
+  - [`docs/reference/target-contract-primitives.md`](docs/reference/target-contract-primitives.md)
+  - [`docs/reference/target-product-artifacts.md`](docs/reference/target-product-artifacts.md)
   - [`docs/reference/first-slice-contract.md`](docs/reference/first-slice-contract.md)
   - [`docs/reference/first-downstream-slice-contract.md`](docs/reference/first-downstream-slice-contract.md)
   - [`docs/concepts/domain-ontology.md`](docs/concepts/domain-ontology.md)
@@ -61,6 +63,12 @@ These are blocking shared foundations for later implementation work:
   [`docs/concepts/bridge-to-target-mapping.md`](docs/concepts/bridge-to-target-mapping.md)
 - the target stage contracts documented in
   [`docs/concepts/pipeline-stage-contracts.md`](docs/concepts/pipeline-stage-contracts.md)
+- the shared target scalar, tuple, dataset-id, and reusable value contracts
+  documented in
+  [`docs/reference/target-contract-primitives.md`](docs/reference/target-contract-primitives.md)
+- the forward-looking target dataset packaging and artifact layout documented
+  in
+  [`docs/reference/target-product-artifacts.md`](docs/reference/target-product-artifacts.md)
 - the bounded first-slice parity and replay contract documented in
   [`docs/reference/first-slice-contract.md`](docs/reference/first-slice-contract.md)
 - the bounded first downstream consumer contract documented in
@@ -96,6 +104,8 @@ Shared-foundation deliverables before broad pipeline expansion:
 - use the bounded first downstream slice owner page for the first
   `EconomicFacts -> ReconciliationState -> Checkpoint` consumer path
   instead of leaving that handoff implicit
+- freeze review-sidecar policy, package landing rules, shared primitive
+  contracts, and target artifact layout before broad parallel implementation
 
 Exit criteria:
 
@@ -115,6 +125,9 @@ Exit criteria:
 - the first vertical slice and its bridge-to-target landing path are explicit
 - downstream record-family contracts, enum vocabularies, and checkpoint value
   shapes are frozen before broad parallel implementation begins
+- no target record field points to an undefined shared type
+- no target package placement is left to implementation-time judgment
+- no target artifact layout is left to local command or author preference
 - broad target package scaffolding does not begin before these contracts are
   frozen
 
@@ -183,8 +196,16 @@ Deliver:
 - freeze the detailed product, taxonomy, id, ordering, fingerprint, temporal,
   and bridge-mapping contracts on the owner pages instead of restating them
   here
+- frozen scalar, tuple, reusable ref, and shared-value contracts for target
+  products
+- frozen target dataset packaging, kernel filenames, and persistence layout
 - freeze the downstream record-family contracts needed for the first
   `EconomicFacts -> ReconciliationState -> Checkpoint` consumer path
+- explicit review-sidecar policy and shared review-attachment rules
+- explicit package landing rules for target-stage code while bridge packages
+  still exist
+- corrected first-slice evidence-member, observation-class, and
+  selection-group taxonomy
 - unified adapter product and facet prep where it removes first-slice drift,
   without broad family migration or wrapper lanes
 - one named first vertical slice with parity and replay gates
@@ -202,6 +223,9 @@ Exit criteria:
   artifact shapes before implementation slices start landing in parallel
 - shared gap, readiness, and checkpoint assertion artifacts are frozen down to
   stable ids, ordering, serialization, and fingerprint rules
+- no target record field still points to an undefined shared type
+- no target package placement is left to implementation-time judgment
+- no target artifact layout is left to local command or author preference
 - broad implementation can start without each stage inventing its own meaning
   for gaps, claims, checkpoint acceptance, or fingerprints
 - broad implementation does not start with target package scaffolding that
@@ -320,7 +344,7 @@ Deliver:
 - trust level and acceptance basis
 - intentional opening-state adoption with provenance
 - manual balance submission as typed checkpoint-owned input
-- `CheckpointAssertionValue`, frozen `assertion_kind` vocabulary, and the
+- `AssertionValue`, frozen `assertion_kind` vocabulary, and the
   bounded first consumer path documented in
   [`docs/reference/first-downstream-slice-contract.md`](docs/reference/first-downstream-slice-contract.md)
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -81,18 +81,30 @@ Shared-foundation deliverables before broad pipeline expansion:
 
 - one typed provenance family across evidence, claims, balances, gaps,
   readiness, checkpoints, accounting, and tax artifacts
+- one target-product versioning, compatibility, canonical-serialization, and
+  fingerprint rule
 - one controlled gap taxonomy with stage ownership, blocking scope,
   `SubjectRef`, candidate interpretations, required evidence, and allowed
   resolution methods
+- one gap-attachment rule that covers subject, group, and dataset scopes
 - one readiness vocabulary reused across all stages
 - one subject-first readiness model with derived projections rather than one
   mandatory global readiness cube
+- one kernel-and-envelope rule with stable rehydration joins
 - one explicit identity seam for instrument, contract, position, location,
   legal owner, beneficial owner, and counterparty identity
+- one minimum `ClaimSet` taxonomy shared across adapters and later compilation
+- one minimum `EconomicFacts` invariant grammar
 - one typed tax-policy selection seam reused by later `TaxInputs` and
   `TaxOutputs` work
+- one minimum `TaxInputs` determinant grammar
 - one checkpoint assertion vocabulary reused by reconciliation, checkpoint
   adoption, accounting, and tax
+- one checkpoint acceptance vocabulary for trust level, acceptance basis,
+  evidence class, continuity proof, and minimum admissibility rules
+- one bridge note for how current planner and translation seams become the first
+  proto-`EvidenceSet` and proto-`ClaimSet` slices
+- one named first vertical slice with parity and replay gates
 
 Exit criteria:
 
@@ -102,6 +114,8 @@ Exit criteria:
   formats
 - dataset summaries derive from subject-level readiness instead of hand-built
   status prose
+- target products have owned versioning and fingerprint rules
+- the first vertical slice and its bridge-to-target landing path are explicit
 
 ## MVP Scope Guardrails
 
@@ -117,10 +131,14 @@ Exit criteria:
   low-confidence partial support
 - prefer one end-to-end vertical slice that proves a new stage over several
   horizontal framework layers with no proven consumer
+- default first vertical slice: the planner-enabled Coinbase retail export
+  family plus statement-backed balance observation flow, unless the active
+  filing workspace requires another Tier A family to land first
 - keep crypto filing-critical coverage primary for the MVP while using generic
   runtime names and boundaries that can later absorb other instrument classes
-- keep current-contract adapter stabilization distinct from the later adapter
-  redesign
+- keep filing-critical adapter stabilization distinct from broad family
+  migration, while allowing unified adapter contract and bridge-mapping work in
+  Phase 0 when it removes first-slice drift
 
 ## Performance Expectations
 
@@ -139,12 +157,14 @@ Rules:
 
 ## Implementation Program
 
-### Phase 0. Shared Foundations And Docs Lock
+### Phase 0. Shared Foundations, Contract Lock, And First-Slice Prep
 
 Goal:
 
 - finish the shared architecture, naming, support-model, and control-plane
   baseline before broad implementation slices land
+- freeze the contracts that the first implementation slice must rely on instead
+  of leaving them to stage-local interpretation
 
 Deliver:
 
@@ -155,12 +175,26 @@ Deliver:
   remains truth in current-state text
 - explicit trust-gate ownership for reconciliation, checkpoints, accounting,
   and tax
+- target-product versioning, serialization, and fingerprint rules
+- kernel-and-envelope rules with stable rehydration joins
+- shared gap scope, `SubjectRef`, and evidence-readiness rules
+- minimum `ClaimSet`, `EconomicFacts`, `Checkpoint`, and `TaxInputs`
+  vocabularies
+- one bridge note for how current planner and translation seams land the first
+  proto-`EvidenceSet` and proto-`ClaimSet` slices
+- unified adapter product and facet prep where it removes first-slice drift,
+  without broad family migration or wrapper lanes
+- one named first vertical slice with parity and replay gates
 
 Exit criteria:
 
 - a contributor can identify what is current, what is target, who owns each
   contract, and what the next slice should land without reading the same
   definition in several conflicting places
+- the first slice does not depend on an implicit adapter rewrite that is not
+  written down
+- broad implementation can start without each stage inventing its own meaning
+  for gaps, claims, checkpoint acceptance, or fingerprints
 
 ### Phase 1. Formalize `EvidenceSet`
 
@@ -177,6 +211,8 @@ Deliver:
 - evidence provenance and locator guarantees aligned with the target contract
 - evidence summary and issue surfaces that remain source-local rather than
   prematurely economic
+- a bridge landing path from planner-owned artifacts into proto-`EvidenceSet`
+  without requiring broad unified-adapter migration first
 
 Exit criteria:
 
@@ -201,6 +237,8 @@ Deliver:
   into final bridge semantics
 - at least one ambiguous row family that survives as a claim rather than being
   coerced into a guessed final fact
+- a bounded adapter-family path that can emit claim-native outputs without
+  making the full unified adapter migration a hidden prerequisite
 
 Exit criteria:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -108,7 +108,7 @@ Shared-foundation deliverables before broad pipeline expansion:
   adoption, accounting, and tax
 - one checkpoint acceptance vocabulary for trust level, acceptance basis,
   evidence class, continuity proof, and minimum admissibility rules
-- one canonical bridge-to-target mapping for how current planner and
+- one bridge-to-target mapping for how current planner and
   translation seams become the first proto-`EvidenceSet` and proto-`ClaimSet`
   slices
 - one named first vertical slice with parity and replay gates
@@ -122,7 +122,7 @@ Exit criteria:
 - dataset summaries derive from subject-level readiness instead of hand-built
   status prose
 - target products have owned versioning and fingerprint rules
-- the canonical bridge-to-target mapping is published and linked as the single
+- the bridge-to-target mapping is published and linked as the single
   authority
 - per-product kernel, id, serialization, fingerprint, and adjudication rules
   are frozen on the target owner page
@@ -199,7 +199,7 @@ Deliver:
 - shared gap scope, `SubjectRef`, and evidence-readiness rules
 - minimum `ClaimSet`, `EconomicFacts`, `Checkpoint`, and `TaxInputs`
   vocabularies
-- one canonical bridge-to-target mapping for how current planner and
+- one bridge-to-target mapping for how current planner and
   translation seams land the first proto-`EvidenceSet` and proto-`ClaimSet`
   slices
 - unified adapter product and facet prep where it removes first-slice drift,

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -63,29 +63,33 @@ contracts.
 Must freeze:
 
 - `EvidenceSet` record families, ids, cardinality, and intentional
-  `selection_plan_fingerprint` identity churn
+  `selection_fingerprint` identity churn
 - critical-path `EvidenceObservationRecord` field tables for
   `document_identity` and `coinbase_statement_balance_row`
-- `ClaimSet` interpretation-scope, bundle, and compilation-decision model
+- `ClaimSet` interpretation-scope, bundle, and bundle-decision model
 - critical-path `ClaimRecord` field tables, `evidence_observation_refs`, and
   the compatibility-sidecar boundary for retained legacy hint fields
 - `AssertionValue`, `PositionRef`, and `ContractRef`
-- shared support artifacts: `GapCore`, `GapExplanation`, `ReviewRecord`,
-  `ReviewExplanation`, `SubjectReadinessRecord`, `ReadinessProjection`,
-  `SubjectRef`, truthful `interpretation_scope_id` attachments, and the
-  downstream shared-subject seams needed for accounting and tax records
+- shared support records and sidecars: `GapRecord`, `GapExplanation`, `ReviewRecord`,
+  `ReviewExplanation`, `ReadinessRecord`, `ReadinessProjection`,
+  `SubjectRef`, truthful `interpretation_scope_id` and `balance_target_id`
+  attachments, and the downstream shared-subject seams needed for accounting
+  and tax records
 - product ids, upstream product-ref multiplicity, and the rule that product
   refs use product ids rather than `dataset_id`
+- target naming rules that distinguish concepts, refs, ids, records,
+  projections, and sidecars without baking bridge-era qualifiers into
+  canonical target names
 - authoritative persistence model, partition scopes, sidecar rules, and
   default filesystem placement
 - migration authority rules, compatibility projections, reader cutovers, and
   retirement gates
 - package ownership and layer placement for shared functionality
-- explicit no-invention rules for non-critical observation and claim families
+- explicit no-invention rules for non-critical observation and claim kinds
 
 Deliver:
 
-- aligned owner docs for target products, ontology, support artifacts, and
+- aligned owner docs for target products, ontology, support records and sidecars, and
   persistence rules
 - explicit cutover matrix for bridge-to-target migration
 - one bounded first upstream slice and one bounded first downstream slice
@@ -98,16 +102,18 @@ Exit criteria:
 
 - no owner concept is defined in two competing places
 - no target product references an undefined record family or ref type
-- no cross-stage support artifact masquerades as a claim family
+- no cross-stage support artifact masquerades as a claim kind
 - claim-stage blockers can attach to `interpretation_scope_id` before subject
   identity resolves, and later-stage blockers can attach to truthful
   accounting or tax subjects without collapsing to dataset-only scope
+- no target id or helper id bakes bridge-era naming into canonical target
+  identity
 - no bridge artifact is left without an authority and retirement rule
 - no hot-path field points to an undefined value ref or sidecar
-- every critical-path observation and claim family has one authoritative kernel
+- every critical-path observation and claim kind has one authoritative kernel
   field table
 - no target product metadata ref uses `dataset_id` where a product id exists
-- non-critical observation and claim families are explicitly deferred rather
+- non-critical observation and claim kinds are explicitly deferred rather
   than left implicit
 - implementation placement is mechanical rather than interpretive
 - the first upstream and downstream slices can be implemented without inventing
@@ -147,9 +153,9 @@ Deliver:
 
 - semantic-only `ClaimSet` emission keyed by `claim_set_id`
 - explicit interpretation scopes, mutually exclusive bundles, and
-  compilation-decision records
+  bundle-decision records
 - frozen first-slice claim fields plus `evidence_observation_refs`
-- shared support artifacts attached to claim scopes where needed
+- shared support records and sidecars attached to claim scopes where needed
 - declared compatibility projections for `EconomicActivityDraft` and
   `SourceTranslationBatch`, with legacy hint fields kept outside canonical
   claims
@@ -158,7 +164,7 @@ Exit criteria:
 
 - ambiguous source meaning can remain explicit without being forced into final
   economic meaning
-- claim compilation decisions remain claim-owned and do not carry economic
+- claim bundle decisions remain claim-owned and do not carry economic
   payload
 
 ## Phase 3. Land `EconomicFacts`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,9 @@ This file is the forward planning document for the repo.
   [`docs/status/current-state.md`](docs/status/current-state.md).
 - Detailed contract ownership lives in:
   - [`docs/concepts/current-bridge-contracts.md`](docs/concepts/current-bridge-contracts.md)
+  - [`docs/concepts/bridge-to-target-mapping.md`](docs/concepts/bridge-to-target-mapping.md)
   - [`docs/concepts/pipeline-stage-contracts.md`](docs/concepts/pipeline-stage-contracts.md)
+  - [`docs/reference/first-slice-contract.md`](docs/reference/first-slice-contract.md)
   - [`docs/concepts/domain-ontology.md`](docs/concepts/domain-ontology.md)
   - [`docs/concepts/gaps-and-readiness.md`](docs/concepts/gaps-and-readiness.md)
   - [`docs/concepts/reconciliation-tax-architecture.md`](docs/concepts/reconciliation-tax-architecture.md)
@@ -54,8 +56,12 @@ These are blocking shared foundations for later implementation work:
 
 - the live bridge contracts documented in
   [`docs/concepts/current-bridge-contracts.md`](docs/concepts/current-bridge-contracts.md)
+- the bridge-to-target transformation rules documented in
+  [`docs/concepts/bridge-to-target-mapping.md`](docs/concepts/bridge-to-target-mapping.md)
 - the target stage contracts documented in
   [`docs/concepts/pipeline-stage-contracts.md`](docs/concepts/pipeline-stage-contracts.md)
+- the bounded first-slice parity and replay contract documented in
+  [`docs/reference/first-slice-contract.md`](docs/reference/first-slice-contract.md)
 - the target ontology and identity seams documented in
   [`docs/concepts/domain-ontology.md`](docs/concepts/domain-ontology.md)
 - the shared gap, readiness, and `SubjectRef` rules documented in
@@ -102,8 +108,9 @@ Shared-foundation deliverables before broad pipeline expansion:
   adoption, accounting, and tax
 - one checkpoint acceptance vocabulary for trust level, acceptance basis,
   evidence class, continuity proof, and minimum admissibility rules
-- one bridge note for how current planner and translation seams become the first
-  proto-`EvidenceSet` and proto-`ClaimSet` slices
+- one canonical bridge-to-target mapping for how current planner and
+  translation seams become the first proto-`EvidenceSet` and proto-`ClaimSet`
+  slices
 - one named first vertical slice with parity and replay gates
 
 Exit criteria:
@@ -115,7 +122,15 @@ Exit criteria:
 - dataset summaries derive from subject-level readiness instead of hand-built
   status prose
 - target products have owned versioning and fingerprint rules
+- the canonical bridge-to-target mapping is published and linked as the single
+  authority
+- per-product kernel, id, serialization, fingerprint, and adjudication rules
+  are frozen on the target owner page
+- `CheckpointAssertion`, issue-to-gap mapping, and review-sidecar rules are
+  defined on their owning pages
 - the first vertical slice and its bridge-to-target landing path are explicit
+- broad target package scaffolding does not begin before these contracts are
+  frozen
 
 ## MVP Scope Guardrails
 
@@ -134,6 +149,10 @@ Exit criteria:
 - default first vertical slice: the planner-enabled Coinbase retail export
   family plus statement-backed balance observation flow, unless the active
   filing workspace requires another Tier A family to land first
+- the repo default first slice is the bounded contract in
+  [`docs/reference/first-slice-contract.md`](docs/reference/first-slice-contract.md);
+  it is not a claim that the actual `2023` to `2025` filing adapter inventory
+  is already known in-repo
 - keep crypto filing-critical coverage primary for the MVP while using generic
   runtime names and boundaries that can later absorb other instrument classes
 - keep filing-critical adapter stabilization distinct from broad family
@@ -180,8 +199,9 @@ Deliver:
 - shared gap scope, `SubjectRef`, and evidence-readiness rules
 - minimum `ClaimSet`, `EconomicFacts`, `Checkpoint`, and `TaxInputs`
   vocabularies
-- one bridge note for how current planner and translation seams land the first
-  proto-`EvidenceSet` and proto-`ClaimSet` slices
+- one canonical bridge-to-target mapping for how current planner and
+  translation seams land the first proto-`EvidenceSet` and proto-`ClaimSet`
+  slices
 - unified adapter product and facet prep where it removes first-slice drift,
   without broad family migration or wrapper lanes
 - one named first vertical slice with parity and replay gates
@@ -193,8 +213,12 @@ Exit criteria:
   definition in several conflicting places
 - the first slice does not depend on an implicit adapter rewrite that is not
   written down
+- the first slice does not depend on inventing ids, ordering, serialization,
+  fingerprints, replay checks, or allowed drift at implementation time
 - broad implementation can start without each stage inventing its own meaning
   for gaps, claims, checkpoint acceptance, or fingerprints
+- broad implementation does not start with target package scaffolding that
+  outruns the frozen contract set
 
 ### Phase 1. Formalize `EvidenceSet`
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,6 +10,7 @@ This file is the forward planning document for the repo.
   - [`docs/concepts/bridge-to-target-mapping.md`](docs/concepts/bridge-to-target-mapping.md)
   - [`docs/concepts/pipeline-stage-contracts.md`](docs/concepts/pipeline-stage-contracts.md)
   - [`docs/reference/first-slice-contract.md`](docs/reference/first-slice-contract.md)
+  - [`docs/reference/first-downstream-slice-contract.md`](docs/reference/first-downstream-slice-contract.md)
   - [`docs/concepts/domain-ontology.md`](docs/concepts/domain-ontology.md)
   - [`docs/concepts/gaps-and-readiness.md`](docs/concepts/gaps-and-readiness.md)
   - [`docs/concepts/reconciliation-tax-architecture.md`](docs/concepts/reconciliation-tax-architecture.md)
@@ -62,6 +63,8 @@ These are blocking shared foundations for later implementation work:
   [`docs/concepts/pipeline-stage-contracts.md`](docs/concepts/pipeline-stage-contracts.md)
 - the bounded first-slice parity and replay contract documented in
   [`docs/reference/first-slice-contract.md`](docs/reference/first-slice-contract.md)
+- the bounded first downstream consumer contract documented in
+  [`docs/reference/first-downstream-slice-contract.md`](docs/reference/first-downstream-slice-contract.md)
 - the target ontology and identity seams documented in
   [`docs/concepts/domain-ontology.md`](docs/concepts/domain-ontology.md)
 - the shared gap, readiness, and `SubjectRef` rules documented in
@@ -90,6 +93,9 @@ Shared-foundation deliverables before broad pipeline expansion:
   of restating family lists, kernel makeup, or bridge landing rules
 - use the bounded first-slice owner page for Coinbase-first replay and parity
   instead of redefining that contract here
+- use the bounded first downstream slice owner page for the first
+  `EconomicFacts -> ReconciliationState -> Checkpoint` consumer path
+  instead of leaving that handoff implicit
 
 Exit criteria:
 
@@ -107,6 +113,8 @@ Exit criteria:
 - `CheckpointAssertion`, issue-to-gap mapping, and review-sidecar rules are
   defined on their owning pages
 - the first vertical slice and its bridge-to-target landing path are explicit
+- downstream record-family contracts, enum vocabularies, and checkpoint value
+  shapes are frozen before broad parallel implementation begins
 - broad target package scaffolding does not begin before these contracts are
   frozen
 
@@ -175,6 +183,8 @@ Deliver:
 - freeze the detailed product, taxonomy, id, ordering, fingerprint, temporal,
   and bridge-mapping contracts on the owner pages instead of restating them
   here
+- freeze the downstream record-family contracts needed for the first
+  `EconomicFacts -> ReconciliationState -> Checkpoint` consumer path
 - unified adapter product and facet prep where it removes first-slice drift,
   without broad family migration or wrapper lanes
 - one named first vertical slice with parity and replay gates
@@ -188,6 +198,10 @@ Exit criteria:
   written down
 - the first slice does not depend on inventing ids, ordering, serialization,
   fingerprints, replay checks, or allowed drift at implementation time
+- downstream stage owner pages define record families, enum vocabularies, and
+  artifact shapes before implementation slices start landing in parallel
+- shared gap, readiness, and checkpoint assertion artifacts are frozen down to
+  stable ids, ordering, serialization, and fingerprint rules
 - broad implementation can start without each stage inventing its own meaning
   for gaps, claims, checkpoint acceptance, or fingerprints
 - broad implementation does not start with target package scaffolding that
@@ -254,10 +268,14 @@ Deliver:
 
 - claim-to-economic compilation seam
 - target-directed economic models aligned to the target ontology
+- explicit `EconomicEventRecord` and `EconomicLegRecord` contracts with frozen
+  `event_family` and `leg_role` vocabularies
 - explicit preservation of settlement, lifecycle, valuation, and identity seams
 - bridge retirement rules for the slices that no longer need
   `EconomicActivityDraft` or `TransactionFact`
 - parity coverage for the first claim-to-economic vertical slice
+- the bounded downstream handoff documented in
+  [`docs/reference/first-downstream-slice-contract.md`](docs/reference/first-downstream-slice-contract.md)
 
 Exit criteria:
 
@@ -276,6 +294,9 @@ Deliver:
 
 - transfer links, balance targets, continuity, and checkpoint candidacy under
   `ReconciliationState`
+- explicit `ContinuitySegmentRecord`, `LinkRecord`, `BalanceTargetRecord`, and
+  `CheckpointCandidateRecord` contracts with frozen ids and status
+  vocabularies
 - target gap and readiness models where the owning stage can support them
 - corroboration sidecars and deterministic correction handling
 - independence from raw capture layout and bridge-only balance assumptions
@@ -299,6 +320,9 @@ Deliver:
 - trust level and acceptance basis
 - intentional opening-state adoption with provenance
 - manual balance submission as typed checkpoint-owned input
+- `CheckpointAssertionValue`, frozen `assertion_kind` vocabulary, and the
+  bounded first consumer path documented in
+  [`docs/reference/first-downstream-slice-contract.md`](docs/reference/first-downstream-slice-contract.md)
 
 Exit criteria:
 
@@ -602,6 +626,12 @@ of the following together:
 - `ROADMAP.md`
 - `docs/concepts/reconciliation-tax-architecture.md`
 - `docs/status/migration-sequence.md`
+
+Program-ownership rule:
+
+- `ROADMAP.md` is the only numbered implementation program of record
+- `docs/status/migration-sequence.md` mirrors landing rules and retirement
+  sequencing without defining competing phase numbers
 
 ## Time Summary
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -9,229 +9,111 @@ This file is the forward planning document for the repo.
   - [`docs/concepts/current-bridge-contracts.md`](docs/concepts/current-bridge-contracts.md)
   - [`docs/concepts/bridge-to-target-mapping.md`](docs/concepts/bridge-to-target-mapping.md)
   - [`docs/concepts/pipeline-stage-contracts.md`](docs/concepts/pipeline-stage-contracts.md)
-  - [`docs/reference/target-contract-primitives.md`](docs/reference/target-contract-primitives.md)
-  - [`docs/reference/target-product-artifacts.md`](docs/reference/target-product-artifacts.md)
-  - [`docs/reference/first-slice-contract.md`](docs/reference/first-slice-contract.md)
-  - [`docs/reference/first-downstream-slice-contract.md`](docs/reference/first-downstream-slice-contract.md)
   - [`docs/concepts/domain-ontology.md`](docs/concepts/domain-ontology.md)
   - [`docs/concepts/gaps-and-readiness.md`](docs/concepts/gaps-and-readiness.md)
   - [`docs/concepts/reconciliation-tax-architecture.md`](docs/concepts/reconciliation-tax-architecture.md)
+  - [`docs/reference/first-slice-contract.md`](docs/reference/first-slice-contract.md)
+  - [`docs/reference/first-downstream-slice-contract.md`](docs/reference/first-downstream-slice-contract.md)
   - [`docs/status/migration-sequence.md`](docs/status/migration-sequence.md)
 
 This roadmap tracks the implementation program from the current bridge toward
 the target stage-first architecture. The current bridge remains the live runtime
-seam, but it is not the long-term architecture center.
+seam until later slices replace it, but it is not the long-term architecture
+center.
 
 ## Planning Anchors
 
 These anchors drive sequencing and acceptance criteria:
 
-- the historical CoinTracking export boundary around `2023-08-05` remains an
-  oracle boundary, not a trusted opening checkpoint
-- the first source-backed checkpoint target remains near `2026-03-23`
-- the filing-critical output horizon remains `2023` through `2025`
 - reconciliation remains the trust gate before checkpoint adoption, accounting,
   and tax
 - checkpoint truth is accepted state with explicit acceptance basis
-- capture identity is metadata, not path
-- typed provenance stays a runtime model and is flattened only when writing
-  artifacts
-- normalization is capture-scoped and reconciliation is source-assembly-scoped
+- source-backed evidence and source-backed checkpoints remain first-class
 - raw-evidence derivation is the supported semantic parity path
+- capture identity is metadata, not path
+- typed provenance stays a runtime model and is flattened only at artifact
+  boundaries
+- normalization is capture-scoped and reconciliation is source-assembly-scoped
 - current bridge names remain current-state truth until later implementation
   slices replace them
+- CoinTracking remains an edge projection and oracle family, not the core
+  ledger model
 
 ## Transition Rules
 
 - preserve current working behavior while new foundations land
 - avoid freezing the current bridge as the long-term architecture center
 - keep adapters and services shippable at every checkpoint
-- keep CoinTracking as one edge projection and oracle family, not a migration
-  anchor
-- preserve current bridge truth while establishing the target stage and
-  ontology ownership model
-- do not rename live bridge symbols or the live repo-only support package as a
-  docs-only side effect; land those as later implementation slices
+- preserve current bridge truth while establishing target product ownership
+- do not let bridge compatibility projections become a second architecture
+  center
+- do not rename live bridge symbols or repo-only support packages as a docs-only
+  side effect
 
-## Cross-Cutting Foundations
-
-These are blocking shared foundations for later implementation work:
-
-- the live bridge contracts documented in
-  [`docs/concepts/current-bridge-contracts.md`](docs/concepts/current-bridge-contracts.md)
-- the bridge-to-target transformation rules documented in
-  [`docs/concepts/bridge-to-target-mapping.md`](docs/concepts/bridge-to-target-mapping.md)
-- the target stage contracts documented in
-  [`docs/concepts/pipeline-stage-contracts.md`](docs/concepts/pipeline-stage-contracts.md)
-- the shared target scalar, tuple, dataset-id, and reusable value contracts
-  documented in
-  [`docs/reference/target-contract-primitives.md`](docs/reference/target-contract-primitives.md)
-- the forward-looking target dataset packaging and artifact layout documented
-  in
-  [`docs/reference/target-product-artifacts.md`](docs/reference/target-product-artifacts.md)
-- the bounded first-slice parity and replay contract documented in
-  [`docs/reference/first-slice-contract.md`](docs/reference/first-slice-contract.md)
-- the bounded first downstream consumer contract documented in
-  [`docs/reference/first-downstream-slice-contract.md`](docs/reference/first-downstream-slice-contract.md)
-- the target ontology and identity seams documented in
-  [`docs/concepts/domain-ontology.md`](docs/concepts/domain-ontology.md)
-- the shared gap, readiness, and `SubjectRef` rules documented in
-  [`docs/concepts/gaps-and-readiness.md`](docs/concepts/gaps-and-readiness.md)
-- bridge-only classification rules documented in
-  [`docs/concepts/transaction-classification.md`](docs/concepts/transaction-classification.md)
-- oracle boundary rules documented in
-  [`docs/concepts/oracle-boundaries.md`](docs/concepts/oracle-boundaries.md)
-- repo-only support boundary direction: the current live package remains
-  `repo_support/`, while later implementation should rename and split that
-  dev-only surface under `dev_support/`
-
-Rules:
-
-- do not let new stages invent their own blocker or readiness surface
-- do not let new work recentre the architecture on the current bridge types
-- do not turn repo-only support into a permanent generic catch-all under the
-  current live `repo_support/` name
-- do not rename live bridge symbols or the live repo-only support package as a
-  docs-only side effect; land those as later implementation slices
-
-Shared-foundation deliverables before broad pipeline expansion:
-
-- freeze the Phase 0 contract details on the owner pages listed above
-- keep roadmap text focused on readiness, sequencing, and exit criteria instead
-  of restating family lists, kernel makeup, or bridge landing rules
-- use the bounded first-slice owner page for Coinbase-first replay and parity
-  instead of redefining that contract here
-- use the bounded first downstream slice owner page for the first
-  `EconomicFacts -> ReconciliationState -> Checkpoint` consumer path
-  instead of leaving that handoff implicit
-- freeze review-sidecar policy, package landing rules, shared primitive
-  contracts, and target artifact layout before broad parallel implementation
-
-Exit criteria:
-
-- shared gap and readiness models exist with typed reducers and artifact
-  contracts
-- every new stage can emit stage-owned gaps without inventing one-off issue
-  formats
-- dataset summaries derive from subject-level readiness instead of hand-built
-  status prose
-- target products have owned versioning and fingerprint rules
-- the bridge-to-target mapping is published and linked as the single
-  authority
-- per-product kernel, id, serialization, fingerprint, and adjudication rules
-  are frozen on the target owner page
-- `CheckpointAssertion`, issue-to-gap mapping, and review-sidecar rules are
-  defined on their owning pages
-- the first vertical slice and its bridge-to-target landing path are explicit
-- downstream record-family contracts, enum vocabularies, and checkpoint value
-  shapes are frozen before broad parallel implementation begins
-- no target record field points to an undefined shared type
-- no target package placement is left to implementation-time judgment
-- no target artifact layout is left to local command or author preference
-- broad target package scaffolding does not begin before these contracts are
-  frozen
-
-## MVP Scope Guardrails
-
-- use the current bridge until the next concrete slice needs a richer stage
-  contract
-- do not wait for every target product to exist before improving the active
-  filing path
-- add new stage models, reducers, or ports only when one bounded slice needs
-  them for correctness, determinism, or later-stage reuse
-- avoid plugin systems, manifest families, or broad orchestration abstractions
-  before a second concrete implementation requires them
-- keep unsupported or deferred behavior explicit through blockers instead of
-  low-confidence partial support
-- prefer one end-to-end vertical slice that proves a new stage over several
-  horizontal framework layers with no proven consumer
-- default first vertical slice: the planner-enabled Coinbase retail export
-  family plus statement-backed balance observation flow, unless the active
-  filing workspace requires another Tier A family to land first
-- the repo default first slice is the bounded contract in
-  [`docs/reference/first-slice-contract.md`](docs/reference/first-slice-contract.md);
-  it is not a claim that the actual `2023` to `2025` filing adapter inventory
-  is already known in-repo
-- keep crypto filing-critical coverage primary for the MVP while using generic
-  runtime names and boundaries that can later absorb other instrument classes
-- keep filing-critical adapter stabilization distinct from broad family
-  migration, while allowing unified adapter contract and bridge-mapping work in
-  Phase 0 when it removes first-slice drift
-
-## Performance Expectations
-
-Rollout choices must preserve bounded recalculation cost.
-
-Rules:
-
-- expensive reducers must be partitionable by the dimensions the owning stage
-  actually uses, with derived reporting projections added only where needed
-- hot-path calculations should operate on compact typed records instead of
-  repeatedly joining provenance, review, or renderer payloads
-- derived snapshots and reusable state should be introduced where replay cost
-  becomes material
-- tax work should support tax-year partitioning and carry-forward reuse instead
-  of recomputing full acquisition history for every output row
-
-## Implementation Program
-
-### Phase 0. Shared Foundations, Contract Lock, And First-Slice Prep
+## Phase 0. Contract Lock And Bounded-Slice Prep
 
 Goal:
 
-- finish the shared architecture, naming, support-model, and control-plane
-  baseline before broad implementation slices land
-- freeze the contracts that the first implementation slice must rely on instead
-  of leaving them to stage-local interpretation
+- freeze the owner-page contracts that bounded implementation slices need
+- remove architecture ambiguity before broad implementation begins
+
+Broad implementation must not begin until the owner docs freeze these
+contracts.
+
+Must freeze:
+
+- `EvidenceSet` record families, ids, cardinality, and intentional
+  `selection_plan_fingerprint` identity churn
+- critical-path `EvidenceObservationRecord` field tables for
+  `document_identity` and `coinbase_statement_balance_row`
+- `ClaimSet` interpretation-scope, bundle, and compilation-decision model
+- critical-path `ClaimRecord` field tables, `evidence_observation_refs`, and
+  the compatibility-sidecar boundary for retained legacy hint fields
+- `AssertionValue`, `PositionRef`, and `ContractRef`
+- shared support artifacts: `GapCore`, `GapExplanation`, `ReviewRecord`,
+  `ReviewExplanation`, `SubjectReadinessRecord`, `ReadinessProjection`,
+  `SubjectRef`, truthful `interpretation_scope_id` attachments, and the
+  downstream shared-subject seams needed for accounting and tax records
+- product ids, upstream product-ref multiplicity, and the rule that product
+  refs use product ids rather than `dataset_id`
+- authoritative persistence model, partition scopes, sidecar rules, and
+  default filesystem placement
+- migration authority rules, compatibility projections, reader cutovers, and
+  retirement gates
+- package ownership and layer placement for shared functionality
+- explicit no-invention rules for non-critical observation and claim families
 
 Deliver:
 
-- focused ownership docs for the current bridge, target stage contracts,
-  ontology, and gap/readiness contracts
-- aligned roadmap, migration, and architecture anchors
-- target `dev_support/` direction documented while current `repo_support/`
-  remains truth in current-state text
-- explicit trust-gate ownership for reconciliation, checkpoints, accounting,
-  and tax
-- freeze the detailed product, taxonomy, id, ordering, fingerprint, temporal,
-  and bridge-mapping contracts on the owner pages instead of restating them
-  here
-- frozen scalar, tuple, reusable ref, and shared-value contracts for target
-  products
-- frozen target dataset packaging, kernel filenames, and persistence layout
-- freeze the downstream record-family contracts needed for the first
-  `EconomicFacts -> ReconciliationState -> Checkpoint` consumer path
-- explicit review-sidecar policy and shared review-attachment rules
-- explicit package landing rules for target-stage code while bridge packages
-  still exist
-- corrected first-slice evidence-member, observation-class, and
-  selection-group taxonomy
-- unified adapter product and facet prep where it removes first-slice drift,
-  without broad family migration or wrapper lanes
-- one named first vertical slice with parity and replay gates
+- aligned owner docs for target products, ontology, support artifacts, and
+  persistence rules
+- explicit cutover matrix for bridge-to-target migration
+- one bounded first upstream slice and one bounded first downstream slice
+- explicit package direction for `domain/` and `application/`
+- explicit fast-path rule that reducers read kernels, not explanation payloads
+- frozen critical-path field tables and product-id rules that later writing
+  work can merge without deciding new structure
 
 Exit criteria:
 
-- a contributor can identify what is current, what is target, who owns each
-  contract, and what the next slice should land without reading the same
-  definition in several conflicting places
-- the first slice does not depend on an implicit adapter rewrite that is not
-  written down
-- the first slice does not depend on inventing ids, ordering, serialization,
-  fingerprints, replay checks, or allowed drift at implementation time
-- downstream stage owner pages define record families, enum vocabularies, and
-  artifact shapes before implementation slices start landing in parallel
-- shared gap, readiness, and checkpoint assertion artifacts are frozen down to
-  stable ids, ordering, serialization, and fingerprint rules
-- no target record field still points to an undefined shared type
-- no target package placement is left to implementation-time judgment
-- no target artifact layout is left to local command or author preference
-- broad implementation can start without each stage inventing its own meaning
-  for gaps, claims, checkpoint acceptance, or fingerprints
-- broad implementation does not start with target package scaffolding that
-  outruns the frozen contract set
+- no owner concept is defined in two competing places
+- no target product references an undefined record family or ref type
+- no cross-stage support artifact masquerades as a claim family
+- claim-stage blockers can attach to `interpretation_scope_id` before subject
+  identity resolves, and later-stage blockers can attach to truthful
+  accounting or tax subjects without collapsing to dataset-only scope
+- no bridge artifact is left without an authority and retirement rule
+- no hot-path field points to an undefined value ref or sidecar
+- every critical-path observation and claim family has one authoritative kernel
+  field table
+- no target product metadata ref uses `dataset_id` where a product id exists
+- non-critical observation and claim families are explicitly deferred rather
+  than left implicit
+- implementation placement is mechanical rather than interpretive
+- the first upstream and downstream slices can be implemented without inventing
+  ids, bundles, values, or reader cutovers
 
-### Phase 1. Formalize `EvidenceSet`
+## Phase 1. Land `EvidenceSet`
 
 Goal:
 
@@ -240,66 +122,60 @@ Goal:
 
 Deliver:
 
-- deterministic evidence selection reports
-- explicit selected, superseded, and blocked evidence outputs
-- source-local parsed observation contracts
-- evidence provenance and locator guarantees aligned with the target contract
-- evidence summary and issue surfaces that remain source-local rather than
-  prematurely economic
-- a bridge landing path from planner-owned artifacts into proto-`EvidenceSet`
-  without requiring broad unified-adapter migration first
+- capture-scoped `EvidenceSet` emission keyed by `evidence_set_id`
+- deterministic selected, superseded, and blocked evidence membership
+- typed evidence observations that survive beyond intake heuristics, including
+  frozen first-slice field tables for `document_identity` and
+  `coinbase_statement_balance_row`
+- bridge compatibility projection for `translation_input_plan.json`
 
 Exit criteria:
 
 - the runtime can explain why every selected source artifact won and why every
-  superseded artifact lost
-- source-local observations survive beyond file-selection time
+  superseded or blocked artifact did not
+- evidence selection becomes authoritative through `EvidenceSet` for the
+  in-scope slice
 
-### Phase 2. Introduce `ClaimSet`
+## Phase 2. Land `ClaimSet`
 
 Goal:
 
-- interpose a real claim layer between evidence selection and final economic
+- interpose a real semantic layer between evidence capture and final economic
   truth
 
 Deliver:
 
-- claim-native contracts for activity, balance, ownership, location,
-  instrument, contract, and valuation meaning
-- claim-owned issues and reviews
-- explicit handling for materially unresolved meaning
-- bridge loosening so ambiguous rows can remain claims without being forced
-  into final bridge semantics
-- at least one ambiguous row family that survives as a claim rather than being
-  coerced into a guessed final fact
-- a bounded adapter-family path that can emit claim-native outputs without
-  making the full unified adapter migration a hidden prerequisite
+- semantic-only `ClaimSet` emission keyed by `claim_set_id`
+- explicit interpretation scopes, mutually exclusive bundles, and
+  compilation-decision records
+- frozen first-slice claim fields plus `evidence_observation_refs`
+- shared support artifacts attached to claim scopes where needed
+- declared compatibility projections for `EconomicActivityDraft` and
+  `SourceTranslationBatch`, with legacy hint fields kept outside canonical
+  claims
 
 Exit criteria:
 
-- at least one adapter family emits claim-native outputs before economic
-  compilation
-- ambiguous source rows can remain claim-complete but economically unresolved
+- ambiguous source meaning can remain explicit without being forced into final
+  economic meaning
+- claim compilation decisions remain claim-owned and do not carry economic
+  payload
 
-### Phase 3. Land `EconomicFacts`
+## Phase 3. Land `EconomicFacts`
 
 Goal:
 
-- move from bridge-first fact shaping toward the target economic layer while
-  preserving parity
+- move accepted economic meaning off the bridge fact path and onto the target
+  economic layer
 
 Deliver:
 
-- claim-to-economic compilation seam
-- target-directed economic models aligned to the target ontology
-- explicit `EconomicEventRecord` and `EconomicLegRecord` contracts with frozen
-  `event_family` and `leg_role` vocabularies
-- explicit preservation of settlement, lifecycle, valuation, and identity seams
-- bridge retirement rules for the slices that no longer need
-  `EconomicActivityDraft` or `TransactionFact`
-- parity coverage for the first claim-to-economic vertical slice
-- the bounded downstream handoff documented in
-  [`docs/reference/first-downstream-slice-contract.md`](docs/reference/first-downstream-slice-contract.md)
+- `EconomicFacts` kernels keyed by `economic_facts_id` over ordered
+  `claim_set_refs`
+- `EconomicEventRecord`, `EconomicLegRecord`, and `ValuationRecord`
+- selected-bundle-based event identity
+- bridge compatibility projection for `TransactionFact`
+- parity coverage for the first claim-to-economic slice
 
 Exit criteria:
 
@@ -307,7 +183,7 @@ Exit criteria:
 - at least one bounded slice proves target economic modeling without wrapper
   lanes
 
-### Phase 4. Land `ReconciliationState`
+## Phase 4. Land `ReconciliationState`
 
 Goal:
 
@@ -316,22 +192,19 @@ Goal:
 
 Deliver:
 
-- transfer links, balance targets, continuity, and checkpoint candidacy under
-  `ReconciliationState`
-- explicit `ContinuitySegmentRecord`, `LinkRecord`, `BalanceTargetRecord`, and
-  `CheckpointCandidateRecord` contracts with frozen ids and status
-  vocabularies
-- target gap and readiness models where the owning stage can support them
-- corroboration sidecars and deterministic correction handling
-- independence from raw capture layout and bridge-only balance assumptions
+- `ContinuitySegmentRecord`, `LinkRecord`, `BalanceTargetRecord`, and
+  `CheckpointCandidateRecord`
+- direct `AssertionValue` fields for expected and observed balance meaning
+- fixed subject and position identity seams for in-scope reconciliation
+- bridge compatibility projection for `balance_snapshots.csv`
 
 Exit criteria:
 
-- reconciliation is expressed as explicit completeness and continuity decisions
+- reconciliation is expressed as explicit continuity and completeness decisions
 - exact balance assertions are one reconciliation surface, not the whole
-  reconciliation product
+  product
 
-### Phase 5. Land `Checkpoint`
+## Phase 5. Land `Checkpoint`
 
 Goal:
 
@@ -339,20 +212,18 @@ Goal:
 
 Deliver:
 
-- accepted checkpoint assertions under `Checkpoint`
-- source-backed checkpoint evidence requirements
-- trust level and acceptance basis
-- intentional opening-state adoption with provenance
-- manual balance submission as typed checkpoint-owned input
-- `AssertionValue`, frozen `assertion_kind` vocabulary, and the
-  bounded first consumer path documented in
-  [`docs/reference/first-downstream-slice-contract.md`](docs/reference/first-downstream-slice-contract.md)
+- `CheckpointRecord` and `CheckpointAssertionRecord`
+- explicit trust level, acceptance basis, evidence class, and continuity proof
+- direct `AssertionValue` accepted truth
+- bridge compatibility projection for `balance_references.csv`
 
 Exit criteria:
 
 - checkpoint truth is explicit accepted state, not an inferred side effect
+- statement-backed checkpoint acceptance is separated cleanly from operator-only
+  runtime aids
 
-### Phase 6. Land `Journal`
+## Phase 6. Land `Journal`
 
 Goal:
 
@@ -360,37 +231,36 @@ Goal:
 
 Deliver:
 
-- internal journal model
-- posting expansion and validation surfaces
-- accounting-owned blockers
-- renderer orchestration over accepted truth
+- `JournalEntryRecord`, `PostingRecord`, and `ValidationRecord`
+- accounting-owned blockers and validation rules
+- renderer orchestration over accepted upstream truth
 
 Exit criteria:
 
-- accounting validates accepted truth without acting as a truth repair layer
+- accounting validates accepted truth without becoming a truth-repair layer
 
-### Phase 7. Land `TaxInputs` And `TaxOutputs`
+## Phase 7. Land `TaxInputs` And `TaxOutputs`
 
 Goal:
 
 - build policy-ready tax determinants and policy-owned outputs from accepted
-  truth
+  upstream truth
 
 Deliver:
 
 - `TaxInputs` contracts
-- tax-policy selection seam
-- first filing-critical policy implementation
-- Canada MVP policy
-- year partitioning, carry-forward state, and explicit tax-owned blockers
-- `TaxOutputs` derived only from selected tax policies over `TaxInputs`
+- selected tax-policy execution over those inputs
+- year partitioning and carry-forward state
+- filing-critical policy outputs derived from accepted runtime truth rather than
+  CoinTracking tax reports
 
 Exit criteria:
 
-- `2023` to `2025` outputs can be produced from reconciled economics plus
-  accepted checkpoint truth without CoinTracking tax reports
+- `2023` to `2025` outputs can be produced from reconciled economics and
+  accepted checkpoint truth without treating CoinTracking tax reports as the
+  ledger
 
-### Phase 8. Repo-Only Support Reset
+## Phase 8. Repo-Only Support Reset
 
 Goal:
 
@@ -399,18 +269,16 @@ Goal:
 Deliver:
 
 - rename `repo_support/` to `dev_support/`
-- split repo-only support by owned seam such as `quality/`,
-  `review_verification/`, `typecheck/`, `fixtures/`, and environment/path
-  helpers
+- split repo-only support by owned seam
 - update control-plane automation, docs, and tests to the new dev-only
   boundary
 
 Exit criteria:
 
 - repo-only support has an explicit dev-only boundary name
-- shared repo-only support no longer reads like a generic support sink
+- shared repo-only support no longer reads like a generic sink
 
-### Phase 9. Public Repo And Agent Hardening
+## Phase 9. Public Repo And Agent Hardening
 
 Goal:
 
@@ -422,23 +290,22 @@ Deliver:
 - publishable fixtures and provenance-safe docs
 - delivery guardrails layered across platform settings, repo-native
   validators, and agent defaults
-- control-plane ownership routing and default-branch guardrail audits
-- repo-native PR review routing and change-sensitive PR-only review checks
+- control-plane ownership routing and docs-maintenance alignment for repo-safe
+  execution guidance
+- repo-native PR review routing and change-sensitive review checks
 - benchmark-backed quality-gate scheduling and explicit CI job splits instead
   of one opaque parity shell
 
 Exit criteria:
 
-- repo-safe fixtures and documentation are maintained without private workflow
-  assumptions
 - a new contributor or coding agent can find the correct roadmap, status,
   concept, guide, and workspace docs without broad context loading
-- the default-branch delivery path is enforced strongly enough that a single
-  agent mistake cannot silently bypass the intended PR-only workflow
 - the repo can audit local CODEOWNERS coverage and live GitHub delivery
-  settings together without broad context loading or one-off shell repair work
+  settings together without broad context loading
+- the default-branch delivery path is enforced strongly enough that one mistake
+  does not silently bypass the intended PR-only workflow
 
-### Phase 10. Post-Core Runtime Expansion
+## Phase 10. Post-Core Runtime Expansion
 
 Goal:
 
@@ -448,7 +315,7 @@ Deliver:
 
 - thin HTTP or agent-facing interfaces over the same typed application
   contracts
-- SQLite-backed active storage behind repository ports
+- alternate storage backends behind repository ports
 - provider-backed AI implementations with explicit audit trails
 - additional productized source and output adapters beyond the current
   high-value evidence sources
@@ -458,12 +325,40 @@ Exit criteria:
 - post-core expansion layers on top of the filing-capable runtime instead of
   destabilizing it
 
+## MVP Guardrails
+
+- use the current bridge until the next concrete slice needs a richer target
+  contract
+- do not wait for every later product to exist before improving the active
+  filing path
+- add new stage models, reducers, or ports only when one bounded slice needs
+  them for correctness, determinism, or later-stage reuse
+- avoid plugin systems, manifest families, or broad orchestration abstractions
+  before a second concrete implementation requires them
+- keep unsupported or deferred behavior explicit through blockers instead of
+  low-confidence partial support
+- prefer one end-to-end vertical slice that proves a new stage over several
+  horizontal framework layers with no proven consumer
+
+## Performance Expectations
+
+Rollout choices must preserve bounded recalculation cost.
+
+Rules:
+
+- expensive reducers must be partitionable by the dimensions the owning stage
+  actually uses
+- hot-path calculations should operate on compact kernel records instead of
+  repeatedly joining provenance, review, or renderer payloads
+- derived snapshots and reusable state should be introduced where replay cost
+  becomes material
+- tax work should support tax-year partitioning and carry-forward reuse instead
+  of recomputing full acquisition history for every output row
+
 ## Guardrails
 
 - keep the active filing path moving while the architecture becomes more
   explicit
-- prefer one end-to-end vertical slice that proves a new stage over horizontal
-  framework buildout with no proven consumer
 - keep unsupported or deferred behavior explicit through blockers instead of
   low-confidence partial support
 - do not reintroduce wrapper lanes, migration shims, or dual active runtime
@@ -472,8 +367,6 @@ Exit criteria:
   together with the owning concept and migration docs
 
 ## Cross-Cutting Workstreams
-
-These workstreams continue across the major phases above.
 
 ### Oracle Lane
 
@@ -495,12 +388,10 @@ These workstreams continue across the major phases above.
 
 - maintain parser and adapter contract tests
 - expand projection parity tests
-- keep semantic parity, capture-registry, and source-assembly coverage as
-  first-class regression surfaces
+- add replay coverage for target kernels and compatibility projections
 - add reconciliation parity and checkpoint continuity tests
 - add journal validation coverage
-- add Canadian tax policy coverage including fees, income, realized PnL, and
-  unsupported-item reporting
+- add tax policy coverage with explicit unsupported-item reporting
 - keep end-to-end smoke workflows for each major slice before removing older
   transition paths
 
@@ -511,161 +402,6 @@ These workstreams continue across the major phases above.
 - no fixture simplification that hides previous edge-case coverage
 - test relocation or renaming is acceptable only when behavior coverage is
   preserved or improved
-- "updating tests to the new structure" is not acceptable if coverage is
-  weakened
-- every refactor slice that changes tests must state:
-  - what old behavior the tests covered
-  - where that same behavior is covered now
-  - whether the assertion got stronger, weaker, or simply moved
-  - whether any expectation changed because of an intentional product decision
-- require a `test parity note` in checkpoint summaries
-- require manual review of deleted test files, deleted assertions, reduced
-  scenario coverage, and fixture simplifications that remove edge cases
-
-### Repo And Package Shaping
-
-- continue splitting hotspot modules and DTO hubs before new reconciliation,
-  checkpoint, accounting, and tax behavior piles into flat files
-- escalate helper clusters into packages once a third related sibling would
-  otherwise appear
-- preserve bounded submodules in existing shared surfaces
-- keep newer workflow seams such as `application/profiling/` and
-  `application/intake/plan/` as packages as they grow
-
-## Filing-Critical Acceptance Criteria
-
-The system is filing-ready only when all of these are true:
-
-- a source-backed checkpoint exists near `2026-03-23`
-- no unresolved material reconciliation issues remain
-- no unresolved material unsupported tax items remain
-- journal validation passes for supported activity
-- the forward-computed state from the `2023-08-05` oracle boundary lands on the
-  source-backed checkpoint
-- `2023`, `2024`, and `2025` outputs can be reproduced from workspace evidence
-
-## Tests To Add
-
-### Schema And Parsing
-
-- multi-leg transaction parsing
-- valuation provenance validation
-- CoinTracking alias normalization
-- correction and supersession chains
-
-### Reconciliation
-
-- transfer pairing across owned wallets and exchanges
-- exact balance assertion workflow over unified balance targets with
-  `source_document` precedence, optional `network_api` hydration, and
-  `operator_assertion` fallback
-- redistribution corrections
-- checkpoint balance assertions
-- forward continuity from oracle boundary to checkpoint
-
-### Accounting
-
-- journal posting generation
-- validation parse-and-balance coverage
-- supported commodity balances matching checkpoint outputs
-
-### Tax
-
-- pooled ACB updates
-- crypto-to-crypto dispositions
-- fee treatment in quote, base, and third asset
-- staking and reward income
-- derivatives and margin realized PnL
-- explicit unsupported-item logging
-
-## Initial Refactor Guidance
-
-Perform only the refactors required to support the new architecture:
-
-- split new domain concepts into dedicated packages rather than expanding
-  `domain/transactions/` or sibling domain capability packages
-- promote workflow helper clusters into a package once a third related sibling
-  would otherwise be added
-- introduce target stage products before expanding downstream policy services
-- replace bridge-era or older transitional artifacts directly while migrating
-  downstream services
-- remove superseded transition-first workflows once replacement consumers land
-
-Do not:
-
-- add SQLite first
-- add a web UI
-- add generic workflow engines
-- re-centralize business rules in adapters
-- keep pushing new semantics into one `category` string or equivalent activity
-  label sink
-
-## Deferred Until Core Rollout Lands
-
-### HTTP, API, And Agent Runtime
-
-- add a thin HTTP layer only over existing application capabilities and typed
-  use-case contracts
-- keep CLI, API, and agent requests on the same service contracts
-- move interface contracts toward resource-oriented request and response shapes
-- prefer explicit job handles and artifact references for long-running work
-
-### Database Adoption
-
-- replace filesystem-backed fact and evidence storage with a SQLite-backed
-  implementation behind repository ports
-- keep raw evidence as files after database adoption
-- add migrations only when the SQLite implementation becomes active
-
-### Provider-Backed AI Runtime
-
-- add provider-backed AI integrations for supported providers
-- persist prompts, review findings, and evidence references in a structured
-  audit trail
-- keep model providers read-only with respect to ledger mutation
-
-### Source And Output Adapter Expansion
-
-- add real blockchain adapters under `adapters/sources/explorers/` when they
-  normalize exported blockchain evidence
-- add real platform API adapters under `adapters/sources/platforms/` when they
-  become productized
-- keep reserved entry points stubbed rather than half-implemented
-- keep adapters self-contained with tests and metadata colocated
-
-### Test Follow-Through
-
-- keep scaffold and golden-refresh commands aligned with any future pack-layout
-  move so fixture authors still have one stable toolchain
-- continue moving adapter packs toward adapter-owned layout so plugin
-  extraction does not require another test-tree rewrite
-- expand the current split test profiles only when additional CI
-  infrastructure is introduced
-
-## Change Control
-
-When roadmap order, architecture, schema, or rollout gates change, update all
-of the following together:
-
-- `ROADMAP.md`
-- `docs/concepts/reconciliation-tax-architecture.md`
-- `docs/status/migration-sequence.md`
-
-Program-ownership rule:
-
-- `ROADMAP.md` is the only numbered implementation program of record
-- `docs/status/migration-sequence.md` mirrors landing rules and retirement
-  sequencing without defining competing phase numbers
-
-## Time Summary
-
-AI-assisted estimate for the filing-critical path:
-
-- `106` to `164` hours
-
-AI-assisted estimate including open-source hardening:
-
-- `126` to `196` hours
-
-Those ranges assume focused implementation with the current repo standards,
-tests, and documentation discipline preserved.
+- every refactor slice that changes tests must state what old behavior was
+  covered, where it is covered now, and whether coverage became stronger,
+  weaker, or simply moved

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,8 @@ status: active
 ---
 
 The TallyLot docs cover the typed runtime, operator workflows, workspace
-model, artifact contracts, and repo standards.
+model, artifact contracts, repo standards, and the owner-page contracts that
+freeze product ids, critical-path kernel fields, and compatibility boundaries.
 
 ## How Docs Are Organized
 
@@ -27,12 +28,11 @@ model, artifact contracts, and repo standards.
 - [Current bridge contracts](concepts/current-bridge-contracts.md)
 - [Bridge-to-target mapping](concepts/bridge-to-target-mapping.md)
 - [Pipeline stage contracts](concepts/pipeline-stage-contracts.md)
-- [Target contract primitives](reference/target-contract-primitives.md)
-- [Target product artifacts](reference/target-product-artifacts.md)
+- [Domain ontology](concepts/domain-ontology.md)
+- [Gaps and readiness](concepts/gaps-and-readiness.md)
+- [Reconciliation and tax architecture](concepts/reconciliation-tax-architecture.md)
 - [First-slice contract](reference/first-slice-contract.md)
 - [First downstream slice contract](reference/first-downstream-slice-contract.md)
-- [Domain ontology](concepts/domain-ontology.md)
-- [Reconciliation and tax architecture](concepts/reconciliation-tax-architecture.md)
 - [Engineering standards](standards/engineering.md)
 - [Workspace model](concepts/workspace-model.md)
 
@@ -43,16 +43,16 @@ Agent-specific routing and repo execution rules live in
 
 <!-- docs-maintenance:start concepts -->
 - [Architecture Overview](concepts/architecture-overview.md): High-level map of the current bridge, the target pipeline, and the focused pages that own each major contract.
-- [Reconciliation And Tax Architecture](concepts/reconciliation-tax-architecture.md): Design anchor for trust gates, performance rules, tax-policy architecture, and filing-critical rollout from the current bridge toward the target pipeline.
+- [Reconciliation And Tax Architecture](concepts/reconciliation-tax-architecture.md): Design anchor for trust gates, persistence rules, performance rules, and filing-critical rollout from the current bridge toward the target pipeline.
 - [Current Bridge Contracts](concepts/current-bridge-contracts.md): Primary concept page for the live bridge contracts, bridge artifacts, and current schema rules.
-- [Bridge To Target Mapping](concepts/bridge-to-target-mapping.md): Single authority for how live bridge boundaries map into the target pipeline during Phase 0 and the first bounded increment.
+- [Bridge To Target Mapping](concepts/bridge-to-target-mapping.md): Single authority for how live bridge surfaces cut over to target products during migration, including writer ownership, reader cutovers, and retirement gates.
 - [Pipeline Stage Contracts](concepts/pipeline-stage-contracts.md): Owning contract for the target pipeline products, stage responsibilities, handoff guarantees, and downstream decision boundaries.
 - [Oracle Boundaries](concepts/oracle-boundaries.md): Boundary rules for normal runtime inputs, adapter inputs and outputs, and oracle-only artifacts.
-- [Domain Ontology](concepts/domain-ontology.md): Primary concept page for the target economic ontology, identity boundaries, package direction, and bridge-versus-target modeling rules.
+- [Domain Ontology](concepts/domain-ontology.md): Owning concept page for the target economic ontology, entity and ref seams, package direction, and bridge-versus-target modeling rules.
 - [Transaction Classification](concepts/transaction-classification.md): Bridge-only classification vocabulary for the current fact-path bridge.
-- [Gaps And Readiness](concepts/gaps-and-readiness.md): Owning concept page for the target gap model, readiness model, sidecar rules, and shared `SubjectRef` contracts.
+- [Gaps And Readiness](concepts/gaps-and-readiness.md): Owning concept page for the target gap model, review model, readiness model, sidecar rules, and shared `SubjectRef` contracts.
 - [Workspace Model](concepts/workspace-model.md): Conceptual overview of the external workspace, seeded files, and mirrored repo guidance.
-- [Unified Adapter Architecture](concepts/unified-adapter-architecture.md): First-principles design anchor for the future unified adapter manifest, facets, adapter products, and deterministic verification model.
+- [Unified Adapter Architecture](concepts/unified-adapter-architecture.md): Forward design for the future adapter manifest, facets, and verification model without re-owning target product contracts.
 <!-- docs-maintenance:end concepts -->
 
 ## Common Tasks
@@ -73,10 +73,10 @@ below when you need the detailed procedure for one stage of the workflow.
 
 <!-- docs-maintenance:start reference -->
 - [Baseline Validation Contract](reference/baseline-validation-contract.md): Baseline oracle package, artifact list, and intent for validation output.
-- [First Slice Contract](reference/first-slice-contract.md): Bounded contract for the default Coinbase-first proto-EvidenceSet and proto-ClaimSet increment.
-- [First Downstream Slice Contract](reference/first-downstream-slice-contract.md): Bounded contract for the first Coinbase-first EconomicFacts, ReconciliationState, and Checkpoint increment.
-- [Target Contract Primitives](reference/target-contract-primitives.md): Shared scalar forms, tuple contracts, dataset ids, and reusable id helpers for forward-looking target products.
-- [Target Product Artifacts](reference/target-product-artifacts.md): Forward-looking dataset packaging, kernel filenames, and persistence layout for target pipeline products.
+- [First Slice Contract](reference/first-slice-contract.md): Bounded contract for the default Coinbase-first EvidenceSet and ClaimSet slice, including cardinality, ids, replay gates, and bridge compatibility projections.
+- [First Downstream Slice Contract](reference/first-downstream-slice-contract.md): Bounded contract for the first Coinbase-first EconomicFacts, ReconciliationState, and Checkpoint slice, including selected-bundle event identity and bridge compatibility projections.
+- [Target Contract Primitives](reference/target-contract-primitives.md): Helper reference for reusable ids and tuples that complement the owner pages without redefining target product contracts.
+- [Target Product Artifacts](reference/target-product-artifacts.md): Helper reference that points to the owner pages for target persistence, partitions, and bounded slice artifact expectations.
 - [Export Checklist](reference/export-checklist.md): Verification export set and staging checklist for round-close work.
 - [Wallet Inventory Artifacts](reference/wallet-inventory-artifacts.md): Artifact contract for location inventory outputs and evidence rows.
 - [Timezone Validation Artifacts](reference/timezone-validation-artifacts.md): Artifact contract for timezone provenance outputs and validation issues.
@@ -96,8 +96,8 @@ that follows the external workspace layout.
 
 <!-- docs-maintenance:start status -->
 - [Current State](status/current-state.md): Implemented runtime capabilities, current operational capabilities, and deferred areas.
-- [Migration Sequence](status/migration-sequence.md): Incremental migration order from the current bridge toward the target stage-first pipeline with parity gates and retirement rules.
-- [Adapter Delivery Plan](status/adapter-delivery-plan.md): Filing-first plan for stabilizing current adapters now and deferring the unified adapter contract rewrite until after filing-critical work.
+- [Migration Sequence](status/migration-sequence.md): Incremental landing and retirement rules for moving from the current bridge to the target pipeline without dual authorities.
+- [Adapter Delivery Plan](status/adapter-delivery-plan.md): Filing-first plan for stabilizing current adapters now and deferring the broad unified adapter redesign until the filing path and bounded first slices are stable.
 <!-- docs-maintenance:end status -->
 
 ## Standards

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,9 @@ model, artifact contracts, and repo standards.
 - [Operator quickstart](guides/operator-quickstart.md)
 - [Architecture overview](concepts/architecture-overview.md)
 - [Current bridge contracts](concepts/current-bridge-contracts.md)
+- [Bridge-to-target mapping](concepts/bridge-to-target-mapping.md)
 - [Pipeline stage contracts](concepts/pipeline-stage-contracts.md)
+- [First-slice contract](reference/first-slice-contract.md)
 - [Domain ontology](concepts/domain-ontology.md)
 - [Reconciliation and tax architecture](concepts/reconciliation-tax-architecture.md)
 - [Engineering standards](standards/engineering.md)
@@ -40,6 +42,7 @@ Agent-specific routing and repo execution rules live in
 - [Architecture Overview](concepts/architecture-overview.md): High-level map of the current bridge, the target pipeline, and the focused pages that own each major contract.
 - [Reconciliation And Tax Architecture](concepts/reconciliation-tax-architecture.md): Design anchor for trust gates, performance rules, tax-policy architecture, and filing-critical rollout from the current bridge toward the target pipeline.
 - [Current Bridge Contracts](concepts/current-bridge-contracts.md): Owning concept page for the live bridge contracts, bridge artifacts, and current schema rules.
+- [Bridge To Target Mapping](concepts/bridge-to-target-mapping.md): Single authority for how live bridge seams land in the target pipeline during Phase 0 and the first bounded slice.
 - [Pipeline Stage Contracts](concepts/pipeline-stage-contracts.md): Owning contract for the target pipeline products, stage responsibilities, handoff guarantees, and downstream decision boundaries.
 - [Oracle Boundaries](concepts/oracle-boundaries.md): Boundary rules for normal runtime inputs, adapter surfaces, and oracle-only artifacts.
 - [Domain Ontology](concepts/domain-ontology.md): Owning concept page for the target economic ontology, identity seams, package direction, and bridge-versus-target modeling rules.
@@ -67,6 +70,7 @@ below when you need the detailed procedure for one stage of the workflow.
 
 <!-- docs-maintenance:start reference -->
 - [Baseline Validation Contract](reference/baseline-validation-contract.md): Baseline oracle package, artifact list, and intent for validation output.
+- [First Slice Contract](reference/first-slice-contract.md): Bounded contract for the default Coinbase-first proto-EvidenceSet and proto-ClaimSet slice.
 - [Export Checklist](reference/export-checklist.md): Verification export set and staging checklist for round-close work.
 - [Wallet Inventory Artifacts](reference/wallet-inventory-artifacts.md): Artifact contract for location inventory outputs and evidence rows.
 - [Timezone Validation Artifacts](reference/timezone-validation-artifacts.md): Artifact contract for timezone provenance outputs and validation issues.

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,8 @@ model, artifact contracts, and repo standards.
 - [Current bridge contracts](concepts/current-bridge-contracts.md)
 - [Bridge-to-target mapping](concepts/bridge-to-target-mapping.md)
 - [Pipeline stage contracts](concepts/pipeline-stage-contracts.md)
+- [Target contract primitives](reference/target-contract-primitives.md)
+- [Target product artifacts](reference/target-product-artifacts.md)
 - [First-slice contract](reference/first-slice-contract.md)
 - [First downstream slice contract](reference/first-downstream-slice-contract.md)
 - [Domain ontology](concepts/domain-ontology.md)
@@ -73,6 +75,8 @@ below when you need the detailed procedure for one stage of the workflow.
 - [Baseline Validation Contract](reference/baseline-validation-contract.md): Baseline oracle package, artifact list, and intent for validation output.
 - [First Slice Contract](reference/first-slice-contract.md): Bounded contract for the default Coinbase-first proto-EvidenceSet and proto-ClaimSet increment.
 - [First Downstream Slice Contract](reference/first-downstream-slice-contract.md): Bounded contract for the first Coinbase-first EconomicFacts, ReconciliationState, and Checkpoint increment.
+- [Target Contract Primitives](reference/target-contract-primitives.md): Shared scalar forms, tuple contracts, dataset ids, and reusable id helpers for forward-looking target products.
+- [Target Product Artifacts](reference/target-product-artifacts.md): Forward-looking dataset packaging, kernel filenames, and persistence layout for target pipeline products.
 - [Export Checklist](reference/export-checklist.md): Verification export set and staging checklist for round-close work.
 - [Wallet Inventory Artifacts](reference/wallet-inventory-artifacts.md): Artifact contract for location inventory outputs and evidence rows.
 - [Timezone Validation Artifacts](reference/timezone-validation-artifacts.md): Artifact contract for timezone provenance outputs and validation issues.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,7 +16,7 @@ model, artifact contracts, and repo standards.
 - Guides describe how to perform a task.
 - Reference pages define factual contracts, artifacts, and workspace semantics.
 - Standards capture repo implementation rules.
-- Status pages describe the current implemented surface and active migration
+- Status pages describe the current implemented capabilities and active migration
   state.
 
 ## Start Here
@@ -41,11 +41,11 @@ Agent-specific routing and repo execution rules live in
 <!-- docs-maintenance:start concepts -->
 - [Architecture Overview](concepts/architecture-overview.md): High-level map of the current bridge, the target pipeline, and the focused pages that own each major contract.
 - [Reconciliation And Tax Architecture](concepts/reconciliation-tax-architecture.md): Design anchor for trust gates, performance rules, tax-policy architecture, and filing-critical rollout from the current bridge toward the target pipeline.
-- [Current Bridge Contracts](concepts/current-bridge-contracts.md): Owning concept page for the live bridge contracts, bridge artifacts, and current schema rules.
-- [Bridge To Target Mapping](concepts/bridge-to-target-mapping.md): Single authority for how live bridge seams land in the target pipeline during Phase 0 and the first bounded slice.
+- [Current Bridge Contracts](concepts/current-bridge-contracts.md): Primary concept page for the live bridge contracts, bridge artifacts, and current schema rules.
+- [Bridge To Target Mapping](concepts/bridge-to-target-mapping.md): Single authority for how live bridge boundaries map into the target pipeline during Phase 0 and the first bounded increment.
 - [Pipeline Stage Contracts](concepts/pipeline-stage-contracts.md): Owning contract for the target pipeline products, stage responsibilities, handoff guarantees, and downstream decision boundaries.
-- [Oracle Boundaries](concepts/oracle-boundaries.md): Boundary rules for normal runtime inputs, adapter surfaces, and oracle-only artifacts.
-- [Domain Ontology](concepts/domain-ontology.md): Owning concept page for the target economic ontology, identity seams, package direction, and bridge-versus-target modeling rules.
+- [Oracle Boundaries](concepts/oracle-boundaries.md): Boundary rules for normal runtime inputs, adapter inputs and outputs, and oracle-only artifacts.
+- [Domain Ontology](concepts/domain-ontology.md): Primary concept page for the target economic ontology, identity boundaries, package direction, and bridge-versus-target modeling rules.
 - [Transaction Classification](concepts/transaction-classification.md): Bridge-only classification vocabulary for the current fact-path bridge.
 - [Gaps And Readiness](concepts/gaps-and-readiness.md): Owning concept page for the target gap model, readiness model, sidecar rules, and shared `SubjectRef` contracts.
 - [Workspace Model](concepts/workspace-model.md): Conceptual overview of the external workspace, seeded files, and mirrored repo guidance.
@@ -70,7 +70,7 @@ below when you need the detailed procedure for one stage of the workflow.
 
 <!-- docs-maintenance:start reference -->
 - [Baseline Validation Contract](reference/baseline-validation-contract.md): Baseline oracle package, artifact list, and intent for validation output.
-- [First Slice Contract](reference/first-slice-contract.md): Bounded contract for the default Coinbase-first proto-EvidenceSet and proto-ClaimSet slice.
+- [First Slice Contract](reference/first-slice-contract.md): Bounded contract for the default Coinbase-first proto-EvidenceSet and proto-ClaimSet increment.
 - [Export Checklist](reference/export-checklist.md): Verification export set and staging checklist for round-close work.
 - [Wallet Inventory Artifacts](reference/wallet-inventory-artifacts.md): Artifact contract for location inventory outputs and evidence rows.
 - [Timezone Validation Artifacts](reference/timezone-validation-artifacts.md): Artifact contract for timezone provenance outputs and validation issues.
@@ -89,7 +89,7 @@ that follows the external workspace layout.
 ## Current Status
 
 <!-- docs-maintenance:start status -->
-- [Current State](status/current-state.md): Implemented runtime capabilities, current operational surface, and deferred areas.
+- [Current State](status/current-state.md): Implemented runtime capabilities, current operational capabilities, and deferred areas.
 - [Migration Sequence](status/migration-sequence.md): Incremental migration order from the current bridge toward the target stage-first pipeline with parity gates and retirement rules.
 - [Adapter Delivery Plan](status/adapter-delivery-plan.md): Filing-first plan for stabilizing current adapters now and deferring the unified adapter contract rewrite until after filing-critical work.
 <!-- docs-maintenance:end status -->
@@ -98,8 +98,8 @@ that follows the external workspace layout.
 
 <!-- docs-maintenance:start standards -->
 - [Engineering Standards](standards/engineering.md): Code placement, typing, modularity, and naming rules for the typed application.
-- [Implementation Working Agreement](standards/implementation.md): Execution rules for shaping, verifying, refactoring, and checkpointing repo work.
-- [Commit Standards](standards/commits.md): Conventional Commit, checkpoint, and PR body rules for stable repo history.
+- [Implementation Working Agreement](standards/implementation.md): Execution rules for shaping, verifying, refactoring, and committing repo work.
+- [Commit Standards](standards/commits.md): Conventional Commit subjects, reviewable commit boundaries, and PR body rules for stable repo history.
 - [Issue Standards](standards/issues.md): Issue scope, privacy rules, template usage, and proactive follow-up issue handling for repo work.
 - [Delivery Guardrails](standards/delivery-guardrails.md): Control hierarchy, enforcement tiers, and exception handling for repo delivery and agent-assisted Git operations.
 <!-- docs-maintenance:end standards -->

--- a/docs/README.md
+++ b/docs/README.md
@@ -28,6 +28,7 @@ model, artifact contracts, and repo standards.
 - [Bridge-to-target mapping](concepts/bridge-to-target-mapping.md)
 - [Pipeline stage contracts](concepts/pipeline-stage-contracts.md)
 - [First-slice contract](reference/first-slice-contract.md)
+- [First downstream slice contract](reference/first-downstream-slice-contract.md)
 - [Domain ontology](concepts/domain-ontology.md)
 - [Reconciliation and tax architecture](concepts/reconciliation-tax-architecture.md)
 - [Engineering standards](standards/engineering.md)
@@ -71,6 +72,7 @@ below when you need the detailed procedure for one stage of the workflow.
 <!-- docs-maintenance:start reference -->
 - [Baseline Validation Contract](reference/baseline-validation-contract.md): Baseline oracle package, artifact list, and intent for validation output.
 - [First Slice Contract](reference/first-slice-contract.md): Bounded contract for the default Coinbase-first proto-EvidenceSet and proto-ClaimSet increment.
+- [First Downstream Slice Contract](reference/first-downstream-slice-contract.md): Bounded contract for the first Coinbase-first EconomicFacts, ReconciliationState, and Checkpoint increment.
 - [Export Checklist](reference/export-checklist.md): Verification export set and staging checklist for round-close work.
 - [Wallet Inventory Artifacts](reference/wallet-inventory-artifacts.md): Artifact contract for location inventory outputs and evidence rows.
 - [Timezone Validation Artifacts](reference/timezone-validation-artifacts.md): Artifact contract for timezone provenance outputs and validation issues.

--- a/docs/concepts/architecture-overview.md
+++ b/docs/concepts/architecture-overview.md
@@ -89,6 +89,12 @@ Use these pages as the owning contract set:
   during migration.
 - [Pipeline Stage Contracts](pipeline-stage-contracts.md)
   Target stage products, responsibilities, and handoff guarantees.
+- [Target Contract Primitives](../reference/target-contract-primitives.md)
+  Shared target scalar forms, tuple contracts, dataset ids, and reusable value
+  primitives.
+- [Target Product Artifacts](../reference/target-product-artifacts.md)
+  Forward-looking target dataset packaging, kernel filenames, and sidecar
+  locations.
 - [First Slice Contract](../reference/first-slice-contract.md)
   Bounded Coinbase-first parity, replay, and allowed-drift contract.
 - [First Downstream Slice Contract](../reference/first-downstream-slice-contract.md)
@@ -107,6 +113,8 @@ Use these pages as the owning contract set:
 Owner-page rule:
 
 - bounded slice references live under `docs/reference/`
+- primitive and artifact authorities are split into dedicated reference pages
+  so owner pages do not compete on low-level wire details
 - numbered program sequencing lives only in [ROADMAP.md](../../ROADMAP.md)
 
 ## Read Next
@@ -115,6 +123,8 @@ Owner-page rule:
 - [Bridge To Target Mapping](bridge-to-target-mapping.md)
 - [Reconciliation And Tax Architecture](reconciliation-tax-architecture.md)
 - [Pipeline Stage Contracts](pipeline-stage-contracts.md)
+- [Target Contract Primitives](../reference/target-contract-primitives.md)
+- [Target Product Artifacts](../reference/target-product-artifacts.md)
 - [First Slice Contract](../reference/first-slice-contract.md)
 - [First Downstream Slice Contract](../reference/first-downstream-slice-contract.md)
 - [Domain Ontology](domain-ontology.md)

--- a/docs/concepts/architecture-overview.md
+++ b/docs/concepts/architecture-overview.md
@@ -91,6 +91,8 @@ Use these pages as the owning contract set:
   Target stage products, responsibilities, and handoff guarantees.
 - [First Slice Contract](../reference/first-slice-contract.md)
   Bounded Coinbase-first parity, replay, and allowed-drift contract.
+- [First Downstream Slice Contract](../reference/first-downstream-slice-contract.md)
+  Bounded first `EconomicFacts -> ReconciliationState -> Checkpoint` contract.
 - [Domain Ontology](domain-ontology.md)
   Target ontology, identity boundaries, and bridge-versus-target modeling rules.
 - [Gaps And Readiness](gaps-and-readiness.md)
@@ -102,6 +104,11 @@ Use these pages as the owning contract set:
 - [Reconciliation And Tax Architecture](reconciliation-tax-architecture.md)
   Trust gates, performance rules, and rollout alignment.
 
+Owner-page rule:
+
+- bounded slice references live under `docs/reference/`
+- numbered program sequencing lives only in [ROADMAP.md](../../ROADMAP.md)
+
 ## Read Next
 
 - [Current Bridge Contracts](current-bridge-contracts.md)
@@ -109,6 +116,7 @@ Use these pages as the owning contract set:
 - [Reconciliation And Tax Architecture](reconciliation-tax-architecture.md)
 - [Pipeline Stage Contracts](pipeline-stage-contracts.md)
 - [First Slice Contract](../reference/first-slice-contract.md)
+- [First Downstream Slice Contract](../reference/first-downstream-slice-contract.md)
 - [Domain Ontology](domain-ontology.md)
 - [Gaps And Readiness](gaps-and-readiness.md)
 - [Oracle Boundaries](oracle-boundaries.md)

--- a/docs/concepts/architecture-overview.md
+++ b/docs/concepts/architecture-overview.md
@@ -84,8 +84,13 @@ Use these pages as the owning contract set:
 
 - [Current Bridge Contracts](current-bridge-contracts.md)
   Live bridge contracts, bridge artifacts, and current schema rules.
+- [Bridge To Target Mapping](bridge-to-target-mapping.md)
+  Bridge-to-target mapping from current bridge boundaries into bounded
+  proto-products during migration.
 - [Pipeline Stage Contracts](pipeline-stage-contracts.md)
   Target stage products, responsibilities, and handoff guarantees.
+- [First Slice Contract](../reference/first-slice-contract.md)
+  Bounded Coinbase-first parity, replay, and allowed-drift contract.
 - [Domain Ontology](domain-ontology.md)
   Target ontology, identity seams, and bridge-versus-target modeling rules.
 - [Gaps And Readiness](gaps-and-readiness.md)
@@ -100,8 +105,10 @@ Use these pages as the owning contract set:
 ## Read Next
 
 - [Current Bridge Contracts](current-bridge-contracts.md)
+- [Bridge To Target Mapping](bridge-to-target-mapping.md)
 - [Reconciliation And Tax Architecture](reconciliation-tax-architecture.md)
 - [Pipeline Stage Contracts](pipeline-stage-contracts.md)
+- [First Slice Contract](../reference/first-slice-contract.md)
 - [Domain Ontology](domain-ontology.md)
 - [Gaps And Readiness](gaps-and-readiness.md)
 - [Oracle Boundaries](oracle-boundaries.md)

--- a/docs/concepts/architecture-overview.md
+++ b/docs/concepts/architecture-overview.md
@@ -8,126 +8,67 @@ status: active
 nav_order: 10
 ---
 
-TallyLot ships a typed Python package and CLI for source-backed intake,
+TallyLot is a typed Python package and CLI for source-backed intake,
 reconciliation, checkpointing, accounting validation, output rendering, and
 tax-oriented work.
 
-## Core Shape
+## Runtime Posture
 
-- `domain/` owns business models, enums, and value objects
-- `application/` owns use-case orchestration over domain models and ports
-- `ports/` defines narrow typed boundaries
-- `infrastructure/` implements ports
-- `adapters/` translates source and output formats
-- `interfaces/` exposes CLI entry points over application capabilities
-
-## Operating Model
-
-- raw evidence and live operator artifacts live in an external workspace, not
-  in the repo
-- the repo owns code, tests, docs, templates, automation, and workspace
-  guidance
-- financial values stay in `Decimal`
-- unsupported or ambiguous facts stay explicit as issues, reviews, or later
-  stage-owned gaps
-
-## Current Bridge
-
-The live runtime bridge currently centers on:
+The live runtime still centers on the current bridge:
 
 - `EconomicActivityDraft`
 - `TransactionFact`
 - `balance_snapshots.csv`
 - `balance_references.csv`
 
-That bridge is:
+That bridge is the current implementation boundary and parity baseline. It is
+not the final architecture center.
 
-- the current implementation boundary
-- the current delivery path
-- the current parity baseline
-- not the final architecture center
-
-Current bridge contracts and artifact rules live in
-[Current Bridge Contracts](current-bridge-contracts.md).
-
-## Target Direction
-
-The target runtime pipeline converges on:
+The target runtime pipeline is:
 
 `EvidenceSet -> ClaimSet -> EconomicFacts -> ReconciliationState -> Checkpoint -> Journal -> TaxInputs -> TaxOutputs`
 
-The target model is stage-first and ontology-first:
+The owner docs freeze product ids, critical-path kernel field tables, and the
+compatibility-sidecar boundary for retained legacy projections.
 
-- source evidence and source-backed checkpoints remain first-class
-- reconciliation and checkpoint trust gates come before accounting and tax
-- CoinTracking remains an edge output and oracle input, not the core ledger
-  model
-- bridge classifications remain current runtime vocabulary, not the long-term
-  ontology center
+## Layer Shape
 
-## System Boundaries
+- `domain/` owns business models, refs, enums, and value objects
+- `application/` owns use-case orchestration over domain models and ports
+- `ports/` defines narrow typed boundaries
+- `infrastructure/` implements ports
+- `adapters/` translates source and output formats
+- `interfaces/` exposes CLI entry points over application capabilities
 
-- raw evidence and operator artifacts live in the external workspace
-- the repo owns code, tests, docs, templates, automation, and mirrored
-  workspace guidance
-- source adapters produce source-local observations, bridge outputs today, and
-  later target-stage inputs
-- reconciliation and checkpoints are trust gates, not renderer side effects
-- accounting and tax consume accepted upstream truth; they do not repair source
-  meaning
-- repo-only dev tooling may evolve under a clearer `dev_support/` boundary
-  later, but current live repo-only support remains `repo_support/`
+Raw evidence and live operator artifacts remain in the external workspace, not
+in the repo.
 
-## Contract Owners
+## Contract Map
 
-Use these pages as the owning contract set:
+Use these pages as the primary owners:
 
-- [Current Bridge Contracts](current-bridge-contracts.md)
-  Live bridge contracts, bridge artifacts, and current schema rules.
-- [Bridge To Target Mapping](bridge-to-target-mapping.md)
-  Primary mapping from current bridge boundaries into bounded proto-products
-  during migration.
-- [Pipeline Stage Contracts](pipeline-stage-contracts.md)
-  Target stage products, responsibilities, and handoff guarantees.
-- [Target Contract Primitives](../reference/target-contract-primitives.md)
-  Shared target scalar forms, tuple contracts, dataset ids, and reusable value
-  primitives.
-- [Target Product Artifacts](../reference/target-product-artifacts.md)
-  Forward-looking target dataset packaging, kernel filenames, and sidecar
-  locations.
-- [First Slice Contract](../reference/first-slice-contract.md)
-  Bounded Coinbase-first parity, replay, and allowed-drift contract.
-- [First Downstream Slice Contract](../reference/first-downstream-slice-contract.md)
-  Bounded first `EconomicFacts -> ReconciliationState -> Checkpoint` contract.
-- [Domain Ontology](domain-ontology.md)
-  Target ontology, identity boundaries, and bridge-versus-target modeling rules.
-- [Gaps And Readiness](gaps-and-readiness.md)
-  Target shared blocker model, readiness model, and `SubjectRef` rules.
-- [Transaction Classification](transaction-classification.md)
-  Current bridge classification vocabulary and bridge-only rules.
-- [Oracle Boundaries](oracle-boundaries.md)
-  Runtime-versus-oracle boundary rules.
-- [Reconciliation And Tax Architecture](reconciliation-tax-architecture.md)
-  Trust gates, performance rules, and rollout alignment.
+| Page | Owns |
+| --- | --- |
+| [Current Bridge Contracts](current-bridge-contracts.md) | live bridge truth and bridge artifact rules |
+| [Bridge To Target Mapping](bridge-to-target-mapping.md) | authoritative writer rules, compatibility projections, and reader cutovers |
+| [Pipeline Stage Contracts](pipeline-stage-contracts.md) | target product kernels, ids, ordering, and handoff rules |
+| [Domain Ontology](domain-ontology.md) | entity seams, ref recipes, and package direction |
+| [Gaps And Readiness](gaps-and-readiness.md) | blockers, reviews, readiness, and `SubjectRef` |
+| [Reconciliation And Tax Architecture](reconciliation-tax-architecture.md) | trust gates, persistence, partitioning, and fast-path rules |
+| [First Slice Contract](../reference/first-slice-contract.md) | bounded upstream `EvidenceSet -> ClaimSet` slice |
+| [First Downstream Slice Contract](../reference/first-downstream-slice-contract.md) | bounded downstream `EconomicFacts -> ReconciliationState -> Checkpoint` slice |
+| [ROADMAP.md](../../ROADMAP.md) | sequencing, gating, and rollout phases |
+| [Current State](../status/current-state.md) | implemented runtime truth |
 
-Owner-page rule:
-
-- bounded slice references live under `docs/reference/`
-- primitive and artifact authorities are split into dedicated reference pages
-  so owner pages do not compete on low-level wire details
-- numbered program sequencing lives only in [ROADMAP.md](../../ROADMAP.md)
+Helper references that do not override those owners remain under
+`docs/reference/`.
 
 ## Read Next
 
 - [Current Bridge Contracts](current-bridge-contracts.md)
 - [Bridge To Target Mapping](bridge-to-target-mapping.md)
-- [Reconciliation And Tax Architecture](reconciliation-tax-architecture.md)
 - [Pipeline Stage Contracts](pipeline-stage-contracts.md)
-- [Target Contract Primitives](../reference/target-contract-primitives.md)
-- [Target Product Artifacts](../reference/target-product-artifacts.md)
-- [First Slice Contract](../reference/first-slice-contract.md)
-- [First Downstream Slice Contract](../reference/first-downstream-slice-contract.md)
 - [Domain Ontology](domain-ontology.md)
 - [Gaps And Readiness](gaps-and-readiness.md)
-- [Oracle Boundaries](oracle-boundaries.md)
-- [Transaction Classification](transaction-classification.md)
+- [Reconciliation And Tax Architecture](reconciliation-tax-architecture.md)
+- [Current State](../status/current-state.md)

--- a/docs/concepts/architecture-overview.md
+++ b/docs/concepts/architecture-overview.md
@@ -42,7 +42,7 @@ The live runtime bridge currently centers on:
 
 That bridge is:
 
-- the current implementation seam
+- the current implementation boundary
 - the current delivery path
 - the current parity baseline
 - not the final architecture center
@@ -60,7 +60,7 @@ The target model is stage-first and ontology-first:
 
 - source evidence and source-backed checkpoints remain first-class
 - reconciliation and checkpoint trust gates come before accounting and tax
-- CoinTracking remains an edge output and oracle surface, not the core ledger
+- CoinTracking remains an edge output and oracle input, not the core ledger
   model
 - bridge classifications remain current runtime vocabulary, not the long-term
   ontology center
@@ -85,14 +85,14 @@ Use these pages as the owning contract set:
 - [Current Bridge Contracts](current-bridge-contracts.md)
   Live bridge contracts, bridge artifacts, and current schema rules.
 - [Bridge To Target Mapping](bridge-to-target-mapping.md)
-  Bridge-to-target mapping from current bridge boundaries into bounded
-  proto-products during migration.
+  Primary mapping from current bridge boundaries into bounded proto-products
+  during migration.
 - [Pipeline Stage Contracts](pipeline-stage-contracts.md)
   Target stage products, responsibilities, and handoff guarantees.
 - [First Slice Contract](../reference/first-slice-contract.md)
   Bounded Coinbase-first parity, replay, and allowed-drift contract.
 - [Domain Ontology](domain-ontology.md)
-  Target ontology, identity seams, and bridge-versus-target modeling rules.
+  Target ontology, identity boundaries, and bridge-versus-target modeling rules.
 - [Gaps And Readiness](gaps-and-readiness.md)
   Target shared blocker model, readiness model, and `SubjectRef` rules.
 - [Transaction Classification](transaction-classification.md)

--- a/docs/concepts/bridge-to-target-mapping.md
+++ b/docs/concepts/bridge-to-target-mapping.md
@@ -33,9 +33,9 @@ Ownership boundaries:
   product kernels, ids, ordering, serialization, and fingerprints for
   `EvidenceSet`, `ClaimSet`, `EconomicFacts`, `ReconciliationState`,
   `Checkpoint`, `Journal`, `TaxInputs`, and `TaxOutputs`.
-- [Gaps And Readiness](gaps-and-readiness.md) owns `GapCore`,
+- [Gaps And Readiness](gaps-and-readiness.md) owns `GapRecord`,
   `GapExplanation`, `ReviewRecord`, `ReviewExplanation`,
-  `SubjectReadinessRecord`, `ReadinessProjection`, and `SubjectRef`.
+  `ReadinessRecord`, `ReadinessProjection`, and `SubjectRef`.
 - this page owns how bridge surfaces move to target products without creating
   dual authorities
 
@@ -45,9 +45,9 @@ Naming rules:
   truth
 - forward-looking docs use target product names directly, even when a slice has
   bounded coverage
-- `ProjectionAnnotation` is not a canonical `ClaimSet` family; if bridge or
-  output compatibility still needs annotation material, it must live in a
-  derived compatibility sidecar
+- bridge or output annotation payloads are not canonical `ClaimSet` kinds; if
+  compatibility still needs annotation material, it must live in a derived
+  compatibility sidecar
 
 ## Migration Authority Rules
 
@@ -89,16 +89,16 @@ cutover contract.
 
 | Current surface | Authoritative source now | Authoritative source after slice | Derived compatibility projection | Active readers now | Target readers after cutover | Cutover gate | Retirement gate |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `translation_input_candidates.json` | planner-enabled normalization | `EvidenceSet` envelope and selection sidecars | optional planner review projection derived from `EvidenceSet` plus planning metadata | normalization review tools and planner inspection flows | evidence review and claim translation flows that read `EvidenceSet` directly | selected, superseded, and blocked membership are preserved with stable `selection_group_id` and `member_id` outcomes | retire once planner/operator review surfaces no longer require the legacy file |
+| `translation_input_candidates.json` | planner-enabled normalization | `EvidenceSet` envelope and selection sidecars | optional planner review projection derived from `EvidenceSet` plus planning metadata | normalization review tools and planner inspection flows | evidence review and claim translation flows that read `EvidenceSet` directly | selected, superseded, and blocked membership are preserved with stable `selection_id` and `member_id` outcomes | retire once planner/operator review surfaces no longer require the legacy file |
 | `translation_input_plan.json` | planner-enabled normalization | `EvidenceSet` | `translation_input_plan.json` regenerated from `EvidenceSet` during the compatibility window | translation entry points that still expect a plan file | evidence consumers and claim translation that read `EvidenceSet` directly | one authoritative `EvidenceSet` exists for the capture and reproduces the same selected, superseded, and blocked decisions | retire when no in-scope reader requires the plan file and parity is enforced on `EvidenceSet` instead |
 | recognized statement parse outputs and balance rows | shared statement extraction outputs | `EvidenceSet` observations | statement-facing compatibility payloads derived from `EvidenceObservationRecord` sidecars | normalization review and statement debugging flows | claim translation and downstream support flows that read `EvidenceSet` observations | statement document identity, row anchors, quantities, and provenance are preserved under `EvidenceSet` | retire legacy parse-only outputs when all readers use `EvidenceSet` observations or declared sidecars |
-| `EconomicActivityDraft` | source translation boundary | `ClaimSet` | `EconomicActivityDraft` rows derived from accepted `InterpretationBundleRecord` and `ClaimRecord` kernels plus declared compatibility sidecars keyed by `claim_id` or `bundle_id` for `economic_kind`, `projection_hint`, `accounting_intent_hint`, `tax_treatment_hint`, `description`, `tx_hash_or_null`, `operation_group_id_or_null`, `confidence`, and `status` | `SourceTranslationBatch` assembly and bridge compilers | economic compilation that reads `ClaimSet` directly | first-slice claim field tables, `evidence_observation_refs`, bundle selection, and the retained legacy claim fields are all frozen either in canonical claim kernels or in declared compatibility sidecars | retire when no bridge compiler or batch builder still consumes drafts |
-| `SourceTranslationBatch` | source translation boundary | `ClaimSet` | `SourceTranslationBatch` bundle derived from `ClaimSet` plus declared compatibility sidecars for `economic_kind`, `projection_hint`, `accounting_intent_hint`, `tax_treatment_hint`, `description`, `tx_hash_or_null`, `operation_group_id_or_null`, `confidence`, and `status`, plus shared support artifacts | current normalization application surface and bridge interop flows | target application paths in `application/claims/` and later `application/economics/` | in-scope readers can be pointed to `ClaimSet` or a declared compatibility surface without semantic loss, and no retained batch-only field remains undefined | retire when no active runtime path reads the batch as its primary semantic surface |
+| `EconomicActivityDraft` | source translation boundary | `ClaimSet` | `EconomicActivityDraft` rows derived from accepted `ClaimBundleRecord` and `ClaimRecord` kernels plus declared compatibility sidecars keyed by `claim_id` or `bundle_id` for `economic_kind`, `projection_hint`, `accounting_intent_hint`, `tax_treatment_hint`, `description`, `tx_hash_or_null`, `operation_group_id_or_null`, `confidence`, and `status` | `SourceTranslationBatch` assembly and bridge compilers | economic compilation that reads `ClaimSet` directly | first-slice claim field tables, `evidence_observation_refs`, bundle selection, and the retained legacy claim fields are all frozen either in canonical claim kernels or in declared compatibility sidecars | retire when no bridge compiler or batch builder still consumes drafts |
+| `SourceTranslationBatch` | source translation boundary | `ClaimSet` | `SourceTranslationBatch` bundle derived from `ClaimSet` plus declared compatibility sidecars for `economic_kind`, `projection_hint`, `accounting_intent_hint`, `tax_treatment_hint`, `description`, `tx_hash_or_null`, `operation_group_id_or_null`, `confidence`, and `status`, plus shared support records and sidecars | current normalization application surface and bridge interop flows | target application paths in `application/claims/` and later `application/economics/` | in-scope readers can be pointed to `ClaimSet` or a declared compatibility surface without semantic loss, and no retained batch-only field remains undefined | retire when no active runtime path reads the batch as its primary semantic surface |
 | `TransactionFact` and `facts.csv` | current bridge fact path | `EconomicFacts` | `TransactionFact` rows and `facts.csv` rendered from `EconomicFacts` plus declared upstream claim compatibility sidecars for `economic_kind`, `projection_hint`, `accounting_intent_hint`, `tax_treatment_hint`, `description`, `tx_hash_or_null`, `operation_group_id_or_null`, `confidence`, and `status` when legacy hint reproduction still needs them | balance builders, output renderers, oracle comparison flows | reconciliation, checkpoint, accounting, and tax paths that read `EconomicFacts` | accepted `EconomicEventRecord` and `EconomicLegRecord` parity is proven and current bridge facts are reproducible from `EconomicFacts` plus declared upstream compatibility sidecars rather than from bridge artifacts as peer authorities | retire when no runtime reader depends on `TransactionFact` as economic authority |
 | `balance_snapshots.csv` | current bridge balance reducers | `ReconciliationState` | `balance_snapshots.csv` derived from `ReconciliationState` for unmigrated balance surfaces | balance inspect/check/summarize and downstream review workflows | reconciliation readers and later checkpoint assembly that read `ReconciliationState` | continuity segments and balance targets exist for the in-scope subjects and reproduce current snapshot results | retire when active balance surfaces read `ReconciliationState` directly |
 | `balance_references.csv` | current bridge balance support path | `Checkpoint` and `ReconciliationState` | `balance_references.csv` derived from `ReconciliationState`, `Checkpoint`, and declared support sidecars | balance inspect/check/summarize and current checkpoint support workflows | checkpoint assembly and reconciliation readers that consume target support directly | direct `AssertionValue` fields, checkpoint candidates, and checkpoint assertions reproduce the current reference content for in-scope subjects | retire when no active surface consumes the CSV as its authoritative support input |
-| `exceptions.csv` and bridge `IssueRecord` outputs | stage-local bridge diagnostics | target product plus shared support artifacts | bridge issue projection derived from `GapCore` and `GapExplanation` when a target stage owns the blocker | operator review and current normalization diagnostics | target support reducers and readiness views | the owning target stage can preserve blocker scope, severity, materiality, and stage ownership | retire per stage when that stage emits target-native gaps for the same scope |
-| `normalization_reviews.csv` and `NormalizationReviewRecord` outputs | stage-local bridge advisory diagnostics | target product plus shared support artifacts | bridge review projection derived from `ReviewRecord` and `ReviewExplanation` | operator review and current normalization diagnostics | target review and readiness views | advisory review scope and provenance are preserved without turning reviews into blockers | retire per stage when that stage emits target-native reviews for the same scope |
+| `exceptions.csv` and bridge `IssueRecord` outputs | stage-local bridge diagnostics | target product plus shared support records | bridge issue projection derived from `GapRecord` and `GapExplanation` when a target stage owns the blocker | operator review and current normalization diagnostics | target support reducers and readiness views | the owning target stage can preserve blocker scope, severity, materiality, and stage ownership | retire per stage when that stage emits target-native gaps for the same scope |
+| `normalization_reviews.csv` and `NormalizationReviewRecord` outputs | stage-local bridge advisory diagnostics | target product plus shared support records and sidecars | bridge review projection derived from `ReviewRecord` and `ReviewExplanation` | operator review and current normalization diagnostics | target review and readiness views | advisory review scope and provenance are preserved without turning reviews into blockers | retire per stage when that stage emits target-native reviews for the same scope |
 | `fact_annotations.json` and `location_annotations.json` | bridge-only sidecar generation | target products plus bridge/output compatibility sidecars | derived annotation sidecars keyed to target ids or bridge projection ids | current bridge renderers and comparison tooling | target-aware output and comparison flows that no longer require canonical annotation payloads in claims | no target semantic meaning depends on annotation payloads and bridge/output consumers can read derived sidecars instead | retire when the affected renderer or comparison flow no longer depends on the annotation file |
 
 ## Compatibility Sidecars And Support Mapping
@@ -108,8 +108,8 @@ surfaces during migration.
 
 Rules:
 
-- `ProjectionAnnotation` remains bridge or output compatibility metadata only
-- no target `ClaimSet` family may be introduced for bridge hints, render notes,
+- bridge or output annotation payloads remain compatibility metadata only
+- no target `ClaimSet` kind may be introduced for bridge hints, render notes,
   or output annotations
 - if a current renderer or comparison path still needs annotation content, emit
   it as a derived sidecar keyed to the relevant `claim_id`, `event_id`, or
@@ -125,13 +125,13 @@ Rules:
 
 Diagnostic mapping rules:
 
-- a blocking bridge `IssueRecord` maps to `GapCore` plus `GapExplanation` only
+- a blocking bridge `IssueRecord` maps to `GapRecord` plus `GapExplanation` only
   when the target stage can preserve blocker scope, severity, blocking stages,
   and provenance
 - a bridge `NormalizationReviewRecord` maps to `ReviewRecord` plus
   `ReviewExplanation`
 - reviews remain advisory even when they share the same factual cause as a gap
-- support artifacts never become claim families
+- support records and sidecars never become claim kinds
 
 ## First Bounded Slice Rules
 

--- a/docs/concepts/bridge-to-target-mapping.md
+++ b/docs/concepts/bridge-to-target-mapping.md
@@ -1,6 +1,6 @@
 ---
 title: "Bridge To Target Mapping"
-summary: "Single authority for how live bridge seams land in the target pipeline during Phase 0 and the first bounded slice."
+summary: "Single authority for how live bridge boundaries map into the target pipeline during Phase 0 and the first bounded increment."
 doc_type: concept
 audience: human
 owner: repo
@@ -14,10 +14,10 @@ related:
   - ROADMAP.md
 ---
 
-Use this page when you need the bridge-to-target mapping from the live bridge
-into the target pipeline. This document owns transformation direction and
-migration continuity. It does not re-own either live bridge truth or target
-product contracts.
+Use this page when you need the primary mapping from the live bridge into the
+target pipeline. This document owns transformation direction and migration
+continuity. It does not re-own either live bridge truth or target product
+contracts.
 
 ## Scope And Naming
 
@@ -26,22 +26,22 @@ Ownership boundaries:
 - [Current Bridge Contracts](current-bridge-contracts.md) owns live runtime
   truth for `EconomicActivityDraft`, `SourceTranslationBatch`,
   `TransactionFact`, and the current bridge artifacts.
-- [Pipeline Stage Contracts](pipeline-stage-contracts.md) owns the canonical
+- [Pipeline Stage Contracts](pipeline-stage-contracts.md) defines the
   meaning of `EvidenceSet`, `ClaimSet`, `EconomicFacts`,
   `ReconciliationState`, `Checkpoint`, `Journal`, `TaxInputs`, and
   `TaxOutputs`.
-- this page owns how current seams land bounded proto-products during
+- this page owns how current bridge boundaries map to bounded proto-products during
   migration, what stays bridge-only, and where continuity rules apply
 
 Naming rules:
 
 - `proto-EvidenceSet` and `proto-ClaimSet` mean bounded coverage of the
-  canonical target products during migration
+  target products during migration
 - `proto-` is a coverage label, not a competing noun or alternate architecture
-- `SourceTranslationBatch` remains the live migration seam until a later slice
+- `SourceTranslationBatch` remains the live migration boundary until a later increment
   replaces it; do not rename it in current-state docs just to match target
   vocabulary
-- the default first slice is the bounded Coinbase-first slice defined in
+- the default first increment is the bounded Coinbase-first increment defined in
   [First Slice Contract](../reference/first-slice-contract.md)
 - the repo does not infer the actual `2023` to `2025` filing adapter inventory
   from these docs; that inventory remains an external delivery-note input until
@@ -51,14 +51,14 @@ Naming rules:
 
 The current bridge families that matter for target mapping are:
 
-| Current surface | Current owner | Current role |
+| Current output | Current owner | Current role |
 | --- | --- | --- |
 | `translation_input_candidates.json` | planner-enabled normalization | deterministic candidate inventory before translation |
 | `translation_input_plan.json` | planner-enabled normalization | selected, superseded, and blocked candidate decisions |
 | `translation_input_issues.csv` | planner-enabled normalization | candidate-selection blocking diagnostics |
 | statement parse outputs and statement-backed quantity rows | shared statement extraction | boundary-parsed quantity observations and source-backed support |
-| `EconomicActivityDraft` | translation seam | provider-local semantic draft before shared fact acceptance |
-| `SourceTranslationBatch` | translation seam | migration bundle of drafts, balance references, issues, reviews, and inventory |
+| `EconomicActivityDraft` | translation boundary | provider-local semantic draft before shared fact acceptance |
+| `SourceTranslationBatch` | translation boundary | migration bundle of drafts, balance references, issues, reviews, and inventory |
 | `TransactionFact` and `facts.csv` | current bridge | accepted bridge approximation of economic truth |
 | `balance_snapshots.csv` | current bridge | derived balance cutoff snapshots over current facts |
 | `balance_references.csv` | current bridge | quantity-backed support references for balances |
@@ -67,28 +67,28 @@ The current bridge families that matter for target mapping are:
 
 ## Bridge-To-Target Mapping Table
 
-| Current surface | Target landing | Mapping rule | Bridge status during migration |
+| Current output | Target destination | Mapping rule | Bridge status during migration |
 | --- | --- | --- | --- |
 | `translation_input_candidates.json` | `EvidenceSet` envelope and selection sidecars | preserve planner candidate membership, coverage, and comparability as evidence-selection reasoning | remains bridge-owned until `EvidenceSet` lands |
-| `translation_input_plan.json` | `EvidenceSet` kernel | selected, superseded, and blocked planner decisions become `selection_status` records under one deterministic `selection_group_id` | dual-emitted during the first slice |
-| recognized statement balance rows | `EvidenceSet` observations and `BalanceObservationClaim` inputs | preserve statement document identity, row identity, as-of time, precision, quantity, and provenance without forcing final checkpoint acceptance | dual-emitted during the first slice |
-| `EconomicActivityDraft` | `ClaimSet` | split one draft into `ActivityClaim`, `InstrumentIdentityClaim`, `LocationClaim`, `BalanceObservationClaim`, `ValuationClaim`, `ProjectionAnnotation`, issue candidates, and review candidates | bridge seam remains live until claim-native slices replace it |
-| `SourceTranslationBatch` | migration continuity between `EvidenceSet`, `ClaimSet`, and current bridge outputs | keep the bundled bridge seam honest while bounded proto-products are emitted beside it | live runtime seam |
-| `TransactionFact` | bridge-only approximation of `EconomicFacts` | treat accepted bridge facts as the current approximation of accepted economic meaning, not as the canonical target contract | bridge-only until `EconomicFacts` lands |
+| `translation_input_plan.json` | `EvidenceSet` kernel | selected, superseded, and blocked planner decisions become `selection_status` records under one deterministic `selection_group_id` | dual-emitted during the first increment |
+| recognized statement balance rows | `EvidenceSet` observations and `BalanceObservationClaim` inputs | preserve statement document identity, row identity, as-of time, precision, quantity, and provenance without forcing final checkpoint acceptance | dual-emitted during the first increment |
+| `EconomicActivityDraft` | `ClaimSet` | split one draft into `ActivityClaim`, `InstrumentIdentityClaim`, `LocationClaim`, `BalanceObservationClaim`, `ValuationClaim`, `ProjectionAnnotation`, issue candidates, and review candidates | bridge boundary remains live until claim-native increments replace it |
+| `SourceTranslationBatch` | migration continuity between `EvidenceSet`, `ClaimSet`, and current bridge outputs | keep the bundled bridge boundary honest while bounded proto-products are emitted beside it | live runtime boundary |
+| `TransactionFact` | bridge-only approximation of `EconomicFacts` | treat accepted bridge facts as the current approximation of accepted economic meaning, not as the final target contract | bridge-only until `EconomicFacts` lands |
 | `balance_snapshots.csv` | later `ReconciliationState` inputs | keep derived snapshots bridge-only; do not claim that they are target reconciliation kernels | bridge-only |
 | `balance_references.csv` | later `Checkpoint` and `ReconciliationState` inputs | keep source-backed and operator assertion references explicit as checkpoint or reconciliation inputs, not accepted checkpoint truth by themselves | bridge-only |
 | `IssueRecord` outputs | `GapCore` plus `GapExplanation` where semantics align | blocking current issues map to target gaps only when owner stage, scope, and blocker meaning are preserved | bridge-only until a stage adopts target gaps |
 | `NormalizationReviewRecord` outputs | review sidecars and paired gap explanations | advisory reviews remain review sidecars unless a paired blocking gap exists | bridge-only until a stage adopts target reviews |
 
-## Bridge-Only Surfaces That Remain
+## Bridge-Only Outputs That Remain
 
-The following surfaces remain bridge-only even after the first slice starts
+The following outputs remain bridge-only even after the first increment starts
 emitting bounded proto-products:
 
 - `SourceTranslationBatch` remains the live transition bundle until later
-  slices replace it end to end
+  increments replace it end to end
 - `TransactionFact` remains the accepted bridge approximation of economic truth
-  and must not be described as the canonical `EconomicFacts` kernel
+  and must not be described as the final `EconomicFacts` kernel
 - bridge-era balance artifacts remain runtime inputs and reporting outputs, not
   target reconciliation or checkpoint products
 - `accounting_intent_hint`, `tax_treatment_hint`, and `projection_hint` remain
@@ -117,33 +117,33 @@ Mapping rules from live bridge diagnostics into the target support model:
 - do not upgrade reviews into gaps or downgrade gaps into reviews just to keep
   bridge facts flowing
 
-The canonical target support contracts still live in
+The target support contracts still live in
 [Gaps And Readiness](gaps-and-readiness.md). This page only fixes the current
-bridge-to-target landing rule.
+bridge-to-target mapping rule.
 
-## First-Slice Landing Rules
+## First-Increment Mapping Rules
 
-The default first slice is intentionally narrow:
+The default first increment is intentionally narrow:
 
 - planner-enabled Coinbase retail export evidence
 - recognized Coinbase statement-backed balance observation flow
 - continued compatibility with current `SourceTranslationBatch`,
   `TransactionFact`, `balance_references.csv`, and `cointracking_csv`
 
-First-slice rules:
+First-increment rules:
 
 - planner-selected, superseded, and blocked candidate records become the first
-  bounded proto-`EvidenceSet` kernel for the slice
+  bounded proto-`EvidenceSet` kernel for the increment
 - recognized statement rows become evidence observations first and
   `BalanceObservationClaim` inputs second; they do not become accepted
-  checkpoint truth inside the slice
-- `EconomicActivityDraft` remains the provider-local pre-economic bridge seam,
+  checkpoint truth inside the increment
+- `EconomicActivityDraft` remains the provider-local pre-economic bridge boundary,
   but its responsibilities are split conceptually into claim families so later
-  slices do not need to rediscover that cut
+  increments do not need to rediscover that cut
 - the shared compiler remains responsible for producing current bridge outputs
   from accepted claims until `EconomicFacts` and later downstream products
   replace that responsibility
-- the first slice must not create a second active runtime center, a permanent
+- the first increment must not create a second active runtime center, a permanent
   dual-write lane, or a repo-wide adapter-facet migration prerequisite
 - unchanged evidence must preserve selected evidence membership, claim identity
   and ordering, compiled bridge facts, balance reference kinds, and

--- a/docs/concepts/bridge-to-target-mapping.md
+++ b/docs/concepts/bridge-to-target-mapping.md
@@ -69,8 +69,8 @@ The current bridge families that matter for target mapping are:
 
 | Current output | Target destination | Mapping rule | Bridge status during migration |
 | --- | --- | --- | --- |
-| `translation_input_candidates.json` | `EvidenceSet` envelope and selection sidecars | preserve planner candidate membership, coverage, and comparability as evidence-selection reasoning | remains bridge-owned until `EvidenceSet` lands |
-| `translation_input_plan.json` | `EvidenceSet` kernel | selected, superseded, and blocked planner decisions become `selection_status` records under one deterministic `selection_group_id` | dual-emitted during the first increment |
+| `translation_input_candidates.json` | `EvidenceSet` envelope and selection sidecars | preserve planner candidate membership, coverage, and comparability as evidence-selection reasoning; these candidates do not become `EvidenceSet` kernel records | remains bridge-owned until `EvidenceSet` lands |
+| `translation_input_plan.json` | `EvidenceSet` kernel | selected, superseded, and blocked planner decisions from this file supply the kernel `selection_status` records under one deterministic `selection_group_id` | dual-emitted during the first increment |
 | recognized statement balance rows | `EvidenceSet` observations and `BalanceObservationClaim` inputs | preserve statement document identity, row identity, as-of time, precision, quantity, and provenance without forcing final checkpoint acceptance | dual-emitted during the first increment |
 | `EconomicActivityDraft` | `ClaimSet` | split one draft into `ActivityClaim`, `InstrumentIdentityClaim`, `LocationClaim`, `BalanceObservationClaim`, `ValuationClaim`, `ProjectionAnnotation`, issue candidates, and review candidates | bridge boundary remains live until claim-native increments replace it |
 | `SourceTranslationBatch` | migration continuity between `EvidenceSet`, `ClaimSet`, and current bridge outputs | keep the bundled bridge boundary honest while bounded proto-products are emitted beside it | live runtime boundary |
@@ -132,8 +132,10 @@ The default first increment is intentionally narrow:
 
 First-increment rules:
 
-- planner-selected, superseded, and blocked candidate records become the first
-  bounded proto-`EvidenceSet` kernel for the increment
+- `translation_input_candidates.json` remains planner candidate reasoning in
+  the `EvidenceSet` envelope or selection sidecars, while
+  `translation_input_plan.json` supplies the kernel `selection_status` records
+  for the increment
 - recognized statement rows become evidence observations first and
   `BalanceObservationClaim` inputs second; they do not become accepted
   checkpoint truth inside the increment

--- a/docs/concepts/bridge-to-target-mapping.md
+++ b/docs/concepts/bridge-to-target-mapping.md
@@ -1,0 +1,151 @@
+---
+title: "Bridge To Target Mapping"
+summary: "Single authority for how live bridge seams land in the target pipeline during Phase 0 and the first bounded slice."
+doc_type: concept
+audience: human
+owner: repo
+status: active
+nav_order: 24
+related:
+  - docs/concepts/current-bridge-contracts.md
+  - docs/concepts/pipeline-stage-contracts.md
+  - docs/reference/first-slice-contract.md
+  - docs/status/migration-sequence.md
+  - ROADMAP.md
+---
+
+Use this page when you need the bridge-to-target mapping from the live bridge
+into the target pipeline. This document owns transformation direction and
+migration continuity. It does not re-own either live bridge truth or target
+product contracts.
+
+## Scope And Naming
+
+Ownership boundaries:
+
+- [Current Bridge Contracts](current-bridge-contracts.md) owns live runtime
+  truth for `EconomicActivityDraft`, `SourceTranslationBatch`,
+  `TransactionFact`, and the current bridge artifacts.
+- [Pipeline Stage Contracts](pipeline-stage-contracts.md) owns the canonical
+  meaning of `EvidenceSet`, `ClaimSet`, `EconomicFacts`,
+  `ReconciliationState`, `Checkpoint`, `Journal`, `TaxInputs`, and
+  `TaxOutputs`.
+- this page owns how current seams land bounded proto-products during
+  migration, what stays bridge-only, and where continuity rules apply
+
+Naming rules:
+
+- `proto-EvidenceSet` and `proto-ClaimSet` mean bounded coverage of the
+  canonical target products during migration
+- `proto-` is a coverage label, not a competing noun or alternate architecture
+- `SourceTranslationBatch` remains the live migration seam until a later slice
+  replaces it; do not rename it in current-state docs just to match target
+  vocabulary
+- the default first slice is the bounded Coinbase-first slice defined in
+  [First Slice Contract](../reference/first-slice-contract.md)
+- the repo does not infer the actual `2023` to `2025` filing adapter inventory
+  from these docs; that inventory remains an external delivery-note input until
+  a concrete workspace source list is recorded separately
+
+## Live Bridge Inventory
+
+The current bridge families that matter for target mapping are:
+
+| Current surface | Current owner | Current role |
+| --- | --- | --- |
+| `translation_input_candidates.json` | planner-enabled normalization | deterministic candidate inventory before translation |
+| `translation_input_plan.json` | planner-enabled normalization | selected, superseded, and blocked candidate decisions |
+| `translation_input_issues.csv` | planner-enabled normalization | candidate-selection blocking diagnostics |
+| statement parse outputs and statement-backed quantity rows | shared statement extraction | boundary-parsed quantity observations and source-backed support |
+| `EconomicActivityDraft` | translation seam | provider-local semantic draft before shared fact acceptance |
+| `SourceTranslationBatch` | translation seam | migration bundle of drafts, balance references, issues, reviews, and inventory |
+| `TransactionFact` and `facts.csv` | current bridge | accepted bridge approximation of economic truth |
+| `balance_snapshots.csv` | current bridge | derived balance cutoff snapshots over current facts |
+| `balance_references.csv` | current bridge | quantity-backed support references for balances |
+| `exceptions.csv` and `normalization_reviews.csv` | current bridge | stage-local issue and review artifacts |
+| `fact_annotations.json` and `location_annotations.json` | current bridge sidecars | bridge-only sidecars keyed to emitted bridge outputs |
+
+## Bridge-To-Target Mapping Table
+
+| Current surface | Target landing | Mapping rule | Bridge status during migration |
+| --- | --- | --- | --- |
+| `translation_input_candidates.json` | `EvidenceSet` envelope and selection sidecars | preserve planner candidate membership, coverage, and comparability as evidence-selection reasoning | remains bridge-owned until `EvidenceSet` lands |
+| `translation_input_plan.json` | `EvidenceSet` kernel | selected, superseded, and blocked planner decisions become `selection_status` records under one deterministic `selection_group_id` | dual-emitted during the first slice |
+| recognized statement balance rows | `EvidenceSet` observations and `BalanceObservationClaim` inputs | preserve statement document identity, row identity, as-of time, precision, quantity, and provenance without forcing final checkpoint acceptance | dual-emitted during the first slice |
+| `EconomicActivityDraft` | `ClaimSet` | split one draft into `ActivityClaim`, `InstrumentIdentityClaim`, `LocationClaim`, `BalanceObservationClaim`, `ValuationClaim`, `ProjectionAnnotation`, issue candidates, and review candidates | bridge seam remains live until claim-native slices replace it |
+| `SourceTranslationBatch` | migration continuity between `EvidenceSet`, `ClaimSet`, and current bridge outputs | keep the bundled bridge seam honest while bounded proto-products are emitted beside it | live runtime seam |
+| `TransactionFact` | bridge-only approximation of `EconomicFacts` | treat accepted bridge facts as the current approximation of accepted economic meaning, not as the canonical target contract | bridge-only until `EconomicFacts` lands |
+| `balance_snapshots.csv` | later `ReconciliationState` inputs | keep derived snapshots bridge-only; do not claim that they are target reconciliation kernels | bridge-only |
+| `balance_references.csv` | later `Checkpoint` and `ReconciliationState` inputs | keep source-backed and operator assertion references explicit as checkpoint or reconciliation inputs, not accepted checkpoint truth by themselves | bridge-only |
+| `IssueRecord` outputs | `GapCore` plus `GapExplanation` where semantics align | blocking current issues map to target gaps only when owner stage, scope, and blocker meaning are preserved | bridge-only until a stage adopts target gaps |
+| `NormalizationReviewRecord` outputs | review sidecars and paired gap explanations | advisory reviews remain review sidecars unless a paired blocking gap exists | bridge-only until a stage adopts target reviews |
+
+## Bridge-Only Surfaces That Remain
+
+The following surfaces remain bridge-only even after the first slice starts
+emitting bounded proto-products:
+
+- `SourceTranslationBatch` remains the live transition bundle until later
+  slices replace it end to end
+- `TransactionFact` remains the accepted bridge approximation of economic truth
+  and must not be described as the canonical `EconomicFacts` kernel
+- bridge-era balance artifacts remain runtime inputs and reporting outputs, not
+  target reconciliation or checkpoint products
+- `accounting_intent_hint`, `tax_treatment_hint`, and `projection_hint` remain
+  bridge-era hint lanes that later stages may reference but must not recenter
+  as target economic truth
+- fact and location annotations remain bridge sidecars; they do not become the
+  only copy of claim, economic, reconciliation, or checkpoint meaning
+
+## Issue And Review Migration
+
+Mapping rules from live bridge diagnostics into the target support model:
+
+- a blocking `IssueRecord` becomes one `GapCore` plus one `GapExplanation`
+  only when the target stage can preserve the same owner stage, blocking
+  stages, scope, materiality, and confidence
+- `issue_id` remains the stable bridge diagnostic id until the replacement
+  stage emits its own target-native ids; do not invent a new id family without
+  carrying a stable source reference
+- `kind`, `severity`, `context_timestamp`, and typed provenance become gap
+  inputs, not free text to be reinterpreted later
+- an advisory `NormalizationReviewRecord` remains a review sidecar unless a
+  paired blocking condition also exists
+- when one blocking condition and one review share the same factual cause, the
+  gap owns the blocker and the review remains a sidecar keyed to the same
+  subject, scope, or decision record
+- do not upgrade reviews into gaps or downgrade gaps into reviews just to keep
+  bridge facts flowing
+
+The canonical target support contracts still live in
+[Gaps And Readiness](gaps-and-readiness.md). This page only fixes the current
+bridge-to-target landing rule.
+
+## First-Slice Landing Rules
+
+The default first slice is intentionally narrow:
+
+- planner-enabled Coinbase retail export evidence
+- recognized Coinbase statement-backed balance observation flow
+- continued compatibility with current `SourceTranslationBatch`,
+  `TransactionFact`, `balance_references.csv`, and `cointracking_csv`
+
+First-slice rules:
+
+- planner-selected, superseded, and blocked candidate records become the first
+  bounded proto-`EvidenceSet` kernel for the slice
+- recognized statement rows become evidence observations first and
+  `BalanceObservationClaim` inputs second; they do not become accepted
+  checkpoint truth inside the slice
+- `EconomicActivityDraft` remains the provider-local pre-economic bridge seam,
+  but its responsibilities are split conceptually into claim families so later
+  slices do not need to rediscover that cut
+- the shared compiler remains responsible for producing current bridge outputs
+  from accepted claims until `EconomicFacts` and later downstream products
+  replace that responsibility
+- the first slice must not create a second active runtime center, a permanent
+  dual-write lane, or a repo-wide adapter-facet migration prerequisite
+- unchanged evidence must preserve selected evidence membership, claim identity
+  and ordering, compiled bridge facts, balance reference kinds, and
+  `cointracking_csv` projection compatibility as defined in
+  [First Slice Contract](../reference/first-slice-contract.md)

--- a/docs/concepts/bridge-to-target-mapping.md
+++ b/docs/concepts/bridge-to-target-mapping.md
@@ -1,6 +1,6 @@
 ---
 title: "Bridge To Target Mapping"
-summary: "Single authority for how live bridge boundaries map into the target pipeline during Phase 0 and the first bounded increment."
+summary: "Single authority for how live bridge surfaces cut over to target products during migration, including writer ownership, reader cutovers, and retirement gates."
 doc_type: concept
 audience: human
 owner: repo
@@ -9,148 +9,158 @@ nav_order: 24
 related:
   - docs/concepts/current-bridge-contracts.md
   - docs/concepts/pipeline-stage-contracts.md
+  - docs/concepts/gaps-and-readiness.md
   - docs/reference/first-slice-contract.md
+  - docs/reference/first-downstream-slice-contract.md
   - docs/status/migration-sequence.md
   - ROADMAP.md
 ---
 
-Use this page when you need the primary mapping from the live bridge into the
-target pipeline. This document owns transformation direction and migration
-continuity. It does not re-own either live bridge truth or target product
+Use this page when you need the migration rule from the live bridge into the
+target pipeline. This document owns transformation direction, authoritative
+writer rules, derived compatibility projections, reader cutovers, and bridge
+retirement gates. It does not re-own live bridge truth or target product
 contracts.
 
-## Scope And Naming
+## Scope And Owner Pages
 
 Ownership boundaries:
 
 - [Current Bridge Contracts](current-bridge-contracts.md) owns live runtime
   truth for `EconomicActivityDraft`, `SourceTranslationBatch`,
   `TransactionFact`, and the current bridge artifacts.
-- [Pipeline Stage Contracts](pipeline-stage-contracts.md) defines the
-  meaning of `EvidenceSet`, `ClaimSet`, `EconomicFacts`,
-  `ReconciliationState`, `Checkpoint`, `Journal`, `TaxInputs`, and
-  `TaxOutputs`.
-- this page owns how current bridge boundaries map to bounded proto-products during
-  migration, what stays bridge-only, and where continuity rules apply
+- [Pipeline Stage Contracts](pipeline-stage-contracts.md) owns the target
+  product kernels, ids, ordering, serialization, and fingerprints for
+  `EvidenceSet`, `ClaimSet`, `EconomicFacts`, `ReconciliationState`,
+  `Checkpoint`, `Journal`, `TaxInputs`, and `TaxOutputs`.
+- [Gaps And Readiness](gaps-and-readiness.md) owns `GapCore`,
+  `GapExplanation`, `ReviewRecord`, `ReviewExplanation`,
+  `SubjectReadinessRecord`, `ReadinessProjection`, and `SubjectRef`.
+- this page owns how bridge surfaces move to target products without creating
+  dual authorities
 
 Naming rules:
 
-- `proto-EvidenceSet` and `proto-ClaimSet` mean bounded coverage of the
-  target products during migration
-- `proto-` is a coverage label, not a competing noun or alternate architecture
-- `SourceTranslationBatch` remains the live migration boundary until a later increment
-  replaces it; do not rename it in current-state docs just to match target
-  vocabulary
-- the default first increment is the bounded Coinbase-first increment defined in
-  [First Slice Contract](../reference/first-slice-contract.md)
-- the repo does not infer the actual `2023` to `2025` filing adapter inventory
-  from these docs; that inventory remains an external delivery-note input until
-  a concrete workspace source list is recorded separately
+- current-state docs keep bridge names where they describe implemented runtime
+  truth
+- forward-looking docs use target product names directly, even when a slice has
+  bounded coverage
+- `ProjectionAnnotation` is not a canonical `ClaimSet` family; if bridge or
+  output compatibility still needs annotation material, it must live in a
+  derived compatibility sidecar
 
-## Live Bridge Inventory
+## Migration Authority Rules
 
-The current bridge families that matter for target mapping are:
+Authoritative writer rule:
 
-| Current output | Current owner | Current role |
-| --- | --- | --- |
-| `translation_input_candidates.json` | planner-enabled normalization | deterministic candidate inventory before translation |
-| `translation_input_plan.json` | planner-enabled normalization | selected, superseded, and blocked candidate decisions |
-| `translation_input_issues.csv` | planner-enabled normalization | candidate-selection blocking diagnostics |
-| statement parse outputs and statement-backed quantity rows | shared statement extraction | boundary-parsed quantity observations and source-backed support |
-| `EconomicActivityDraft` | translation boundary | provider-local semantic draft before shared fact acceptance |
-| `SourceTranslationBatch` | translation boundary | migration bundle of drafts, balance references, issues, reviews, and inventory |
-| `TransactionFact` and `facts.csv` | current bridge | accepted bridge approximation of economic truth |
-| `balance_snapshots.csv` | current bridge | derived balance cutoff snapshots over current facts |
-| `balance_references.csv` | current bridge | quantity-backed support references for balances |
-| `exceptions.csv` and `normalization_reviews.csv` | current bridge | stage-local issue and review artifacts |
-| `fact_annotations.json` and `location_annotations.json` | current bridge sidecars | bridge-only sidecars keyed to emitted bridge outputs |
+- as soon as a target product exists for an in-scope family, that product
+  becomes the sole authoritative persisted source for that scope
+- any remaining bridge surface for that scope becomes a derived compatibility
+  projection only
 
-## Bridge-To-Target Mapping Table
+Consumer rule:
 
-| Current output | Target destination | Mapping rule | Bridge status during migration |
-| --- | --- | --- | --- |
-| `translation_input_candidates.json` | `EvidenceSet` envelope and selection sidecars | preserve planner candidate membership, coverage, and comparability as evidence-selection reasoning; these candidates do not become `EvidenceSet` kernel records | remains bridge-owned until `EvidenceSet` lands |
-| `translation_input_plan.json` | `EvidenceSet` kernel | selected, superseded, and blocked planner decisions from this file supply the kernel `selection_status` records under one deterministic `selection_group_id` | dual-emitted during the first increment |
-| recognized statement balance rows | `EvidenceSet` observations and `BalanceObservationClaim` inputs | preserve statement document identity, row identity, as-of time, precision, quantity, and provenance as typed observations under the owning statement document without forcing final checkpoint acceptance | dual-emitted during the first increment |
-| `EconomicActivityDraft` | `ClaimSet` | split one draft into `ActivityClaim`, `InstrumentIdentityClaim`, `LocationClaim`, `BalanceObservationClaim`, `ValuationClaim`, `ProjectionAnnotation`, issue candidates, and review candidates | bridge boundary remains live until claim-native increments replace it |
-| `SourceTranslationBatch` | migration continuity between `EvidenceSet`, `ClaimSet`, and current bridge outputs | keep the bundled bridge boundary honest while bounded proto-products are emitted beside it | live runtime boundary |
-| `TransactionFact` | bridge-only approximation of `EconomicFacts` | treat accepted bridge facts as the current approximation of accepted economic meaning, not as the final target contract | bridge-only until `EconomicFacts` lands |
-| `balance_snapshots.csv` | later `ReconciliationState` inputs | keep derived snapshots bridge-only; do not claim that they are target reconciliation kernels | bridge-only |
-| `balance_references.csv` | later `Checkpoint` and `ReconciliationState` inputs | keep source-backed and operator assertion references explicit as checkpoint or reconciliation inputs, not accepted checkpoint truth by themselves | bridge-only |
-| `IssueRecord` outputs | `GapCore` plus `GapExplanation` where semantics align | blocking current issues map to target gaps only when owner stage, scope, and blocker meaning are preserved | bridge-only until a stage adopts target gaps |
-| `NormalizationReviewRecord` outputs | review sidecars and paired gap explanations | advisory reviews remain review sidecars unless a paired blocking gap exists | bridge-only until a stage adopts target reviews |
+- a consumer may read the bridge surface or the target product, never both as
+  peer authorities
+- if a consumer is not yet migrated, it reads the derived bridge projection
+- if a consumer is migrated, it reads the target product only
 
-## Bridge-Only Outputs That Remain
+Compatibility rule:
 
-The following outputs remain bridge-only even after the first increment starts
-emitting bounded proto-products:
+- unchanged bridge outputs during the compatibility window must be reproducible
+  from the authoritative target kernel plus its declared upstream refs
+- compatibility projections may add bridge-local formatting or schema shaping,
+  but they may not invent semantic content that is absent from the authoritative
+  target product
 
-- `SourceTranslationBatch` remains the live transition bundle until later
-  increments replace it end to end
-- `TransactionFact` remains the accepted bridge approximation of economic truth
-  and must not be described as the final `EconomicFacts` kernel
-- bridge-era balance artifacts remain runtime inputs and reporting outputs, not
-  target reconciliation or checkpoint products
-- `accounting_intent_hint`, `tax_treatment_hint`, and `projection_hint` remain
-  bridge-era hint lanes that later stages may reference but must not recenter
-  as target economic truth
-- fact and location annotations remain bridge sidecars; they do not become the
-  only copy of claim, economic, reconciliation, or checkpoint meaning
+No-dual-center rule:
 
-## Issue And Review Migration
+- `SourceTranslationBatch`, `TransactionFact`, `balance_snapshots.csv`, and
+  `balance_references.csv` may remain live compatibility surfaces during
+  migration
+- none of those surfaces may remain a second architecture center once the
+  corresponding target product is authoritative for that scope
 
-Mapping rules from live bridge diagnostics into the target support model:
+## Cutover Matrix
 
-- a blocking `IssueRecord` becomes one `GapCore` plus one `GapExplanation`
-  only when the target stage can preserve the same owner stage, blocking
-  stages, scope, materiality, and confidence
-- `issue_id` remains the stable bridge diagnostic id until the replacement
-  stage emits its own target-native ids; do not invent a new id family without
-  carrying a stable source reference
-- `kind`, `severity`, `context_timestamp`, and typed provenance become gap
-  inputs, not free text to be reinterpreted later
-- an advisory `NormalizationReviewRecord` remains a review sidecar unless a
-  paired blocking condition also exists
-- when one blocking condition and one review share the same factual cause, the
-  gap owns the blocker and the review remains a sidecar keyed to the same
-  subject, scope, or decision record
-- do not upgrade reviews into gaps or downgrade gaps into reviews just to keep
-  bridge facts flowing
+Every implementation slice must name the authoritative writer and active reader
+for each affected surface before code lands. Use this matrix as the default
+cutover contract.
 
-The target support contracts still live in
-[Gaps And Readiness](gaps-and-readiness.md). This page only fixes the current
-bridge-to-target mapping rule.
+| Current surface | Authoritative source now | Authoritative source after slice | Derived compatibility projection | Active readers now | Target readers after cutover | Cutover gate | Retirement gate |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `translation_input_candidates.json` | planner-enabled normalization | `EvidenceSet` envelope and selection sidecars | optional planner review projection derived from `EvidenceSet` plus planning metadata | normalization review tools and planner inspection flows | evidence review and claim translation flows that read `EvidenceSet` directly | selected, superseded, and blocked membership are preserved with stable `selection_group_id` and `member_id` outcomes | retire once planner/operator review surfaces no longer require the legacy file |
+| `translation_input_plan.json` | planner-enabled normalization | `EvidenceSet` | `translation_input_plan.json` regenerated from `EvidenceSet` during the compatibility window | translation entry points that still expect a plan file | evidence consumers and claim translation that read `EvidenceSet` directly | one authoritative `EvidenceSet` exists for the capture and reproduces the same selected, superseded, and blocked decisions | retire when no in-scope reader requires the plan file and parity is enforced on `EvidenceSet` instead |
+| recognized statement parse outputs and balance rows | shared statement extraction outputs | `EvidenceSet` observations | statement-facing compatibility payloads derived from `EvidenceObservationRecord` sidecars | normalization review and statement debugging flows | claim translation and downstream support flows that read `EvidenceSet` observations | statement document identity, row anchors, quantities, and provenance are preserved under `EvidenceSet` | retire legacy parse-only outputs when all readers use `EvidenceSet` observations or declared sidecars |
+| `EconomicActivityDraft` | source translation boundary | `ClaimSet` | `EconomicActivityDraft` rows derived from accepted `InterpretationBundleRecord` and `ClaimRecord` kernels plus declared compatibility sidecars keyed by `claim_id` or `bundle_id` for `economic_kind`, `projection_hint`, `accounting_intent_hint`, `tax_treatment_hint`, `description`, `tx_hash_or_null`, `operation_group_id_or_null`, `confidence`, and `status` | `SourceTranslationBatch` assembly and bridge compilers | economic compilation that reads `ClaimSet` directly | first-slice claim field tables, `evidence_observation_refs`, bundle selection, and the retained legacy claim fields are all frozen either in canonical claim kernels or in declared compatibility sidecars | retire when no bridge compiler or batch builder still consumes drafts |
+| `SourceTranslationBatch` | source translation boundary | `ClaimSet` | `SourceTranslationBatch` bundle derived from `ClaimSet` plus declared compatibility sidecars for `economic_kind`, `projection_hint`, `accounting_intent_hint`, `tax_treatment_hint`, `description`, `tx_hash_or_null`, `operation_group_id_or_null`, `confidence`, and `status`, plus shared support artifacts | current normalization application surface and bridge interop flows | target application paths in `application/claims/` and later `application/economics/` | in-scope readers can be pointed to `ClaimSet` or a declared compatibility surface without semantic loss, and no retained batch-only field remains undefined | retire when no active runtime path reads the batch as its primary semantic surface |
+| `TransactionFact` and `facts.csv` | current bridge fact path | `EconomicFacts` | `TransactionFact` rows and `facts.csv` rendered from `EconomicFacts` plus declared upstream claim compatibility sidecars for `economic_kind`, `projection_hint`, `accounting_intent_hint`, `tax_treatment_hint`, `description`, `tx_hash_or_null`, `operation_group_id_or_null`, `confidence`, and `status` when legacy hint reproduction still needs them | balance builders, output renderers, oracle comparison flows | reconciliation, checkpoint, accounting, and tax paths that read `EconomicFacts` | accepted `EconomicEventRecord` and `EconomicLegRecord` parity is proven and current bridge facts are reproducible from `EconomicFacts` plus declared upstream compatibility sidecars rather than from bridge artifacts as peer authorities | retire when no runtime reader depends on `TransactionFact` as economic authority |
+| `balance_snapshots.csv` | current bridge balance reducers | `ReconciliationState` | `balance_snapshots.csv` derived from `ReconciliationState` for unmigrated balance surfaces | balance inspect/check/summarize and downstream review workflows | reconciliation readers and later checkpoint assembly that read `ReconciliationState` | continuity segments and balance targets exist for the in-scope subjects and reproduce current snapshot results | retire when active balance surfaces read `ReconciliationState` directly |
+| `balance_references.csv` | current bridge balance support path | `Checkpoint` and `ReconciliationState` | `balance_references.csv` derived from `ReconciliationState`, `Checkpoint`, and declared support sidecars | balance inspect/check/summarize and current checkpoint support workflows | checkpoint assembly and reconciliation readers that consume target support directly | direct `AssertionValue` fields, checkpoint candidates, and checkpoint assertions reproduce the current reference content for in-scope subjects | retire when no active surface consumes the CSV as its authoritative support input |
+| `exceptions.csv` and bridge `IssueRecord` outputs | stage-local bridge diagnostics | target product plus shared support artifacts | bridge issue projection derived from `GapCore` and `GapExplanation` when a target stage owns the blocker | operator review and current normalization diagnostics | target support reducers and readiness views | the owning target stage can preserve blocker scope, severity, materiality, and stage ownership | retire per stage when that stage emits target-native gaps for the same scope |
+| `normalization_reviews.csv` and `NormalizationReviewRecord` outputs | stage-local bridge advisory diagnostics | target product plus shared support artifacts | bridge review projection derived from `ReviewRecord` and `ReviewExplanation` | operator review and current normalization diagnostics | target review and readiness views | advisory review scope and provenance are preserved without turning reviews into blockers | retire per stage when that stage emits target-native reviews for the same scope |
+| `fact_annotations.json` and `location_annotations.json` | bridge-only sidecar generation | target products plus bridge/output compatibility sidecars | derived annotation sidecars keyed to target ids or bridge projection ids | current bridge renderers and comparison tooling | target-aware output and comparison flows that no longer require canonical annotation payloads in claims | no target semantic meaning depends on annotation payloads and bridge/output consumers can read derived sidecars instead | retire when the affected renderer or comparison flow no longer depends on the annotation file |
 
-## First-Increment Mapping Rules
+## Compatibility Sidecars And Support Mapping
 
-The default first increment is intentionally narrow:
+Bridge-only annotations and diagnostics keep their meaning only as compatibility
+surfaces during migration.
 
-- planner-enabled Coinbase retail export evidence
-- recognized Coinbase statement-backed balance observation flow
-- continued compatibility with current `SourceTranslationBatch`,
-  `TransactionFact`, `balance_references.csv`, and `cointracking_csv`
+Rules:
 
-First-increment rules:
+- `ProjectionAnnotation` remains bridge or output compatibility metadata only
+- no target `ClaimSet` family may be introduced for bridge hints, render notes,
+  or output annotations
+- if a current renderer or comparison path still needs annotation content, emit
+  it as a derived sidecar keyed to the relevant `claim_id`, `event_id`, or
+  bridge projection id
+- legacy claim-local bridge fields such as `economic_kind`, `projection_hint`,
+  `accounting_intent_hint`, `tax_treatment_hint`, `description`,
+  `tx_hash_or_null`, `operation_group_id_or_null`, `confidence`, and `status`
+  remain outside canonical `ClaimSet` kernels and survive only through
+  declared compatibility sidecars when a live bridge reader still needs them
+- `provider_operation_key` stays satisfied by canonical
+  `ActivityClaim.provider_activity_kind` and does not require a duplicate
+  compatibility-only field
 
-- `translation_input_candidates.json` remains planner candidate reasoning in
-  the `EvidenceSet` envelope or selection sidecars, while
-  `translation_input_plan.json` supplies the kernel `selection_status` records
-  for the increment
-- recognized statement rows become evidence observations first and
-  `BalanceObservationClaim` inputs second; they do not become evidence member
-  families or accepted checkpoint truth inside the increment
-- `EconomicActivityDraft` remains the provider-local pre-economic bridge boundary,
-  but its responsibilities are split conceptually into claim families so later
-  increments do not need to rediscover that cut
-- the shared compiler remains responsible for producing current bridge outputs
-  from accepted claims until `EconomicFacts` and later downstream products
-  replace that responsibility
-- first-slice observation classes, evidence member families, and bounded
-  `selection_group_id` rules are frozen only on
-  [First Slice Contract](../reference/first-slice-contract.md)
-- the first increment must not create a second active runtime center, a permanent
-  dual-write lane, or a repo-wide adapter-facet migration prerequisite
-- unchanged evidence must preserve selected evidence membership, claim identity
-  and ordering, compiled bridge facts, balance reference kinds, and
-  `cointracking_csv` projection compatibility as defined in
-  [First Slice Contract](../reference/first-slice-contract.md)
+Diagnostic mapping rules:
+
+- a blocking bridge `IssueRecord` maps to `GapCore` plus `GapExplanation` only
+  when the target stage can preserve blocker scope, severity, blocking stages,
+  and provenance
+- a bridge `NormalizationReviewRecord` maps to `ReviewRecord` plus
+  `ReviewExplanation`
+- reviews remain advisory even when they share the same factual cause as a gap
+- support artifacts never become claim families
+
+## First Bounded Slice Rules
+
+The default first upstream slice and first downstream slice use this page as
+their migration authority.
+
+Required cutovers now:
+
+- `translation_input_plan.json` becomes a compatibility projection from
+  `EvidenceSet`
+- `EconomicActivityDraft` and `SourceTranslationBatch` become compatibility
+  projections from `ClaimSet`
+- `TransactionFact` becomes a compatibility projection from `EconomicFacts`
+- `balance_snapshots.csv` becomes a compatibility projection from
+  `ReconciliationState`
+- `balance_references.csv` becomes a compatibility projection from
+  `ReconciliationState` and `Checkpoint`
+- current balance inspect/check/summarize remains on bridge compatibility
+  projections until those application surfaces are repointed to target products
+
+## Retirement Discipline
+
+No bridge artifact is retired until all of the following are true:
+
+- the authoritative target product for the affected scope is persisted
+- every active reader for that scope has a declared target reader or derived
+  compatibility reader
+- parity and replay gates for the affected slice pass on unchanged evidence
+- current-state docs are updated if the live runtime surface actually changed
+
+Bridge retirement is therefore per scope and per reader, not one repo-wide
+rename event.

--- a/docs/concepts/bridge-to-target-mapping.md
+++ b/docs/concepts/bridge-to-target-mapping.md
@@ -71,7 +71,7 @@ The current bridge families that matter for target mapping are:
 | --- | --- | --- | --- |
 | `translation_input_candidates.json` | `EvidenceSet` envelope and selection sidecars | preserve planner candidate membership, coverage, and comparability as evidence-selection reasoning; these candidates do not become `EvidenceSet` kernel records | remains bridge-owned until `EvidenceSet` lands |
 | `translation_input_plan.json` | `EvidenceSet` kernel | selected, superseded, and blocked planner decisions from this file supply the kernel `selection_status` records under one deterministic `selection_group_id` | dual-emitted during the first increment |
-| recognized statement balance rows | `EvidenceSet` observations and `BalanceObservationClaim` inputs | preserve statement document identity, row identity, as-of time, precision, quantity, and provenance without forcing final checkpoint acceptance | dual-emitted during the first increment |
+| recognized statement balance rows | `EvidenceSet` observations and `BalanceObservationClaim` inputs | preserve statement document identity, row identity, as-of time, precision, quantity, and provenance as typed observations under the owning statement document without forcing final checkpoint acceptance | dual-emitted during the first increment |
 | `EconomicActivityDraft` | `ClaimSet` | split one draft into `ActivityClaim`, `InstrumentIdentityClaim`, `LocationClaim`, `BalanceObservationClaim`, `ValuationClaim`, `ProjectionAnnotation`, issue candidates, and review candidates | bridge boundary remains live until claim-native increments replace it |
 | `SourceTranslationBatch` | migration continuity between `EvidenceSet`, `ClaimSet`, and current bridge outputs | keep the bundled bridge boundary honest while bounded proto-products are emitted beside it | live runtime boundary |
 | `TransactionFact` | bridge-only approximation of `EconomicFacts` | treat accepted bridge facts as the current approximation of accepted economic meaning, not as the final target contract | bridge-only until `EconomicFacts` lands |
@@ -137,14 +137,17 @@ First-increment rules:
   `translation_input_plan.json` supplies the kernel `selection_status` records
   for the increment
 - recognized statement rows become evidence observations first and
-  `BalanceObservationClaim` inputs second; they do not become accepted
-  checkpoint truth inside the increment
+  `BalanceObservationClaim` inputs second; they do not become evidence member
+  families or accepted checkpoint truth inside the increment
 - `EconomicActivityDraft` remains the provider-local pre-economic bridge boundary,
   but its responsibilities are split conceptually into claim families so later
   increments do not need to rediscover that cut
 - the shared compiler remains responsible for producing current bridge outputs
   from accepted claims until `EconomicFacts` and later downstream products
   replace that responsibility
+- first-slice observation classes, evidence member families, and bounded
+  `selection_group_id` rules are frozen only on
+  [First Slice Contract](../reference/first-slice-contract.md)
 - the first increment must not create a second active runtime center, a permanent
   dual-write lane, or a repo-wide adapter-facet migration prerequisite
 - unchanged evidence must preserve selected evidence membership, claim identity

--- a/docs/concepts/current-bridge-contracts.md
+++ b/docs/concepts/current-bridge-contracts.md
@@ -1,6 +1,6 @@
 ---
 title: "Current Bridge Contracts"
-summary: "Owning concept page for the live bridge contracts, bridge artifacts, and current schema rules."
+summary: "Primary concept page for the live bridge contracts, bridge artifacts, and current schema rules."
 doc_type: concept
 audience: human
 owner: repo
@@ -12,7 +12,7 @@ Use this page when you need the current runtime truth for the bridge that
 exists today. This document owns the live bridge contracts and artifact rules.
 
 The current bridge is real runtime behavior, not a historical footnote. It is
-the active implementation seam until later bounded slices replace it. At the
+the active implementation boundary until later bounded increments replace it. At the
 same time, it is not the final architecture center. Future stage contracts live
 in [Pipeline Stage Contracts](pipeline-stage-contracts.md).
 
@@ -27,7 +27,7 @@ The live bridge currently centers on:
 
 That bridge is:
 
-- the live implementation seam
+- the live implementation boundary
 - the current delivery path
 - the current parity baseline
 - not the final architecture center
@@ -40,7 +40,7 @@ That bridge is:
 - planner-enabled adapters provide translation input candidates and the core
   selects the winning plan
 - ambiguity blocks fact and balance artifact emission
-- assembled source datasets are the reconciliation input surface
+- assembled source datasets are the reconciliation input
 - provenance stays typed in runtime models and is flattened only at artifact
   boundaries
 - operator-confirmed balance references may support runtime progress but do not
@@ -255,7 +255,7 @@ Rules:
 
 - the current serializer persists all of these fields together because that is
   live bridge truth
-- this mixed shape is not the canonical target kernel rule for future products
+- this mixed shape is not the target kernel rule for future products
 - forward transformation rules and bounded proto-product mapping now live in
   [Bridge To Target Mapping](bridge-to-target-mapping.md)
 

--- a/docs/concepts/current-bridge-contracts.md
+++ b/docs/concepts/current-bridge-contracts.md
@@ -259,6 +259,23 @@ Rules:
 - forward transformation rules and bounded proto-product mapping now live in
   [Bridge To Target Mapping](bridge-to-target-mapping.md)
 
+### Bridge Fact Replay Fingerprint
+
+For first-slice replay and parity checks, compiled bridge facts use one bridge
+replay fingerprint contract.
+
+Rules:
+
+- fingerprint input is `[schema_version, ordered_fact_rows]`
+- fact row order is `[timestamp, effective_at_or_null, fact_id]`
+- leg order within each fact is `leg_id`
+- include `fact_id`, identity fields, time fields, participant fields,
+  semantic fields, `legs`, `FactLegPolicy`, and `status`
+- exclude `description`, `raw_file`, `raw_row_ref`, `confidence`,
+  `fact_annotations.json`, and other bridge sidecars
+- serialize as stable UTF-8 JSON with stable object-key order and SHA-256
+  hashing
+
 ### Current Normalization Window Contract
 
 - runtime timestamps are timezone-aware UTC in drafts, facts, balance
@@ -309,8 +326,8 @@ Rules:
 
 ### Transitional Adapter Draft Seam
 
-Source normalization should translate through `EconomicActivityDraft` until all
-adapters emit `TransactionFact` artifacts directly.
+Source normalization currently translates through `EconomicActivityDraft`
+before shared bridge fact compilation.
 
 Required draft responsibilities:
 

--- a/docs/concepts/current-bridge-contracts.md
+++ b/docs/concepts/current-bridge-contracts.md
@@ -16,6 +16,9 @@ the active implementation boundary until later bounded increments replace it. At
 same time, it is not the final architecture center. Future stage contracts live
 in [Pipeline Stage Contracts](pipeline-stage-contracts.md).
 
+During migration, bridge compatibility projections may remain valid runtime
+surfaces for unmigrated readers, but they are never target contracts.
+
 ## Bridge Purpose And Limits
 
 The live bridge currently centers on:

--- a/docs/concepts/current-bridge-contracts.md
+++ b/docs/concepts/current-bridge-contracts.md
@@ -216,6 +216,49 @@ Current bridge bundle to preserve:
   - no other non-primary leg kinds
   - renderers derive inbound and outbound adapter concepts from sign
 
+### Mixed Kernel Bridge Note
+
+`TransactionFact` currently mixes computationally important fields, bridge
+semantics, and bridge envelope detail in one record.
+
+Computational core still carried today:
+
+- `fact_id`
+- `source`
+- `adapter_id`
+- `timestamp`
+- `effective_at`
+- `effective_precision`
+- `location_id`
+- `legs`
+- `leg_policy`
+
+Bridge semantic layer still carried today:
+
+- `economic_kind`
+- `projection_hint`
+- `accounting_intent_hint`
+- `tax_treatment_hint`
+
+Bridge envelope and audit detail still carried today:
+
+- `description`
+- `provider_operation_key`
+- `operation_group_id`
+- `tx_hash`
+- `raw_file`
+- `raw_row_ref`
+- `confidence`
+- `status`
+
+Rules:
+
+- the current serializer persists all of these fields together because that is
+  live bridge truth
+- this mixed shape is not the canonical target kernel rule for future products
+- forward transformation rules and bounded proto-product mapping now live in
+  [Bridge To Target Mapping](bridge-to-target-mapping.md)
+
 ### Current Normalization Window Contract
 
 - runtime timestamps are timezone-aware UTC in drafts, facts, balance
@@ -318,3 +361,6 @@ Rules:
   than mutating current bridge pages into a blended current-and-future hybrid
 - treat this bridge as the active runtime seam that later target slices must
   replace cleanly, not as a structure that should be immortalized
+- use [Bridge To Target Mapping](bridge-to-target-mapping.md) as the single
+  authority for how these bridge seams land in bounded proto-products during
+  migration

--- a/docs/concepts/domain-ontology.md
+++ b/docs/concepts/domain-ontology.md
@@ -122,6 +122,33 @@ Rules:
   redefine them into incompatible local variants
 - accepted checkpoint truth should be modeled as checkpoint assertions first
   and checkpoint containers second
+- checkpoint assertions carry one `CheckpointAssertionValue`, not one
+  untyped convenience payload
+
+## `CheckpointAssertionValue`
+
+`CheckpointAssertionValue` is the target union carried by
+`Checkpoint.accepted_value`.
+
+Variants:
+
+- `QuantityValue`
+- `MoneyValue`
+- `OwnerValue`
+- `LocationValue`
+
+Variant rules:
+
+- `QuantityValue` carries one signed quantity plus the subject references needed
+  to explain what was measured
+- `MoneyValue` carries one monetary amount plus one currency
+- `OwnerValue` carries one accepted ownership state over legal-owner,
+  beneficial-owner, or counterparty references
+- `LocationValue` carries one accepted location state
+- the union remains explicit so a later implementation cannot silently use one
+  scalar type to stand in for quantity, money, ownership, and location truth
+- checkpoint assertion ids and fingerprints must treat the accepted-value
+  variant and its canonical content as semantically relevant
 
 ## Valuation
 
@@ -375,39 +402,44 @@ Bridge-specific classification rules live in
 - do not force a docs-only bridge rename just to make the target vocabulary
   appear already implemented
 
-## Package Direction
+## Required Package Ownership
 
-The target package direction should follow the ontology and stage ownership:
+The target package layout follows stage ownership and is not advisory.
 
-- `domain/claims/` for source-local claim types
-- `domain/economics/` for economic events, legs, valuations, settlement, and
-  lifecycle state
-- `domain/reconciliation/` for continuity, linkage, readiness, and checkpoint
-  candidacy
-- `domain/checkpoints/` for accepted checkpoint truth and checkpoint
-  assertions
+Required domain ownership:
+
+- `domain/evidence/` for evidence-member identity, typed observations, and
+  other source-local evidence concepts
+- `domain/claims/` for source-local claim types and interpretation-group
+  semantics
+- `domain/economics/` for economic events, economic legs, valuations,
+  settlement state, and lifecycle state
+- `domain/reconciliation/` for continuity segments, link state, balance
+  targets, readiness reducers, and checkpoint candidacy
+- `domain/checkpoints/` for accepted checkpoint truth, checkpoint assertions,
+  and `CheckpointAssertionValue`
 - `domain/accounting/` for journals, entries, postings, and validation outputs
-- `domain/tax/` for tax inputs, policy contracts, carry-forward state, and
-  outputs
+- `domain/tax/` for tax determinants, basis transitions, tax-policy contracts,
+  carry-forward state, and outputs
 
-Suggested application ownership:
+Required application ownership:
 
-- `application/intake/` for capture planning, apply, and evidence selection
-- `application/evidence/` for shared statement extraction and provenance
-  locator handling
+- `application/intake/` for capture planning and apply
+- `application/evidence/` for shared statement extraction, evidence selection,
+  and provenance locator handling
 - `application/profiling/` for capture profile construction, inventory
   inspection, and timezone review
 - `application/normalization/` for evidence-to-claim translation planning and
   current bridge artifact production
 - `application/normalization/assembly/` for deterministic merge of accepted
   capture outputs into assembled source datasets
-- `application/reconciliation/` for links, continuity, readiness reducers, and
-  checkpoint candidates
+- `application/reconciliation/` for continuity, linkage, balance-target
+  evaluation, readiness reducers, and checkpoint candidates
 - `application/checkpoints/` for checkpoint evidence assembly, manual balance
   submission validation, and checkpoint acceptance
 - `application/accounting/` for journal expansion, validation, and summaries
-- `application/tax/` for tax-input assembly, policy selection, and tax-output
-  rendering
+- `application/tax/` for tax-input assembly, basis transitions, policy
+  selection, and tax-output rendering
 - `application/outputs/` for downstream renderer orchestration
 
 Boundary rules:
@@ -417,5 +449,12 @@ Boundary rules:
 - `application/` depends on domain and ports
 - `domain/` has no infrastructure imports
 
-This is target direction only. It does not claim the current runtime already
-uses that package layout.
+Implementation-shaping rule:
+
+- use this page plus
+  [First Downstream Slice Contract](../reference/first-downstream-slice-contract.md)
+  when choosing where new target-stage work lands
+- do not leave package placement to drafting-time judgment once the target
+  contract already names the owning stage
+- this page defines the required target ownership model; it does not claim the
+  current runtime already uses that package layout

--- a/docs/concepts/domain-ontology.md
+++ b/docs/concepts/domain-ontology.md
@@ -102,6 +102,9 @@ Implication:
 - shared infrastructure may reference them generically only through the
   `SubjectRef` rules owned by
   [Gaps And Readiness](gaps-and-readiness.md)
+- the same shared-infrastructure rule applies when generic attachment is needed
+  for `Instrument`, `Location`, ownership identities, counterparties, or
+  `CheckpointAssertion`
 
 ## Valuation
 
@@ -122,6 +125,9 @@ Rules:
 
 - valuation belongs in the economic model when it changes checkpoint,
   accounting, or tax behavior
+- valuation purpose should be explicit enough to distinguish checkpoint,
+  accounting, tax, and general market-observation use instead of letting one
+  valuation silently stand in for another job
 - valuation should not be hidden only inside renderer metadata or one-off
   policy blobs
 - missing or uncertain valuation should remain explicit when downstream stages
@@ -157,6 +163,22 @@ The target economic layer must be able to express:
 
 Economic facts should describe what happened economically, not what one export
 format calls the row.
+
+Minimum invariant seams:
+
+- one stable event identity
+- one event-kind family that distinguishes asset movement, cash movement,
+  obligations or rights, settlement, collateral, financing, fees or rebates,
+  withholding, lifecycle restructure, and correction or supersession behavior
+- one stable leg set with signed quantities and explicit leg roles
+- explicit effective time and temporal precision when exact timing is not known
+- explicit settlement and lifecycle state where continuity or later treatment
+  depends on them
+- explicit supersession lineage for corrections instead of in-place mutation
+- ownership and counterparty references where they are known and later stages
+  rely on them
+- valuation records with explicit purpose where downstream behavior depends on
+  them
 
 ## Ownership And Counterparty Modeling
 

--- a/docs/concepts/domain-ontology.md
+++ b/docs/concepts/domain-ontology.md
@@ -38,7 +38,7 @@ The target model should use these concepts explicitly:
 - `AssertionValue`
 - `CheckpointAssertion`
 - `Posting`
-- `BasisPoolRef`
+- `BasisPool`
 
 These are not interchangeable labels. They represent distinct business
 concepts, and the model should keep them distinct even when one adapter or one
@@ -78,9 +78,9 @@ The target model uses explicit ref seams rather than one generic identity pool.
 | `LegalOwnerRef` | one resolved legal-owner identity | `[legal_owner_id]` |
 | `BeneficialOwnerRef` | one resolved beneficial-owner identity | `[beneficial_owner_id]` |
 | `CounterpartyRef` | one resolved counterparty identity | `[counterparty_id]` |
-| `ContractRef` | one resolved contract identity | `[contract_kind, legal_owner_ref_or_null, beneficial_owner_ref_or_null, counterparty_ref_or_null, contract_anchor]` |
-| `PositionRef` | one resolved economic position identity | `[beneficial_owner_ref, location_ref_or_null, instrument_ref_or_null, contract_ref_or_null, position_scope]` |
-| `BasisPoolRef` | one pooled-basis or basis-tracking identity seam | `[tax_policy_id, jurisdiction_or_regime, beneficial_owner_ref, pool_scope]` |
+| `ContractRef` | one resolved contract identity | `[contract_kind, legal_owner_ref, beneficial_owner_ref, counterparty_ref, contract_key]` |
+| `PositionRef` | one resolved economic position identity | `[beneficial_owner_ref, location_ref, instrument_ref, contract_ref, position_key]` |
+| `BasisPoolRef` | one pooled-basis or basis-tracking identity seam | `[tax_policy_id, jurisdiction_or_regime, beneficial_owner_ref, pool_key]` |
 
 Rules:
 
@@ -88,11 +88,13 @@ Rules:
 - resolve only the identity that the current stage can prove safely
 - preserve unresolved identity as explicit blockers instead of guessing across
   seams
+- nullable tuple slots keep the base ref name; nullability is part of the
+  tuple contract, not the tuple-slot name
 - when a stable-id recipe or fingerprint input includes one of these refs, use
   the canonical tuple above rather than an object-name shorthand
-- `contract_anchor` is the stage-owned stable discriminator for one contract
+- `contract_key` is the stage-owned stable discriminator for one contract
   instance
-- `position_scope` is the stage-owned stable discriminator for one economic
+- `position_key` is the stage-owned stable discriminator for one economic
   exposure or holding surface
 
 ### `ContractRef` Versus `PositionRef`
@@ -151,7 +153,7 @@ Variant rules:
 - assertion ids and fingerprints must treat the value variant and its canonical
   content as semantically relevant
 - the canonical `AssertionValue` fingerprint uses one canonical UTF-8 JSON array
-  `[assertion_value_kind, canonical_value_payload]`
+  `[assertion_value_kind, value_content]`
 
 ## `CheckpointAssertion`
 
@@ -261,7 +263,7 @@ format calls the row.
 Minimum invariant seams:
 
 - one stable event identity
-- one event-family vocabulary that distinguishes asset movement, cash movement,
+- one event-kind vocabulary that distinguishes asset movement, cash movement,
   obligations or rights, settlement, collateral, financing, fees or rebates,
   withholding, lifecycle restructure, and correction or supersession behavior
 - one stable leg set with signed quantities and explicit leg roles
@@ -331,8 +333,8 @@ First-slice rule:
 - `location_ref` must resolve to the Coinbase-held custodial spot location or
   sub-location in scope
 - `instrument_ref` must resolve to the in-scope spot asset
-- `contract_ref_or_null` stays `null` in the first downstream slice
-- later slices may widen `position_scope` values and contract participation,
+- `contract_ref` stays `null` in the first downstream slice
+- later slices may widen `position_key` values and contract participation,
   but they must keep the canonical tuple shape unchanged
 
 ## Bridge Classifications Versus Target Ontology
@@ -358,6 +360,12 @@ Bridge-specific classification rules live in
 - keep bridge names in live bridge code until later implementation slices land
 - use target ontology names when defining new target-layer concepts in docs and
   later implementation work
+- distinguish concept, ref, and record names explicitly:
+  `BasisPool` is a concept, `BasisPoolRef` is an identity seam, and
+  `*Record` names belong to persisted kernels
+- do not bake bridge, legacy, current, or compatibility qualifiers into
+  target-layer concept names or helper ids unless the name is intentionally
+  current-state or adapter-local
 - do not force a docs-only bridge rename just to make the target vocabulary
   appear already implemented
 

--- a/docs/concepts/domain-ontology.md
+++ b/docs/concepts/domain-ontology.md
@@ -1,6 +1,6 @@
 ---
 title: "Domain Ontology"
-summary: "Owning concept page for the target economic ontology, identity seams, package direction, and bridge-versus-target modeling rules."
+summary: "Primary concept page for the target economic ontology, identity boundaries, package direction, and bridge-versus-target modeling rules."
 doc_type: concept
 audience: human
 owner: repo
@@ -9,14 +9,14 @@ nav_order: 35
 ---
 
 Use this page when shaping the target domain model. This document owns the
-target ontology and identity seams.
+target ontology and identity boundaries.
 
 Current bridge note:
 
 - current bridge code still uses `EconomicActivityDraft`, `TransactionFact`,
   layered bridge classifications, and fact-leg policies
 - those bridge contracts remain current-state runtime truth
-- this page defines the target ontology that later implementation slices should
+- this page defines the target ontology that later implementation increments should
   grow toward
 
 ## Core Business Concepts
@@ -42,7 +42,7 @@ The target model should use these concepts explicitly:
 
 These are not interchangeable labels. They represent distinct business
 concepts, and the model should keep them distinct even when one adapter or one
-reporting surface happens to collapse them operationally.
+report happens to collapse them operationally.
 
 ## Generic Core Requirements
 
@@ -56,7 +56,7 @@ The target core should remain:
 Rules:
 
 - crypto is the current filing scope, not the ontology center
-- CoinTracking is an edge import, export, and oracle surface, not a runtime
+- CoinTracking is an edge import, export, and oracle input, not a runtime
   dependency
 - persistence implements the model; it does not define the model
 - no wrapper lanes, compatibility shims, or legacy parallel runtime models
@@ -65,9 +65,9 @@ Rules:
   ready
 - tests and parity must be preserved or strengthened through refactors
 
-## Identity Seams
+## Identity Boundaries
 
-Keep these seams separate:
+Keep these boundaries separate:
 
 - instrument identity
 - contract identity
@@ -82,7 +82,7 @@ Rules:
 - do not collapse these identities into one generic id family
 - resolve only the identity that the current stage can prove safely
 - preserve unresolved identity as explicit blockers instead of guessing across
-  seams
+  boundaries
 
 Identity resolution should be incremental and explicit. Earlier stages may know
 less than later stages, and that is acceptable as long as uncertainty stays

--- a/docs/concepts/domain-ontology.md
+++ b/docs/concepts/domain-ontology.md
@@ -1,6 +1,6 @@
 ---
 title: "Domain Ontology"
-summary: "Primary concept page for the target economic ontology, identity boundaries, package direction, and bridge-versus-target modeling rules."
+summary: "Owning concept page for the target economic ontology, entity and ref seams, package direction, and bridge-versus-target modeling rules."
 doc_type: concept
 audience: human
 owner: repo
@@ -9,35 +9,35 @@ nav_order: 35
 ---
 
 Use this page when shaping the target domain model. This document owns the
-target ontology and identity boundaries.
+target ontology, entity seams, ref recipes, and forward package direction.
 
 Current bridge note:
 
 - current bridge code still uses `EconomicActivityDraft`, `TransactionFact`,
   layered bridge classifications, and fact-leg policies
 - those bridge contracts remain current-state runtime truth
-- this page defines the target ontology that later implementation increments should
-  grow toward
+- this page defines the target ontology that later implementation increments
+  should grow toward
 
 ## Core Business Concepts
 
 The target model should use these concepts explicitly:
 
 - `Instrument`
-- `Position`
-- `Contract`
 - `Location`
 - `LegalOwner`
 - `BeneficialOwner`
 - `Counterparty`
+- `Contract`
+- `Position`
 - `EconomicEvent`
 - `EconomicLeg`
+- `Valuation`
 - `SettlementState`
 - `LifecycleEvent`
-- `Valuation`
+- `AssertionValue`
 - `CheckpointAssertion`
 - `Posting`
-- `TaxInput`
 - `BasisPoolRef`
 
 These are not interchangeable labels. They represent distinct business
@@ -65,70 +65,71 @@ Rules:
   ready
 - tests and parity must be preserved or strengthened through refactors
 
-## Identity Boundaries
+## Entity And Ref Seams
 
-Keep these boundaries separate:
+The target model uses explicit ref seams rather than one generic identity pool.
 
-- instrument identity
-- contract identity
-- position identity
-- location identity
-- legal owner identity
-- beneficial owner identity
-- counterparty identity
+### Canonical Ref Shapes
+
+| Ref | Meaning | Canonical tuple |
+| --- | --- | --- |
+| `InstrumentRef` | one resolved instrument identity | `[instrument_id]` |
+| `LocationRef` | one resolved location identity | `[location_id]` |
+| `LegalOwnerRef` | one resolved legal-owner identity | `[legal_owner_id]` |
+| `BeneficialOwnerRef` | one resolved beneficial-owner identity | `[beneficial_owner_id]` |
+| `CounterpartyRef` | one resolved counterparty identity | `[counterparty_id]` |
+| `ContractRef` | one resolved contract identity | `[contract_kind, legal_owner_ref_or_null, beneficial_owner_ref_or_null, counterparty_ref_or_null, contract_anchor]` |
+| `PositionRef` | one resolved economic position identity | `[beneficial_owner_ref, location_ref_or_null, instrument_ref_or_null, contract_ref_or_null, position_scope]` |
+| `BasisPoolRef` | one pooled-basis or basis-tracking identity seam | `[tax_policy_id, jurisdiction_or_regime, beneficial_owner_ref, pool_scope]` |
 
 Rules:
 
-- do not collapse these identities into one generic id family
+- do not collapse these refs into one generic id family
 - resolve only the identity that the current stage can prove safely
 - preserve unresolved identity as explicit blockers instead of guessing across
-  boundaries
+  seams
+- when a stable-id recipe or fingerprint input includes one of these refs, use
+  the canonical tuple above rather than an object-name shorthand
+- `contract_anchor` is the stage-owned stable discriminator for one contract
+  instance
+- `position_scope` is the stage-owned stable discriminator for one economic
+  exposure or holding surface
 
-Identity resolution should be incremental and explicit. Earlier stages may know
-less than later stages, and that is acceptable as long as uncertainty stays
-visible.
-
-## `Contract` Versus `Position`
+### `ContractRef` Versus `PositionRef`
 
 Do not collapse `Contract` and `Position`.
 
-- `Contract` is a specific agreement instance with terms
+- `Contract` is a specific agreement instance with terms, rights, and duties
 - `Position` is an economic exposure or holding state that may arise from one
   contract, many contracts, or no explicit contract
 
-Implication:
+Implications:
 
 - business logic should model `Contract` and `Position` explicitly where the
   distinction matters
-- shared infrastructure may reference them generically only through the
+- shared infrastructure may point at them generically only through the
   `SubjectRef` rules owned by
   [Gaps And Readiness](gaps-and-readiness.md)
 - the same shared-infrastructure rule applies when generic attachment is needed
   for `Instrument`, `Location`, ownership identities, counterparties, or
   `CheckpointAssertion`
 
-## `CheckpointAssertion`
-
-`CheckpointAssertion` is the accepted checkpoint-truth record for one subject
-and one as-of point.
+## Ownership And Counterparty Modeling
 
 Rules:
 
-- it is distinct from a reconciliation `CheckpointCandidate`
-- it is distinct from a computed `BalanceSnapshot`
-- it is distinct from a raw `BalanceReference`
-- it is distinct from the containing accepted `Checkpoint`
-- downstream stages may consume checkpoint assertions, but they must not
-  redefine them into incompatible local variants
-- accepted checkpoint truth should be modeled as checkpoint assertions first
-  and checkpoint containers second
-- checkpoint assertions carry one shared `AssertionValue`, not one untyped
-  convenience payload
+- beneficial ownership is not interchangeable with legal ownership
+- counterparty identity is a separate seam, not an ownership alias
+- when an event changes ownership or legal rights in a way that matters later,
+  preserve that explicitly rather than hiding it behind a generic transfer
+  label
+- unresolved ownership transitions should remain visible to reconciliation,
+  checkpoint, accounting, or tax as appropriate
 
 ## `AssertionValue`
 
-`AssertionValue` is the shared value union carried by accepted checkpoint
-assertions and reconciliation comparison values.
+`AssertionValue` is the shared value union reused by reconciliation targets,
+accepted checkpoints, accounting reuse, and downstream tax reasoning.
 
 Variants:
 
@@ -147,12 +148,28 @@ Variant rules:
 - `LocationValue` carries one accepted location state
 - the union remains explicit so a later implementation cannot silently use one
   scalar type to stand in for quantity, money, ownership, and location truth
-- `CheckpointAssertion.accepted_value` carries exactly one `AssertionValue`
-- downstream `BalanceTargetRecord.expected_value` and
-  `BalanceTargetRecord.observed_value_or_null` reuse the same union instead of
-  inventing a second reconciliation-only value type
-- exact field, serialization, and fingerprint rules for the shared union live
-  in [Target Contract Primitives](../reference/target-contract-primitives.md)
+- assertion ids and fingerprints must treat the value variant and its canonical
+  content as semantically relevant
+- the canonical `AssertionValue` fingerprint uses one canonical UTF-8 JSON array
+  `[assertion_value_kind, canonical_value_payload]`
+
+## `CheckpointAssertion`
+
+`CheckpointAssertion` is the accepted checkpoint-truth record for one subject
+and one as-of point.
+
+Rules:
+
+- it is distinct from a reconciliation `CheckpointCandidate`
+- it is distinct from a computed `BalanceSnapshot`
+- it is distinct from a raw `BalanceReference`
+- it is distinct from the containing accepted `Checkpoint`
+- downstream stages may consume checkpoint assertions, but they must not
+  redefine them into incompatible local variants
+- accepted checkpoint truth should be modeled as checkpoint assertions first
+  and checkpoint containers second
+- checkpoint assertions carry one `AssertionValue`, not one untyped convenience
+  payload
 
 ## Valuation
 
@@ -164,20 +181,26 @@ Minimum valuation concerns:
 - currency
 - purpose
 - timestamp
-- precision
 - source
 - confidence
 - provenance
+
+### `ValuationPurpose`
+
+Shared vocabulary:
+
+- `economic_observation`
+- `checkpoint_support`
+- `accounting_measurement`
+- `tax_measurement`
+- `market_reference`
 
 Rules:
 
 - valuation belongs in the economic model when it changes checkpoint,
   accounting, or tax behavior
-- when downstream behavior depends on persisted valuation truth, the target
-  runtime emits first-class `ValuationRecord` rows under `EconomicFacts`
-- valuation purpose should be explicit enough to distinguish checkpoint,
-  accounting, tax, and general market-observation use instead of letting one
-  valuation silently stand in for another job
+- valuation purpose must be explicit enough to distinguish economic,
+  checkpoint, accounting, tax, and market-reference jobs
 - valuation should not be hidden only inside renderer metadata or one-off
   policy blobs
 - missing or uncertain valuation should remain explicit when downstream stages
@@ -190,7 +213,8 @@ Time rules must survive replay, retroactive correction, and cross-stage audit.
 Required distinctions:
 
 - `effective_at` expresses when the economic or checkpoint meaning applies
-- `effective_precision` preserves whether that time is exact or date-scoped
+- date-scoped and timestamp-scoped meaning stay distinct in canonical scalar
+  form
 - `recorded_at` expresses when the system accepted or recorded the later-stage
   truth
 
@@ -202,9 +226,6 @@ Rules:
   than mutating prior accepted truth in place
 - later stages may compare `effective_at` and `recorded_at`, but they should
   not collapse them into one timeline just to make replay look simpler
-- earlier accepted records are never rewritten in place; later accepted records
-  preserve correction lineage through their own `recorded_at` plus explicit
-  supersession references
 
 ## Economic Model
 
@@ -240,30 +261,18 @@ format calls the row.
 Minimum invariant seams:
 
 - one stable event identity
-- one event-kind family that distinguishes asset movement, cash movement,
+- one event-family vocabulary that distinguishes asset movement, cash movement,
   obligations or rights, settlement, collateral, financing, fees or rebates,
   withholding, lifecycle restructure, and correction or supersession behavior
 - one stable leg set with signed quantities and explicit leg roles
-- explicit effective time and temporal precision when exact timing is not known
+- explicit effective time in canonical temporal form
 - explicit settlement and lifecycle state where continuity or later treatment
   depends on them
 - explicit supersession lineage for corrections instead of in-place mutation
-- ownership and counterparty references where they are known and later stages
-  rely on them
+- ownership and counterparty refs where they are known and later stages rely on
+  them
 - valuation records with explicit purpose where downstream behavior depends on
   them
-
-## Ownership And Counterparty Modeling
-
-Rules:
-
-- beneficial ownership is not interchangeable with legal ownership
-- counterparty identity is a separate seam, not an ownership alias
-- when an event changes ownership or legal rights in a way that matters later,
-  preserve that explicitly rather than hiding it behind a generic transfer
-  label
-- unresolved ownership transitions should remain visible to reconciliation,
-  checkpoint, accounting, or tax as appropriate
 
 ## `SettlementState`
 
@@ -285,23 +294,6 @@ Rules:
   continuity matters
 - settlement state should not be inferred later from one output-specific row
   label when the economic model can carry it directly
-
-Allowed transitions:
-
-| Current state | Allowed next states | Terminal |
-| --- | --- | --- |
-| `unknown` | `pending`, `partial`, `settled`, `failed`, `reversed` | no |
-| `pending` | `partial`, `settled`, `failed`, `reversed` | no |
-| `partial` | `settled`, `failed`, `reversed` | no |
-| `settled` | `reversed` | no |
-| `failed` | none | yes |
-| `reversed` | none | yes |
-
-Rules:
-
-- accepted state must move only through the transitions above
-- `failed` and `reversed` are terminal settlement states for one accepted
-  event chain
 
 ## `LifecycleEvent`
 
@@ -326,45 +318,22 @@ Rules:
 - lifecycle events belong in the target economic model, not only in adapter
   annotations or tax-policy notes
 
-Allowed transitions:
+## First Downstream Slice Restriction
 
-| Current lifecycle state | Allowed next states | Terminal |
-| --- | --- | --- |
-| `created` | `amended`, `migrated`, `rolled`, `restructured`, `terminated`, `superseded` | no |
-| `amended` | `amended`, `migrated`, `rolled`, `restructured`, `terminated`, `superseded` | no |
-| `migrated` | `amended`, `rolled`, `restructured`, `terminated`, `superseded` | no |
-| `rolled` | `amended`, `rolled`, `restructured`, `terminated`, `superseded` | no |
-| `restructured` | `amended`, `migrated`, `rolled`, `restructured`, `terminated`, `superseded` | no |
-| `terminated` | none | yes |
-| `superseded` | none | yes |
+The first bounded downstream slice intentionally uses a narrow `PositionRef`
+surface for Coinbase-held spot balances.
 
-Rules:
+First-slice rule:
 
-- accepted lifecycle state must move only through the transitions above
-- `terminated` and `superseded` are terminal lifecycle states for one accepted
-  chain
-
-## Basis Pool
-
-`BasisPoolRef` is the shared identity seam for pooled-basis or basis-tracking
-state reused by tax inputs and policy execution.
-
-Minimum key dimensions:
-
-- tax policy
-- jurisdiction or regime
-- beneficial owner
-- pool scope
-
-Rules:
-
-- basis pools are first-class domain seams, not renderer metadata
-- reconciliation and checkpoint stages may reference basis-relevant state, but
-  tax owns basis-pool transitions and treatment
-- pooled-basis jurisdictions must not force each stage to invent its own pool
-  identity model
-- `BasisPoolRef` serializes and sorts as
-  `[tax_policy_id, jurisdiction_or_regime, beneficial_owner_ref, pool_scope]`
+- the first downstream slice may use only
+  `PositionRef = [beneficial_owner_ref, location_ref, instrument_ref, null, "custodial_spot_balance"]`
+- `beneficial_owner_ref` must resolve to the filing beneficial owner in scope
+- `location_ref` must resolve to the Coinbase-held custodial spot location or
+  sub-location in scope
+- `instrument_ref` must resolve to the in-scope spot asset
+- `contract_ref_or_null` stays `null` in the first downstream slice
+- later slices may widen `position_scope` values and contract participation,
+  but they must keep the canonical tuple shape unchanged
 
 ## Bridge Classifications Versus Target Ontology
 
@@ -381,68 +350,16 @@ Rules:
 - output hints and policy hints remain downstream aids, not the primary source
   of economic truth
 
-## Neutral Export Surface
-
-The target-neutral domain API should not be inferred from the current bridge
-export surface.
-
-Rules:
-
-- the root `domain` export surface is current-state convenience, not target API
-  precedent
-- current bridge-era helpers such as `asset_claim()` are crypto-oriented
-  identity conveniences, not the intended neutral ontology center
-- later target package exports should follow stage and ontology ownership, not
-  the current bridge-era convenience surface
-- do not treat bridge-era crypto helpers as a reason to shape new core models
-  around crypto-first assumptions
-
 Bridge-specific classification rules live in
 [Transaction Classification](transaction-classification.md), not here.
 
 ## Naming Posture
 
 - keep bridge names in live bridge code until later implementation slices land
-- use target ontology names when defining new target-layer concepts in docs
-  and later implementation work
+- use target ontology names when defining new target-layer concepts in docs and
+  later implementation work
 - do not force a docs-only bridge rename just to make the target vocabulary
   appear already implemented
-
-## Shared Support Ownership
-
-The target shared-support boundary is required and not optional.
-
-Required ownership:
-
-- `domain/support/` owns `SubjectRef`, `GapCore`, `GapExplanation`,
-  readiness primitives, and shared review attachment rules
-- current `domain/issues/` remains current-state bridge truth for live bridge
-  issue and review models until later implementation replaces them
-
-Rules:
-
-- target-stage gap, readiness, or review-attachment contracts must not land in
-  `domain/issues/`
-- bridge-era issue and review models remain accurate in current-state docs,
-  but they do not become the long-term shared-support boundary
-
-## Implementation Landing Rules During Migration
-
-Use these rules when placing new target-stage code while current bridge
-packages still exist.
-
-Rules:
-
-- target evidence models land in `domain/evidence/` and
-  `application/evidence/`
-- first claim-native emission lands in `domain/claims/` plus
-  `application/normalization/`
-- target economic compilation lands in `domain/economics/` plus
-  `application/economics/`
-- target shared support types do not land in `domain/issues/`
-- bridge-only extensions may stay in current bridge packages until replaced
-- no new target-stage records land in `domain/transactions/`,
-  `domain/balances/`, `domain/issues/`, or `application/facts/`
 
 ## Required Package Ownership
 
@@ -450,34 +367,34 @@ The target package layout follows stage ownership and is not advisory.
 
 Required domain ownership:
 
-- `domain/evidence/` for evidence-member identity, typed observations, and
-  other source-local evidence concepts
-- `domain/claims/` for source-local claim types and interpretation-group
-  semantics
-- `domain/economics/` for economic events, economic legs, valuations,
-  settlement state, and lifecycle state
-- `domain/reconciliation/` for continuity segments, link state, balance
-  targets, readiness reducers, and checkpoint candidacy
-- `domain/checkpoints/` for accepted checkpoint truth and checkpoint assertions
-- `domain/accounting/` for journals, entries, postings, and validation outputs
-- `domain/tax/` for tax determinants, basis transitions, tax-policy contracts,
+- `domain/entities/` for refs and stable identity seams
+- `domain/evidence/` for evidence members, observations, and selection
+  decisions
+- `domain/claims/` for claims, interpretation scopes, bundles, and compilation
+  decisions
+- `domain/economics/` for events, legs, valuations, settlement state, and
+  lifecycle state
+- `domain/assertions/` for `AssertionValue` and its variants
+- `domain/support/` for gaps, reviews, readiness, and `SubjectRef`
+- `domain/reconciliation/` for continuity segments, links, balance targets, and
+  checkpoint candidates
+- `domain/checkpoints/` for accepted checkpoint truth
+- `domain/accounting/` for journal models
+- `domain/tax/` for determinants, basis transitions, tax-policy contracts,
   carry-forward state, and outputs
-- `domain/support/` for `SubjectRef`, gap and readiness primitives, and shared
-  review attachment rules
 
 Required application ownership:
 
 - `application/intake/` for capture planning and apply
-- `application/evidence/` for shared statement extraction, evidence selection,
-  and provenance locator handling
 - `application/profiling/` for capture profile construction, inventory
   inspection, and timezone review
-- `application/normalization/` for evidence-to-claim translation planning and
-  current bridge artifact production plus the bounded first claim-emission seam
-- `application/normalization/assembly/` for deterministic merge of accepted
-  capture outputs into assembled source datasets
-- `application/economics/` for `ClaimSet -> EconomicFacts` compilation and
-  bridge interop during migration
+- `application/evidence/` for shared statement extraction, evidence selection,
+  and provenance locator handling
+- `application/claims/` for evidence-to-claim translation
+- `application/economics/` for claim compilation to economic facts
+- `application/bridge_compat/` for bridge compatibility projections only
+- `application/normalization/` for current-state migration-era orchestration
+  while the live bridge still exists
 - `application/reconciliation/` for continuity, linkage, balance-target
   evaluation, readiness reducers, and checkpoint candidates
 - `application/checkpoints/` for checkpoint evidence assembly, manual balance
@@ -486,9 +403,13 @@ Required application ownership:
 - `application/tax/` for tax-input assembly, basis transitions, policy
   selection, and tax-output rendering
 - `application/outputs/` for downstream renderer orchestration
+- `application/workspace/` for workspace resolution and initialization
 
 Boundary rules:
 
+- `application/normalization/` is current-state truth now, but the
+  forward-looking target model treats it as migration-era orchestration that
+  splits into `evidence`, `claims`, `economics`, and `bridge_compat`
 - `interfaces/` orchestrates services only
 - `infrastructure/` implements ports
 - `application/` depends on domain and ports
@@ -499,7 +420,7 @@ Implementation-shaping rule:
 - use this page plus
   [First Downstream Slice Contract](../reference/first-downstream-slice-contract.md)
   when choosing where new target-stage work lands
-- do not leave package placement to drafting-time judgment once the target
-  contract already names the owning stage
+- do not leave package placement to implementation-time judgment once the
+  target contract already names the owning stage
 - this page defines the required target ownership model; it does not claim the
   current runtime already uses that package layout

--- a/docs/concepts/domain-ontology.md
+++ b/docs/concepts/domain-ontology.md
@@ -38,6 +38,7 @@ The target model should use these concepts explicitly:
 - `CheckpointAssertion`
 - `Posting`
 - `TaxInput`
+- `BasisPoolRef`
 
 These are not interchangeable labels. They represent distinct business
 concepts, and the model should keep them distinct even when one adapter or one
@@ -106,6 +107,22 @@ Implication:
   for `Instrument`, `Location`, ownership identities, counterparties, or
   `CheckpointAssertion`
 
+## `CheckpointAssertion`
+
+`CheckpointAssertion` is the accepted checkpoint-truth record for one subject
+and one as-of point.
+
+Rules:
+
+- it is distinct from a reconciliation `CheckpointCandidate`
+- it is distinct from a computed `BalanceSnapshot`
+- it is distinct from a raw `BalanceReference`
+- it is distinct from the containing accepted `Checkpoint`
+- downstream stages may consume checkpoint assertions, but they must not
+  redefine them into incompatible local variants
+- accepted checkpoint truth should be modeled as checkpoint assertions first
+  and checkpoint containers second
+
 ## Valuation
 
 Valuation is first-class whenever it changes downstream behavior.
@@ -132,6 +149,26 @@ Rules:
   policy blobs
 - missing or uncertain valuation should remain explicit when downstream stages
   still need to reason about it
+
+## Temporal Semantics
+
+Time rules must survive replay, retroactive correction, and cross-stage audit.
+
+Required distinctions:
+
+- `effective_at` expresses when the economic or checkpoint meaning applies
+- `effective_precision` preserves whether that time is exact or date-scoped
+- `recorded_at` expresses when the system accepted or recorded the later-stage
+  truth
+
+Rules:
+
+- `effective_at` and `recorded_at` are not interchangeable
+- date-only meaning must remain distinct from exact timestamps
+- retroactive corrections emit superseding records with explicit lineage rather
+  than mutating prior accepted truth in place
+- later stages may compare `effective_at` and `recorded_at`, but they should
+  not collapse them into one timeline just to make replay look simpler
 
 ## Economic Model
 
@@ -192,16 +229,69 @@ Rules:
 - unresolved ownership transitions should remain visible to reconciliation,
   checkpoint, accounting, or tax as appropriate
 
-## Settlement And Lifecycle State
+## `SettlementState`
+
+`SettlementState` remains first-class whenever completeness, continuity, or
+later treatment depends on it.
+
+Shared vocabulary:
+
+- `pending`
+- `partial`
+- `settled`
+- `failed`
+- `reversed`
+- `unknown`
 
 Rules:
 
 - settlement state should remain explicit where timing, completeness, or
   continuity matters
-- lifecycle changes such as restructurings, migrations, contract rolls, and
-  supersession chains should not be flattened into generic trade-like labels
+- settlement state should not be inferred later from one output-specific row
+  label when the economic model can carry it directly
+
+## `LifecycleEvent`
+
+`LifecycleEvent` remains first-class whenever restructurings, migrations,
+rolls, term changes, or supersession chains affect later reasoning.
+
+Shared vocabulary:
+
+- `created`
+- `amended`
+- `migrated`
+- `rolled`
+- `restructured`
+- `terminated`
+- `superseded`
+
+Rules:
+
+- lifecycle changes should not be flattened into generic trade-like labels
 - corrections should preserve supersession lineage instead of mutating earlier
   accepted meaning in place
+- lifecycle events belong in the target economic model, not only in adapter
+  annotations or tax-policy notes
+
+## Basis Pool
+
+`BasisPoolRef` is the shared identity seam for pooled-basis or basis-tracking
+state reused by tax inputs and policy execution.
+
+Minimum key dimensions:
+
+- tax policy
+- jurisdiction or regime
+- beneficial owner
+- pool scope
+
+Rules:
+
+- basis pools are first-class domain seams, not renderer metadata
+- reconciliation and checkpoint stages may reference basis-relevant state, but
+  tax owns basis-pool transitions and treatment
+- pooled-basis jurisdictions must not force each stage to invent its own pool
+  identity model
 
 ## Bridge Classifications Versus Target Ontology
 
@@ -217,6 +307,22 @@ Rules:
   ontology, not by endlessly adding new activity labels
 - output hints and policy hints remain downstream aids, not the primary source
   of economic truth
+
+## Neutral Export Surface
+
+The target-neutral domain API should not be inferred from the current bridge
+export surface.
+
+Rules:
+
+- the root `domain` export surface is current-state convenience, not target API
+  precedent
+- current bridge-era helpers such as `asset_claim()` are crypto-oriented
+  identity conveniences, not the intended neutral ontology center
+- later target package exports should follow stage and ontology ownership, not
+  the current bridge-era convenience surface
+- do not treat bridge-era crypto helpers as a reason to shape new core models
+  around crypto-first assumptions
 
 Bridge-specific classification rules live in
 [Transaction Classification](transaction-classification.md), not here.

--- a/docs/concepts/domain-ontology.md
+++ b/docs/concepts/domain-ontology.md
@@ -122,13 +122,13 @@ Rules:
   redefine them into incompatible local variants
 - accepted checkpoint truth should be modeled as checkpoint assertions first
   and checkpoint containers second
-- checkpoint assertions carry one `CheckpointAssertionValue`, not one
-  untyped convenience payload
+- checkpoint assertions carry one shared `AssertionValue`, not one untyped
+  convenience payload
 
-## `CheckpointAssertionValue`
+## `AssertionValue`
 
-`CheckpointAssertionValue` is the target union carried by
-`Checkpoint.accepted_value`.
+`AssertionValue` is the shared value union carried by accepted checkpoint
+assertions and reconciliation comparison values.
 
 Variants:
 
@@ -147,8 +147,12 @@ Variant rules:
 - `LocationValue` carries one accepted location state
 - the union remains explicit so a later implementation cannot silently use one
   scalar type to stand in for quantity, money, ownership, and location truth
-- checkpoint assertion ids and fingerprints must treat the accepted-value
-  variant and its canonical content as semantically relevant
+- `CheckpointAssertion.accepted_value` carries exactly one `AssertionValue`
+- downstream `BalanceTargetRecord.expected_value` and
+  `BalanceTargetRecord.observed_value_or_null` reuse the same union instead of
+  inventing a second reconciliation-only value type
+- exact field, serialization, and fingerprint rules for the shared union live
+  in [Target Contract Primitives](../reference/target-contract-primitives.md)
 
 ## Valuation
 
@@ -169,6 +173,8 @@ Rules:
 
 - valuation belongs in the economic model when it changes checkpoint,
   accounting, or tax behavior
+- when downstream behavior depends on persisted valuation truth, the target
+  runtime emits first-class `ValuationRecord` rows under `EconomicFacts`
 - valuation purpose should be explicit enough to distinguish checkpoint,
   accounting, tax, and general market-observation use instead of letting one
   valuation silently stand in for another job
@@ -402,6 +408,42 @@ Bridge-specific classification rules live in
 - do not force a docs-only bridge rename just to make the target vocabulary
   appear already implemented
 
+## Shared Support Ownership
+
+The target shared-support boundary is required and not optional.
+
+Required ownership:
+
+- `domain/support/` owns `SubjectRef`, `GapCore`, `GapExplanation`,
+  readiness primitives, and shared review attachment rules
+- current `domain/issues/` remains current-state bridge truth for live bridge
+  issue and review models until later implementation replaces them
+
+Rules:
+
+- target-stage gap, readiness, or review-attachment contracts must not land in
+  `domain/issues/`
+- bridge-era issue and review models remain accurate in current-state docs,
+  but they do not become the long-term shared-support boundary
+
+## Implementation Landing Rules During Migration
+
+Use these rules when placing new target-stage code while current bridge
+packages still exist.
+
+Rules:
+
+- target evidence models land in `domain/evidence/` and
+  `application/evidence/`
+- first claim-native emission lands in `domain/claims/` plus
+  `application/normalization/`
+- target economic compilation lands in `domain/economics/` plus
+  `application/economics/`
+- target shared support types do not land in `domain/issues/`
+- bridge-only extensions may stay in current bridge packages until replaced
+- no new target-stage records land in `domain/transactions/`,
+  `domain/balances/`, `domain/issues/`, or `application/facts/`
+
 ## Required Package Ownership
 
 The target package layout follows stage ownership and is not advisory.
@@ -416,11 +458,12 @@ Required domain ownership:
   settlement state, and lifecycle state
 - `domain/reconciliation/` for continuity segments, link state, balance
   targets, readiness reducers, and checkpoint candidacy
-- `domain/checkpoints/` for accepted checkpoint truth, checkpoint assertions,
-  and `CheckpointAssertionValue`
+- `domain/checkpoints/` for accepted checkpoint truth and checkpoint assertions
 - `domain/accounting/` for journals, entries, postings, and validation outputs
 - `domain/tax/` for tax determinants, basis transitions, tax-policy contracts,
   carry-forward state, and outputs
+- `domain/support/` for `SubjectRef`, gap and readiness primitives, and shared
+  review attachment rules
 
 Required application ownership:
 
@@ -430,9 +473,11 @@ Required application ownership:
 - `application/profiling/` for capture profile construction, inventory
   inspection, and timezone review
 - `application/normalization/` for evidence-to-claim translation planning and
-  current bridge artifact production
+  current bridge artifact production plus the bounded first claim-emission seam
 - `application/normalization/assembly/` for deterministic merge of accepted
   capture outputs into assembled source datasets
+- `application/economics/` for `ClaimSet -> EconomicFacts` compilation and
+  bridge interop during migration
 - `application/reconciliation/` for continuity, linkage, balance-target
   evaluation, readiness reducers, and checkpoint candidates
 - `application/checkpoints/` for checkpoint evidence assembly, manual balance

--- a/docs/concepts/domain-ontology.md
+++ b/docs/concepts/domain-ontology.md
@@ -169,6 +169,9 @@ Rules:
   than mutating prior accepted truth in place
 - later stages may compare `effective_at` and `recorded_at`, but they should
   not collapse them into one timeline just to make replay look simpler
+- earlier accepted records are never rewritten in place; later accepted records
+  preserve correction lineage through their own `recorded_at` plus explicit
+  supersession references
 
 ## Economic Model
 
@@ -250,6 +253,23 @@ Rules:
 - settlement state should not be inferred later from one output-specific row
   label when the economic model can carry it directly
 
+Allowed transitions:
+
+| Current state | Allowed next states | Terminal |
+| --- | --- | --- |
+| `unknown` | `pending`, `partial`, `settled`, `failed`, `reversed` | no |
+| `pending` | `partial`, `settled`, `failed`, `reversed` | no |
+| `partial` | `settled`, `failed`, `reversed` | no |
+| `settled` | `reversed` | no |
+| `failed` | none | yes |
+| `reversed` | none | yes |
+
+Rules:
+
+- accepted state must move only through the transitions above
+- `failed` and `reversed` are terminal settlement states for one accepted
+  event chain
+
 ## `LifecycleEvent`
 
 `LifecycleEvent` remains first-class whenever restructurings, migrations,
@@ -273,6 +293,24 @@ Rules:
 - lifecycle events belong in the target economic model, not only in adapter
   annotations or tax-policy notes
 
+Allowed transitions:
+
+| Current lifecycle state | Allowed next states | Terminal |
+| --- | --- | --- |
+| `created` | `amended`, `migrated`, `rolled`, `restructured`, `terminated`, `superseded` | no |
+| `amended` | `amended`, `migrated`, `rolled`, `restructured`, `terminated`, `superseded` | no |
+| `migrated` | `amended`, `rolled`, `restructured`, `terminated`, `superseded` | no |
+| `rolled` | `amended`, `rolled`, `restructured`, `terminated`, `superseded` | no |
+| `restructured` | `amended`, `migrated`, `rolled`, `restructured`, `terminated`, `superseded` | no |
+| `terminated` | none | yes |
+| `superseded` | none | yes |
+
+Rules:
+
+- accepted lifecycle state must move only through the transitions above
+- `terminated` and `superseded` are terminal lifecycle states for one accepted
+  chain
+
 ## Basis Pool
 
 `BasisPoolRef` is the shared identity seam for pooled-basis or basis-tracking
@@ -292,6 +330,8 @@ Rules:
   tax owns basis-pool transitions and treatment
 - pooled-basis jurisdictions must not force each stage to invent its own pool
   identity model
+- `BasisPoolRef` serializes and sorts as
+  `[tax_policy_id, jurisdiction_or_regime, beneficial_owner_ref, pool_scope]`
 
 ## Bridge Classifications Versus Target Ontology
 

--- a/docs/concepts/gaps-and-readiness.md
+++ b/docs/concepts/gaps-and-readiness.md
@@ -22,14 +22,14 @@ Current runtime note:
 
 ## Design Rules
 
-- shared support types should stay compact and stage-neutral
+- shared support types stay compact and stage-neutral
 - explanation-heavy payloads belong in sidecars, not in the hot-path core
-- stage-owned blockers stay explicit; no stage should invent an incompatible
+- stage-owned blockers stay explicit; no stage may invent an incompatible
   blocker surface
 - dataset summaries are derived from subject-level truth, not stored as the
   only truth
-- shared support structures should help stages interoperate without erasing
-  stage ownership
+- shared support structures help stages interoperate without erasing stage
+  ownership
 
 ## Provenance
 
@@ -42,8 +42,8 @@ Rules:
 - file and member identity stay separate from row, page, or anchor identity
 - capture identity stays separate from human-readable labels and file-system
   paths
-- shared support models should link to provenance rather than embedding large
-  repeated evidence payloads directly
+- shared support models link to provenance rather than embedding large repeated
+  evidence payloads directly
 
 ## `SubjectRef`
 
@@ -77,6 +77,8 @@ Rules:
 - use `Contract` and `Position` explicitly in business logic and modeling
 - use `SubjectRef` only where shared infrastructure needs a generic pointer
 - do not use `SubjectRef` as an excuse to stop modeling the true concept
+- `SubjectRef` serializes, sorts, and fingerprints as
+  `[subject_kind, subject_id]`
 
 ## Non-Subject Scope Identity
 
@@ -102,6 +104,28 @@ Rules:
 - do not attach a gap to `dataset` scope when `subject`, `selection_group`, or
   `checkpoint_candidate` would be truthful
 
+## Shared Stage Vocabulary
+
+Use one stage vocabulary across gaps, readiness, checkpoint reuse, and
+downstream reporting.
+
+Shared stage vocabulary:
+
+- `evidence`
+- `claim`
+- `economic`
+- `reconciliation`
+- `checkpoint`
+- `accounting`
+- `tax`
+
+Rules:
+
+- `owner_stage` and `blocking_stages` use this vocabulary
+- readiness records and projections use this vocabulary
+- do not use alternate labels such as `semantic` once target-stage artifacts
+  are emitted
+
 ## Gap Model
 
 The target shared gap model splits compact blocking truth from explanation.
@@ -112,37 +136,92 @@ Purpose:
 
 - compact shared blocker record used across stages
 
-Minimum fields:
+Kernel fields:
 
 - `gap_id`
 - `owner_stage`
 - `blocking_stages`
 - `scope_kind`
+- `scope_id_or_null`
+- `subject_ref_or_null`
 - `gap_kind`
+- `gap_anchor`
 - `status`
 - `materiality`
 - `confidence`
-- `subject_ref` when `scope_kind` is `subject`
 
-Rules:
+Controlled vocabularies:
 
-- `scope_kind` is the attachment contract for the gap core
-- supported `scope_kind` values are:
+- `scope_kind`:
   - `subject`
   - `selection_group`
   - `continuity_segment`
   - `checkpoint_candidate`
   - `dataset`
-- use `subject_ref` whenever one truthful subject exists
-- use non-subject scope kinds only when no narrower truthful subject exists
+- `gap_kind`:
+  - `missing_evidence`
+  - `unresolved_identity`
+  - `unresolved_linkage`
+  - `contradiction`
+  - `policy_required_determination`
+  - `operator_override_required`
+- `status`:
+  - `open`
+  - `resolved`
+  - `superseded`
+- `materiality`:
+  - `material`
+  - `contextual`
+  - `informational`
+- `confidence`:
+  - `high`
+  - `medium`
+  - `low`
+
+Stable ids:
+
+- `gap_id` identifies one shared blocker record
+- `gap_id` uses component array
+  `[owner_stage, scope_kind, scope_anchor, gap_kind, gap_anchor]`
+- `scope_anchor` uses the `SubjectRef` tuple when `scope_kind` is `subject`
+- `scope_anchor` uses `scope_id_or_null` when `scope_kind` is not `subject`
+- `scope_id_or_null` is required when `scope_kind` is not `subject`
+- `subject_ref_or_null` is required when `scope_kind` is `subject`
+- `gap_anchor` is the stage-owned stable discriminator for one blocking
+  condition inside the declared scope
+
+Ordering:
+
+- sort by tuple
+  `[owner_stage, scope_kind, subject_ref_or_null, scope_id_or_null, gap_kind, gap_id]`
+- use JSON `null` ordering for `subject_ref_or_null` and `scope_id_or_null`
+  when one field is not applicable
+
+Serialization:
+
+- serialize kernel records only
+- use stable object-key ordering
+- preserve the declared gap order above
+- sort `blocking_stages` in canonical stage order
+
+Fingerprint inputs:
+
+- kernel records in canonical order
+- `schema_version`
+- sorted `blocking_stages`
+
+Rules:
+
 - `GapCore` is the shared blocking truth
 - it stays compact enough for reducers, indexing, and hot-path references
 - it must not absorb large explanatory text blobs
 - `owner_stage` identifies who owns the gap semantics
 - `blocking_stages` identifies who is blocked by the unresolved condition
-- later stages may add stage-local subtyping, but they should not redefine the
+- stages may add stage-local subtyping later, but they must not redefine the
   shared core out of existence
 - non-subject scopes must still use stable ids rather than prose labels
+- `resolved` and `superseded` gaps remain valid persisted history; they are not
+  deleted in place
 
 ### `GapExplanation`
 
@@ -150,7 +229,7 @@ Purpose:
 
 - explanation sidecar keyed to one `GapCore`
 
-Minimum fields:
+Fields:
 
 - `gap_id`
 - `known_facts`
@@ -161,48 +240,38 @@ Minimum fields:
 - `recommended_next_action`
 - `provenance_refs`
 
+Ordering:
+
+- sort by `gap_id`
+- preserve list order inside one explanation field when the owning stage has a
+  meaningful canonical order
+
+Serialization:
+
+- serialize explanation records only
+- use stable object-key ordering
+- preserve the declared explanation order above
+- sort `provenance_refs` when the stage does not declare a stronger order
+
+Fingerprint inputs:
+
+- explanation records in canonical order
+- `schema_version`
+- `gap_id`
+- sorted `provenance_refs`
+
 Rules:
 
 - explanation belongs in `GapExplanation`, not in `GapCore`
-- explanation may grow richer over time without bloating the compact shared
-  blocker record
+- explanation may grow richer over time without bloating the compact blocker
+  record
 - stages may attach richer explanation or decision history later, but the
-  common explanation shape should stay recognizable across the repo
-
-### Minimum Gap Taxonomy
-
-- `missing_evidence`
-- `unresolved_identity`
-- `unresolved_linkage`
-- `contradiction`
-- `policy_required_determination`
-- `operator_override_required`
-
-Rules:
-
-- gap ownership stays explicit by stage
-- accounting-owned gaps, reconciliation-owned gaps, checkpoint-owned gaps, and
-  tax-owned gaps must not be conflated operationally
-- stages may add stage-local subtyping later, but not by replacing the shared
-  taxonomy completely
-- materiality and confidence should remain first-class attributes on the gap
-  core, not only free-text explanation details
+  common explanation shape stays recognizable across the repo
 
 ## Readiness Model
 
 Readiness is subject-first, stage-specific, and reducible into reporting
 projections.
-
-### `ReadinessStage`
-
-Shared stage vocabulary:
-
-- `evidence`
-- `semantic`
-- `reconciliation`
-- `checkpoint`
-- `accounting`
-- `tax`
 
 ### `ReadinessStatus`
 
@@ -225,46 +294,46 @@ Purpose:
 
 - stage-specific readiness for one `SubjectRef`
 
-Minimum fields:
+Kernel fields:
 
 - `subject_ref`
 - `stage`
 - `status`
 - `blocking_gap_ids`
 
-Optional derived context may include:
+Stable ids:
 
-- confidence
-- materiality
-- provenance or explanation references
+- `subject_readiness_id` identifies one readiness record for one subject and
+  one stage
+- `subject_readiness_id` uses component array `[subject_ref, stage]`
+
+Ordering:
+
+- sort by tuple `[stage, subject_ref.subject_kind, subject_ref.subject_id]`
+- sort `blocking_gap_ids` lexicographically
+
+Serialization:
+
+- serialize readiness records only
+- use stable object-key ordering
+- preserve the declared readiness order above
+
+Fingerprint inputs:
+
+- readiness records in canonical order
+- `schema_version`
+- sorted `blocking_gap_ids`
 
 Rules:
 
 - subject readiness is the base truth
 - `evidence` readiness covers deterministic evidence selection and observation
   completeness before semantic commitment
-- reducers should work from subject readiness plus gaps, not from hand-built
-  whole-dataset statuses
+- reducers work from subject readiness plus gaps, not from hand-built whole
+  dataset statuses
 - a subject may be ready for one stage and blocked for another
-- readiness should point to blocking gap ids rather than hiding blockers in
-  summary text
-
-## Reducer Rules
-
-Readiness reducers should remain compact, deterministic, and subject-first.
-
-Rules:
-
-- reducers work from `GapCore`, stable scope ids, and subject readiness records
-- reducers must not infer readiness from explanation prose
-- reducers may roll up from subject truth into reporting projections, but the
-  projection is derived output, not the only stored truth
-- `partial` readiness requires at least one resolved assertion plus at least
-  one open blocking gap id
-- if no required assertion has resolved yet, status is `blocked`, not `partial`
-- if no blocker applies, status is `ready`, not `partial`
-- dataset summaries should be reproducible from ordered readiness and gap
-  records without manual status editing
+- readiness points to blocking gap ids rather than hiding blockers in summary
+  text
 
 ### `ReadinessProjection`
 
@@ -272,23 +341,74 @@ Purpose:
 
 - derived reporting view over subject readiness
 
-Allowed optional projection dimensions:
+Fields:
 
-- source
-- location
-- instrument
-- continuity segment
-- checkpoint date
-- tax year
+- `projection_id`
+- `stage`
+- `projection_dimension`
+- `projection_key`
+- `status`
+- `blocking_gap_ids`
+- `ready_subject_count`
+- `partial_subject_count`
+- `blocked_subject_count`
+- `not_applicable_subject_count`
+
+Controlled `projection_dimension` vocabulary:
+
+- `source`
+- `location`
+- `instrument`
+- `continuity_segment`
+- `checkpoint_date`
+- `tax_year`
+- `dataset`
+
+Projection-key rules:
+
+- `source` uses the source string
+- `location` uses one `location_id`
+- `instrument` uses one `instrument_id`
+- `continuity_segment` uses one `continuity_segment_id`
+- `checkpoint_date` uses one canonical `YYYY-MM-DD` date string
+- `tax_year` uses one integer tax year
+- `dataset` uses one `dataset_id`
+
+Stable ids:
+
+- `projection_id` identifies one derived readiness projection
+- `projection_id` uses component array
+  `[stage, projection_dimension, projection_key]`
+
+Ordering:
+
+- sort by tuple `[stage, projection_dimension, projection_key]`
+- sort `blocking_gap_ids` lexicographically
+
+Serialization:
+
+- serialize projection records only
+- use stable object-key ordering
+- preserve the declared projection order above
+
+Fingerprint inputs:
+
+- projection records in canonical order
+- `schema_version`
+- sorted `blocking_gap_ids`
+- the ordered `SubjectReadinessRecord` ids that fed the projection
 
 Rules:
 
-- these are reporting and recalculation dimensions, not mandatory keys on
-  every readiness record
-- a stage should use only the dimensions it actually owns or can derive
-  safely
-- do not turn readiness into a mandatory global cube just to satisfy one
-  report
+- projections are derived output, not the only stored truth
+- `partial` requires at least one resolved assertion plus at least one open
+  blocking gap id
+- if no required assertion has resolved yet, status is `blocked`, not
+  `partial`
+- if no blocker applies, status is `ready`, not `partial`
+- dataset summaries remain reproducible from ordered readiness and gap records
+  without manual status editing
+- stages use only the dimensions they actually own or can derive safely
 
 ## Shared Checkpoint Assertions
 
@@ -297,7 +417,7 @@ checkpoints, accounting, and tax.
 
 Rules:
 
-- checkpoint assertions should stay first-class and referenceable
+- checkpoint assertions stay first-class and referenceable
 - downstream stages may reuse them, but should not redefine them into
   incompatible local variants
 
@@ -315,8 +435,8 @@ Mapping rules:
   blocking condition also exists
 - when one factual cause produces both a blocker and an advisory review, the
   blocker lands in `GapCore` and the review remains keyed sidecar context
-- current bridge ids should remain traceable when later stages adopt
-  target-native gap or review ids
+- current bridge ids remain traceable when later stages adopt target-native gap
+  or review ids
 
 ## Anti-Duplication And Sidecar Rules
 
@@ -368,5 +488,5 @@ Performance implication:
   outputs today
 - later implementation may map current bridge issues and reviews into the
   target gap/readiness model where the stage ownership and semantics line up
-- current-state docs should keep current issue and review names where accuracy
+- current-state docs keep current issue and review names where accuracy
   requires them

--- a/docs/concepts/gaps-and-readiness.md
+++ b/docs/concepts/gaps-and-readiness.md
@@ -100,7 +100,10 @@ Rules:
 - `checkpoint_candidate_id` identifies one reconciliation-owned checkpoint
   proposal before acceptance
 - `dataset_id` identifies one persisted stage kernel or one explicit slice-wide
-  dataset under review
+  dataset under review; its reusable wire identity is owned by
+  [Target Contract Primitives](../reference/target-contract-primitives.md) and
+  its persisted dataset packaging is owned by
+  [Target Product Artifacts](../reference/target-product-artifacts.md)
 - do not attach a gap to `dataset` scope when `subject`, `selection_group`, or
   `checkpoint_candidate` would be truthful
 
@@ -421,6 +424,24 @@ Rules:
 - downstream stages may reuse them, but should not redefine them into
   incompatible local variants
 
+## Review Sidecar Rules
+
+The target runtime does not define one shared cross-stage `ReviewRecord`
+kernel.
+
+Rules:
+
+- reviews are advisory and never block by themselves
+- a review may pair with one gap through `paired_gap_id`
+- when a blocker and a review share one cause, the gap owns the blocker and
+  the review remains sidecar context
+- downstream stages must not require upstream review sidecars as kernel inputs
+- persisted review sidecars remain stage-local under `sidecars/reviews.json`
+  as owned by
+  [Target Product Artifacts](../reference/target-product-artifacts.md)
+- `NormalizationReviewRecord` maps to stage-local review sidecars, not to a
+  shared target review kernel
+
 ## Bridge Mapping From Issue And Review Records
 
 The live bridge still emits `IssueRecord` and `NormalizationReviewRecord`.
@@ -431,8 +452,8 @@ Mapping rules:
   when owner stage, blocking stages, scope, and blocker semantics align
 - `IssueRecord.kind`, `severity`, `context_timestamp`, and typed provenance are
   gap inputs, not free text to reinterpret later
-- `NormalizationReviewRecord` remains a review sidecar unless a paired
-  blocking condition also exists
+- `NormalizationReviewRecord` remains a stage-local review sidecar unless a
+  paired blocking condition also exists
 - when one factual cause produces both a blocker and an advisory review, the
   blocker lands in `GapCore` and the review remains keyed sidecar context
 - current bridge ids remain traceable when later stages adopt target-native gap

--- a/docs/concepts/gaps-and-readiness.md
+++ b/docs/concepts/gaps-and-readiness.md
@@ -54,13 +54,26 @@ Minimum fields:
 - `subject_kind`
 - `subject_id`
 
-Initial supported `subject_kind` values:
+Supported `subject_kind` values for shared infrastructure:
 
+- `evidence_member`
+- `evidence_record`
+- `claim`
+- `instrument`
+- `location`
+- `legal_owner`
+- `beneficial_owner`
+- `counterparty`
 - `position`
 - `contract`
+- `economic_event`
+- `checkpoint_assertion`
 
 Rules:
 
+- use the narrowest truthful subject kind the current stage can prove safely
+- early-stage gaps may attach to evidence or claim subjects before business
+  identities are fully resolved
 - use `Contract` and `Position` explicitly in business logic and modeling
 - use `SubjectRef` only where shared infrastructure needs a generic pointer
 - do not use `SubjectRef` as an excuse to stop modeling the true concept
@@ -80,14 +93,24 @@ Minimum fields:
 - `gap_id`
 - `owner_stage`
 - `blocking_stages`
-- `subject_ref`
+- `scope_kind`
 - `gap_kind`
 - `status`
 - `materiality`
 - `confidence`
+- `subject_ref` when `scope_kind` is `subject`
 
 Rules:
 
+- `scope_kind` is the attachment contract for the gap core
+- supported `scope_kind` values are:
+  - `subject`
+  - `selection_group`
+  - `continuity_segment`
+  - `checkpoint_candidate`
+  - `dataset`
+- use `subject_ref` whenever one truthful subject exists
+- use non-subject scope kinds only when no narrower truthful subject exists
 - `GapCore` is the shared blocking truth
 - it stays compact enough for reducers, indexing, and hot-path references
 - it must not absorb large explanatory text blobs
@@ -149,6 +172,7 @@ projections.
 
 Shared stage vocabulary:
 
+- `evidence`
 - `semantic`
 - `reconciliation`
 - `checkpoint`
@@ -186,6 +210,8 @@ Optional derived context may include:
 Rules:
 
 - subject readiness is the base truth
+- `evidence` readiness covers deterministic evidence selection and observation
+  completeness before semantic commitment
 - reducers should work from subject readiness plus gaps, not from hand-built
   whole-dataset statuses
 - a subject may be ready for one stage and blocked for another

--- a/docs/concepts/gaps-and-readiness.md
+++ b/docs/concepts/gaps-and-readiness.md
@@ -60,7 +60,7 @@ Supported `subject_kind` values for shared infrastructure:
 - `evidence_member`
 - `evidence_observation`
 - `claim`
-- `interpretation_bundle`
+- `claim_bundle`
 - `instrument`
 - `location`
 - `legal_owner`
@@ -98,30 +98,35 @@ Non-subject scopes are allowed only when no narrower truthful subject exists.
 
 Required scope ids:
 
-- `selection_group_id`
+- `selection_id`
 - `interpretation_scope_id`
 - `continuity_segment_id`
+- `balance_target_id`
 - `checkpoint_candidate_id`
 - `dataset_id`
 
 Rules:
 
 - every non-subject gap or review attachment uses one stable scope id
-- `selection_group_id` identifies one deterministic evidence-selection
+- `selection_id` identifies one deterministic evidence-selection
   decision boundary
 - `interpretation_scope_id` identifies one claim-stage semantic decision
   boundary before bundle selection or subject resolution is final
 - `continuity_segment_id` identifies one bounded reconciliation window
+- `balance_target_id` identifies one reconciliation-owned balance assertion
+  target when one exact target is the truthful blocker or review scope
 - `checkpoint_candidate_id` identifies one reconciliation-owned checkpoint
   proposal before acceptance
 - `dataset_id` identifies one shared support attachment scope over one
   canonical product kernel and is not a substitute for a narrower scope
 - do not attach a gap or review to `dataset` scope when `subject`,
-  `selection_group`, or `checkpoint_candidate` would be truthful
+  `selection`, `interpretation_scope`, `continuity_segment`,
+  `balance_target`, or `checkpoint_candidate` would be truthful
 
 ### `dataset_id`
 
-`dataset_id` is defined once for all target support artifacts.
+`dataset_id` is defined once for all target support records, projections, and
+sidecars.
 
 Rules:
 
@@ -136,8 +141,8 @@ Rules:
   exists
 - `dataset_id` is used only for shared reporting and sidecar attachment when no
   narrower truthful subject or scope exists
-- `dataset_id` must not replace `selection_group_id`,
-  `interpretation_scope_id`, `continuity_segment_id`,
+- `dataset_id` must not replace `selection_id`,
+  `interpretation_scope_id`, `continuity_segment_id`, `balance_target_id`,
   `checkpoint_candidate_id`, or one record id when those are truthful
 
 ## Shared Stage Vocabulary
@@ -166,7 +171,7 @@ Rules:
 
 The target shared gap model splits compact blocking truth from explanation.
 
-### `GapCore`
+### `GapRecord`
 
 Purpose:
 
@@ -178,10 +183,10 @@ Kernel fields:
 - `owner_stage`
 - `blocking_stages`
 - `scope_kind`
-- `scope_id_or_null`
-- `subject_ref_or_null`
+- `scope_id`
+- `subject_ref`
 - `gap_kind`
-- `gap_anchor`
+- `gap_key`
 - `status`
 - `materiality`
 - `confidence`
@@ -190,9 +195,10 @@ Controlled vocabularies:
 
 - `scope_kind`:
   - `subject`
-  - `selection_group`
+  - `selection`
   - `interpretation_scope`
   - `continuity_segment`
+  - `balance_target`
   - `checkpoint_candidate`
   - `dataset`
 - `gap_kind`:
@@ -219,20 +225,19 @@ Stable ids:
 
 - `gap_id` identifies one shared blocker record
 - `gap_id` uses component array
-  `[owner_stage, scope_kind, scope_anchor, gap_kind, gap_anchor]`
-- `scope_anchor` uses the `SubjectRef` tuple when `scope_kind` is `subject`
-- `scope_anchor` uses `scope_id_or_null` when `scope_kind` is not `subject`
-- `scope_id_or_null` is required when `scope_kind` is not `subject`
-- `subject_ref_or_null` is required when `scope_kind` is `subject`
-- `gap_anchor` is the stage-owned stable discriminator for one blocking
+  `[owner_stage, scope_kind, scope_key, gap_kind, gap_key]`
+- `scope_key` uses the `SubjectRef` tuple when `scope_kind` is `subject`
+- `scope_key` uses `scope_id` when `scope_kind` is not `subject`
+- `scope_id` is required when `scope_kind` is not `subject`
+- `subject_ref` is required when `scope_kind` is `subject`
+- `gap_key` is the stage-owned stable discriminator for one blocking
   condition inside the declared scope
 
 Ordering:
 
 - sort by tuple
-  `[owner_stage, scope_kind, subject_ref_or_null, scope_id_or_null, gap_kind, gap_id]`
-- use JSON `null` ordering for `subject_ref_or_null` and `scope_id_or_null`
-  when one field is not applicable
+  `[owner_stage, scope_kind, subject_ref, scope_id, gap_kind, gap_id]`
+- use JSON `null` ordering for inactive `subject_ref` and `scope_id` fields
 
 Serialization:
 
@@ -249,7 +254,7 @@ Fingerprint inputs:
 
 Rules:
 
-- `GapCore` is the shared blocking truth
+- `GapRecord` is the shared blocking truth
 - it stays compact enough for reducers, indexing, and hot-path references
 - it must not absorb large explanatory text blobs
 - `owner_stage` identifies who owns the gap semantics
@@ -264,7 +269,7 @@ Rules:
 
 Purpose:
 
-- explanation sidecar keyed to one `GapCore`
+- explanation sidecar keyed to one `GapRecord`
 
 Fields:
 
@@ -299,7 +304,7 @@ Fingerprint inputs:
 
 Rules:
 
-- explanation belongs in `GapExplanation`, not in `GapCore`
+- explanation belongs in `GapExplanation`, not in `GapRecord`
 - explanation may grow richer over time without bloating the compact blocker
   record
 - stages may attach richer explanation or decision history later, but the
@@ -321,10 +326,10 @@ Kernel fields:
 - `review_id`
 - `owner_stage`
 - `scope_kind`
-- `scope_id_or_null`
-- `subject_ref_or_null`
+- `scope_id`
+- `subject_ref`
 - `review_kind`
-- `review_anchor`
+- `review_key`
 - `status`
 - `confidence`
 - `paired_gap_ids`
@@ -333,9 +338,10 @@ Controlled vocabularies:
 
 - `scope_kind`:
   - `subject`
-  - `selection_group`
+  - `selection`
   - `interpretation_scope`
   - `continuity_segment`
+  - `balance_target`
   - `checkpoint_candidate`
   - `dataset`
 - `status`:
@@ -352,19 +358,18 @@ Stable ids:
 
 - `review_id` identifies one advisory record
 - `review_id` uses component array
-  `[owner_stage, scope_kind, scope_anchor, review_kind, review_anchor]`
-- `scope_anchor` uses the `SubjectRef` tuple when `scope_kind` is `subject`
-- `scope_anchor` uses `scope_id_or_null` when `scope_kind` is not `subject`
+  `[owner_stage, scope_kind, scope_key, review_kind, review_key]`
+- `scope_key` uses the `SubjectRef` tuple when `scope_kind` is `subject`
+- `scope_key` uses `scope_id` when `scope_kind` is not `subject`
 - `review_kind` is the owner-stage stable advisory label for one review family
-- `review_anchor` is the owner-stage stable discriminator for one advisory
+- `review_key` is the owner-stage stable discriminator for one advisory
   observation inside the declared scope
 
 Ordering:
 
 - sort by tuple
-  `[owner_stage, scope_kind, subject_ref_or_null, scope_id_or_null, review_kind, review_id]`
-- use JSON `null` ordering for `subject_ref_or_null` and `scope_id_or_null`
-  when one field is not applicable
+  `[owner_stage, scope_kind, subject_ref, scope_id, review_kind, review_id]`
+- use JSON `null` ordering for inactive `subject_ref` and `scope_id` fields
 - sort `paired_gap_ids` lexicographically
 
 Serialization:
@@ -447,7 +452,7 @@ Shared status vocabulary:
 - at least one blocking gap still open
 - the remaining uncertainty is recorded through gap ids, not prose-only summary
 
-### `SubjectReadinessRecord`
+### `ReadinessRecord`
 
 Purpose:
 
@@ -455,7 +460,7 @@ Purpose:
 
 Kernel fields:
 
-- `subject_readiness_id`
+- `readiness_id`
 - `subject_ref`
 - `stage`
 - `status`
@@ -463,9 +468,9 @@ Kernel fields:
 
 Stable ids:
 
-- `subject_readiness_id` identifies one readiness record for one subject and
+- `readiness_id` identifies one readiness record for one subject and
   one stage
-- `subject_readiness_id` uses component array `[subject_ref, stage]`
+- `readiness_id` uses component array `[subject_ref, stage]`
 
 Ordering:
 
@@ -556,7 +561,7 @@ Fingerprint inputs:
 - projection records in canonical order
 - `schema_version`
 - sorted `blocking_gap_ids`
-- the ordered `SubjectReadinessRecord` ids that fed the projection
+- the ordered `ReadinessRecord` ids that fed the projection
 
 Rules:
 
@@ -576,14 +581,14 @@ The live bridge still emits `IssueRecord` and `NormalizationReviewRecord`.
 
 Mapping rules:
 
-- a blocking `IssueRecord` maps to one `GapCore` plus one `GapExplanation`
+- a blocking `IssueRecord` maps to one `GapRecord` plus one `GapExplanation`
   when owner stage, blocking stages, scope, and blocker semantics align
 - `IssueRecord.kind`, `severity`, `context_timestamp`, and typed provenance are
   gap inputs, not free text to reinterpret later
 - `NormalizationReviewRecord` maps to one `ReviewRecord` plus one
   `ReviewExplanation` when owner stage, scope, and advisory meaning align
 - when one factual cause produces both a blocker and an advisory review, the
-  blocker lands in `GapCore` and the review remains keyed sidecar context
+  blocker lands in `GapRecord` and the review remains keyed sidecar context
 - current bridge ids remain traceable when later stages adopt target-native gap
   or review ids
 

--- a/docs/concepts/gaps-and-readiness.md
+++ b/docs/concepts/gaps-and-readiness.md
@@ -78,6 +78,30 @@ Rules:
 - use `SubjectRef` only where shared infrastructure needs a generic pointer
 - do not use `SubjectRef` as an excuse to stop modeling the true concept
 
+## Non-Subject Scope Identity
+
+Non-subject scopes are allowed only when no narrower truthful subject exists.
+
+Required scope ids:
+
+- `selection_group_id`
+- `continuity_segment_id`
+- `checkpoint_candidate_id`
+- `dataset_id`
+
+Rules:
+
+- every non-subject gap attachment uses one stable scope id
+- `selection_group_id` identifies one deterministic evidence-selection
+  decision boundary
+- `continuity_segment_id` identifies one bounded reconciliation window
+- `checkpoint_candidate_id` identifies one reconciliation-owned checkpoint
+  proposal before acceptance
+- `dataset_id` identifies one persisted stage kernel or one explicit slice-wide
+  dataset under review
+- do not attach a gap to `dataset` scope when `subject`, `selection_group`, or
+  `checkpoint_candidate` would be truthful
+
 ## Gap Model
 
 The target shared gap model splits compact blocking truth from explanation.
@@ -118,6 +142,7 @@ Rules:
 - `blocking_stages` identifies who is blocked by the unresolved condition
 - later stages may add stage-local subtyping, but they should not redefine the
   shared core out of existence
+- non-subject scopes must still use stable ids rather than prose labels
 
 ### `GapExplanation`
 
@@ -188,6 +213,12 @@ Shared status vocabulary:
 - `partial`
 - `not_applicable`
 
+`partial` means:
+
+- some required interpretations or assertions resolved
+- at least one blocking gap still open
+- the remaining uncertainty is recorded through gap ids, not prose-only summary
+
 ### `SubjectReadinessRecord`
 
 Purpose:
@@ -217,6 +248,23 @@ Rules:
 - a subject may be ready for one stage and blocked for another
 - readiness should point to blocking gap ids rather than hiding blockers in
   summary text
+
+## Reducer Rules
+
+Readiness reducers should remain compact, deterministic, and subject-first.
+
+Rules:
+
+- reducers work from `GapCore`, stable scope ids, and subject readiness records
+- reducers must not infer readiness from explanation prose
+- reducers may roll up from subject truth into reporting projections, but the
+  projection is derived output, not the only stored truth
+- `partial` readiness requires at least one resolved assertion plus at least
+  one open blocking gap id
+- if no required assertion has resolved yet, status is `blocked`, not `partial`
+- if no blocker applies, status is `ready`, not `partial`
+- dataset summaries should be reproducible from ordered readiness and gap
+  records without manual status editing
 
 ### `ReadinessProjection`
 
@@ -252,6 +300,23 @@ Rules:
 - checkpoint assertions should stay first-class and referenceable
 - downstream stages may reuse them, but should not redefine them into
   incompatible local variants
+
+## Bridge Mapping From Issue And Review Records
+
+The live bridge still emits `IssueRecord` and `NormalizationReviewRecord`.
+
+Mapping rules:
+
+- a blocking `IssueRecord` maps to one `GapCore` plus one `GapExplanation`
+  when owner stage, blocking stages, scope, and blocker semantics align
+- `IssueRecord.kind`, `severity`, `context_timestamp`, and typed provenance are
+  gap inputs, not free text to reinterpret later
+- `NormalizationReviewRecord` remains a review sidecar unless a paired
+  blocking condition also exists
+- when one factual cause produces both a blocker and an advisory review, the
+  blocker lands in `GapCore` and the review remains keyed sidecar context
+- current bridge ids should remain traceable when later stages adopt
+  target-native gap or review ids
 
 ## Anti-Duplication And Sidecar Rules
 

--- a/docs/concepts/gaps-and-readiness.md
+++ b/docs/concepts/gaps-and-readiness.md
@@ -1,6 +1,6 @@
 ---
 title: "Gaps And Readiness"
-summary: "Owning concept page for the target gap model, readiness model, sidecar rules, and shared `SubjectRef` contracts."
+summary: "Owning concept page for the target gap model, review model, readiness model, sidecar rules, and shared `SubjectRef` contracts."
 doc_type: concept
 audience: human
 owner: repo
@@ -8,9 +8,9 @@ status: active
 nav_order: 45
 ---
 
-Use this page when defining shared blocker, readiness, or generic
-subject-reference contracts. This document owns the target cross-stage gap and
-readiness model.
+Use this page when defining shared blocker, review, readiness, or generic
+subject-reference contracts. This document owns the target cross-stage support
+model.
 
 Current runtime note:
 
@@ -23,11 +23,12 @@ Current runtime note:
 ## Design Rules
 
 - shared support types stay compact and stage-neutral
-- explanation-heavy payloads belong in sidecars, not in the hot-path core
+- explanation-heavy payloads belong in sidecars, not in hot-path kernels
 - stage-owned blockers stay explicit; no stage may invent an incompatible
   blocker surface
-- dataset summaries are derived from subject-level truth, not stored as the
-  only truth
+- reviews stay advisory and must never become hidden blockers
+- dataset summaries are derived from subject-level or scope-level truth, not
+  stored as the only truth
 - shared support structures help stages interoperate without erasing stage
   ownership
 
@@ -40,7 +41,7 @@ Rules:
 - provenance stays typed in runtime models
 - flattening happens only at artifact and export boundaries
 - file and member identity stay separate from row, page, or anchor identity
-- capture identity stays separate from human-readable labels and file-system
+- capture identity stays separate from human-readable labels and filesystem
   paths
 - shared support models link to provenance rather than embedding large repeated
   evidence payloads directly
@@ -57,8 +58,9 @@ Minimum fields:
 Supported `subject_kind` values for shared infrastructure:
 
 - `evidence_member`
-- `evidence_record`
+- `evidence_observation`
 - `claim`
+- `interpretation_bundle`
 - `instrument`
 - `location`
 - `legal_owner`
@@ -67,13 +69,23 @@ Supported `subject_kind` values for shared infrastructure:
 - `position`
 - `contract`
 - `economic_event`
+- `economic_leg`
+- `valuation`
 - `checkpoint_assertion`
+- `journal_entry`
+- `posting`
+- `basis_pool`
+- `tax_determinant`
+- `tax_output`
 
 Rules:
 
 - use the narrowest truthful subject kind the current stage can prove safely
-- early-stage gaps may attach to evidence or claim subjects before business
-  identities are fully resolved
+- early-stage gaps and reviews may attach to evidence or claim subjects before
+  business identities are fully resolved
+- later-stage gaps and reviews may attach to `journal_entry`, `posting`,
+  `basis_pool`, `tax_determinant`, or `tax_output` when that later-stage
+  record is the truthful shared pointer
 - use `Contract` and `Position` explicitly in business logic and modeling
 - use `SubjectRef` only where shared infrastructure needs a generic pointer
 - do not use `SubjectRef` as an excuse to stop modeling the true concept
@@ -87,29 +99,50 @@ Non-subject scopes are allowed only when no narrower truthful subject exists.
 Required scope ids:
 
 - `selection_group_id`
+- `interpretation_scope_id`
 - `continuity_segment_id`
 - `checkpoint_candidate_id`
 - `dataset_id`
 
 Rules:
 
-- every non-subject gap attachment uses one stable scope id
+- every non-subject gap or review attachment uses one stable scope id
 - `selection_group_id` identifies one deterministic evidence-selection
   decision boundary
+- `interpretation_scope_id` identifies one claim-stage semantic decision
+  boundary before bundle selection or subject resolution is final
 - `continuity_segment_id` identifies one bounded reconciliation window
 - `checkpoint_candidate_id` identifies one reconciliation-owned checkpoint
   proposal before acceptance
-- `dataset_id` identifies one persisted stage kernel or one explicit slice-wide
-  dataset under review; its reusable wire identity is owned by
-  [Target Contract Primitives](../reference/target-contract-primitives.md) and
-  its persisted dataset packaging is owned by
-  [Target Product Artifacts](../reference/target-product-artifacts.md)
-- do not attach a gap to `dataset` scope when `subject`, `selection_group`, or
-  `checkpoint_candidate` would be truthful
+- `dataset_id` identifies one shared support attachment scope over one
+  canonical product kernel and is not a substitute for a narrower scope
+- do not attach a gap or review to `dataset` scope when `subject`,
+  `selection_group`, or `checkpoint_candidate` would be truthful
+
+### `dataset_id`
+
+`dataset_id` is defined once for all target support artifacts.
+
+Rules:
+
+- `dataset_id` is `<product_kind>:<kernel_fingerprint>`
+- `product_kind` uses the lower-snake-case target product name
+- `kernel_fingerprint` is the canonical product fingerprint owned by
+  [Pipeline Stage Contracts](pipeline-stage-contracts.md)
+- `dataset_id` is derived after canonical kernel fingerprinting and is not a
+  kernel metadata field or a fingerprint input itself
+- `dataset_id` is never a target product id, never an upstream product ref,
+  and never the primary reader key when one product id or narrower record id
+  exists
+- `dataset_id` is used only for shared reporting and sidecar attachment when no
+  narrower truthful subject or scope exists
+- `dataset_id` must not replace `selection_group_id`,
+  `interpretation_scope_id`, `continuity_segment_id`,
+  `checkpoint_candidate_id`, or one record id when those are truthful
 
 ## Shared Stage Vocabulary
 
-Use one stage vocabulary across gaps, readiness, checkpoint reuse, and
+Use one stage vocabulary across gaps, reviews, readiness, checkpoint reuse, and
 downstream reporting.
 
 Shared stage vocabulary:
@@ -158,6 +191,7 @@ Controlled vocabularies:
 - `scope_kind`:
   - `subject`
   - `selection_group`
+  - `interpretation_scope`
   - `continuity_segment`
   - `checkpoint_candidate`
   - `dataset`
@@ -271,6 +305,128 @@ Rules:
 - stages may attach richer explanation or decision history later, but the
   common explanation shape stays recognizable across the repo
 
+## Review Model
+
+The target shared review model carries advisory context without becoming a
+hidden blocker surface.
+
+### `ReviewRecord`
+
+Purpose:
+
+- compact shared advisory record used across stages
+
+Kernel fields:
+
+- `review_id`
+- `owner_stage`
+- `scope_kind`
+- `scope_id_or_null`
+- `subject_ref_or_null`
+- `review_kind`
+- `review_anchor`
+- `status`
+- `confidence`
+- `paired_gap_ids`
+
+Controlled vocabularies:
+
+- `scope_kind`:
+  - `subject`
+  - `selection_group`
+  - `interpretation_scope`
+  - `continuity_segment`
+  - `checkpoint_candidate`
+  - `dataset`
+- `status`:
+  - `open`
+  - `acknowledged`
+  - `resolved`
+  - `superseded`
+- `confidence`:
+  - `high`
+  - `medium`
+  - `low`
+
+Stable ids:
+
+- `review_id` identifies one advisory record
+- `review_id` uses component array
+  `[owner_stage, scope_kind, scope_anchor, review_kind, review_anchor]`
+- `scope_anchor` uses the `SubjectRef` tuple when `scope_kind` is `subject`
+- `scope_anchor` uses `scope_id_or_null` when `scope_kind` is not `subject`
+- `review_kind` is the owner-stage stable advisory label for one review family
+- `review_anchor` is the owner-stage stable discriminator for one advisory
+  observation inside the declared scope
+
+Ordering:
+
+- sort by tuple
+  `[owner_stage, scope_kind, subject_ref_or_null, scope_id_or_null, review_kind, review_id]`
+- use JSON `null` ordering for `subject_ref_or_null` and `scope_id_or_null`
+  when one field is not applicable
+- sort `paired_gap_ids` lexicographically
+
+Serialization:
+
+- serialize review kernel records only
+- use stable object-key ordering
+- preserve the declared review order above
+
+Fingerprint inputs:
+
+- review records in canonical order
+- `schema_version`
+- sorted `paired_gap_ids`
+
+Rules:
+
+- reviews are advisory only
+- reviews use the same scope attachment scheme as gaps
+- reviews never block on their own
+- a review may coexist with a paired gap on the same subject or scope
+- shared review records must not become a second blocker model in disguise
+
+### `ReviewExplanation`
+
+Purpose:
+
+- explanation sidecar keyed to one `ReviewRecord`
+
+Fields:
+
+- `review_id`
+- `summary`
+- `known_facts`
+- `recommended_follow_up`
+- `provenance_refs`
+
+Ordering:
+
+- sort by `review_id`
+- preserve list order inside one explanation field when the owning stage has a
+  meaningful canonical order
+
+Serialization:
+
+- serialize explanation records only
+- use stable object-key ordering
+- preserve the declared explanation order above
+- sort `provenance_refs` when the stage does not declare a stronger order
+
+Fingerprint inputs:
+
+- explanation records in canonical order
+- `schema_version`
+- `review_id`
+- sorted `provenance_refs`
+
+Rules:
+
+- explanation belongs in `ReviewExplanation`, not in `ReviewRecord`
+- review explanation may become richer over time without changing the advisory
+  core
+
 ## Readiness Model
 
 Readiness is subject-first, stage-specific, and reducible into reporting
@@ -299,6 +455,7 @@ Purpose:
 
 Kernel fields:
 
+- `subject_readiness_id`
 - `subject_ref`
 - `stage`
 - `status`
@@ -332,8 +489,8 @@ Rules:
 - subject readiness is the base truth
 - `evidence` readiness covers deterministic evidence selection and observation
   completeness before semantic commitment
-- reducers work from subject readiness plus gaps, not from hand-built whole
-  dataset statuses
+- reducers work from subject readiness plus gaps, not from hand-built
+  whole-dataset statuses
 - a subject may be ready for one stage and blocked for another
 - readiness points to blocking gap ids rather than hiding blockers in summary
   text
@@ -413,35 +570,6 @@ Rules:
   without manual status editing
 - stages use only the dimensions they actually own or can derive safely
 
-## Shared Checkpoint Assertions
-
-Use one shared checkpoint-assertion vocabulary across reconciliation,
-checkpoints, accounting, and tax.
-
-Rules:
-
-- checkpoint assertions stay first-class and referenceable
-- downstream stages may reuse them, but should not redefine them into
-  incompatible local variants
-
-## Review Sidecar Rules
-
-The target runtime does not define one shared cross-stage `ReviewRecord`
-kernel.
-
-Rules:
-
-- reviews are advisory and never block by themselves
-- a review may pair with one gap through `paired_gap_id`
-- when a blocker and a review share one cause, the gap owns the blocker and
-  the review remains sidecar context
-- downstream stages must not require upstream review sidecars as kernel inputs
-- persisted review sidecars remain stage-local under `sidecars/reviews.json`
-  as owned by
-  [Target Product Artifacts](../reference/target-product-artifacts.md)
-- `NormalizationReviewRecord` maps to stage-local review sidecars, not to a
-  shared target review kernel
-
 ## Bridge Mapping From Issue And Review Records
 
 The live bridge still emits `IssueRecord` and `NormalizationReviewRecord`.
@@ -452,8 +580,8 @@ Mapping rules:
   when owner stage, blocking stages, scope, and blocker semantics align
 - `IssueRecord.kind`, `severity`, `context_timestamp`, and typed provenance are
   gap inputs, not free text to reinterpret later
-- `NormalizationReviewRecord` remains a stage-local review sidecar unless a
-  paired blocking condition also exists
+- `NormalizationReviewRecord` maps to one `ReviewRecord` plus one
+  `ReviewExplanation` when owner stage, scope, and advisory meaning align
 - when one factual cause produces both a blocker and an advisory review, the
   blocker lands in `GapCore` and the review remains keyed sidecar context
 - current bridge ids remain traceable when later stages adopt target-native gap
@@ -466,27 +594,32 @@ Copy only when meaning changes.
 Meaning:
 
 - one stage owns one semantic payload
-- downstream stages reference upstream records by stable ids
+- downstream stages reference upstream records by stable ids or product ids
+- `dataset_id` is allowed only for shared reporting and sidecar attachment
+  when no narrower truthful product id, scope id, or record id exists
 - downstream stages add stage-owned outputs only
 
 Keep these first-class:
 
+- evidence members
+- evidence observations
+- claims and interpretation bundles
 - economic events
 - economic legs
-- identities
+- valuations
+- identities and refs
 - ownership state
 - settlement and lifecycle state
-- valuations
 - checkpoint assertions
 - postings
-- tax inputs
+- tax determinants and outputs
 
 Use sidecars only for:
 
 - provenance
 - gaps
-- readiness
 - reviews
+- readiness
 - annotations
 - comparison traces
 - policy explanations
@@ -501,13 +634,14 @@ Performance implication:
 
 - avoiding semantic duplication is also a performance rule
 - repeated full payloads increase read amplification, join cost, and drift risk
-- the correct shape is stable ids plus stage-owned deltas
+- the correct shape is stable ids or product ids plus stage-owned deltas, with
+  `dataset_id` reserved for shared reporting or sidecar attachment only
 
-## Current-to-Target Boundary
+## Current-To-Target Boundary
 
 - current `IssueRecord` and `NormalizationReviewRecord` remain live bridge
   outputs today
 - later implementation may map current bridge issues and reviews into the
-  target gap/readiness model where the stage ownership and semantics line up
+  target support model where stage ownership and semantics line up
 - current-state docs keep current issue and review names where accuracy
   requires them

--- a/docs/concepts/oracle-boundaries.md
+++ b/docs/concepts/oracle-boundaries.md
@@ -1,6 +1,6 @@
 ---
 title: "Oracle Boundaries"
-summary: "Boundary rules for normal runtime inputs, adapter surfaces, and oracle-only artifacts."
+summary: "Boundary rules for normal runtime inputs, adapter inputs and outputs, and oracle-only artifacts."
 doc_type: concept
 audience: human
 owner: repo
@@ -10,7 +10,7 @@ nav_order: 30
 
 Use this document to keep the next architecture phase platform-agnostic. It
 defines which artifacts are normal runtime inputs, which ones are optional
-adapter-format surfaces, and which ones are oracle-only support files.
+adapter-format outputs, and which ones are oracle-only support files.
 
 The goal is simple: the system must be able to reconstruct, reconcile, journal,
 and compute tax state from source evidence and intentional checkpoints without
@@ -24,7 +24,7 @@ depending on any one portfolio tracker.
   adapters or policies are crypto-first.
 - Source evidence and source-backed checkpoints are first-class.
 - Operator confirmations may support runtime reconciliation, but they are a
-  lower-trust reference surface than source-backed evidence.
+  lower-trust reference input than source-backed evidence.
 - Output and import adapters are optional edges, not central dependencies.
 - Oracle artifacts are comparison aids only.
 - No tax, reconciliation, or journal logic may require CoinTracking-specific
@@ -63,7 +63,7 @@ Current runtime note:
 
 - today's bridge path still centers on `TransactionFact` plus shared balance
   artifacts
-- treat that bridge as an incremental delivery seam, not as the long-term
+- treat that bridge as an incremental delivery boundary, not as the long-term
   endpoint of the architecture
 
 ## CoinTracking-Specific Rules
@@ -72,7 +72,7 @@ CoinTracking support is intentionally narrow:
 
 - CoinTracking import/export shapes may be supported as adapters.
 - CoinTracking row types may be targeted by adapter-local renderer mappings
-  when producing that export surface.
+  when producing that export output.
 - CoinTracking reports may be parsed for comparison by dev-only tooling.
 - CoinTracking tax outputs may be used as black-box oracles during validation.
 
@@ -136,7 +136,7 @@ Those artifacts may support comparison, but not checkpoint existence.
 - Keep import-shape parsing behind adapter boundaries.
 - Keep domain services unaware of CoinTracking report schemas.
 - Keep crypto-, FX-, and security-specific terms out of shared core abstractions
-  unless the concept is inherently specific to that surface.
+  unless the concept is inherently specific to that adapter or output.
 - Keep tax policy operating on `TaxInputs` built from reconciled economics and
   accepted checkpoint truth only.
 - Keep journal rendering operating on reconciled economics, accepted checkpoint

--- a/docs/concepts/pipeline-stage-contracts.md
+++ b/docs/concepts/pipeline-stage-contracts.md
@@ -75,6 +75,22 @@ Shared rules:
   and sidecar payloads that do not change kernel meaning
 - sidecars and explanation payloads use their own schema and fingerprint rules
   when they are persisted independently
+- every stable id defined on this page uses the format
+  `<kind>:<sha256(lowercase-hex)>`
+- the hash input is one canonical UTF-8 JSON array of ordered components
+- component arrays use the owning product's canonical scalar forms exactly as
+  emitted; do not add hidden trimming, lowercasing, or resorting outside the
+  declared tuple rules
+
+### Composite Tuple Rules
+
+- `SubjectRef` serializes and sorts as
+  `[subject_kind, subject_id]`
+- `BasisPoolRef` serializes and sorts as
+  `[tax_policy_id, jurisdiction_or_regime, beneficial_owner_ref, pool_scope]`
+- when one stable-id recipe, ordering rule, or fingerprint input includes one
+  of these composite references, use the tuple form above rather than an
+  object-name shorthand
 
 ### Kernel And Envelope Rule
 
@@ -172,6 +188,22 @@ Envelope content may include:
 - `observation_id` identifies one typed observation under one evidence member
 - `selection_group_id` identifies one deterministic evidence-selection
   decision boundary
+- `evidence_set_id` uses component array
+  `[source, adapter_id, capture_uid, selection_group_id]`
+- `member_id` uses component array
+  `[evidence_set_id, member_class, member_locator_identity]`
+- `observation_id` uses component array
+  `[member_id, observation_class, observation_anchor]`
+- `selection_group_id` is emitted by the evidence-selection stage and remains a
+  stable upstream id rather than a downstream recomputation
+- `member_class` is the stable evidence-family or member-role label emitted for
+  the member
+- `member_locator_identity` is the stage-owned stable locator tuple for one
+  evidence member
+- `observation_class` is the stable observation family label emitted for one
+  typed observation
+- `observation_anchor` is the stable row, page, anchor, or typed observation
+  locator emitted for that observation
 
 ### EvidenceSet Ordering
 
@@ -192,7 +224,7 @@ Envelope content may include:
 
 ### EvidenceSet Fingerprint Inputs
 
-- kernel records in declared order
+- kernel records in canonical order
 - `schema_version`
 - `manifest_fingerprint_ref`
 - `plan_fingerprint_ref`
@@ -242,18 +274,60 @@ Envelope content may include:
 - advisory review payloads
 - output-oriented annotations
 
+### Minimum ClaimSet Taxonomy
+
+This section is the sole owner of the shared minimum `ClaimSet` family
+vocabulary.
+
+| Claim family | Shared role | Default first-slice status |
+| --- | --- | --- |
+| `ActivityClaim` | provider-local activity or transaction meaning before shared compilation | in scope |
+| `BalanceObservationClaim` | quantity-backed balance or as-of observation tied to evidence | in scope |
+| `OwnershipClaim` | provider-local ownership or control assertion that may matter later | canonical but out of scope |
+| `LocationClaim` | provider-local location or sub-location assertion | in scope |
+| `StatementClaim` | parsed statement row or document-level semantic claim | canonical but out of scope |
+| `InstrumentIdentityClaim` | provider-local instrument identity assertion | in scope |
+| `ContractTermClaim` | provider-local term or contract assertion needed later | canonical but out of scope |
+| `ValuationClaim` | valuation observation whose purpose affects later behavior | in scope |
+| `ProjectionAnnotation` | output-oriented metadata that is not accepted economic truth | in scope |
+| `IssueCandidate` | blocking pre-economic diagnostic candidate | in scope |
+| `ReviewCandidate` | advisory pre-economic review candidate | in scope |
+
+Rules:
+
+- secondary docs may reference these claim families, but they must not publish
+  competing repo-wide family lists
+- later slices may use canonical families that are out of scope for the default
+  first slice without redefining the shared vocabulary
+
 ### ClaimSet Stable Ids
 
 - `claim_set_id` identifies one bounded semantic emission over one evidence set
 - `claim_id` identifies one claim family member with one stable semantic role
 - `interpretation_group_id` identifies one mutually exclusive claim bundle
+- `claim_set_id` uses component array
+  `[evidence_set_id, claim_emitter_id]`
+- `claim_id` uses component array
+  `[claim_set_id, claim_family, claim_anchor, interpretation_group_id]`
+- `interpretation_group_id` uses component array
+  `[claim_set_id, bundle_anchor, bundle_discriminator]`
+- `claim_emitter_id` is the stable id of the translation family or shared
+  compiler boundary that emitted the claim set
+- `claim_anchor` is the stable provider-local anchor for one asserted meaning;
+  slice-specific anchor choices live in
+  [First Slice Contract](../reference/first-slice-contract.md)
+- `bundle_anchor` is the stable anchor shared by all mutually exclusive bundles
+  over the same source-local meaning
+- `bundle_discriminator` is `default` when one anchor has exactly one bundle;
+  otherwise use `alt:1`, `alt:2`, and so on in canonical bundle order under
+  that anchor
 
 ### ClaimSet Ordering
 
-- sort by `claim_family`
-- then `effective_at` when present
-- then `claim_id`
-- then `interpretation_group_id`
+- sort by tuple
+  `[claim_family, effective_at_or_null, claim_id, interpretation_group_id]`
+- use JSON `null` for `effective_at_or_null` when the claim has no effective
+  time
 
 ### ClaimSet Serialization
 
@@ -264,7 +338,7 @@ Envelope content may include:
 
 ### ClaimSet Fingerprint Inputs
 
-- kernel records in declared order
+- kernel records in canonical order
 - `schema_version`
 - `claim_set_id`
 - referenced `EvidenceSet` ids or fingerprints
@@ -549,12 +623,13 @@ Envelope content may include:
 - `checkpoint_id` identifies one accepted checkpoint container
 - `checkpoint_assertion_id` identifies one accepted checkpoint truth record for
   one subject and one as-of point
+- `checkpoint_assertion_id` uses component array
+  `[assertion_kind, asserted_as_of_at, subject_ref.subject_kind, subject_ref.subject_id]`
 
 ### Checkpoint Ordering
 
-- sort by `asserted_as_of_at`
-- then `subject_ref`
-- then `checkpoint_assertion_id`
+- sort by tuple
+  `[asserted_as_of_at, subject_ref.subject_kind, subject_ref.subject_id, checkpoint_assertion_id]`
 
 ### Checkpoint Serialization
 
@@ -564,7 +639,7 @@ Envelope content may include:
 
 ### Checkpoint Fingerprint Inputs
 
-- kernel checkpoint assertion records in declared order
+- kernel checkpoint assertion records in canonical order
 - `schema_version`
 - referenced `ReconciliationState` ids or fingerprints
 - referenced accepted evidence ids
@@ -679,7 +754,7 @@ Envelope content may include:
 
 ### Journal Fingerprint Inputs
 
-- kernel journal records in declared order
+- kernel journal records in canonical order
 - `schema_version`
 - referenced `EconomicFacts` ids
 - referenced `Checkpoint` assertion ids
@@ -739,13 +814,17 @@ Envelope content may include:
 
 - `determinant_id` identifies one tax determinant
 - `basis_pool_ref` identifies one tax basis or pool seam reused across tax years
+- `determinant_id` uses component array
+  `[tax_year, determinant_family, basis_pool_ref.tax_policy_id, basis_pool_ref.jurisdiction_or_regime, basis_pool_ref.beneficial_owner_ref, basis_pool_ref.pool_scope, determinant_anchor]`
+- `basis_pool_ref` serializes, sorts, and fingerprints using
+  `[tax_policy_id, jurisdiction_or_regime, beneficial_owner_ref, pool_scope]`
+- `determinant_anchor` is the stable tax-owned anchor for one determinant under
+  one basis or pool scope
 
 ### TaxInputs Ordering
 
-- sort by `tax_year`
-- then `basis_pool_ref`
-- then `determinant_family`
-- then `determinant_id`
+- sort by tuple
+  `[tax_year, basis_pool_ref.tax_policy_id, basis_pool_ref.jurisdiction_or_regime, basis_pool_ref.beneficial_owner_ref, basis_pool_ref.pool_scope, determinant_family, determinant_id]`
 
 ### TaxInputs Serialization
 
@@ -755,7 +834,7 @@ Envelope content may include:
 
 ### TaxInputs Fingerprint Inputs
 
-- kernel determinant records in declared order
+- kernel determinant records in canonical order
 - `schema_version`
 - referenced `EconomicFacts` ids
 - referenced `Checkpoint` assertion ids

--- a/docs/concepts/pipeline-stage-contracts.md
+++ b/docs/concepts/pipeline-stage-contracts.md
@@ -53,6 +53,41 @@ Shared rules:
 - stage contracts should stay compact enough for deterministic replay and
   partitioned recomputation
 
+## Shared Product Rules
+
+### Versioning, Serialization, And Fingerprints
+
+- every target product carries a `schema_version`
+- readers accept only the declared supported versions for that product
+- unknown schema versions fail fast
+- compatibility is forward-only by default; do not promise long-lived in-place
+  compatibility unless the owning product explicitly declares a narrower
+  compatibility window
+- regeneration from upstream products or evidence is the normal recovery path
+  for incompatible target-stage artifacts
+- every target product defines one canonical serialization and one stable
+  fingerprint over semantically relevant content
+- fingerprints include semantically relevant upstream references and owning
+  decisions, but exclude presentation-only formatting noise and derived
+  explanation payloads that do not change kernel meaning
+- sidecars and explanation payloads use their own schema and fingerprint rules
+  when persisted independently
+- presentation-only formatting or ordering noise must not affect fingerprints
+
+### Kernel And Envelope Rule
+
+- every target product separates a compact computational kernel from optional
+  envelopes or sidecars
+- the kernel holds stable ids, ordering keys, owning decisions, and the
+  downstream-required references needed for replay and reducers
+- envelopes and sidecars hold provenance detail, explanation, reviews,
+  comparison traces, and policy notes
+- any later rehydration path must join through stable ids emitted by the kernel
+- sidecars must not become the only copy of business meaning or determinant
+  state
+- replay and parity gates operate on kernels first and inspect envelopes
+  separately when the slice requires them
+
 ## `EvidenceSet`
 
 Purpose:
@@ -111,7 +146,7 @@ Owns:
 Carries:
 
 - activity claims
-- balance claims
+- balance observation claims
 - ownership claims
 - location claims
 - instrument claims
@@ -120,11 +155,25 @@ Carries:
 - candidate interpretations
 - claim-owned issues and reviews
 
+Minimum claim-family distinctions:
+
+- `ActivityClaim`
+- `BalanceObservationClaim`
+- `OwnershipClaim`
+- `LocationClaim`
+- `InstrumentIdentityClaim`
+- `ContractTermClaim`
+- `ValuationClaim`
+- `ProjectionAnnotation`
+- blocking issue and review candidate surfaces
+
 Must guarantee:
 
 - source-local semantics only
 - preserved ambiguity where one safe final interpretation is unavailable
 - provenance for every claim
+- adapters may add provider-local subtyping, but they must preserve the shared
+  claim-family distinctions above so later compilation is interoperable
 
 Must not:
 
@@ -164,6 +213,19 @@ Carries:
 - valuations
 - confidence and ambiguity markers
 
+Minimum accepted economic determinants:
+
+- stable event identity and event-kind family
+- effective time and temporal precision
+- one stable leg set with signed quantities and explicit leg roles
+- settlement state where later stages depend on it
+- lifecycle state where later stages depend on it
+- supersession or correction lineage
+- ownership and counterparty references where known
+- valuation records with explicit purpose where downstream behavior depends on
+  them
+- stable references back to accepted upstream claims
+
 Must support:
 
 - holdings movements
@@ -177,6 +239,14 @@ Must support:
 - corporate actions
 - restructurings
 - lifecycle-heavy activity
+
+Rules:
+
+- accepted event kinds stay jurisdiction-neutral and output-neutral
+- corrections preserve supersession lineage instead of mutating accepted
+  economic truth in place
+- unresolved economic detail may remain explicit only where later stages can
+  still reason safely from the accepted kernel
 
 Must not:
 
@@ -257,11 +327,52 @@ Carries:
 - continuity decisions into accepted state
 - trust level and acceptance basis
 
+Controlled checkpoint vocabularies:
+
+- `trust_level`:
+  - `filing_ready`
+  - `analysis_ready`
+  - `operator_only`
+- `acceptance_basis`:
+  - `source_document`
+  - `source_system_balance`
+  - `reconciled_continuity`
+  - `adopted_opening_state`
+  - `operator_assertion`
+- `evidence_class`:
+  - `statement_balance`
+  - `platform_balance`
+  - `wallet_snapshot`
+  - `inventory_proof`
+  - `operator_assertion`
+- `continuity_proof`:
+  - `direct_observation`
+  - `reconciled_rollforward`
+  - `opening_state_rollforward`
+  - `partial_continuity`
+
+Minimum admissibility rules:
+
+- `filing_ready` requires:
+  - `acceptance_basis` other than `operator_assertion`
+  - `evidence_class` other than `operator_assertion`
+  - `continuity_proof` other than `partial_continuity`
+- `analysis_ready` may use `operator_assertion` or `partial_continuity`, but the
+  lower-trust basis must stay explicit in the accepted checkpoint record
+- `operator_only` is required when accepted checkpoint truth relies solely on
+  operator assertion without a source-backed evidence class
+- `adopted_opening_state` remains a distinct acceptance basis and must preserve
+  provenance plus the continuity proof used to roll it into accepted state
+
 Must guarantee:
 
 - accepted checkpoint truth is first-class
 - source-backed evidence remains preferred
 - operator assertions do not silently become filing-ready checkpoint truth
+- `filing_ready` checkpoint truth must not rely solely on `operator_assertion`
+  acceptance
+- adopted opening state remains explicit instead of masquerading as direct
+  observation
 
 Must not:
 
@@ -335,11 +446,37 @@ Carries:
 - basis or pool state transitions
 - tax-owned unresolved items
 
+Minimum determinant families:
+
+- `acquisition`
+- `disposition`
+- `income`
+- `expense_or_fee`
+- `financing_cost`
+- `internal_transfer`
+- `basis_adjustment`
+- `corporate_action`
+
+Each determinant preserves, where applicable:
+
+- stable determinant identity
+- determinant family
+- effective time and temporal precision
+- instrument, pool, or other affected subject reference
+- quantity and direction
+- tax-relevant valuation
+- ownership or counterparty references
+- upstream economic-event references
+- accepted checkpoint or opening-state references when tax basis depends on them
+- basis or pool transition references
+
 Must guarantee:
 
 - jurisdiction-neutral determinants
 - explicit basis-affecting state changes
 - explicit tax-owned blockers where upstream truth is not tax-complete
+- tax-incomplete items stay explicit instead of being upgraded into guessed
+  treatment
 
 Must not:
 

--- a/docs/concepts/pipeline-stage-contracts.md
+++ b/docs/concepts/pipeline-stage-contracts.md
@@ -33,8 +33,8 @@ The target runtime pipeline is:
 - no stage may duplicate upstream semantic payloads unless the meaning has
   changed
 - target-product kernel rules in this page are authoritative; other docs may
-  point here but should not restate competing kernel, id, or fingerprint
-  contracts
+  point here but should not restate competing kernel, id, fingerprint, or
+  sidecar contracts
 
 ## Handoff Rules
 
@@ -52,26 +52,14 @@ Shared rules:
   silently rewrite upstream truth to make their own outputs look tidy
 - if a stage cannot support a required decision, it emits explicit blockers,
   unresolved records, or deferred records rather than inventing a fallback
-- replay and parity gates operate on kernels first and inspect envelopes
+- replay and parity gates operate on kernels first and inspect sidecars
   separately only where the slice requires them
 
 ## Shared Product Rules
 
-Shared primitive and artifact authorities used by this page live in
-[Target Contract Primitives](../reference/target-contract-primitives.md) and
-[Target Product Artifacts](../reference/target-product-artifacts.md). This
-page remains the owner of stage semantics, record families, stage-owned
-vocabularies, and handoff guarantees.
-
 ### Versioning, Serialization, And Fingerprints
 
 - every target product carries a `schema_version`
-- `schema_version` is a product-level kernel field persisted once per emitted
-  product beside the ordered kernel records for that product
-- readers accept only the declared supported versions for that product
-- unknown schema versions fail fast
-- compatibility is forward-only by default; regeneration from upstream
-  products or evidence is the normal recovery path for incompatible artifacts
 - every target product defines one stable serialization and one stable
   fingerprint over semantically relevant kernel content
 - kernel fingerprints use stable UTF-8 JSON serialization with stable object
@@ -79,41 +67,93 @@ vocabularies, and handoff guarantees.
 - fingerprints include semantically relevant upstream ids or upstream
   fingerprint references plus owning-stage decisions
 - fingerprints exclude presentation-only formatting noise, explanation text,
-  and sidecar payloads that do not change kernel meaning
+  comparison traces, and sidecars that do not change kernel meaning
+- compatibility is forward-only by default; regeneration from upstream products
+  or evidence is the normal recovery path for incompatible artifacts
+
+### Stable Id Format
+
 - every stable id defined on this page uses the format
   `<kind>:<sha256(lowercase-hex)>`
 - the hash input is one canonical UTF-8 JSON array of ordered components
 - component arrays use the owning product's canonical scalar forms exactly as
   emitted; do not add hidden trimming, lowercasing, or resorting outside the
   declared tuple rules
-- canonical scalar forms, admissible anchor components, shared dataset
-  identity, reusable tuple contracts, and default target dataset packaging are
-  owned by the reference pages above rather than redefined here
+
+### Product Id And Upstream Ref Rules
+
+- every target product carries one product id in product metadata
+- `EvidenceSet` and `ClaimSet` keep `evidence_set_id` and `claim_set_id` as
+  their product ids
+- later products use dedicated product ids:
+  `economic_facts_id`, `reconciliation_state_id`, `checkpoint_run_id`,
+  `journal_run_id`, `tax_inputs_id`, and `tax_outputs_id`
+- upstream product metadata refs use product ids only; they never use
+  `dataset_id` or a raw kernel fingerprint
+- ordered metadata fields such as `claim_set_refs`,
+  `reconciliation_state_refs`, and `economic_facts_refs` sort
+  lexicographically by product id unless the owning product declares a
+  stronger canonical order
+- `dataset_id` remains a derived shared-support and reporting attachment only;
+  it is not a product id or upstream product ref
+
+### Record Reference Rule
+
+- when a kernel field name ends with `_ref`, `_refs`, or `_id_or_null` and the
+  stem names one target product owned on this page, the field uses that
+  product's metadata id or ordered product-id list
+- when a kernel field name ends with `_ref`, `_refs`, or `_id_or_null` and the
+  stem names one target record family owned on this page, the field uses that
+  record family's stable id or ordered stable-id list
+- helper tuple refs such as `SubjectRef`, `BasisPoolRef`,
+  `ValuationSourceRef`, `AccountRef`, `CommodityRef`, and `OriginRef` remain
+  owned by their helper pages and are called out explicitly where used
 
 ### Composite Tuple Rules
 
 - `SubjectRef` serializes and sorts as `[subject_kind, subject_id]`
 - `BasisPoolRef` serializes and sorts as
   `[tax_policy_id, jurisdiction_or_regime, beneficial_owner_ref, pool_scope]`
-- plain `*_ref` and `*_refs` fields point to stable ids unless the owning page
-  explicitly names a structured tuple contract such as `SubjectRef`,
-  `BasisPoolRef`, `AccountRef`, `CommodityRef`, or `OriginRef`
-- when one stable-id recipe, ordering rule, or fingerprint input includes one
-  of these composite references, use the tuple form above rather than an
+- when one stable-id recipe, ordering rule, or fingerprint input includes a
+  domain ref whose canonical tuple is owned by
+  [Domain Ontology](domain-ontology.md), use that tuple form rather than an
   object-name shorthand
 
-### Kernel And Envelope Rule
+### Temporal Scalar Rule
+
+- where a field or id recipe uses a temporal scalar such as `effective_at`,
+  `target_as_of_at`, `asserted_as_of_at`, or `valued_at_or_null`, the
+  canonical serialized form must preserve whether the meaning is date-scoped
+  or timestamp-scoped
+- stages may carry an additional precision field when that stage needs it
+  operationally, but the stable id and fingerprint use the canonical temporal
+  scalar only once
+
+### Kernel And Sidecar Rule
 
 - every target product separates a compact computational kernel from optional
-  envelopes or sidecars
+  sidecars
 - the kernel holds stable ids, ordering keys, owning decisions, and the
   downstream-required references needed for replay and reducers
-- the envelope holds provenance detail, explanation, reviews, comparison
-  traces, and policy notes
+- sidecars hold provenance detail, explanation, reviews, comparison traces,
+  policy notes, and other non-kernel context
 - sidecars must not become the only copy of determinant state or business
   meaning
 - any later rehydration path must join through stable ids emitted by the
   kernel
+
+### Dataset Id And Sidecar Attachment
+
+- every target product has one canonical kernel fingerprint
+- the shared `dataset_id` contract is owned by
+  [Gaps And Readiness](gaps-and-readiness.md)
+- `dataset_id` is derived from the emitted kernel fingerprint after canonical
+  fingerprinting; it is not part of kernel metadata or fingerprint inputs
+- `dataset_id` is the product-level attachment surface for readiness,
+  comparison, and other shared sidecars when no narrower truthful scope exists
+- `dataset_id` is not a substitute for a narrower record id or stage-owned
+  scope such as `selection_group_id`, `continuity_segment_id`, or
+  `checkpoint_candidate_id`
 
 ### Shared Kernel Status Vocabulary
 
@@ -125,8 +165,6 @@ Use these bounded status vocabularies across target kernels:
   - `blocked`
 - `claim_status`:
   - `asserted`
-  - `blocked`
-  - `advisory`
   - `superseded`
 - `compilation_outcome`:
   - `accepted`
@@ -150,31 +188,61 @@ Use these bounded status vocabularies across target kernels:
 
 Purpose:
 
-- deterministic intake output before semantic commitment
+- deterministic, capture-scoped evidence output before semantic commitment
+
+Product metadata:
+
+- `evidence_set_id`
+- `schema_version`
+- `selection_plan_fingerprint`
+- `manifest_fingerprint_ref`
 
 Owns:
 
 - selected evidence membership
 - superseded and blocked alternatives
 - deterministic evidence-selection decisions
-- typed provenance and locator identity for selected evidence
-- source-local parsed observations that do not yet require economic meaning
+- typed provenance and locator identity for selected evidence members
+- source-local typed observations that do not yet require economic meaning
 
 Record families:
 
-- `EvidenceRecord`
+- `EvidenceMemberRecord`
   - `evidence_set_id`
+  - `selection_group_id`
+  - `member_id`
   - `source`
   - `adapter_id`
   - `capture_uid`
-  - `member_id`
-  - `selection_group_id`
-  - `observation_id`
+  - `member_family`
+  - `member_locator_identity`
   - `selection_status`
   - `manifest_fingerprint_ref`
-  - `plan_fingerprint_ref`
+- `EvidenceObservationRecord`
+  - `evidence_set_id`
+  - `member_id`
+  - `observation_id`
+  - `observation_family`
+  - `observation_anchor`
+  - `observed_at_or_null`
+  - `observed_precision_or_null`
+  - `provenance_refs`
+- `SelectionDecisionRecord`
+  - `evidence_set_id`
+  - `selection_group_id`
+  - `selection_group_anchor`
+  - `selection_plan_fingerprint`
+  - `decision_basis`
+  - `blocking_gap_refs`
 
-Envelope content may include:
+Cardinality:
+
+- one `SelectionDecisionRecord` exists per `selection_group_id`
+- one or more `EvidenceMemberRecord` rows may belong to one
+  `selection_group_id`
+- zero or more `EvidenceObservationRecord` rows may belong to one `member_id`
+
+Envelope or sidecar content may include:
 
 - document metadata
 - statement row detail
@@ -183,220 +251,336 @@ Envelope content may include:
 - parse diagnostics
 - rich provenance payloads
 
+Controlled vocabularies:
+
+- `decision_basis`:
+  - `single_member_match`
+  - `coverage_preferred`
+  - `freshness_preferred`
+  - `content_duplicate`
+  - `ambiguous_overlap`
+  - `upstream_blocker`
+
+### First-Slice Critical-Path Observation Families
+
+The `EvidenceObservationRecord` shell above is required for every observation.
+For the first bounded slice, these family-specific kernel fields are also
+required:
+
+| `observation_family` | Family-owned kernel fields |
+| --- | --- |
+| `document_identity` | `statement_kind`, `document_effective_at_or_null`, `document_effective_precision_or_null`, `statement_as_of_at_or_null`, `statement_as_of_precision_or_null` |
+| `coinbase_statement_balance_row` | `account_label_or_null`, `wallet_label_or_null`, `balance_kind`, `asset_symbol`, `quantity_or_null`, `observed_at_or_null`, `observed_precision_or_null`, `notes_or_null`, `staked_quantity_text_or_null`, `value_amount_text_or_null`, `value_currency_or_null`, `price_amount_text_or_null`, `price_currency_or_null` |
+
+Rules:
+
+- the family-specific fields above are kernel meaning, not sidecar detail
+- `document_identity.statement_kind` uses the recognized statement-adapter
+  kind for the selected document member
+- `document_identity.statement_as_of_at_or_null` lifts the current parsed
+  statement as-of time and `statement_as_of_precision_or_null` follows the
+  repo-wide temporal precision contract for that value
+- `document_identity.document_effective_at_or_null` lifts the current parsed
+  document-effective time when present and
+  `document_effective_precision_or_null` follows the same temporal contract
+- `coinbase_statement_balance_row.observed_at_or_null` and
+  `observed_precision_or_null` lift the current statement-row as-of value and
+  precision directly
+- `coinbase_statement_balance_row` label, quantity, note, and valuation-text
+  fields lift the current statement-row contract directly; `pdf_file` and
+  `raw_row_ref` stay in provenance and observation anchors rather than
+  duplicated business payload
+- `document_identity` may leave the shell `observed_at_or_null` and
+  `observed_precision_or_null` empty when the meaningful document times are
+  instead expressed through the family-owned document-effective or
+  statement-as-of fields
+- do not add a generic `observation_payload` blob to stand in for a family
+  table
+- no new observation family may be implemented until this page or the owning
+  bounded slice page defines its kernel field table explicitly
+
 Stable ids:
 
-- `evidence_set_id` identifies one bounded evidence emission for one source,
-  adapter, capture, and selection-group scope
+- `evidence_set_id` identifies one capture-scoped evidence emission
+- `selection_group_id` identifies one deterministic evidence-selection
+  decision boundary under one evidence set
 - `member_id` identifies one selected, superseded, or blocked evidence member
 - `observation_id` identifies one typed observation under one evidence member
-- `selection_group_id` identifies one deterministic evidence-selection
-  decision boundary
 - `evidence_set_id` uses component array
-  `[source, adapter_id, capture_uid, selection_group_id]`
+  `[source, adapter_id, capture_uid, selection_plan_fingerprint]`
+- `selection_group_id` uses component array
+  `[evidence_set_id, selection_group_anchor]`
 - `member_id` uses component array
-  `[evidence_set_id, member_class, member_locator_identity]`
+  `[evidence_set_id, member_family, member_locator_identity]`
 - `observation_id` uses component array
-  `[member_id, observation_class, observation_anchor]`
-- `selection_group_id` is emitted by the evidence-selection stage and remains a
-  stable upstream id rather than a downstream recomputation; it is a
-  decision-boundary id, not an evidence member family
-- `member_class` is the stable evidence member-family or member-role label
-  emitted for the member
-- `member_locator_identity` is the stage-owned stable locator tuple for one
-  evidence member
-- `observation_class` is the stable typed observation label emitted for one
-  observation under the owning evidence member
-- `observation_anchor` is the stable row, page, anchor, or typed observation
-  locator emitted for that observation
+  `[member_id, observation_family, observation_anchor]`
+- `selection_group_anchor` is emitted by the evidence-selection stage and
+  remains a stable upstream id rather than a downstream recomputation
+- because `selection_plan_fingerprint` is part of `evidence_set_id`, a change
+  in the authoritative selection plan intentionally produces a new
+  capture-scoped `EvidenceSet` identity
 
 Ordering:
 
-- sort by `source`
-- then `capture_uid`
-- then `selection_group_id`
-- then `selection_status`
-- then `member_id`
-- then `observation_id`
+- `EvidenceMemberRecord` rows sort by tuple
+  `[selection_group_id, selection_status, member_id]`
+- `EvidenceObservationRecord` rows sort by `[member_id, observation_id]`
+- `SelectionDecisionRecord` rows sort by `[selection_group_id]`
 
 Serialization:
 
-- serialize `EvidenceRecord` rows only
+- serialize each evidence record family as its own ordered array
+- persist product metadata once per emitted kernel
 - use stable object-key ordering
-- preserve the declared evidence order above
-- represent timestamps and `Decimal` values using the repo's stable string
-  forms so the fingerprint is independent of language runtime defaults
+- preserve the declared order above
+- sort `provenance_refs` and `blocking_gap_refs` lexicographically
 
 Fingerprint inputs:
 
-- canonical `EvidenceRecord` rows
-- `schema_version`
-- `manifest_fingerprint_ref`
-- `plan_fingerprint_ref`
-- selected upstream provenance ids that affect member identity
+- product metadata
+- canonical `EvidenceMemberRecord` rows
+- canonical `EvidenceObservationRecord` rows
+- canonical `SelectionDecisionRecord` rows
+
+Must guarantee:
+
+- one capture-scoped authoritative evidence kernel
+- deterministic evidence membership and selection decisions
+- typed observations that survive beyond intake-time heuristics
+- no duplication of member membership inside decision records
+
+Must not:
+
+- force economic interpretation
+- collapse many selection groups into one fake product-wide decision
+- use file order as identity
 
 Handoff to `ClaimSet`:
 
 - `EvidenceSet` provides selected evidence, typed observations, provenance, and
-  deterministic selection reasoning
-- it does not provide final economic interpretation, final ownership meaning,
-  checkpoint acceptance, journal logic, or tax treatment
+  deterministic selection decisions
+- it does not provide final economic interpretation, checkpoint acceptance,
+  journal logic, or tax treatment
 
 ## `ClaimSet`
 
 Purpose:
 
-- source-local meaning layer before economic truth is fixed
+- semantic-only source-local meaning before economic truth is fixed
+
+Product metadata:
+
+- `claim_set_id`
+- `schema_version`
+- `evidence_set_ref`
+- `claim_emitter_id`
 
 Owns:
 
 - source-local semantic assertions derived from evidence
-- explicitly unresolved meaning when one safe final interpretation is not yet
-  available
-- claim-owned issues and reviews
+- explicit interpretation scope and mutually exclusive semantic bundles
+- compilation decisions over interpretation scopes
 
 Record families:
 
 - `ClaimRecord`
   - `claim_set_id`
+  - `interpretation_scope_id`
+  - `bundle_id`
   - `claim_id`
   - `claim_family`
   - `claim_status`
-  - `interpretation_group_id`
+  - `claim_anchor`
   - `evidence_member_refs`
-  - `effective_at`
-  - `effective_precision`
+  - `evidence_observation_refs`
+  - `effective_at_or_null`
+  - `effective_precision_or_null`
   - `provenance_refs`
+- `InterpretationBundleRecord`
+  - `claim_set_id`
+  - `interpretation_scope_id`
+  - `bundle_id`
+  - `bundle_discriminator`
+  - `scope_anchor`
+  - `claim_refs`
 - `CompilationDecisionRecord`
   - `claim_set_id`
-  - `adjudication_record_id`
-  - `interpretation_group_id`
+  - `interpretation_scope_id`
+  - `compilation_decision_id`
   - `compilation_outcome`
-  - `accepted_claim_refs`
-  - `rejected_claim_refs`
-  - `deferred_claim_refs`
+  - `selected_bundle_id_or_null`
+  - `rejected_bundle_refs`
+  - `deferred_bundle_refs`
   - `resolution_basis`
   - `blocking_gap_refs`
 
-Envelope content may include:
+Cardinality:
 
-- provider-local semantic detail
-- comparison traces
-- claim explanation
-- advisory review payloads
-- output-oriented annotations
+- one or more `InterpretationBundleRecord` rows may exist per
+  `interpretation_scope_id`
+- one `CompilationDecisionRecord` exists per `interpretation_scope_id`
+- one or more `ClaimRecord` rows may exist per `bundle_id`
 
-### Minimum ClaimSet Taxonomy
+Canonical claim families:
 
-This section is the sole owner of the shared minimum `ClaimSet` family
-vocabulary.
+- `ActivityClaim`
+- `BalanceObservationClaim`
+- `InstrumentIdentityClaim`
+- `LocationClaim`
+- `LegalOwnerClaim`
+- `BeneficialOwnerClaim`
+- `CounterpartyClaim`
+- `StatementClaim`
+- `ContractTermClaim`
+- `ValuationClaim`
 
-| Claim family | Shared role | Default first-slice status |
-| --- | --- | --- |
-| `ActivityClaim` | provider-local activity or transaction meaning before shared compilation | in scope |
-| `BalanceObservationClaim` | quantity-backed balance or as-of observation tied to evidence | in scope |
-| `OwnershipClaim` | provider-local ownership or control assertion that may matter later | canonical but out of scope |
-| `LocationClaim` | provider-local location or sub-location assertion | in scope |
-| `StatementClaim` | parsed statement row or document-level semantic claim | canonical but out of scope |
-| `InstrumentIdentityClaim` | provider-local instrument identity assertion | in scope |
-| `ContractTermClaim` | provider-local term or contract assertion needed later | canonical but out of scope |
-| `ValuationClaim` | valuation observation whose purpose affects later behavior | in scope |
-| `ProjectionAnnotation` | output-oriented metadata that is not accepted economic truth | in scope |
-| `IssueCandidate` | blocking pre-economic diagnostic candidate | in scope |
-| `ReviewCandidate` | advisory pre-economic review candidate | in scope |
+Controlled vocabularies:
+
+- `resolution_basis`:
+  - `single_bundle_match`
+  - `insufficient_identity`
+  - `insufficient_temporal_precision`
+  - `conflicting_claims`
+  - `upstream_blocker`
+  - `policy_deferred`
+  - `superseded_by_later_claims`
+
+### First-Slice Critical-Path Claim Families
+
+The `ClaimRecord` shell above is required for every claim. For the first
+bounded slice, these family-specific kernel fields are also required:
+
+| `claim_family` | Family-owned kernel fields |
+| --- | --- |
+| `ActivityClaim` | `provider_activity_kind`, `location_claim_ref_or_null`, `activity_leg_specs` |
+| `BalanceObservationClaim` | `location_claim_ref`, `instrument_claim_refs`, `balance_kind`, `quantity`, `observed_at_or_null`, `observed_precision_or_null` |
+| `InstrumentIdentityClaim` | `scheme`, `value`, `venue_or_null`, `kind_hint`, `display_name_or_null`, `precision_hint_or_null` |
+| `LocationClaim` | `location_ref`, `account_label_or_null`, `wallet_label_or_null` |
+| `BeneficialOwnerClaim` | `beneficial_owner_ref` |
+| `ValuationClaim` | `valuation_measure_kind`, `valuation_purpose`, `amount`, `currency`, `valued_at_or_null`, `valued_precision_or_null`, `location_claim_ref_or_null`, `instrument_claim_refs` |
+
+`activity_leg_specs` entry shape:
+
+- `leg_slot`
+- `leg_kind`
+- `quantity`
+- `instrument_claim_refs`
+- `location_claim_ref_or_null`
+- `subtype_or_null`
+- `attributed_to_leg_slot_or_null`
+
+First-slice linkage rules:
+
+- `ActivityClaim.provider_activity_kind` is the canonical home for the current
+  provider-local activity type used by the bounded slice
+- `activity_leg_specs` lift ordered leg meaning from the current
+  `EconomicLegDraft` contract, including sign, instrument identity claims,
+  optional subtype, optional attributed-leg linkage, and optional location
+- retail activity claims use `evidence_member_refs` plus the first-slice scope
+  anchor `[retail_member_id, raw_row_ref]`; they do not require a retail-row
+  observation family in this pass
+- statement-derived claims use both `evidence_member_refs` and
+  `evidence_observation_refs`
+- `BalanceObservationClaim` must include the row observation id in
+  `evidence_observation_refs` and may also include the paired
+  `document_identity` observation id for the same statement document
+- `ValuationClaim` is canonically defined now but emits zero rows by default in
+  the first bounded slice until a later owner-doc pass locks canonical numeric
+  statement valuation inputs
+
+### Derived Compatibility Sidecars
+
+Derived compatibility sidecars keep legacy draft and fact reproduction fields out of
+canonical `ClaimSet` payloads.
 
 Rules:
 
-- secondary docs may reference these claim families, but they must not publish
-  competing repo-wide family lists
-- later slices may use canonical families that are out of scope for the
-  default first slice without redefining the shared vocabulary
+- these bridge-only fields must live only in derived compatibility sidecars
+  keyed by `claim_id` or `bundle_id`:
+  `economic_kind`, `projection_hint`, `accounting_intent_hint`,
+  `tax_treatment_hint`, `description`, `tx_hash_or_null`,
+  `operation_group_id_or_null`, `confidence`, and `status`
+- `provider_operation_key` is satisfied by
+  `ActivityClaim.provider_activity_kind` and must not be duplicated into a
+  compatibility sidecar field
+- review markers map to shared support artifacts rather than canonical claims
+  or bridge-compat semantic payloads
+- adapter-local extras may survive only as envelope or compatibility-sidecar
+  detail and never as canonical `ClaimSet` kernel meaning
+- do not add a generic `claim_payload` blob to stand in for a family table
+- no non-critical claim family may be implemented until this page or the
+  owning bounded slice page defines its kernel field table explicitly
 
 Stable ids:
 
-- `claim_set_id` identifies one bounded semantic emission over one evidence set
-- `claim_id` identifies one claim family member with one stable semantic role
-- `interpretation_group_id` identifies one mutually exclusive claim bundle
-- `adjudication_record_id` identifies one compilation-decision record
+- `claim_set_id` identifies one semantic emission over one evidence set
+- `interpretation_scope_id` identifies one provider-local semantic scope that
+  may admit one or more mutually exclusive bundles
+- `bundle_id` identifies one mutually exclusive semantic bundle
+- `claim_id` identifies one semantic assertion under one bundle
+- `compilation_decision_id` identifies one compilation-decision record for one
+  interpretation scope
 - `claim_set_id` uses component array `[evidence_set_id, claim_emitter_id]`
-- `claim_id` uses component array
-  `[claim_set_id, claim_family, claim_anchor, interpretation_group_id]`
-- `interpretation_group_id` uses component array
-  `[claim_set_id, bundle_anchor, bundle_discriminator]`
-- `adjudication_record_id` uses component array
-  `[claim_set_id, interpretation_group_id, compilation_outcome, resolution_basis, accepted_claim_refs, rejected_claim_refs, deferred_claim_refs]`
-- `claim_emitter_id` is the stable id of the translation family or shared
-  compiler boundary that emitted the claim set; its reusable id recipe is
-  owned by
-  [Target Contract Primitives](../reference/target-contract-primitives.md)
-- `claim_emitter_id` is product-scoped `ClaimSet` metadata, not an implicit
-  local variable or adapter-private constant
-- `claim_anchor` is the stable provider-local anchor for one asserted meaning;
-  the shared admissibility rules for anchor components live in
-  [Target Contract Primitives](../reference/target-contract-primitives.md),
-  while slice-specific anchor choices live in
-  [First Slice Contract](../reference/first-slice-contract.md)
-- `bundle_anchor` is the stable anchor shared by all mutually exclusive bundles
-  over the same source-local meaning; its admissibility rules also live in
-  [Target Contract Primitives](../reference/target-contract-primitives.md)
-- `bundle_discriminator` is `default` when one anchor has exactly one bundle;
-  otherwise use `alt:1`, `alt:2`, and so on in canonical bundle order under
-  that anchor
-
-Controlled `resolution_basis` vocabulary:
-
-- `single_bundle_match`
-- `insufficient_identity`
-- `insufficient_temporal_precision`
-- `conflicting_claims`
-- `upstream_blocker`
-- `policy_deferred`
-- `superseded_by_later_claims`
+- `interpretation_scope_id` uses component array `[claim_set_id, scope_anchor]`
+- `bundle_id` uses component array
+  `[interpretation_scope_id, bundle_discriminator]`
+- `claim_id` uses component array `[bundle_id, claim_family, claim_anchor]`
+- `compilation_decision_id` uses component array
+  `[claim_set_id, interpretation_scope_id]`
 
 Ordering:
 
 - `ClaimRecord` rows sort by tuple
-  `[claim_family, effective_at_or_null, claim_id, interpretation_group_id]`
-- use JSON `null` for `effective_at_or_null` when the claim has no effective
-  time
+  `[bundle_id, claim_family, effective_at_or_null, effective_precision_or_null, claim_id]`
+- `InterpretationBundleRecord` rows sort by
+  `[interpretation_scope_id, bundle_discriminator, bundle_id]`
 - `CompilationDecisionRecord` rows sort by
-  `[interpretation_group_id, adjudication_record_id]`
+  `[interpretation_scope_id, compilation_decision_id]`
 
 Serialization:
 
-- serialize `ClaimRecord` rows and `CompilationDecisionRecord` rows as separate
-  ordered arrays
+- serialize each claim record family as its own ordered array
+- persist product metadata once per emitted kernel
 - use stable object-key ordering
-- preserve the declared claim and decision order above
-- sort `evidence_member_refs`, `provenance_refs`, `accepted_claim_refs`,
-  `rejected_claim_refs`, `deferred_claim_refs`, and `blocking_gap_refs`
+- preserve the declared order above
+- sort `evidence_member_refs`, `evidence_observation_refs`, `provenance_refs`, `claim_refs`,
+  `rejected_bundle_refs`, `deferred_bundle_refs`, and `blocking_gap_refs`
   lexicographically
 
 Fingerprint inputs:
 
+- product metadata
 - canonical `ClaimRecord` rows
+- canonical `InterpretationBundleRecord` rows
 - canonical `CompilationDecisionRecord` rows
-- `schema_version`
-- referenced `EvidenceSet` ids or fingerprints
 
 Must guarantee:
 
 - source-local semantics only
+- explicit interpretation scope and bundle structure
 - preserved ambiguity where one safe final interpretation is unavailable
-- provenance for every claim
-- adapters may add provider-local subtyping, but they must preserve the shared
-  claim-family distinctions so later compilation remains interoperable
+- claim-stage gaps and reviews may attach to `interpretation_scope_id` when
+  no narrower truthful subject has resolved yet
+- family-owned kernel fields are frozen wherever this page defines them; later
+  writing and implementation must not invent alternate shells or generic
+  payload blobs for those families
+- no semantic promotion of reviews, blockers, or renderer metadata into claim
+  families
+- claim-owned compilation decisions that record bundle acceptance, blocking,
+  deferral, or supersession without carrying economic payloads
 
 Must not:
 
 - force unresolved meaning into final economic or policy interpretations
-- silently discard materially relevant alternative interpretations
+- treat bridge compatibility annotations as canonical claims
+- silently discard materially relevant alternative bundles
 
 Handoff to `EconomicFacts`:
 
-- `ClaimSet` hands off source-local assertions, interpretation groups, and
-  claim-owned blockers
-- the compiler decides which claims can become accepted economic truth and
-  which remain blocked, deferred, or superseded
+- `ClaimSet` hands off source-local assertions, mutually exclusive bundles, and
+  compilation decisions
+- the compiler decides which bundle can become accepted economic truth and
+  which scopes remain blocked, deferred, or superseded
 
 ## `EconomicFacts`
 
@@ -404,22 +588,27 @@ Purpose:
 
 - economic truth the system can safely assert
 
+Product metadata:
+
+- `economic_facts_id`
+- `schema_version`
+- `claim_set_refs`
+
 Owns:
 
 - accepted economic meaning
 - accepted identity resolution needed for economic truth
-- stable economic event and leg structure
+- stable economic event, leg, and valuation structure
 - explicit remaining ambiguity that is still economically safe to preserve
 
 Record families:
 
 - `EconomicEventRecord`
   - `event_id`
+  - `bundle_id`
+  - `compilation_decision_id`
   - `event_family`
-  - `adjudication_record_id`
-  - `accepted_claim_refs`
-  - `effective_at`
-  - `effective_precision`
+  - `effective_at_or_null`
   - `recorded_at`
   - `settlement_state`
   - `lifecycle_state`
@@ -438,14 +627,14 @@ Record families:
   - `valuation_ref_or_null`
 - `ValuationRecord`
   - `valuation_id`
+  - `valuation_source_ref`
+  - `valuation_purpose`
   - `amount`
   - `currency`
-  - `valuation_purpose`
   - `valued_at_or_null`
-  - `value_precision_or_null`
-  - `source_kind`
-  - `confidence`
+  - `valued_precision_or_null`
   - `provenance_refs`
+  - `confidence`
 
 Controlled vocabularies:
 
@@ -470,83 +659,74 @@ Controlled vocabularies:
   - `fee`
   - `rebate`
   - `withholding`
-- `valuation_purpose`:
-  - `economic`
-  - `checkpoint_support`
-  - `accounting_support`
-  - `tax_support`
-  - `market_observation`
-
-Envelope content may include:
-
-- ownership and counterparty explanation
-- explanation of accepted identity seams
-- supporting claim traces
-- review context carried forward for audit
 
 Stable ids:
 
+- `economic_facts_id` identifies one accepted economic kernel over one or more
+  `ClaimSet` partitions
 - `event_id` identifies one accepted economic event
 - `leg_id` identifies one stable leg under one accepted event
-- `valuation_id` identifies one persisted valuation kernel record
-- `event_id` uses component array `[adjudication_record_id, event_index]`
+- `valuation_id` identifies one valuation record used by one or more accepted
+  events or legs
+- `economic_facts_id` uses component array `[ordered_claim_set_refs]`
+- `valuation_source_ref` uses `ValuationSourceRef` from
+  [Target Contract Primitives](../reference/target-contract-primitives.md)
+- `event_id` uses component array `[bundle_id, event_index]`
 - `leg_id` uses component array `[event_id, leg_role, subject_ref, leg_index]`
 - `valuation_id` uses component array
-  `[amount, currency, valuation_purpose, valued_at_or_null, value_precision_or_null, source_kind, confidence, provenance_refs]`
+  `[valuation_source_ref, valuation_purpose, amount, currency, valued_at_or_null, valued_precision_or_null]`
 - `event_index` and `leg_index` are zero-based canonical positions in declared
   event and leg order
-- `valuation_ref_or_null` points to `valuation_id` when a downstream stage
-  must reason from persisted valuation truth instead of rehydrating envelope
-  detail
+- `compilation_decision_id` may be referenced for audit, but it does not define
+  event identity
 
 Ordering:
 
-- `EconomicEventRecord` rows sort by `effective_at` when present
-- otherwise sort by `recorded_at`
-- then `event_id`
+- `EconomicEventRecord` rows sort by `effective_at_or_null`, then `recorded_at`,
+  then `event_id`
 - `EconomicLegRecord` rows sort by `[event_id, leg_id]`
 - `ValuationRecord` rows sort by `[valuation_purpose, valued_at_or_null, valuation_id]`
 
 Serialization:
 
-- serialize `EconomicEventRecord`, `EconomicLegRecord`, and `ValuationRecord`
-  rows as separate ordered arrays
+- serialize each economic record family as its own ordered array
+- persist product metadata once per emitted kernel
 - use stable object-key ordering
-- preserve the declared event and leg order above
-- sort `provenance_refs` lexicographically when a stronger stage-owned order is
-  not declared
+- preserve the declared order above
+- sort `provenance_refs` lexicographically
 
 Fingerprint inputs:
 
+- product metadata
 - canonical `EconomicEventRecord` rows
 - canonical `EconomicLegRecord` rows
 - canonical `ValuationRecord` rows
-- `schema_version`
-- referenced `CompilationDecisionRecord` ids
 
 Must guarantee:
 
 - accepted event families stay jurisdiction-neutral and output-neutral
-- event and leg records carry the computation-critical determinants needed for
-  later reconciliation, checkpointing, accounting, and tax
-- valuation records stay first-class kernel truth whenever later checkpoint,
-  accounting, or tax behavior depends on them
+- event identity is driven by the selected semantic bundle, not by compilation
+  bookkeeping noise
+- event, leg, and valuation records carry the computation-critical
+  determinants needed for later reconciliation, checkpointing, accounting, and
+  tax
 - corrections preserve supersession lineage instead of mutating accepted
   economic truth in place
-- unresolved economic detail may remain explicit only where later stages can
-  still reason safely from the accepted kernel
 
 Must not:
 
 - collapse to spot-trade assumptions
 - let output hints drive core behavior
-- push leg quantity, location, or instrument truth into envelopes only
+- push leg quantity, location, instrument, or valuation truth into sidecars
+  only
 
 Handoff to `ReconciliationState`:
 
-- `EconomicFacts` provides accepted economic events, economic legs, identity
-  seams, settlement links, lifecycle state, and valuation records or
-  references where they are already safe
+- `EconomicFacts` provides accepted economic events, legs, identity seams,
+  settlement state, lifecycle state, and valuations where they are already
+  safe
+- it records the upstream `claim_set_refs` that justified the accepted
+  economic kernel
 - it does not claim that continuity is complete, transfers are fully linked, or
   checkpoint truth is accepted
 
@@ -556,6 +736,12 @@ Purpose:
 
 - completeness, linkage, continuity, checkpoint candidates, and
   reconciliation-owned blockers
+
+Product metadata:
+
+- `reconciliation_state_id`
+- `schema_version`
+- `economic_facts_ref`
 
 Owns:
 
@@ -573,9 +759,7 @@ Record families:
   - `source`
   - `subject_ref`
   - `segment_start_at_or_null`
-  - `segment_start_precision_or_null`
   - `segment_end_at_or_null`
-  - `segment_end_precision_or_null`
   - `reconciliation_status`
   - `checkpoint_date_or_null`
 - `LinkRecord`
@@ -591,7 +775,6 @@ Record families:
   - `subject_ref`
   - `target_kind`
   - `target_as_of_at`
-  - `target_precision`
   - `expected_value`
   - `observed_value_or_null`
   - `balance_target_status`
@@ -629,7 +812,7 @@ Controlled vocabularies:
   - `blocked`
   - `superseded`
 
-Envelope content may include:
+Envelope or sidecar content may include:
 
 - corroboration sidecars
 - continuity explanation
@@ -637,31 +820,36 @@ Envelope content may include:
 - comparison traces
 - stage-owned gap and readiness sidecars
 
+Product-root cardinality:
+
+- one `ReconciliationState` kernel owns exactly one `ContinuitySegmentRecord`
+- zero or more `LinkRecord`, `BalanceTargetRecord`, and
+  `CheckpointCandidateRecord` rows may exist under that one continuity segment
+
 Stable ids:
 
+- `reconciliation_state_id` identifies one continuity-segment-scoped
+  reconciliation kernel
 - `continuity_segment_id` identifies one bounded continuity window
 - `link_id` identifies one owned transfer or settlement linkage
 - `balance_target_id` identifies one reconciliation-owned balance assertion
   target
 - `checkpoint_candidate_id` identifies one reconciliation-owned checkpoint
   proposal
+- `reconciliation_state_id` uses component array
+  `[economic_facts_ref, continuity_segment_id]`
 - `continuity_segment_id` uses component array
-  `[source, subject_ref, segment_start_at_or_null, segment_start_precision_or_null, segment_end_at_or_null, segment_end_precision_or_null]`
+  `[source, subject_ref, segment_start_at_or_null, segment_end_at_or_null]`
 - `link_id` uses component array
   `[continuity_segment_id, link_kind, left_event_ref, right_event_ref]`
 - `balance_target_id` uses component array
-  `[continuity_segment_id, subject_ref, target_kind, target_as_of_at, target_precision, expected_value_fingerprint]`
+  `[continuity_segment_id, subject_ref, target_kind, target_as_of_at, expected_value_fingerprint]`
 - `checkpoint_candidate_id` uses component array
-  `[continuity_segment_id, subject_ref, checkpoint_date, supporting_balance_target_refs, supporting_evidence_refs]`
-- `expected_value` and `observed_value_or_null` use the shared
-  `AssertionValue` union owned by
-  [Target Contract Primitives](../reference/target-contract-primitives.md)
-- `expected_value_fingerprint` is the canonical fingerprint of one
-  `AssertionValue` and keeps stable-id recipes on admissible scalar inputs
-- reconciliation comparison values stay inline because they are
-  kernel-critical determinants, not detachable sidecars
-- `checkpoint_candidate_id` depends on supporting refs only; it does not
-  include observed-value payloads or comparison text
+  `[continuity_segment_id, subject_ref, checkpoint_date, supporting_balance_target_refs]`
+- `expected_value_fingerprint` is the canonical fingerprint of the
+  `AssertionValue` carried in `expected_value`
+- `supporting_evidence_refs` provide audit support, but they are not part of
+  candidate identity
 
 Ordering:
 
@@ -677,6 +865,7 @@ Ordering:
 Serialization:
 
 - serialize each reconciliation record family as its own ordered array
+- persist product metadata once per emitted kernel
 - use stable object-key ordering
 - preserve the declared order above
 - sort `supporting_balance_target_refs` and `supporting_evidence_refs`
@@ -684,12 +873,11 @@ Serialization:
 
 Fingerprint inputs:
 
+- product metadata
 - canonical `ContinuitySegmentRecord` rows
 - canonical `LinkRecord` rows
 - canonical `BalanceTargetRecord` rows
 - canonical `CheckpointCandidateRecord` rows
-- `schema_version`
-- referenced `EconomicFacts` ids or fingerprints
 
 Must guarantee:
 
@@ -697,13 +885,13 @@ Must guarantee:
 - explicit continuity decisions
 - explicit missing-leg and missing-evidence surfaces
 - preservation of partial truth when the whole window is not yet clean
-- no rewriting of upstream truth to satisfy checks
+- no rewriting of upstream economics to satisfy checks
 
 Must not:
 
 - reclassify upstream economics to make continuity easier
 - bury missing evidence inside whole-dataset summaries
-- use stable-id recipes that depend on undeclared fields or hidden indexes
+- use value refs that point to undefined payloads outside the kernel
 
 Handoff to `Checkpoint`:
 
@@ -716,6 +904,13 @@ Handoff to `Checkpoint`:
 Purpose:
 
 - accepted checkpoint truth and acceptance basis
+
+Product metadata:
+
+- `checkpoint_run_id`
+- `schema_version`
+- `reconciliation_state_refs`
+- `asserted_as_of_at`
 
 Owns:
 
@@ -740,7 +935,7 @@ Record families:
   - `acceptance_basis`
   - `evidence_class`
   - `continuity_proof`
-  - `reconciliation_refs`
+  - `checkpoint_candidate_refs`
 
 Controlled vocabularies:
 
@@ -772,7 +967,7 @@ Controlled vocabularies:
   - `opening_state_rollforward`
   - `partial_continuity`
 
-Envelope content may include:
+Envelope or sidecar content may include:
 
 - supporting evidence refs
 - supporting provenance detail
@@ -780,18 +975,26 @@ Envelope content may include:
 - opening-state adoption detail
 - acceptance rationale
 
+Product-root cardinality:
+
+- one `Checkpoint` kernel owns exactly one `CheckpointRecord`
+- one or more `CheckpointAssertionRecord` rows may exist under that one
+  checkpoint container
+
 Stable ids:
 
+- `checkpoint_run_id` identifies one accepted checkpoint kernel
 - `checkpoint_id` identifies one accepted checkpoint container
 - `checkpoint_assertion_id` identifies one accepted checkpoint truth record for
   one subject and one as-of point
+- `checkpoint_run_id` uses component array
+  `[ordered_reconciliation_state_refs, asserted_as_of_at]`
 - `checkpoint_id` uses component array
   `[asserted_as_of_at, ordered_checkpoint_assertion_ids]`
 - `checkpoint_assertion_id` uses component array
   `[assertion_kind, asserted_as_of_at, subject_ref, accepted_value_fingerprint]`
 - `accepted_value_fingerprint` is the canonical fingerprint of one
-  `AssertionValue` from
-  [Target Contract Primitives](../reference/target-contract-primitives.md)
+  `AssertionValue` variant from [Domain Ontology](domain-ontology.md)
 
 Ordering:
 
@@ -801,20 +1004,25 @@ Ordering:
 
 Serialization:
 
-- serialize `CheckpointRecord` rows and `CheckpointAssertionRecord` rows as
-  separate ordered arrays
+- serialize each checkpoint record family as its own ordered array
+- persist product metadata once per emitted kernel
 - use stable object-key ordering
-- preserve the declared checkpoint order above
-- sort `reconciliation_refs` lexicographically
+- preserve the declared order above
+- sort `checkpoint_candidate_refs` lexicographically
+
+Lineage rule:
+
+- `checkpoint_candidate_refs` uses ordered `checkpoint_candidate_id` values
+  when reconciliation-owned candidates support the accepted assertion
+- product-level `reconciliation_state_refs` remain the broader upstream
+  partition lineage; assertion-level candidate refs point only at the accepted
+  candidate path when that narrower lineage exists
 
 Fingerprint inputs:
 
+- product metadata
 - canonical `CheckpointRecord` rows
 - canonical `CheckpointAssertionRecord` rows
-- `schema_version`
-- referenced `ReconciliationState` ids or fingerprints
-- referenced accepted evidence ids
-- referenced opening-state ids when adoption is used
 
 Minimum admissibility rules:
 
@@ -844,7 +1052,7 @@ Must not:
 
 Handoff to `Journal` and `TaxInputs`:
 
-- `Checkpoint` provides accepted balances, accepted opening state where used,
+- `Checkpoint` provides accepted assertions, accepted opening state where used,
   and the acceptance basis
 - downstream accounting and tax stages consume that accepted truth rather than
   re-deciding checkpoint trust locally
@@ -854,6 +1062,13 @@ Handoff to `Journal` and `TaxInputs`:
 Purpose:
 
 - accounting expansion and validation over accepted truth
+
+Product metadata:
+
+- `journal_run_id`
+- `schema_version`
+- `economic_facts_refs`
+- `checkpoint_ref`
 
 Owns:
 
@@ -867,8 +1082,7 @@ Record families:
   - `journal_id`
   - `entry_id`
   - `entry_kind`
-  - `effective_at`
-  - `effective_precision`
+  - `effective_at_or_null`
   - `economic_event_refs`
   - `checkpoint_assertion_refs`
   - `journal_status`
@@ -904,20 +1118,31 @@ Controlled vocabularies:
   - `passed`
   - `blocked`
 
-Envelope content may include:
+Envelope or sidecar content may include:
 
 - posting explanation
 - validation notes
 - renderer-facing annotations
 - accounting-owned gap sidecars
 
+Product-root cardinality:
+
+- one `Journal` kernel may contain many entries, postings, and validations
+- one emitted `Journal` kernel must contain exactly one distinct `journal_id`
+
 Stable ids:
 
+- `journal_run_id` identifies one emitted `Journal` kernel
 - `journal_id` identifies one accounting emission over a canonical set of
   upstream entries
 - `entry_id` identifies one journal entry
 - `posting_id` identifies one posting under one journal entry
 - `validation_id` identifies one validation result under one journal entry
+- `account_ref`, `commodity_ref`, and `origin_ref` use `AccountRef`,
+  `CommodityRef`, and `OriginRef` from
+  [Target Contract Primitives](../reference/target-contract-primitives.md)
+- `journal_run_id` uses component array
+  `[checkpoint_ref, ordered_economic_facts_refs]`
 - `journal_id` uses component array
   `[ordered_economic_event_refs, ordered_checkpoint_assertion_refs, ordered_entry_kinds]`
 - `entry_id` uses component array
@@ -925,25 +1150,18 @@ Stable ids:
 - `posting_id` uses component array
   `[entry_id, account_ref, commodity_ref, amount, posting_side, origin_ref]`
 - `validation_id` uses component array `[entry_id, validation_kind]`
-- `ordered_economic_event_refs`, `ordered_checkpoint_assertion_refs`, and
-  `ordered_entry_kinds` are the canonical flattened journal-level arrays
-  derived from the emitted `JournalEntryRecord` rows
-- `account_ref`, `commodity_ref`, and `origin_ref` use the structured tuple
-  contracts owned by
-  [Target Contract Primitives](../reference/target-contract-primitives.md)
-- `origin_ref` points to the immediate kernel origin for the posting rather
-  than to a provider label, renderer label, or free-form source string
 
 Ordering:
 
 - `JournalEntryRecord` rows sort by `[effective_at_or_null, entry_kind, entry_id]`
 - `PostingRecord` rows sort by
-  `[entry_id, posting_side, account_ref, commodity_ref, posting_id]`
+  `[entry_id, posting_side, account_ref, commodity_ref, origin_ref, posting_id]`
 - `ValidationRecord` rows sort by `[entry_id, validation_kind, validation_id]`
 
 Serialization:
 
 - serialize each journal record family as its own ordered array
+- persist product metadata once per emitted kernel
 - use stable object-key ordering
 - preserve the declared order above
 - sort `economic_event_refs`, `checkpoint_assertion_refs`, and
@@ -951,12 +1169,10 @@ Serialization:
 
 Fingerprint inputs:
 
+- product metadata
 - canonical `JournalEntryRecord` rows
 - canonical `PostingRecord` rows
 - canonical `ValidationRecord` rows
-- `schema_version`
-- referenced `EconomicFacts` ids
-- referenced `Checkpoint` assertion ids
 
 Must guarantee:
 
@@ -968,7 +1184,8 @@ Must guarantee:
 Must not:
 
 - become a truth repair layer
-- hide postings or validation blockers in envelopes only
+- hide postings or validation blockers in sidecars only
+- claim to operate without accepted `EconomicFacts` and `Checkpoint` inputs
 
 Handoff to downstream renderers:
 
@@ -982,6 +1199,13 @@ Handoff to downstream renderers:
 Purpose:
 
 - policy-ready, jurisdiction-neutral tax input surface
+
+Product metadata:
+
+- `tax_inputs_id`
+- `schema_version`
+- `economic_facts_refs`
+- `checkpoint_ref`
 
 Owns:
 
@@ -998,8 +1222,7 @@ Record families:
   - `basis_pool_ref`
   - `beneficial_owner_ref`
   - `instrument_ref`
-  - `effective_at`
-  - `effective_precision`
+  - `effective_at_or_null`
   - `quantity`
   - `direction`
   - `valuation_ref_or_null`
@@ -1035,7 +1258,7 @@ Controlled vocabularies:
   - `pool_close`
   - `carry_forward`
 
-Envelope content may include:
+Envelope or sidecar content may include:
 
 - tax-relevant valuation detail
 - supporting ownership and counterparty context
@@ -1044,10 +1267,13 @@ Envelope content may include:
 
 Stable ids:
 
+- `tax_inputs_id` identifies one emitted `TaxInputs` kernel
 - `determinant_id` identifies one tax determinant
 - `basis_transition_id` identifies one basis or pool transition
+- `tax_inputs_id` uses component array
+  `[checkpoint_ref, ordered_economic_facts_refs]`
 - `determinant_id` uses component array
-  `[tax_year, determinant_family, basis_pool_ref, beneficial_owner_ref, instrument_ref, effective_at_or_null, effective_precision_or_null, quantity, direction, economic_event_refs, checkpoint_assertion_refs]`
+  `[tax_year, determinant_family, basis_pool_ref, beneficial_owner_ref, instrument_ref, effective_at_or_null, quantity, direction, economic_event_refs, checkpoint_assertion_refs]`
 - `basis_transition_id` uses component array
   `[basis_pool_ref, transition_kind, from_determinant_ref_or_null, to_determinant_ref]`
 
@@ -1060,19 +1286,17 @@ Ordering:
 
 Serialization:
 
-- serialize `TaxDeterminantRecord` rows and `BasisTransitionRecord` rows as
-  separate ordered arrays
+- serialize each tax-input record family as its own ordered array
+- persist product metadata once per emitted kernel
 - use stable object-key ordering
-- preserve the declared determinant and transition order above
+- preserve the declared order above
 - sort `economic_event_refs` and `checkpoint_assertion_refs` lexicographically
 
 Fingerprint inputs:
 
+- product metadata
 - canonical `TaxDeterminantRecord` rows
 - canonical `BasisTransitionRecord` rows
-- `schema_version`
-- referenced `EconomicFacts` ids
-- referenced `Checkpoint` assertion ids
 
 Must guarantee:
 
@@ -1088,20 +1312,28 @@ Must not:
 - decide source meaning, reconciliation truth, checkpoint truth, or accounting
   truth
 - push effective time, quantity, direction, or basis transitions into
-  envelopes only
+  sidecars only
 
 Handoff to `TaxOutputs`:
 
 - `TaxInputs` provides the determinant surface that selected policies operate
   on
 - the policy layer decides treatment and output shape, not the upstream claim,
-  economic, or reconciliation layers
+  economic, reconciliation, or checkpoint layers
 
 ## `TaxOutputs`
 
 Purpose:
 
 - one selected tax policy's outputs
+
+Product metadata:
+
+- `tax_outputs_id`
+- `schema_version`
+- `tax_inputs_ref`
+- `policy_id`
+- `tax_year`
 
 Owns:
 
@@ -1113,7 +1345,7 @@ Record families:
 
 - `TaxOutputRecord`
   - `tax_output_id`
-  - `tax_policy_id`
+  - `policy_id`
   - `output_family`
   - `tax_year`
   - `tax_status`
@@ -1139,31 +1371,38 @@ Controlled vocabularies:
   - `carry_forward_state`
   - `unsupported_items_report`
 
-Envelope content may include:
+Envelope or sidecar content may include:
 
 - policy-specific summaries
 - schedules and forms
 - carry-forward explanation
 - unsupported-coverage notes
 
+Product-root cardinality:
+
+- one `TaxOutputs` kernel may contain many `TaxOutputRecord`,
+  `CarryForwardRecord`, and `UnsupportedItemRecord` rows
+- one emitted `TaxOutputs` kernel must contain exactly one `policy_id` and one
+  `tax_year`
+
 Stable ids:
 
+- `tax_outputs_id` identifies one emitted `TaxOutputs` kernel
 - `tax_output_id` identifies one policy-owned output emission
 - `carry_forward_id` identifies one carry-forward state record
 - `unsupported_item_id` identifies one persisted unsupported-item record
+- `tax_outputs_id` uses component array `[tax_inputs_ref, policy_id, tax_year]`
 - `tax_output_id` uses component array
-  `[tax_policy_id, output_family, tax_year, basis_pool_refs]`
+  `[policy_id, output_family, tax_year, basis_pool_refs]`
 - `carry_forward_id` uses component array
   `[tax_output_id, basis_pool_ref, next_tax_year]`
 - `unsupported_item_id` uses component array
   `[tax_output_id, determinant_ref]`
-- `tax_policy_id` uses the reusable `TaxPolicyId` contract owned by
-  [Target Contract Primitives](../reference/target-contract-primitives.md)
 
 Ordering:
 
 - `TaxOutputRecord` rows sort by
-  `[tax_policy_id, tax_year, output_family, tax_output_id]`
+  `[policy_id, tax_year, output_family, tax_output_id]`
 - `CarryForwardRecord` rows sort by
   `[tax_output_id, next_tax_year, basis_pool_ref, carry_forward_id]`
 - `UnsupportedItemRecord` rows sort by
@@ -1172,18 +1411,17 @@ Ordering:
 Serialization:
 
 - serialize each tax-output record family as its own ordered array
+- persist product metadata once per emitted kernel
 - use stable object-key ordering
 - preserve the declared order above
 - sort `basis_pool_refs` and `blocking_gap_refs` lexicographically
 
 Fingerprint inputs:
 
+- product metadata
 - canonical `TaxOutputRecord` rows
 - canonical `CarryForwardRecord` rows
 - canonical `UnsupportedItemRecord` rows
-- `schema_version`
-- referenced `TaxInputs` ids or fingerprints
-- selected `tax_policy_id`
 
 Must guarantee:
 
@@ -1195,6 +1433,7 @@ Must not:
 
 - claim to come directly from `EconomicFacts` or `ReconciliationState`
 - backfill earlier-stage semantic gaps by guessing
+- claim to operate without accepted `EconomicFacts` and `Checkpoint` inputs
 
 ## Shared Contract References
 
@@ -1203,20 +1442,15 @@ The pipeline products rely on shared supporting contracts defined elsewhere:
 - [Current Bridge Contracts](current-bridge-contracts.md) for the live bridge
   runtime truth
 - [Bridge To Target Mapping](bridge-to-target-mapping.md) for the primary
-  current-to-target transformation rules
+  current-to-target transformation rules and migration authority matrix
 - [First Slice Contract](../reference/first-slice-contract.md) for the bounded
   Coinbase-first replay and parity contract
 - [First Downstream Slice Contract](../reference/first-downstream-slice-contract.md)
   for the first bounded `EconomicFacts -> ReconciliationState -> Checkpoint`
   contract
-- [Target Contract Primitives](../reference/target-contract-primitives.md) for
-  canonical scalar forms, reusable tuple contracts, shared `AssertionValue`,
-  and reusable target ids
-- [Target Product Artifacts](../reference/target-product-artifacts.md) for
-  target dataset packaging, kernel filenames, and sidecar locations
-- [Domain Ontology](domain-ontology.md) for the target ontology and identity
-  seams
+- [Domain Ontology](domain-ontology.md) for entity seams, refs,
+  `AssertionValue`, and package ownership
 - [Gaps And Readiness](gaps-and-readiness.md) for `GapCore`,
-  `GapExplanation`, readiness, and `SubjectRef`
+  `GapExplanation`, reviews, readiness, and `SubjectRef`
 - [Reconciliation And Tax Architecture](reconciliation-tax-architecture.md) for
-  performance rules, partitioning rules, and filing-critical acceptance
+  persistence rules, partitioning rules, and fast-path expectations

--- a/docs/concepts/pipeline-stage-contracts.md
+++ b/docs/concepts/pipeline-stage-contracts.md
@@ -32,6 +32,8 @@ The target runtime pipeline is:
 - no stage may suppress uncertainty that a later stage must still see
 - no stage may duplicate upstream semantic payloads unless the meaning has
   changed
+- target-product kernel rules in this page are canonical; other docs may point
+  here but should not restate competing kernel, id, or fingerprint contracts
 
 ## Handoff Rules
 
@@ -44,14 +46,13 @@ Every stage contract should answer four questions clearly:
 
 Shared rules:
 
-- every output must preserve stable ids and enough provenance linkage for later
-  audit
-- a later stage may add stage-owned sidecars and summaries, but it should not
-  silently rewrite upstream truth just to make its own outputs look tidy
-- if a stage cannot support a required decision, it should emit explicit
-  blockers or unresolved records rather than inventing a one-off fallback lane
-- stage contracts should stay compact enough for deterministic replay and
-  partitioned recomputation
+- every output preserves stable ids and enough upstream linkage for later audit
+- later stages may add stage-owned sidecars and summaries, but must not
+  silently rewrite upstream truth to make their own outputs look tidy
+- if a stage cannot support a required decision, it emits explicit blockers,
+  unresolved records, or deferred records rather than inventing a fallback
+- replay and parity gates operate on kernels first and inspect envelopes
+  separately only where the slice requires them
 
 ## Shared Product Rules
 
@@ -61,18 +62,19 @@ Shared rules:
 - readers accept only the declared supported versions for that product
 - unknown schema versions fail fast
 - compatibility is forward-only by default; do not promise long-lived in-place
-  compatibility unless the owning product explicitly declares a narrower
-  compatibility window
+  compatibility unless the owning product explicitly declares a narrower window
 - regeneration from upstream products or evidence is the normal recovery path
   for incompatible target-stage artifacts
 - every target product defines one canonical serialization and one stable
-  fingerprint over semantically relevant content
-- fingerprints include semantically relevant upstream references and owning
-  decisions, but exclude presentation-only formatting noise and derived
-  explanation payloads that do not change kernel meaning
+  fingerprint over semantically relevant kernel content
+- kernel fingerprints use canonical UTF-8 JSON serialization with stable object
+  key order and declared array order, hashed with SHA-256
+- fingerprints include semantically relevant upstream ids or upstream
+  fingerprint references plus owning stage decisions
+- fingerprints exclude presentation-only formatting noise, explanation text,
+  and sidecar payloads that do not change kernel meaning
 - sidecars and explanation payloads use their own schema and fingerprint rules
-  when persisted independently
-- presentation-only formatting or ordering noise must not affect fingerprints
+  when they are persisted independently
 
 ### Kernel And Envelope Rule
 
@@ -80,13 +82,47 @@ Shared rules:
   envelopes or sidecars
 - the kernel holds stable ids, ordering keys, owning decisions, and the
   downstream-required references needed for replay and reducers
-- envelopes and sidecars hold provenance detail, explanation, reviews,
-  comparison traces, and policy notes
-- any later rehydration path must join through stable ids emitted by the kernel
-- sidecars must not become the only copy of business meaning or determinant
-  state
-- replay and parity gates operate on kernels first and inspect envelopes
-  separately when the slice requires them
+- the envelope holds provenance detail, explanation, reviews, comparison
+  traces, and policy notes
+- sidecars must not become the only copy of determinant state or business
+  meaning
+- any later rehydration path must join through stable ids emitted by the
+  kernel
+
+### Shared Kernel Status Vocabulary
+
+Use these bounded status vocabularies across target kernels:
+
+- `selection_status`:
+  - `selected`
+  - `superseded`
+  - `blocked`
+- `claim_status`:
+  - `asserted`
+  - `blocked`
+  - `advisory`
+  - `superseded`
+- `compilation_outcome`:
+  - `accepted`
+  - `blocked`
+  - `deferred`
+  - `superseded`
+- `reconciliation_status`:
+  - `complete`
+  - `partial`
+  - `blocked`
+- `checkpoint_status`:
+  - `accepted`
+  - `adopted`
+  - `blocked`
+- `journal_status`:
+  - `expanded`
+  - `validated`
+  - `blocked`
+- `tax_status`:
+  - `ready`
+  - `partial`
+  - `blocked`
 
 ## `EvidenceSet`
 
@@ -102,31 +138,70 @@ Owns:
 - typed provenance and locator identity for selected evidence
 - source-local parsed observations that do not yet require economic meaning
 
-Carries:
+### EvidenceSet Kernel
 
-- selected source artifacts
-- source-local parsed observations
-- provenance
-- document, statement, and inventory observations
-- selected, superseded, and blocked alternatives
-- deterministic selection decisions
+Kernel fields:
 
-Must guarantee:
+- `evidence_set_id`
+- `source`
+- `adapter_id`
+- `capture_uid`
+- `member_id`
+- `selection_group_id`
+- `observation_id`
+- `selection_status`
+- `manifest_fingerprint_ref`
+- `plan_fingerprint_ref`
 
-- deterministic selection
-- stable provenance and locators
-- no forced economic meaning
-- no forced reconciliation, accounting, or tax decisions
+### EvidenceSet Envelope
 
-Must not:
+Envelope content may include:
 
-- invent economic or policy meaning
-- hide file-winner logic inside adapter-local heuristics
+- document metadata
+- statement row detail
+- inventory detail
+- candidate-selection reasoning
+- parse diagnostics
+- rich provenance payloads
+
+### EvidenceSet Stable Ids
+
+- `evidence_set_id` identifies one bounded evidence emission for one source,
+  adapter, capture, and selection-group scope
+- `member_id` identifies one selected, superseded, or blocked evidence member
+- `observation_id` identifies one typed observation under one evidence member
+- `selection_group_id` identifies one deterministic evidence-selection
+  decision boundary
+
+### EvidenceSet Canonical Ordering
+
+- sort by `source`
+- then `capture_uid`
+- then `selection_group_id`
+- then `selection_status`
+- then `member_id`
+- then `observation_id`
+
+### EvidenceSet Canonical Serialization
+
+- serialize kernel records only
+- use stable object-key ordering
+- preserve the declared kernel record order above
+- represent timestamps and `Decimal` values using the repo's canonical string
+  forms so the fingerprint is independent of language runtime defaults
+
+### EvidenceSet Fingerprint Inputs
+
+- kernel records in canonical order
+- `schema_version`
+- `manifest_fingerprint_ref`
+- `plan_fingerprint_ref`
+- selected upstream provenance ids that affect member identity
 
 Handoff to `ClaimSet`:
 
 - `EvidenceSet` provides selected evidence, typed observations, provenance, and
-  selection reasoning
+  deterministic selection reasoning
 - it does not provide final economic interpretation, final ownership meaning,
   checkpoint acceptance, journal logic, or tax treatment
 
@@ -143,29 +218,57 @@ Owns:
   available
 - claim-owned issues and reviews
 
-Carries:
+### ClaimSet Kernel
 
-- activity claims
-- balance observation claims
-- ownership claims
-- location claims
-- instrument claims
-- contract claims
-- valuation claims
-- candidate interpretations
-- claim-owned issues and reviews
+Kernel fields:
 
-Minimum claim-family distinctions:
+- `claim_set_id`
+- `claim_id`
+- `claim_family`
+- `claim_status`
+- `interpretation_group_id`
+- `evidence_member_refs`
+- `effective_at`
+- `effective_precision`
+- `provenance_refs`
 
-- `ActivityClaim`
-- `BalanceObservationClaim`
-- `OwnershipClaim`
-- `LocationClaim`
-- `InstrumentIdentityClaim`
-- `ContractTermClaim`
-- `ValuationClaim`
-- `ProjectionAnnotation`
-- blocking issue and review candidate surfaces
+### ClaimSet Envelope
+
+Envelope content may include:
+
+- provider-local semantic detail
+- comparison traces
+- claim explanation
+- advisory review payloads
+- output-oriented annotations
+
+### ClaimSet Stable Ids
+
+- `claim_set_id` identifies one bounded semantic emission over one evidence set
+- `claim_id` identifies one claim family member with one stable semantic role
+- `interpretation_group_id` identifies one mutually exclusive claim bundle
+
+### ClaimSet Canonical Ordering
+
+- sort by `claim_family`
+- then `effective_at` when present
+- then `claim_id`
+- then `interpretation_group_id`
+
+### ClaimSet Canonical Serialization
+
+- serialize kernel records only
+- use stable object-key ordering
+- preserve the declared claim order above
+- include evidence-member refs and provenance refs in sorted order
+
+### ClaimSet Fingerprint Inputs
+
+- kernel records in canonical order
+- `schema_version`
+- `claim_set_id`
+- referenced `EvidenceSet` ids or fingerprints
+- `interpretation_group_id`
 
 Must guarantee:
 
@@ -173,19 +276,49 @@ Must guarantee:
 - preserved ambiguity where one safe final interpretation is unavailable
 - provenance for every claim
 - adapters may add provider-local subtyping, but they must preserve the shared
-  claim-family distinctions above so later compilation is interoperable
+  claim-family distinctions so later compilation remains interoperable
 
 Must not:
 
 - force unresolved meaning into final economic or policy interpretations
 - silently discard materially relevant alternative interpretations
 
+### ClaimSet -> EconomicFacts Adjudication
+
+The compiler owns adjudication between `ClaimSet` and `EconomicFacts`.
+
+`InterpretationGroup`:
+
+- one stable `interpretation_group_id`
+- one bounded set of mutually exclusive claims or claim bundles
+- one status describing whether the group is still unresolved, accepted, or
+  blocked
+- one shared contract that keeps mutually exclusive meanings explicit instead
+  of flattening them into one guessed record
+
+`CompilationDecision`:
+
+- one stable `adjudication_record_id`
+- one `compilation_outcome`
+- accepted or rejected claim references
+- one resolution basis describing why the compiler accepted, deferred, or
+  blocked the interpretation group
+
+Adjudication rules:
+
+- interpretation groups are bundle-atomic
+- the compiler may accept one whole interpretation group, block one whole
+  interpretation group, or defer one whole interpretation group
+- partial emission is allowed only across independent interpretation groups
+- partial emission is never allowed by accepting only part of one mutually
+  dependent group
+
 Handoff to `EconomicFacts`:
 
-- `ClaimSet` hands off source-local assertions and explicitly unresolved
-  branches
-- the compiler is responsible for deciding which claims can become accepted
-  economic truth and which must remain blocked or unresolved
+- `ClaimSet` hands off source-local assertions, interpretation groups, and
+  claim-owned blockers
+- the compiler decides which claims can become accepted economic truth and
+  which remain blocked, deferred, or superseded
 
 ## `EconomicFacts`
 
@@ -200,31 +333,58 @@ Owns:
 - stable economic event and leg structure
 - explicit remaining ambiguity that is still economically safe to preserve
 
-Carries:
+### EconomicFacts Kernel
 
-- economic events
-- economic legs
-- instrument identity
-- contract identity where relevant
-- position identity where relevant
-- owner and counterparty identity where known
-- temporal precision
-- settlement and supersession links
-- valuations
-- confidence and ambiguity markers
+Kernel fields:
 
-Minimum accepted economic determinants:
+- `event_id`
+- `event_family`
+- `leg_id`
+- `accepted_claim_refs`
+- `adjudication_record_id`
+- `effective_at`
+- `effective_precision`
+- `recorded_at`
+- `settlement_state`
+- `lifecycle_state`
+- `supersedes_event_id`
 
-- stable event identity and event-kind family
-- effective time and temporal precision
-- one stable leg set with signed quantities and explicit leg roles
-- settlement state where later stages depend on it
-- lifecycle state where later stages depend on it
-- supersession or correction lineage
-- ownership and counterparty references where known
-- valuation records with explicit purpose where downstream behavior depends on
-  them
-- stable references back to accepted upstream claims
+### EconomicFacts Envelope
+
+Envelope content may include:
+
+- detailed valuations
+- ownership and counterparty context
+- explanation of accepted identity seams
+- supporting claim traces
+- review context carried forward for audit
+
+### EconomicFacts Stable Ids
+
+- `event_id` identifies one accepted economic event
+- `leg_id` identifies one stable leg under one accepted event
+- `adjudication_record_id` identifies one compiler decision record
+
+### EconomicFacts Canonical Ordering
+
+- sort by `effective_at` when present
+- otherwise by `recorded_at`
+- then `event_id`
+- then `leg_id`
+
+### EconomicFacts Canonical Serialization
+
+- serialize kernel event records and kernel leg records only
+- use stable object-key ordering
+- preserve the declared event and leg order above
+
+### EconomicFacts Fingerprint Inputs
+
+- kernel event and leg records in canonical order
+- `schema_version`
+- accepted claim refs
+- `adjudication_record_id`
+- supersession links
 
 Must support:
 
@@ -242,7 +402,7 @@ Must support:
 
 Rules:
 
-- accepted event kinds stay jurisdiction-neutral and output-neutral
+- accepted event families stay jurisdiction-neutral and output-neutral
 - corrections preserve supersession lineage instead of mutating accepted
   economic truth in place
 - unresolved economic detail may remain explicit only where later stages can
@@ -276,17 +436,57 @@ Owns:
 - checkpoint candidacy derived from reconciled economics plus checkpoint
   evidence
 
-Carries:
+### ReconciliationState Kernel
 
-- transfer links
-- balance targets and assertions
-- continuity windows
-- missing funding and settlement legs
-- unresolved ownership transitions
+Kernel fields:
+
+- `reconciliation_state_id`
+- `continuity_segment_id`
+- `link_id`
+- `checkpoint_candidate_id`
+- `subject_ref`
+- `reconciliation_status`
+- `balance_target_refs`
+- `checkpoint_date`
+
+### ReconciliationState Envelope
+
+Envelope content may include:
+
 - corroboration sidecars
-- checkpoint candidates
-- reconciliation-owned gaps
-- readiness records
+- continuity explanation
+- missing-leg detail
+- comparison traces
+- stage-owned gap and readiness sidecars
+
+### ReconciliationState Stable Ids
+
+- `reconciliation_state_id` identifies one persisted reconciliation product
+- `continuity_segment_id` identifies one bounded continuity window
+- `link_id` identifies one owned transfer or settlement linkage
+- `checkpoint_candidate_id` identifies one reconciliation-owned checkpoint
+  proposal
+
+### ReconciliationState Canonical Ordering
+
+- sort by `checkpoint_date`
+- then `continuity_segment_id`
+- then `link_id`
+- then `checkpoint_candidate_id`
+
+### ReconciliationState Canonical Serialization
+
+- serialize kernel reconciliation records only
+- use stable object-key ordering
+- preserve the declared reconciliation order above
+
+### ReconciliationState Fingerprint Inputs
+
+- kernel reconciliation records in canonical order
+- `schema_version`
+- referenced `EconomicFacts` ids or fingerprints
+- referenced balance-target ids
+- referenced checkpoint evidence ids
 
 Must guarantee:
 
@@ -319,13 +519,56 @@ Owns:
 - adopted opening state when intentionally used
 - acceptance basis, trust level, and continuity into accepted state
 
-Carries:
+### Checkpoint Kernel
 
-- accepted checkpoint assertions
-- adopted opening state when intentionally used
-- supporting evidence and provenance
-- continuity decisions into accepted state
-- trust level and acceptance basis
+Kernel fields:
+
+- `checkpoint_id`
+- `checkpoint_assertion_id`
+- `subject_ref`
+- `assertion_kind`
+- `asserted_as_of_at`
+- `accepted_value`
+- `trust_level`
+- `acceptance_basis`
+- `evidence_class`
+- `continuity_proof`
+
+### Checkpoint Envelope
+
+Envelope content may include:
+
+- supporting evidence refs
+- supporting provenance detail
+- continuity explanation
+- opening-state adoption detail
+- acceptance rationale
+
+### Checkpoint Stable Ids
+
+- `checkpoint_id` identifies one accepted checkpoint container
+- `checkpoint_assertion_id` identifies one accepted checkpoint truth record for
+  one subject and one as-of point
+
+### Checkpoint Canonical Ordering
+
+- sort by `asserted_as_of_at`
+- then `subject_ref`
+- then `checkpoint_assertion_id`
+
+### Checkpoint Canonical Serialization
+
+- serialize kernel checkpoint assertion records only
+- use stable object-key ordering
+- preserve the declared checkpoint order above
+
+### Checkpoint Fingerprint Inputs
+
+- kernel checkpoint assertion records in canonical order
+- `schema_version`
+- referenced `ReconciliationState` ids or fingerprints
+- referenced accepted evidence ids
+- referenced opening-state ids when adoption is used
 
 Controlled checkpoint vocabularies:
 
@@ -357,8 +600,8 @@ Minimum admissibility rules:
   - `acceptance_basis` other than `operator_assertion`
   - `evidence_class` other than `operator_assertion`
   - `continuity_proof` other than `partial_continuity`
-- `analysis_ready` may use `operator_assertion` or `partial_continuity`, but the
-  lower-trust basis must stay explicit in the accepted checkpoint record
+- `analysis_ready` may use `operator_assertion` or `partial_continuity`, but
+  the lower-trust basis must stay explicit in the accepted checkpoint record
 - `operator_only` is required when accepted checkpoint truth relies solely on
   operator assertion without a source-backed evidence class
 - `adopted_opening_state` remains a distinct acceptance basis and must preserve
@@ -369,8 +612,6 @@ Must guarantee:
 - accepted checkpoint truth is first-class
 - source-backed evidence remains preferred
 - operator assertions do not silently become filing-ready checkpoint truth
-- `filing_ready` checkpoint truth must not rely solely on `operator_assertion`
-  acceptance
 - adopted opening state remains explicit instead of masquerading as direct
   observation
 
@@ -383,8 +624,8 @@ Handoff to `Journal` and `TaxInputs`:
 
 - `Checkpoint` provides accepted balances, accepted opening state where used,
   and the acceptance basis
-- downstream accounting and tax stages must consume that accepted truth rather
-  than re-deciding checkpoint trust locally
+- downstream accounting and tax stages consume that accepted truth rather than
+  re-deciding checkpoint trust locally
 
 ## `Journal`
 
@@ -398,12 +639,50 @@ Owns:
 - accounting validation results
 - accounting-owned gaps
 
-Carries:
+### Journal Kernel
 
-- journal entries and postings
-- provenance back to accepted upstream truth
-- validation results
-- accounting-owned gaps
+Kernel fields:
+
+- `journal_id`
+- `entry_id`
+- `posting_id`
+- `economic_event_refs`
+- `checkpoint_assertion_refs`
+- `journal_status`
+
+### Journal Envelope
+
+Envelope content may include:
+
+- posting explanation
+- validation notes
+- renderer-facing annotations
+- accounting-owned gap sidecars
+
+### Journal Stable Ids
+
+- `journal_id` identifies one accounting emission
+- `entry_id` identifies one journal entry
+- `posting_id` identifies one posting under one journal entry
+
+### Journal Canonical Ordering
+
+- sort by `journal_id`
+- then `entry_id`
+- then `posting_id`
+
+### Journal Canonical Serialization
+
+- serialize kernel journal records only
+- use stable object-key ordering
+- preserve the declared journal order above
+
+### Journal Fingerprint Inputs
+
+- kernel journal records in canonical order
+- `schema_version`
+- referenced `EconomicFacts` ids
+- referenced `Checkpoint` assertion ids
 
 Must guarantee:
 
@@ -434,17 +713,53 @@ Owns:
   truth
 - explicit tax-owned blockers where upstream truth is still not tax-complete
 
-Carries:
+### TaxInputs Kernel
 
-- acquisitions
-- dispositions
-- income events
-- financing costs
-- internal transfers
-- corporate actions
-- tax-relevant valuations
-- basis or pool state transitions
-- tax-owned unresolved items
+Kernel fields:
+
+- `determinant_id`
+- `determinant_family`
+- `basis_pool_ref`
+- `beneficial_owner_ref`
+- `instrument_ref`
+- `economic_event_refs`
+- `checkpoint_assertion_refs`
+- `tax_year`
+
+### TaxInputs Envelope
+
+Envelope content may include:
+
+- tax-relevant valuation detail
+- supporting ownership and counterparty context
+- pool-transition explanation
+- tax-owned blocker detail
+
+### TaxInputs Stable Ids
+
+- `determinant_id` identifies one tax determinant
+- `basis_pool_ref` identifies one tax basis or pool seam reused across tax years
+
+### TaxInputs Canonical Ordering
+
+- sort by `tax_year`
+- then `basis_pool_ref`
+- then `determinant_family`
+- then `determinant_id`
+
+### TaxInputs Canonical Serialization
+
+- serialize kernel determinant records only
+- use stable object-key ordering
+- preserve the declared determinant order above
+
+### TaxInputs Fingerprint Inputs
+
+- kernel determinant records in canonical order
+- `schema_version`
+- referenced `EconomicFacts` ids
+- referenced `Checkpoint` assertion ids
+- referenced basis-pool ids
 
 Minimum determinant families:
 
@@ -503,13 +818,49 @@ Owns:
 - tax-policy explanations, limitations, and unsupported outputs
 - tax-owned blockers that survive policy execution
 
-Carries:
+### TaxOutputs Kernel
 
-- summaries
-- forms and schedules
-- carry-forward state
-- unsupported or deferred outputs
-- policy-specific notes
+Kernel fields:
+
+- `tax_output_id`
+- `policy_id`
+- `output_family`
+- `tax_year`
+- `basis_pool_refs`
+- `tax_status`
+
+### TaxOutputs Envelope
+
+Envelope content may include:
+
+- policy-specific summaries
+- schedules and forms
+- carry-forward explanation
+- unsupported-coverage notes
+
+### TaxOutputs Stable Ids
+
+- `tax_output_id` identifies one policy-owned output emission
+
+### TaxOutputs Canonical Ordering
+
+- sort by `policy_id`
+- then `tax_year`
+- then `output_family`
+- then `tax_output_id`
+
+### TaxOutputs Canonical Serialization
+
+- serialize kernel tax-output records only
+- use stable object-key ordering
+- preserve the declared tax-output order above
+
+### TaxOutputs Fingerprint Inputs
+
+- kernel tax-output records in canonical order
+- `schema_version`
+- referenced `TaxInputs` ids or fingerprints
+- selected `policy_id`
 
 Must guarantee:
 
@@ -528,10 +879,14 @@ The pipeline products rely on shared supporting contracts defined elsewhere:
 
 - [Current Bridge Contracts](current-bridge-contracts.md) for the live bridge
   runtime truth
+- [Bridge To Target Mapping](bridge-to-target-mapping.md) for the canonical
+  current-to-target transformation rules
+- [First Slice Contract](../reference/first-slice-contract.md) for the bounded
+  Coinbase-first replay and parity contract
 - [Domain Ontology](domain-ontology.md) for the target ontology and identity
   seams
 - [Gaps And Readiness](gaps-and-readiness.md) for `GapCore`,
   `GapExplanation`, readiness, and `SubjectRef`
 - [Reconciliation And Tax Architecture](reconciliation-tax-architecture.md) for
-  performance rules, tax-policy architecture, and filing-critical acceptance
+  performance rules, partitioning rules, and filing-critical acceptance
   criteria

--- a/docs/concepts/pipeline-stage-contracts.md
+++ b/docs/concepts/pipeline-stage-contracts.md
@@ -32,7 +32,7 @@ The target runtime pipeline is:
 - no stage may suppress uncertainty that a later stage must still see
 - no stage may duplicate upstream semantic payloads unless the meaning has
   changed
-- target-product kernel rules in this page are canonical; other docs may point
+- target-product kernel rules in this page are authoritative; other docs may point
   here but should not restate competing kernel, id, or fingerprint contracts
 
 ## Handoff Rules
@@ -65,9 +65,9 @@ Shared rules:
   compatibility unless the owning product explicitly declares a narrower window
 - regeneration from upstream products or evidence is the normal recovery path
   for incompatible target-stage artifacts
-- every target product defines one canonical serialization and one stable
+- every target product defines one stable serialization and one stable
   fingerprint over semantically relevant kernel content
-- kernel fingerprints use canonical UTF-8 JSON serialization with stable object
+- kernel fingerprints use stable UTF-8 JSON serialization with stable object
   key order and declared array order, hashed with SHA-256
 - fingerprints include semantically relevant upstream ids or upstream
   fingerprint references plus owning stage decisions
@@ -173,7 +173,7 @@ Envelope content may include:
 - `selection_group_id` identifies one deterministic evidence-selection
   decision boundary
 
-### EvidenceSet Canonical Ordering
+### EvidenceSet Ordering
 
 - sort by `source`
 - then `capture_uid`
@@ -182,17 +182,17 @@ Envelope content may include:
 - then `member_id`
 - then `observation_id`
 
-### EvidenceSet Canonical Serialization
+### EvidenceSet Serialization
 
 - serialize kernel records only
 - use stable object-key ordering
 - preserve the declared kernel record order above
-- represent timestamps and `Decimal` values using the repo's canonical string
+- represent timestamps and `Decimal` values using the repo's stable string
   forms so the fingerprint is independent of language runtime defaults
 
 ### EvidenceSet Fingerprint Inputs
 
-- kernel records in canonical order
+- kernel records in declared order
 - `schema_version`
 - `manifest_fingerprint_ref`
 - `plan_fingerprint_ref`
@@ -248,14 +248,14 @@ Envelope content may include:
 - `claim_id` identifies one claim family member with one stable semantic role
 - `interpretation_group_id` identifies one mutually exclusive claim bundle
 
-### ClaimSet Canonical Ordering
+### ClaimSet Ordering
 
 - sort by `claim_family`
 - then `effective_at` when present
 - then `claim_id`
 - then `interpretation_group_id`
 
-### ClaimSet Canonical Serialization
+### ClaimSet Serialization
 
 - serialize kernel records only
 - use stable object-key ordering
@@ -264,7 +264,7 @@ Envelope content may include:
 
 ### ClaimSet Fingerprint Inputs
 
-- kernel records in canonical order
+- kernel records in declared order
 - `schema_version`
 - `claim_set_id`
 - referenced `EvidenceSet` ids or fingerprints
@@ -365,14 +365,14 @@ Envelope content may include:
 - `leg_id` identifies one stable leg under one accepted event
 - `adjudication_record_id` identifies one compiler decision record
 
-### EconomicFacts Canonical Ordering
+### EconomicFacts Ordering
 
 - sort by `effective_at` when present
 - otherwise by `recorded_at`
 - then `event_id`
 - then `leg_id`
 
-### EconomicFacts Canonical Serialization
+### EconomicFacts Serialization
 
 - serialize kernel event records and kernel leg records only
 - use stable object-key ordering
@@ -380,7 +380,7 @@ Envelope content may include:
 
 ### EconomicFacts Fingerprint Inputs
 
-- kernel event and leg records in canonical order
+- kernel event and leg records in declared order
 - `schema_version`
 - accepted claim refs
 - `adjudication_record_id`
@@ -467,14 +467,14 @@ Envelope content may include:
 - `checkpoint_candidate_id` identifies one reconciliation-owned checkpoint
   proposal
 
-### ReconciliationState Canonical Ordering
+### ReconciliationState Ordering
 
 - sort by `checkpoint_date`
 - then `continuity_segment_id`
 - then `link_id`
 - then `checkpoint_candidate_id`
 
-### ReconciliationState Canonical Serialization
+### ReconciliationState Serialization
 
 - serialize kernel reconciliation records only
 - use stable object-key ordering
@@ -482,7 +482,7 @@ Envelope content may include:
 
 ### ReconciliationState Fingerprint Inputs
 
-- kernel reconciliation records in canonical order
+- kernel reconciliation records in declared order
 - `schema_version`
 - referenced `EconomicFacts` ids or fingerprints
 - referenced balance-target ids
@@ -550,13 +550,13 @@ Envelope content may include:
 - `checkpoint_assertion_id` identifies one accepted checkpoint truth record for
   one subject and one as-of point
 
-### Checkpoint Canonical Ordering
+### Checkpoint Ordering
 
 - sort by `asserted_as_of_at`
 - then `subject_ref`
 - then `checkpoint_assertion_id`
 
-### Checkpoint Canonical Serialization
+### Checkpoint Serialization
 
 - serialize kernel checkpoint assertion records only
 - use stable object-key ordering
@@ -564,7 +564,7 @@ Envelope content may include:
 
 ### Checkpoint Fingerprint Inputs
 
-- kernel checkpoint assertion records in canonical order
+- kernel checkpoint assertion records in declared order
 - `schema_version`
 - referenced `ReconciliationState` ids or fingerprints
 - referenced accepted evidence ids
@@ -665,13 +665,13 @@ Envelope content may include:
 - `entry_id` identifies one journal entry
 - `posting_id` identifies one posting under one journal entry
 
-### Journal Canonical Ordering
+### Journal Ordering
 
 - sort by `journal_id`
 - then `entry_id`
 - then `posting_id`
 
-### Journal Canonical Serialization
+### Journal Serialization
 
 - serialize kernel journal records only
 - use stable object-key ordering
@@ -679,7 +679,7 @@ Envelope content may include:
 
 ### Journal Fingerprint Inputs
 
-- kernel journal records in canonical order
+- kernel journal records in declared order
 - `schema_version`
 - referenced `EconomicFacts` ids
 - referenced `Checkpoint` assertion ids
@@ -740,14 +740,14 @@ Envelope content may include:
 - `determinant_id` identifies one tax determinant
 - `basis_pool_ref` identifies one tax basis or pool seam reused across tax years
 
-### TaxInputs Canonical Ordering
+### TaxInputs Ordering
 
 - sort by `tax_year`
 - then `basis_pool_ref`
 - then `determinant_family`
 - then `determinant_id`
 
-### TaxInputs Canonical Serialization
+### TaxInputs Serialization
 
 - serialize kernel determinant records only
 - use stable object-key ordering
@@ -755,7 +755,7 @@ Envelope content may include:
 
 ### TaxInputs Fingerprint Inputs
 
-- kernel determinant records in canonical order
+- kernel determinant records in declared order
 - `schema_version`
 - referenced `EconomicFacts` ids
 - referenced `Checkpoint` assertion ids
@@ -842,14 +842,14 @@ Envelope content may include:
 
 - `tax_output_id` identifies one policy-owned output emission
 
-### TaxOutputs Canonical Ordering
+### TaxOutputs Ordering
 
 - sort by `policy_id`
 - then `tax_year`
 - then `output_family`
 - then `tax_output_id`
 
-### TaxOutputs Canonical Serialization
+### TaxOutputs Serialization
 
 - serialize kernel tax-output records only
 - use stable object-key ordering
@@ -857,7 +857,7 @@ Envelope content may include:
 
 ### TaxOutputs Fingerprint Inputs
 
-- kernel tax-output records in canonical order
+- kernel tax-output records in declared order
 - `schema_version`
 - referenced `TaxInputs` ids or fingerprints
 - selected `policy_id`
@@ -879,7 +879,7 @@ The pipeline products rely on shared supporting contracts defined elsewhere:
 
 - [Current Bridge Contracts](current-bridge-contracts.md) for the live bridge
   runtime truth
-- [Bridge To Target Mapping](bridge-to-target-mapping.md) for the canonical
+- [Bridge To Target Mapping](bridge-to-target-mapping.md) for the primary
   current-to-target transformation rules
 - [First Slice Contract](../reference/first-slice-contract.md) for the bounded
   Coinbase-first replay and parity contract

--- a/docs/concepts/pipeline-stage-contracts.md
+++ b/docs/concepts/pipeline-stage-contracts.md
@@ -32,15 +32,16 @@ The target runtime pipeline is:
 - no stage may suppress uncertainty that a later stage must still see
 - no stage may duplicate upstream semantic payloads unless the meaning has
   changed
-- target-product kernel rules in this page are authoritative; other docs may point
-  here but should not restate competing kernel, id, or fingerprint contracts
+- target-product kernel rules in this page are authoritative; other docs may
+  point here but should not restate competing kernel, id, or fingerprint
+  contracts
 
 ## Handoff Rules
 
-Every stage contract should answer four questions clearly:
+Every stage contract answers four questions:
 
 - what comes in
-- what the stage is allowed to decide
+- what the stage may decide
 - what comes out
 - what remains explicitly unresolved for later stages
 
@@ -61,24 +62,18 @@ Shared rules:
 - every target product carries a `schema_version`
 - `schema_version` is a product-level kernel field persisted once per emitted
   product beside the ordered kernel records for that product
-- per-record kernel field lists below do not repeat `schema_version` unless one
-  product truly carries it on every record
 - readers accept only the declared supported versions for that product
 - unknown schema versions fail fast
-- compatibility is forward-only by default; do not promise long-lived in-place
-  compatibility unless the owning product explicitly declares a narrower window
-- regeneration from upstream products or evidence is the normal recovery path
-  for incompatible target-stage artifacts
+- compatibility is forward-only by default; regeneration from upstream
+  products or evidence is the normal recovery path for incompatible artifacts
 - every target product defines one stable serialization and one stable
   fingerprint over semantically relevant kernel content
 - kernel fingerprints use stable UTF-8 JSON serialization with stable object
   key order and declared array order, hashed with SHA-256
 - fingerprints include semantically relevant upstream ids or upstream
-  fingerprint references plus owning stage decisions
+  fingerprint references plus owning-stage decisions
 - fingerprints exclude presentation-only formatting noise, explanation text,
   and sidecar payloads that do not change kernel meaning
-- sidecars and explanation payloads use their own schema and fingerprint rules
-  when they are persisted independently
 - every stable id defined on this page uses the format
   `<kind>:<sha256(lowercase-hex)>`
 - the hash input is one canonical UTF-8 JSON array of ordered components
@@ -88,8 +83,7 @@ Shared rules:
 
 ### Composite Tuple Rules
 
-- `SubjectRef` serializes and sorts as
-  `[subject_kind, subject_id]`
+- `SubjectRef` serializes and sorts as `[subject_kind, subject_id]`
 - `BasisPoolRef` serializes and sorts as
   `[tax_policy_id, jurisdiction_or_regime, beneficial_owner_ref, pool_scope]`
 - when one stable-id recipe, ordering rule, or fingerprint input includes one
@@ -131,10 +125,6 @@ Use these bounded status vocabularies across target kernels:
   - `complete`
   - `partial`
   - `blocked`
-- `checkpoint_status`:
-  - `accepted`
-  - `adopted`
-  - `blocked`
 - `journal_status`:
   - `expanded`
   - `validated`
@@ -154,26 +144,23 @@ Owns:
 
 - selected evidence membership
 - superseded and blocked alternatives
-- deterministic evidence selection decisions
+- deterministic evidence-selection decisions
 - typed provenance and locator identity for selected evidence
 - source-local parsed observations that do not yet require economic meaning
 
-### EvidenceSet Kernel
+Record families:
 
-Kernel fields:
-
-- `evidence_set_id`
-- `source`
-- `adapter_id`
-- `capture_uid`
-- `member_id`
-- `selection_group_id`
-- `observation_id`
-- `selection_status`
-- `manifest_fingerprint_ref`
-- `plan_fingerprint_ref`
-
-### EvidenceSet Envelope
+- `EvidenceRecord`
+  - `evidence_set_id`
+  - `source`
+  - `adapter_id`
+  - `capture_uid`
+  - `member_id`
+  - `selection_group_id`
+  - `observation_id`
+  - `selection_status`
+  - `manifest_fingerprint_ref`
+  - `plan_fingerprint_ref`
 
 Envelope content may include:
 
@@ -184,7 +171,7 @@ Envelope content may include:
 - parse diagnostics
 - rich provenance payloads
 
-### EvidenceSet Stable Ids
+Stable ids:
 
 - `evidence_set_id` identifies one bounded evidence emission for one source,
   adapter, capture, and selection-group scope
@@ -209,7 +196,7 @@ Envelope content may include:
 - `observation_anchor` is the stable row, page, anchor, or typed observation
   locator emitted for that observation
 
-### EvidenceSet Ordering
+Ordering:
 
 - sort by `source`
 - then `capture_uid`
@@ -218,17 +205,17 @@ Envelope content may include:
 - then `member_id`
 - then `observation_id`
 
-### EvidenceSet Serialization
+Serialization:
 
-- serialize kernel records only
+- serialize `EvidenceRecord` rows only
 - use stable object-key ordering
-- preserve the declared kernel record order above
+- preserve the declared evidence order above
 - represent timestamps and `Decimal` values using the repo's stable string
   forms so the fingerprint is independent of language runtime defaults
 
-### EvidenceSet Fingerprint Inputs
+Fingerprint inputs:
 
-- kernel records in canonical order
+- canonical `EvidenceRecord` rows
 - `schema_version`
 - `manifest_fingerprint_ref`
 - `plan_fingerprint_ref`
@@ -254,21 +241,28 @@ Owns:
   available
 - claim-owned issues and reviews
 
-### ClaimSet Kernel
+Record families:
 
-Kernel fields:
-
-- `claim_set_id`
-- `claim_id`
-- `claim_family`
-- `claim_status`
-- `interpretation_group_id`
-- `evidence_member_refs`
-- `effective_at`
-- `effective_precision`
-- `provenance_refs`
-
-### ClaimSet Envelope
+- `ClaimRecord`
+  - `claim_set_id`
+  - `claim_id`
+  - `claim_family`
+  - `claim_status`
+  - `interpretation_group_id`
+  - `evidence_member_refs`
+  - `effective_at`
+  - `effective_precision`
+  - `provenance_refs`
+- `CompilationDecisionRecord`
+  - `claim_set_id`
+  - `adjudication_record_id`
+  - `interpretation_group_id`
+  - `compilation_outcome`
+  - `accepted_claim_refs`
+  - `rejected_claim_refs`
+  - `deferred_claim_refs`
+  - `resolution_basis`
+  - `blocking_gap_refs`
 
 Envelope content may include:
 
@@ -301,20 +295,22 @@ Rules:
 
 - secondary docs may reference these claim families, but they must not publish
   competing repo-wide family lists
-- later slices may use canonical families that are out of scope for the default
-  first slice without redefining the shared vocabulary
+- later slices may use canonical families that are out of scope for the
+  default first slice without redefining the shared vocabulary
 
-### ClaimSet Stable Ids
+Stable ids:
 
 - `claim_set_id` identifies one bounded semantic emission over one evidence set
 - `claim_id` identifies one claim family member with one stable semantic role
 - `interpretation_group_id` identifies one mutually exclusive claim bundle
-- `claim_set_id` uses component array
-  `[evidence_set_id, claim_emitter_id]`
+- `adjudication_record_id` identifies one compilation-decision record
+- `claim_set_id` uses component array `[evidence_set_id, claim_emitter_id]`
 - `claim_id` uses component array
   `[claim_set_id, claim_family, claim_anchor, interpretation_group_id]`
 - `interpretation_group_id` uses component array
   `[claim_set_id, bundle_anchor, bundle_discriminator]`
+- `adjudication_record_id` uses component array
+  `[claim_set_id, interpretation_group_id, compilation_outcome, resolution_basis, accepted_claim_refs, rejected_claim_refs, deferred_claim_refs]`
 - `claim_emitter_id` is the stable id of the translation family or shared
   compiler boundary that emitted the claim set
 - `claim_anchor` is the stable provider-local anchor for one asserted meaning;
@@ -325,81 +321,6 @@ Rules:
 - `bundle_discriminator` is `default` when one anchor has exactly one bundle;
   otherwise use `alt:1`, `alt:2`, and so on in canonical bundle order under
   that anchor
-
-### ClaimSet Ordering
-
-- sort by tuple
-  `[claim_family, effective_at_or_null, claim_id, interpretation_group_id]`
-- use JSON `null` for `effective_at_or_null` when the claim has no effective
-  time
-
-### ClaimSet Serialization
-
-- serialize kernel records only
-- use stable object-key ordering
-- preserve the declared claim order above
-- include evidence-member refs and provenance refs in sorted order
-
-### ClaimSet Fingerprint Inputs
-
-- kernel records in canonical order
-- `schema_version`
-- `claim_set_id`
-- referenced `EvidenceSet` ids or fingerprints
-- `interpretation_group_id`
-
-Must guarantee:
-
-- source-local semantics only
-- preserved ambiguity where one safe final interpretation is unavailable
-- provenance for every claim
-- adapters may add provider-local subtyping, but they must preserve the shared
-  claim-family distinctions so later compilation remains interoperable
-
-Must not:
-
-- force unresolved meaning into final economic or policy interpretations
-- silently discard materially relevant alternative interpretations
-
-### ClaimSet -> EconomicFacts Adjudication
-
-The compiler owns adjudication between `ClaimSet` and `EconomicFacts`.
-
-`InterpretationGroup`:
-
-- one stable `interpretation_group_id`
-- one bounded set of mutually exclusive claims or claim bundles
-- one status describing whether the group is still unresolved, accepted, or
-  blocked
-- one shared contract that keeps mutually exclusive meanings explicit instead
-  of flattening them into one guessed record
-
-`CompilationDecision`:
-
-- one stable `adjudication_record_id`
-- one `compilation_outcome`
-- accepted or rejected claim references
-- one resolution basis describing why the compiler accepted, deferred, or
-  blocked the interpretation group
-
-### CompilationDecision Kernel
-
-Kernel fields:
-
-- `claim_set_id`
-- `adjudication_record_id`
-- `interpretation_group_id`
-- `compilation_outcome`
-- `accepted_claim_refs`
-- `rejected_claim_refs`
-- `deferred_claim_refs`
-- `resolution_basis`
-- `blocking_gap_refs`
-
-Stable ids:
-
-- `adjudication_record_id` uses component array
-  `[claim_set_id, interpretation_group_id, compilation_outcome, resolution_basis, accepted_claim_refs, rejected_claim_refs, deferred_claim_refs]`
 
 Controlled `resolution_basis` vocabulary:
 
@@ -413,23 +334,42 @@ Controlled `resolution_basis` vocabulary:
 
 Ordering:
 
-- sort by `interpretation_group_id`
-- then `adjudication_record_id`
+- `ClaimRecord` rows sort by tuple
+  `[claim_family, effective_at_or_null, claim_id, interpretation_group_id]`
+- use JSON `null` for `effective_at_or_null` when the claim has no effective
+  time
+- `CompilationDecisionRecord` rows sort by
+  `[interpretation_group_id, adjudication_record_id]`
 
 Serialization:
 
-- serialize kernel decision records only
+- serialize `ClaimRecord` rows and `CompilationDecisionRecord` rows as separate
+  ordered arrays
 - use stable object-key ordering
-- preserve sorted claim-ref and gap-ref arrays
+- preserve the declared claim and decision order above
+- sort `evidence_member_refs`, `provenance_refs`, `accepted_claim_refs`,
+  `rejected_claim_refs`, `deferred_claim_refs`, and `blocking_gap_refs`
+  lexicographically
 
-Adjudication rules:
+Fingerprint inputs:
 
-- interpretation groups are bundle-atomic
-- the compiler may accept one whole interpretation group, block one whole
-  interpretation group, or defer one whole interpretation group
-- partial emission is allowed only across independent interpretation groups
-- partial emission is never allowed by accepting only part of one mutually
-  dependent group
+- canonical `ClaimRecord` rows
+- canonical `CompilationDecisionRecord` rows
+- `schema_version`
+- referenced `EvidenceSet` ids or fingerprints
+
+Must guarantee:
+
+- source-local semantics only
+- preserved ambiguity where one safe final interpretation is unavailable
+- provenance for every claim
+- adapters may add provider-local subtyping, but they must preserve the shared
+  claim-family distinctions so later compilation remains interoperable
+
+Must not:
+
+- force unresolved meaning into final economic or policy interpretations
+- silently discard materially relevant alternative interpretations
 
 Handoff to `EconomicFacts`:
 
@@ -451,80 +391,99 @@ Owns:
 - stable economic event and leg structure
 - explicit remaining ambiguity that is still economically safe to preserve
 
-### EconomicFacts Kernel
+Record families:
 
-Kernel fields:
+- `EconomicEventRecord`
+  - `event_id`
+  - `event_family`
+  - `adjudication_record_id`
+  - `accepted_claim_refs`
+  - `effective_at`
+  - `effective_precision`
+  - `recorded_at`
+  - `settlement_state`
+  - `lifecycle_state`
+  - `legal_owner_ref_or_null`
+  - `beneficial_owner_ref_or_null`
+  - `counterparty_ref_or_null`
+  - `supersedes_event_id_or_null`
+- `EconomicLegRecord`
+  - `leg_id`
+  - `event_id`
+  - `leg_role`
+  - `subject_ref`
+  - `instrument_ref_or_null`
+  - `location_ref_or_null`
+  - `quantity`
+  - `valuation_ref_or_null`
 
-- `event_id`
-- `event_family`
-- `leg_id`
-- `accepted_claim_refs`
-- `adjudication_record_id`
-- `effective_at`
-- `effective_precision`
-- `recorded_at`
-- `settlement_state`
-- `lifecycle_state`
-- `supersedes_event_id`
+Controlled vocabularies:
 
-### EconomicFacts Envelope
+- `event_family`:
+  - `asset_movement`
+  - `cash_movement`
+  - `obligation_or_right`
+  - `settlement`
+  - `collateral_change`
+  - `financing_flow`
+  - `fee_or_rebate`
+  - `withholding`
+  - `lifecycle_restructure`
+  - `correction`
+- `leg_role`:
+  - `holding_change`
+  - `cash_change`
+  - `obligation_change`
+  - `settlement_change`
+  - `collateral_change`
+  - `financing_change`
+  - `fee`
+  - `rebate`
+  - `withholding`
 
 Envelope content may include:
 
 - detailed valuations
-- ownership and counterparty context
+- ownership and counterparty explanation
 - explanation of accepted identity seams
 - supporting claim traces
 - review context carried forward for audit
 
-### EconomicFacts Stable Ids
+Stable ids:
 
 - `event_id` identifies one accepted economic event
 - `leg_id` identifies one stable leg under one accepted event
-- `adjudication_record_id` identifies one compiler decision record
 - `event_id` uses component array `[adjudication_record_id, event_index]`
-- `leg_id` uses component array `[event_id, leg_index]`
+- `leg_id` uses component array `[event_id, leg_role, subject_ref, leg_index]`
 - `event_index` and `leg_index` are zero-based canonical positions in declared
   event and leg order
 
-### EconomicFacts Ordering
+Ordering:
 
-- sort by `effective_at` when present
-- otherwise by `recorded_at`
+- `EconomicEventRecord` rows sort by `effective_at` when present
+- otherwise sort by `recorded_at`
 - then `event_id`
-- then `leg_id`
+- `EconomicLegRecord` rows sort by `[event_id, leg_id]`
 
-### EconomicFacts Serialization
+Serialization:
 
-- serialize kernel event records and kernel leg records only
+- serialize `EconomicEventRecord` rows and `EconomicLegRecord` rows as separate
+  ordered arrays
 - use stable object-key ordering
 - preserve the declared event and leg order above
 
-### EconomicFacts Fingerprint Inputs
+Fingerprint inputs:
 
-- kernel event and leg records in declared order
+- canonical `EconomicEventRecord` rows
+- canonical `EconomicLegRecord` rows
 - `schema_version`
-- accepted claim refs
-- `adjudication_record_id`
-- supersession links
+- referenced `CompilationDecisionRecord` ids
 
-Must support:
-
-- holdings movements
-- cash movements
-- obligations and rights
-- settlements
-- collateral changes
-- financing flows
-- fees, rebates, and withholding
-- corrections and supersession chains
-- corporate actions
-- restructurings
-- lifecycle-heavy activity
-
-Rules:
+Must guarantee:
 
 - accepted event families stay jurisdiction-neutral and output-neutral
+- event and leg records carry the computation-critical determinants needed for
+  later reconciliation, checkpointing, accounting, and tax
 - corrections preserve supersession lineage instead of mutating accepted
   economic truth in place
 - unresolved economic detail may remain explicit only where later stages can
@@ -534,11 +493,13 @@ Must not:
 
 - collapse to spot-trade assumptions
 - let output hints drive core behavior
+- push leg quantity, location, or instrument truth into envelopes only
 
 Handoff to `ReconciliationState`:
 
-- `EconomicFacts` provides accepted economic events, legs, identity seams,
-  settlement links, lifecycle state, and valuations where they are already safe
+- `EconomicFacts` provides accepted economic events, economic legs, identity
+  seams, settlement links, lifecycle state, and valuation references where
+  they are already safe
 - it does not claim that continuity is complete, transfers are fully linked, or
   checkpoint truth is accepted
 
@@ -558,20 +519,68 @@ Owns:
 - checkpoint candidacy derived from reconciled economics plus checkpoint
   evidence
 
-### ReconciliationState Kernel
+Record families:
 
-Kernel fields:
+- `ContinuitySegmentRecord`
+  - `continuity_segment_id`
+  - `source`
+  - `subject_ref`
+  - `segment_start_at_or_null`
+  - `segment_start_precision_or_null`
+  - `segment_end_at_or_null`
+  - `segment_end_precision_or_null`
+  - `reconciliation_status`
+  - `checkpoint_date_or_null`
+- `LinkRecord`
+  - `link_id`
+  - `continuity_segment_id`
+  - `link_kind`
+  - `left_event_ref`
+  - `right_event_ref`
+  - `link_status`
+- `BalanceTargetRecord`
+  - `balance_target_id`
+  - `continuity_segment_id`
+  - `subject_ref`
+  - `target_kind`
+  - `target_as_of_at`
+  - `target_precision`
+  - `expected_value_ref`
+  - `observed_value_ref_or_null`
+  - `balance_target_status`
+- `CheckpointCandidateRecord`
+  - `checkpoint_candidate_id`
+  - `continuity_segment_id`
+  - `subject_ref`
+  - `checkpoint_date`
+  - `candidate_status`
+  - `supporting_balance_target_refs`
+  - `supporting_evidence_refs`
 
-- `reconciliation_state_id`
-- `continuity_segment_id`
-- `link_id`
-- `checkpoint_candidate_id`
-- `subject_ref`
-- `reconciliation_status`
-- `balance_target_refs`
-- `checkpoint_date`
+Controlled vocabularies:
 
-### ReconciliationState Envelope
+- `link_kind`:
+  - `transfer_pair`
+  - `settlement_pair`
+- `link_status`:
+  - `linked`
+  - `candidate`
+  - `blocked`
+  - `superseded`
+- `target_kind`:
+  - `exact_balance`
+  - `range_balance`
+  - `continuity_anchor`
+- `balance_target_status`:
+  - `matched`
+  - `mismatched`
+  - `missing_observation`
+  - `blocked`
+- `candidate_status`:
+  - `ready`
+  - `partial`
+  - `blocked`
+  - `superseded`
 
 Envelope content may include:
 
@@ -581,45 +590,50 @@ Envelope content may include:
 - comparison traces
 - stage-owned gap and readiness sidecars
 
-### ReconciliationState Stable Ids
+Stable ids:
 
-- `reconciliation_state_id` identifies one persisted reconciliation product
 - `continuity_segment_id` identifies one bounded continuity window
 - `link_id` identifies one owned transfer or settlement linkage
+- `balance_target_id` identifies one reconciliation-owned balance assertion
+  target
 - `checkpoint_candidate_id` identifies one reconciliation-owned checkpoint
   proposal
 - `continuity_segment_id` uses component array
-  `[source, subject_ref, segment_start_or_null, segment_end_or_null]`
-- `link_id` uses component array `[continuity_segment_id, link_index]`
+  `[source, subject_ref, segment_start_at_or_null, segment_start_precision_or_null, segment_end_at_or_null, segment_end_precision_or_null]`
+- `link_id` uses component array
+  `[continuity_segment_id, link_kind, left_event_ref, right_event_ref]`
+- `balance_target_id` uses component array
+  `[continuity_segment_id, subject_ref, target_kind, target_as_of_at, target_precision, expected_value_ref]`
 - `checkpoint_candidate_id` uses component array
-  `[checkpoint_date, subject_ref, continuity_segment_id, candidate_index]`
-- `reconciliation_state_id` uses component array
+  `[continuity_segment_id, subject_ref, checkpoint_date, supporting_balance_target_refs, supporting_evidence_refs]`
+
+Ordering:
+
+- `ContinuitySegmentRecord` rows sort by
+  `[checkpoint_date_or_null, source, subject_ref, continuity_segment_id]`
+- `LinkRecord` rows sort by
+  `[continuity_segment_id, link_kind, left_event_ref, right_event_ref, link_id]`
+- `BalanceTargetRecord` rows sort by
+  `[continuity_segment_id, subject_ref, target_as_of_at, balance_target_id]`
+- `CheckpointCandidateRecord` rows sort by
   `[checkpoint_date, subject_ref, continuity_segment_id, checkpoint_candidate_id]`
-- `segment_start_or_null` and `segment_end_or_null` use canonical timestamp
-  scalars or JSON `null`
-- `link_index` and `candidate_index` are zero-based canonical positions in
-  declared order
 
-### ReconciliationState Ordering
+Serialization:
 
-- sort by `checkpoint_date`
-- then `continuity_segment_id`
-- then `link_id`
-- then `checkpoint_candidate_id`
-
-### ReconciliationState Serialization
-
-- serialize kernel reconciliation records only
+- serialize each reconciliation record family as its own ordered array
 - use stable object-key ordering
-- preserve the declared reconciliation order above
+- preserve the declared order above
+- sort `supporting_balance_target_refs` and `supporting_evidence_refs`
+  lexicographically
 
-### ReconciliationState Fingerprint Inputs
+Fingerprint inputs:
 
-- kernel reconciliation records in declared order
+- canonical `ContinuitySegmentRecord` rows
+- canonical `LinkRecord` rows
+- canonical `BalanceTargetRecord` rows
+- canonical `CheckpointCandidateRecord` rows
 - `schema_version`
 - referenced `EconomicFacts` ids or fingerprints
-- referenced balance-target ids
-- referenced checkpoint evidence ids
 
 Must guarantee:
 
@@ -633,6 +647,7 @@ Must not:
 
 - reclassify upstream economics to make continuity easier
 - bury missing evidence inside whole-dataset summaries
+- use stable-id recipes that depend on undeclared fields or hidden indexes
 
 Handoff to `Checkpoint`:
 
@@ -652,64 +667,33 @@ Owns:
 - adopted opening state when intentionally used
 - acceptance basis, trust level, and continuity into accepted state
 
-### Checkpoint Kernel
+Record families:
 
-Kernel fields:
+- `CheckpointRecord`
+  - `checkpoint_id`
+  - `asserted_as_of_at`
+  - `ordered_checkpoint_assertion_ids`
+- `CheckpointAssertionRecord`
+  - `checkpoint_assertion_id`
+  - `checkpoint_id`
+  - `subject_ref`
+  - `assertion_kind`
+  - `asserted_as_of_at`
+  - `accepted_value`
+  - `trust_level`
+  - `acceptance_basis`
+  - `evidence_class`
+  - `continuity_proof`
+  - `reconciliation_refs`
 
-- `checkpoint_id`
-- `checkpoint_assertion_id`
-- `subject_ref`
-- `assertion_kind`
-- `asserted_as_of_at`
-- `accepted_value`
-- `trust_level`
-- `acceptance_basis`
-- `evidence_class`
-- `continuity_proof`
+Controlled vocabularies:
 
-### Checkpoint Envelope
-
-Envelope content may include:
-
-- supporting evidence refs
-- supporting provenance detail
-- continuity explanation
-- opening-state adoption detail
-- acceptance rationale
-
-### Checkpoint Stable Ids
-
-- `checkpoint_id` identifies one accepted checkpoint container
-- `checkpoint_assertion_id` identifies one accepted checkpoint truth record for
-  one subject and one as-of point
-- `checkpoint_id` uses component array
-  `[asserted_as_of_at, ordered_checkpoint_assertion_ids]`
-- `checkpoint_assertion_id` uses component array
-  `[assertion_kind, asserted_as_of_at, subject_ref.subject_kind, subject_ref.subject_id]`
-- `ordered_checkpoint_assertion_ids` is the canonical ordered list of
-  assertion ids persisted in that accepted checkpoint container
-
-### Checkpoint Ordering
-
-- sort by tuple
-  `[asserted_as_of_at, subject_ref.subject_kind, subject_ref.subject_id, checkpoint_assertion_id]`
-
-### Checkpoint Serialization
-
-- serialize kernel checkpoint assertion records only
-- use stable object-key ordering
-- preserve the declared checkpoint order above
-
-### Checkpoint Fingerprint Inputs
-
-- kernel checkpoint assertion records in canonical order
-- `schema_version`
-- referenced `ReconciliationState` ids or fingerprints
-- referenced accepted evidence ids
-- referenced opening-state ids when adoption is used
-
-Controlled checkpoint vocabularies:
-
+- `assertion_kind`:
+  - `position_quantity`
+  - `cash_quantity`
+  - `basis_value`
+  - `ownership_state`
+  - `location_state`
 - `trust_level`:
   - `filing_ready`
   - `analysis_ready`
@@ -732,6 +716,50 @@ Controlled checkpoint vocabularies:
   - `opening_state_rollforward`
   - `partial_continuity`
 
+Envelope content may include:
+
+- supporting evidence refs
+- supporting provenance detail
+- continuity explanation
+- opening-state adoption detail
+- acceptance rationale
+
+Stable ids:
+
+- `checkpoint_id` identifies one accepted checkpoint container
+- `checkpoint_assertion_id` identifies one accepted checkpoint truth record for
+  one subject and one as-of point
+- `checkpoint_id` uses component array
+  `[asserted_as_of_at, ordered_checkpoint_assertion_ids]`
+- `checkpoint_assertion_id` uses component array
+  `[assertion_kind, asserted_as_of_at, subject_ref, accepted_value_fingerprint]`
+- `accepted_value_fingerprint` is the canonical fingerprint of one
+  `CheckpointAssertionValue` variant from
+  [Domain Ontology](domain-ontology.md)
+
+Ordering:
+
+- `CheckpointRecord` rows sort by `[asserted_as_of_at, checkpoint_id]`
+- `CheckpointAssertionRecord` rows sort by tuple
+  `[asserted_as_of_at, subject_ref.subject_kind, subject_ref.subject_id, checkpoint_assertion_id]`
+
+Serialization:
+
+- serialize `CheckpointRecord` rows and `CheckpointAssertionRecord` rows as
+  separate ordered arrays
+- use stable object-key ordering
+- preserve the declared checkpoint order above
+- sort `reconciliation_refs` lexicographically
+
+Fingerprint inputs:
+
+- canonical `CheckpointRecord` rows
+- canonical `CheckpointAssertionRecord` rows
+- `schema_version`
+- referenced `ReconciliationState` ids or fingerprints
+- referenced accepted evidence ids
+- referenced opening-state ids when adoption is used
+
 Minimum admissibility rules:
 
 - `filing_ready` requires:
@@ -739,7 +767,7 @@ Minimum admissibility rules:
   - `evidence_class` other than `operator_assertion`
   - `continuity_proof` other than `partial_continuity`
 - `analysis_ready` may use `operator_assertion` or `partial_continuity`, but
-  the lower-trust basis must stay explicit in the accepted checkpoint record
+  the lower-trust basis stays explicit in the accepted checkpoint record
 - `operator_only` is required when accepted checkpoint truth relies solely on
   operator assertion without a source-backed evidence class
 - `adopted_opening_state` remains a distinct acceptance basis and must preserve
@@ -777,18 +805,48 @@ Owns:
 - accounting validation results
 - accounting-owned gaps
 
-### Journal Kernel
+Record families:
 
-Kernel fields:
+- `JournalEntryRecord`
+  - `journal_id`
+  - `entry_id`
+  - `entry_kind`
+  - `effective_at`
+  - `effective_precision`
+  - `economic_event_refs`
+  - `checkpoint_assertion_refs`
+  - `journal_status`
+- `PostingRecord`
+  - `posting_id`
+  - `entry_id`
+  - `account_ref`
+  - `commodity_ref`
+  - `amount`
+  - `posting_side`
+  - `source_ref`
+- `ValidationRecord`
+  - `validation_id`
+  - `entry_id`
+  - `validation_kind`
+  - `validation_status`
+  - `blocking_gap_refs`
 
-- `journal_id`
-- `entry_id`
-- `posting_id`
-- `economic_event_refs`
-- `checkpoint_assertion_refs`
-- `journal_status`
+Controlled vocabularies:
 
-### Journal Envelope
+- `entry_kind`:
+  - `economic_event_entry`
+  - `checkpoint_opening_entry`
+  - `adjustment_entry`
+- `posting_side`:
+  - `debit`
+  - `credit`
+- `validation_kind`:
+  - `balanced`
+  - `commodity_balance`
+  - `unsupported_coverage`
+- `validation_status`:
+  - `passed`
+  - `blocked`
 
 Envelope content may include:
 
@@ -797,35 +855,44 @@ Envelope content may include:
 - renderer-facing annotations
 - accounting-owned gap sidecars
 
-### Journal Stable Ids
+Stable ids:
 
-- `journal_id` identifies one accounting emission
+- `journal_id` identifies one accounting emission over a canonical set of
+  upstream entries
 - `entry_id` identifies one journal entry
 - `posting_id` identifies one posting under one journal entry
+- `validation_id` identifies one validation result under one journal entry
 - `journal_id` uses component array
-  `[ordered_economic_event_refs, ordered_checkpoint_assertion_refs]`
-- `entry_id` uses component array `[journal_id, entry_index]`
-- `posting_id` uses component array `[entry_id, posting_index]`
-- `ordered_economic_event_refs` and `ordered_checkpoint_assertion_refs` use
-  the canonical reference ordering declared by the emitted journal product
-- `entry_index` and `posting_index` are zero-based canonical positions in
-  declared order
+  `[ordered_economic_event_refs, ordered_checkpoint_assertion_refs, ordered_entry_kinds]`
+- `entry_id` uses component array
+  `[journal_id, entry_kind, effective_at_or_null, economic_event_refs, checkpoint_assertion_refs]`
+- `posting_id` uses component array
+  `[entry_id, account_ref, commodity_ref, amount, posting_side, source_ref]`
+- `validation_id` uses component array `[entry_id, validation_kind]`
+- `ordered_economic_event_refs`, `ordered_checkpoint_assertion_refs`, and
+  `ordered_entry_kinds` are the canonical flattened journal-level arrays
+  derived from the emitted `JournalEntryRecord` rows
 
-### Journal Ordering
+Ordering:
 
-- sort by `journal_id`
-- then `entry_id`
-- then `posting_id`
+- `JournalEntryRecord` rows sort by `[effective_at_or_null, entry_kind, entry_id]`
+- `PostingRecord` rows sort by
+  `[entry_id, posting_side, account_ref, commodity_ref, posting_id]`
+- `ValidationRecord` rows sort by `[entry_id, validation_kind, validation_id]`
 
-### Journal Serialization
+Serialization:
 
-- serialize kernel journal records only
+- serialize each journal record family as its own ordered array
 - use stable object-key ordering
-- preserve the declared journal order above
+- preserve the declared order above
+- sort `economic_event_refs`, `checkpoint_assertion_refs`, and
+  `blocking_gap_refs` lexicographically
 
-### Journal Fingerprint Inputs
+Fingerprint inputs:
 
-- kernel journal records in canonical order
+- canonical `JournalEntryRecord` rows
+- canonical `PostingRecord` rows
+- canonical `ValidationRecord` rows
 - `schema_version`
 - referenced `EconomicFacts` ids
 - referenced `Checkpoint` assertion ids
@@ -835,10 +902,12 @@ Must guarantee:
 - deterministic posting expansion
 - explicit validation
 - explicit unsupported accounting coverage
+- posting determinants required for validation remain part of the kernel
 
 Must not:
 
 - become a truth repair layer
+- hide postings or validation blockers in envelopes only
 
 Handoff to downstream renderers:
 
@@ -859,20 +928,51 @@ Owns:
   truth
 - explicit tax-owned blockers where upstream truth is still not tax-complete
 
-### TaxInputs Kernel
+Record families:
 
-Kernel fields:
+- `TaxDeterminantRecord`
+  - `determinant_id`
+  - `determinant_family`
+  - `tax_year`
+  - `basis_pool_ref`
+  - `beneficial_owner_ref`
+  - `instrument_ref`
+  - `effective_at`
+  - `effective_precision`
+  - `quantity`
+  - `direction`
+  - `valuation_ref_or_null`
+  - `counterparty_ref_or_null`
+  - `economic_event_refs`
+  - `checkpoint_assertion_refs`
+  - `basis_transition_ref_or_null`
+- `BasisTransitionRecord`
+  - `basis_transition_id`
+  - `basis_pool_ref`
+  - `from_determinant_ref_or_null`
+  - `to_determinant_ref`
+  - `transition_kind`
 
-- `determinant_id`
-- `determinant_family`
-- `basis_pool_ref`
-- `beneficial_owner_ref`
-- `instrument_ref`
-- `economic_event_refs`
-- `checkpoint_assertion_refs`
-- `tax_year`
+Controlled vocabularies:
 
-### TaxInputs Envelope
+- `determinant_family`:
+  - `acquisition`
+  - `disposition`
+  - `income`
+  - `expense_or_fee`
+  - `financing_cost`
+  - `internal_transfer`
+  - `basis_adjustment`
+  - `corporate_action`
+- `direction`:
+  - `increase`
+  - `decrease`
+  - `neutral`
+- `transition_kind`:
+  - `pool_open`
+  - `pool_adjustment`
+  - `pool_close`
+  - `carry_forward`
 
 Envelope content may include:
 
@@ -881,59 +981,37 @@ Envelope content may include:
 - pool-transition explanation
 - tax-owned blocker detail
 
-### TaxInputs Stable Ids
+Stable ids:
 
 - `determinant_id` identifies one tax determinant
-- `basis_pool_ref` identifies one tax basis or pool seam reused across tax years
+- `basis_transition_id` identifies one basis or pool transition
 - `determinant_id` uses component array
-  `[tax_year, determinant_family, basis_pool_ref.tax_policy_id, basis_pool_ref.jurisdiction_or_regime, basis_pool_ref.beneficial_owner_ref, basis_pool_ref.pool_scope, determinant_anchor]`
-- `basis_pool_ref` serializes, sorts, and fingerprints using
-  `[tax_policy_id, jurisdiction_or_regime, beneficial_owner_ref, pool_scope]`
-- `determinant_anchor` is the stable tax-owned anchor for one determinant under
-  one basis or pool scope
+  `[tax_year, determinant_family, basis_pool_ref, beneficial_owner_ref, instrument_ref, effective_at_or_null, effective_precision_or_null, quantity, direction, economic_event_refs, checkpoint_assertion_refs]`
+- `basis_transition_id` uses component array
+  `[basis_pool_ref, transition_kind, from_determinant_ref_or_null, to_determinant_ref]`
 
-### TaxInputs Ordering
+Ordering:
 
-- sort by tuple
-  `[tax_year, basis_pool_ref.tax_policy_id, basis_pool_ref.jurisdiction_or_regime, basis_pool_ref.beneficial_owner_ref, basis_pool_ref.pool_scope, determinant_family, determinant_id]`
+- `TaxDeterminantRecord` rows sort by tuple
+  `[tax_year, basis_pool_ref.tax_policy_id, basis_pool_ref.jurisdiction_or_regime, basis_pool_ref.beneficial_owner_ref, basis_pool_ref.pool_scope, determinant_family, effective_at_or_null, determinant_id]`
+- `BasisTransitionRecord` rows sort by
+  `[basis_pool_ref.tax_policy_id, basis_pool_ref.jurisdiction_or_regime, basis_pool_ref.beneficial_owner_ref, basis_pool_ref.pool_scope, transition_kind, basis_transition_id]`
 
-### TaxInputs Serialization
+Serialization:
 
-- serialize kernel determinant records only
+- serialize `TaxDeterminantRecord` rows and `BasisTransitionRecord` rows as
+  separate ordered arrays
 - use stable object-key ordering
-- preserve the declared determinant order above
+- preserve the declared determinant and transition order above
+- sort `economic_event_refs` and `checkpoint_assertion_refs` lexicographically
 
-### TaxInputs Fingerprint Inputs
+Fingerprint inputs:
 
-- kernel determinant records in canonical order
+- canonical `TaxDeterminantRecord` rows
+- canonical `BasisTransitionRecord` rows
 - `schema_version`
 - referenced `EconomicFacts` ids
 - referenced `Checkpoint` assertion ids
-- referenced basis-pool ids
-
-Minimum determinant families:
-
-- `acquisition`
-- `disposition`
-- `income`
-- `expense_or_fee`
-- `financing_cost`
-- `internal_transfer`
-- `basis_adjustment`
-- `corporate_action`
-
-Each determinant preserves, where applicable:
-
-- stable determinant identity
-- determinant family
-- effective time and temporal precision
-- instrument, pool, or other affected subject reference
-- quantity and direction
-- tax-relevant valuation
-- ownership or counterparty references
-- upstream economic-event references
-- accepted checkpoint or opening-state references when tax basis depends on them
-- basis or pool transition references
 
 Must guarantee:
 
@@ -948,6 +1026,8 @@ Must not:
 - embed one jurisdiction's output schema
 - decide source meaning, reconciliation truth, checkpoint truth, or accounting
   truth
+- push effective time, quantity, direction, or basis transitions into
+  envelopes only
 
 Handoff to `TaxOutputs`:
 
@@ -968,18 +1048,35 @@ Owns:
 - tax-policy explanations, limitations, and unsupported outputs
 - tax-owned blockers that survive policy execution
 
-### TaxOutputs Kernel
+Record families:
 
-Kernel fields:
+- `TaxOutputRecord`
+  - `tax_output_id`
+  - `policy_id`
+  - `output_family`
+  - `tax_year`
+  - `tax_status`
+  - `basis_pool_refs`
+- `CarryForwardRecord`
+  - `carry_forward_id`
+  - `tax_output_id`
+  - `basis_pool_ref`
+  - `next_tax_year`
+  - `state_fingerprint_ref`
+- `UnsupportedItemRecord`
+  - `unsupported_item_id`
+  - `tax_output_id`
+  - `determinant_ref`
+  - `blocking_gap_refs`
 
-- `tax_output_id`
-- `policy_id`
-- `output_family`
-- `tax_year`
-- `basis_pool_refs`
-- `tax_status`
+Controlled vocabularies:
 
-### TaxOutputs Envelope
+- `output_family`:
+  - `realized_gains_schedule`
+  - `income_schedule`
+  - `expense_schedule`
+  - `carry_forward_state`
+  - `unsupported_items_report`
 
 Envelope content may include:
 
@@ -988,30 +1085,39 @@ Envelope content may include:
 - carry-forward explanation
 - unsupported-coverage notes
 
-### TaxOutputs Stable Ids
+Stable ids:
 
 - `tax_output_id` identifies one policy-owned output emission
+- `carry_forward_id` identifies one carry-forward state record
+- `unsupported_item_id` identifies one persisted unsupported-item record
 - `tax_output_id` uses component array
-  `[policy_id, output_family, tax_year, ordered_basis_pool_refs]`
-- `ordered_basis_pool_refs` is the canonical ordered list of basis-pool tuple
-  references included in that emitted tax output
+  `[policy_id, output_family, tax_year, basis_pool_refs]`
+- `carry_forward_id` uses component array
+  `[tax_output_id, basis_pool_ref, next_tax_year]`
+- `unsupported_item_id` uses component array
+  `[tax_output_id, determinant_ref]`
 
-### TaxOutputs Ordering
+Ordering:
 
-- sort by `policy_id`
-- then `tax_year`
-- then `output_family`
-- then `tax_output_id`
+- `TaxOutputRecord` rows sort by
+  `[policy_id, tax_year, output_family, tax_output_id]`
+- `CarryForwardRecord` rows sort by
+  `[tax_output_id, next_tax_year, basis_pool_ref, carry_forward_id]`
+- `UnsupportedItemRecord` rows sort by
+  `[tax_output_id, determinant_ref, unsupported_item_id]`
 
-### TaxOutputs Serialization
+Serialization:
 
-- serialize kernel tax-output records only
+- serialize each tax-output record family as its own ordered array
 - use stable object-key ordering
-- preserve the declared tax-output order above
+- preserve the declared order above
+- sort `basis_pool_refs` and `blocking_gap_refs` lexicographically
 
-### TaxOutputs Fingerprint Inputs
+Fingerprint inputs:
 
-- kernel tax-output records in declared order
+- canonical `TaxOutputRecord` rows
+- canonical `CarryForwardRecord` rows
+- canonical `UnsupportedItemRecord` rows
 - `schema_version`
 - referenced `TaxInputs` ids or fingerprints
 - selected `policy_id`
@@ -1037,10 +1143,12 @@ The pipeline products rely on shared supporting contracts defined elsewhere:
   current-to-target transformation rules
 - [First Slice Contract](../reference/first-slice-contract.md) for the bounded
   Coinbase-first replay and parity contract
+- [First Downstream Slice Contract](../reference/first-downstream-slice-contract.md)
+  for the first bounded `EconomicFacts -> ReconciliationState -> Checkpoint`
+  contract
 - [Domain Ontology](domain-ontology.md) for the target ontology and identity
   seams
 - [Gaps And Readiness](gaps-and-readiness.md) for `GapCore`,
   `GapExplanation`, readiness, and `SubjectRef`
 - [Reconciliation And Tax Architecture](reconciliation-tax-architecture.md) for
   performance rules, partitioning rules, and filing-critical acceptance
-  criteria

--- a/docs/concepts/pipeline-stage-contracts.md
+++ b/docs/concepts/pipeline-stage-contracts.md
@@ -99,10 +99,10 @@ Shared rules:
 
 ### Record Reference Rule
 
-- when a kernel field name ends with `_ref`, `_refs`, or `_id_or_null` and the
+- when a kernel field name ends with `_ref`, `_refs`, or `_id` and the
   stem names one target product owned on this page, the field uses that
   product's metadata id or ordered product-id list
-- when a kernel field name ends with `_ref`, `_refs`, or `_id_or_null` and the
+- when a kernel field name ends with `_ref`, `_refs`, or `_id` and the
   stem names one target record family owned on this page, the field uses that
   record family's stable id or ordered stable-id list
 - helper tuple refs such as `SubjectRef`, `BasisPoolRef`,
@@ -113,7 +113,7 @@ Shared rules:
 
 - `SubjectRef` serializes and sorts as `[subject_kind, subject_id]`
 - `BasisPoolRef` serializes and sorts as
-  `[tax_policy_id, jurisdiction_or_regime, beneficial_owner_ref, pool_scope]`
+  `[tax_policy_id, jurisdiction_or_regime, beneficial_owner_ref, pool_key]`
 - when one stable-id recipe, ordering rule, or fingerprint input includes a
   domain ref whose canonical tuple is owned by
   [Domain Ontology](domain-ontology.md), use that tuple form rather than an
@@ -122,12 +122,14 @@ Shared rules:
 ### Temporal Scalar Rule
 
 - where a field or id recipe uses a temporal scalar such as `effective_at`,
-  `target_as_of_at`, `asserted_as_of_at`, or `valued_at_or_null`, the
+  `target_as_of_at`, `asserted_as_of_at`, or `valued_at`, the
   canonical serialized form must preserve whether the meaning is date-scoped
   or timestamp-scoped
 - stages may carry an additional precision field when that stage needs it
   operationally, but the stable id and fingerprint use the canonical temporal
   scalar only once
+- nullable fields keep the same canonical field name as the non-null case;
+  optionality belongs in the field contract, not the field name
 
 ### Kernel And Sidecar Rule
 
@@ -152,8 +154,8 @@ Shared rules:
 - `dataset_id` is the product-level attachment surface for readiness,
   comparison, and other shared sidecars when no narrower truthful scope exists
 - `dataset_id` is not a substitute for a narrower record id or stage-owned
-  scope such as `selection_group_id`, `continuity_segment_id`, or
-  `checkpoint_candidate_id`
+  scope such as `selection_id`, `continuity_segment_id`,
+  `balance_target_id`, or `checkpoint_candidate_id`
 
 ### Shared Kernel Status Vocabulary
 
@@ -166,7 +168,7 @@ Use these bounded status vocabularies across target kernels:
 - `claim_status`:
   - `asserted`
   - `superseded`
-- `compilation_outcome`:
+- `bundle_outcome`:
   - `accepted`
   - `blocked`
   - `deferred`
@@ -194,8 +196,8 @@ Product metadata:
 
 - `evidence_set_id`
 - `schema_version`
-- `selection_plan_fingerprint`
-- `manifest_fingerprint_ref`
+- `selection_fingerprint`
+- `manifest_fingerprint`
 
 Owns:
 
@@ -209,37 +211,37 @@ Record families:
 
 - `EvidenceMemberRecord`
   - `evidence_set_id`
-  - `selection_group_id`
+  - `selection_id`
   - `member_id`
   - `source`
   - `adapter_id`
   - `capture_uid`
-  - `member_family`
-  - `member_locator_identity`
+  - `member_kind`
+  - `member_locator`
   - `selection_status`
-  - `manifest_fingerprint_ref`
+  - `manifest_fingerprint`
 - `EvidenceObservationRecord`
   - `evidence_set_id`
   - `member_id`
   - `observation_id`
-  - `observation_family`
-  - `observation_anchor`
-  - `observed_at_or_null`
-  - `observed_precision_or_null`
+  - `observation_kind`
+  - `observation_key`
+  - `observed_at`
+  - `observed_precision`
   - `provenance_refs`
-- `SelectionDecisionRecord`
+- `SelectionRecord`
   - `evidence_set_id`
-  - `selection_group_id`
-  - `selection_group_anchor`
-  - `selection_plan_fingerprint`
-  - `decision_basis`
+  - `selection_id`
+  - `selection_key`
+  - `selection_fingerprint`
+  - `selection_basis`
   - `blocking_gap_refs`
 
 Cardinality:
 
-- one `SelectionDecisionRecord` exists per `selection_group_id`
+- one `SelectionRecord` exists per `selection_id`
 - one or more `EvidenceMemberRecord` rows may belong to one
-  `selection_group_id`
+  `selection_id`
 - zero or more `EvidenceObservationRecord` rows may belong to one `member_id`
 
 Envelope or sidecar content may include:
@@ -253,7 +255,7 @@ Envelope or sidecar content may include:
 
 Controlled vocabularies:
 
-- `decision_basis`:
+- `selection_basis`:
   - `single_member_match`
   - `coverage_preferred`
   - `freshness_preferred`
@@ -261,71 +263,71 @@ Controlled vocabularies:
   - `ambiguous_overlap`
   - `upstream_blocker`
 
-### First-Slice Critical-Path Observation Families
+### First-Slice Critical-Path Observation Kinds
 
 The `EvidenceObservationRecord` shell above is required for every observation.
-For the first bounded slice, these family-specific kernel fields are also
+For the first bounded slice, these kind-specific kernel fields are also
 required:
 
-| `observation_family` | Family-owned kernel fields |
+| `observation_kind` | Kind-owned kernel fields |
 | --- | --- |
-| `document_identity` | `statement_kind`, `document_effective_at_or_null`, `document_effective_precision_or_null`, `statement_as_of_at_or_null`, `statement_as_of_precision_or_null` |
-| `coinbase_statement_balance_row` | `account_label_or_null`, `wallet_label_or_null`, `balance_kind`, `asset_symbol`, `quantity_or_null`, `observed_at_or_null`, `observed_precision_or_null`, `notes_or_null`, `staked_quantity_text_or_null`, `value_amount_text_or_null`, `value_currency_or_null`, `price_amount_text_or_null`, `price_currency_or_null` |
+| `document_identity` | `statement_kind`, `document_effective_at`, `document_effective_precision`, `statement_as_of_at`, `statement_as_of_precision` |
+| `coinbase_statement_balance_row` | `account_label`, `wallet_label`, `balance_kind`, `asset_symbol`, `quantity`, `observed_at`, `observed_precision`, `notes`, `staked_quantity_text`, `value_amount_text`, `value_currency`, `price_amount_text`, `price_currency` |
 
 Rules:
 
-- the family-specific fields above are kernel meaning, not sidecar detail
+- the kind-specific fields above are kernel meaning, not sidecar detail
 - `document_identity.statement_kind` uses the recognized statement-adapter
   kind for the selected document member
-- `document_identity.statement_as_of_at_or_null` lifts the current parsed
-  statement as-of time and `statement_as_of_precision_or_null` follows the
+- `document_identity.statement_as_of_at` lifts the current parsed statement
+  as-of time and `statement_as_of_precision` follows the
   repo-wide temporal precision contract for that value
-- `document_identity.document_effective_at_or_null` lifts the current parsed
-  document-effective time when present and
-  `document_effective_precision_or_null` follows the same temporal contract
-- `coinbase_statement_balance_row.observed_at_or_null` and
-  `observed_precision_or_null` lift the current statement-row as-of value and
+- `document_identity.document_effective_at` lifts the current parsed
+  document-effective time when present and `document_effective_precision`
+  follows the same temporal contract
+- `coinbase_statement_balance_row.observed_at` and `observed_precision` lift
+  the current statement-row as-of value and
   precision directly
-- `coinbase_statement_balance_row` label, quantity, note, and valuation-text
+- `coinbase_statement_balance_row` label, quantity, notes, and valuation-text
   fields lift the current statement-row contract directly; `pdf_file` and
   `raw_row_ref` stay in provenance and observation anchors rather than
   duplicated business payload
-- `document_identity` may leave the shell `observed_at_or_null` and
-  `observed_precision_or_null` empty when the meaningful document times are
-  instead expressed through the family-owned document-effective or
+- `document_identity` may leave the shell `observed_at` and
+  `observed_precision` empty when the meaningful document times are
+  instead expressed through the kind-owned document-effective or
   statement-as-of fields
-- do not add a generic `observation_payload` blob to stand in for a family
+- do not add a generic `observation_payload` blob to stand in for a kind
   table
-- no new observation family may be implemented until this page or the owning
+- no new observation kind may be implemented until this page or the owning
   bounded slice page defines its kernel field table explicitly
 
 Stable ids:
 
 - `evidence_set_id` identifies one capture-scoped evidence emission
-- `selection_group_id` identifies one deterministic evidence-selection
+- `selection_id` identifies one deterministic evidence-selection
   decision boundary under one evidence set
 - `member_id` identifies one selected, superseded, or blocked evidence member
 - `observation_id` identifies one typed observation under one evidence member
 - `evidence_set_id` uses component array
-  `[source, adapter_id, capture_uid, selection_plan_fingerprint]`
-- `selection_group_id` uses component array
-  `[evidence_set_id, selection_group_anchor]`
+  `[source, adapter_id, capture_uid, selection_fingerprint]`
+- `selection_id` uses component array
+  `[evidence_set_id, selection_key]`
 - `member_id` uses component array
-  `[evidence_set_id, member_family, member_locator_identity]`
+  `[evidence_set_id, member_kind, member_locator]`
 - `observation_id` uses component array
-  `[member_id, observation_family, observation_anchor]`
-- `selection_group_anchor` is emitted by the evidence-selection stage and
+  `[member_id, observation_kind, observation_key]`
+- `selection_key` is emitted by the evidence-selection stage and
   remains a stable upstream id rather than a downstream recomputation
-- because `selection_plan_fingerprint` is part of `evidence_set_id`, a change
-  in the authoritative selection plan intentionally produces a new
+- because `selection_fingerprint` is part of `evidence_set_id`, a change in
+  the authoritative selection state intentionally produces a new
   capture-scoped `EvidenceSet` identity
 
 Ordering:
 
 - `EvidenceMemberRecord` rows sort by tuple
-  `[selection_group_id, selection_status, member_id]`
+  `[selection_id, selection_status, member_id]`
 - `EvidenceObservationRecord` rows sort by `[member_id, observation_id]`
-- `SelectionDecisionRecord` rows sort by `[selection_group_id]`
+- `SelectionRecord` rows sort by `[selection_id]`
 
 Serialization:
 
@@ -340,7 +342,7 @@ Fingerprint inputs:
 - product metadata
 - canonical `EvidenceMemberRecord` rows
 - canonical `EvidenceObservationRecord` rows
-- canonical `SelectionDecisionRecord` rows
+- canonical `SelectionRecord` rows
 
 Must guarantee:
 
@@ -352,7 +354,7 @@ Must guarantee:
 Must not:
 
 - force economic interpretation
-- collapse many selection groups into one fake product-wide decision
+- collapse many selections into one fake product-wide decision
 - use file order as identity
 
 Handoff to `ClaimSet`:
@@ -373,13 +375,13 @@ Product metadata:
 - `claim_set_id`
 - `schema_version`
 - `evidence_set_ref`
-- `claim_emitter_id`
+- `claim_producer_id`
 
 Owns:
 
 - source-local semantic assertions derived from evidence
 - explicit interpretation scope and mutually exclusive semantic bundles
-- compilation decisions over interpretation scopes
+- bundle decisions over interpretation scopes
 
 Record families:
 
@@ -388,27 +390,27 @@ Record families:
   - `interpretation_scope_id`
   - `bundle_id`
   - `claim_id`
-  - `claim_family`
+  - `claim_kind`
   - `claim_status`
-  - `claim_anchor`
+  - `claim_key`
   - `evidence_member_refs`
   - `evidence_observation_refs`
-  - `effective_at_or_null`
-  - `effective_precision_or_null`
+  - `effective_at`
+  - `effective_precision`
   - `provenance_refs`
-- `InterpretationBundleRecord`
+- `ClaimBundleRecord`
   - `claim_set_id`
   - `interpretation_scope_id`
   - `bundle_id`
-  - `bundle_discriminator`
-  - `scope_anchor`
+  - `bundle_key`
+  - `scope_key`
   - `claim_refs`
-- `CompilationDecisionRecord`
+- `BundleDecisionRecord`
   - `claim_set_id`
   - `interpretation_scope_id`
-  - `compilation_decision_id`
-  - `compilation_outcome`
-  - `selected_bundle_id_or_null`
+  - `bundle_decision_id`
+  - `bundle_outcome`
+  - `selected_bundle_id`
   - `rejected_bundle_refs`
   - `deferred_bundle_refs`
   - `resolution_basis`
@@ -416,12 +418,11 @@ Record families:
 
 Cardinality:
 
-- one or more `InterpretationBundleRecord` rows may exist per
-  `interpretation_scope_id`
-- one `CompilationDecisionRecord` exists per `interpretation_scope_id`
+- one or more `ClaimBundleRecord` rows may exist per `interpretation_scope_id`
+- one `BundleDecisionRecord` exists per `interpretation_scope_id`
 - one or more `ClaimRecord` rows may exist per `bundle_id`
 
-Canonical claim families:
+Canonical claim kinds:
 
 - `ActivityClaim`
 - `BalanceObservationClaim`
@@ -445,19 +446,19 @@ Controlled vocabularies:
   - `policy_deferred`
   - `superseded_by_later_claims`
 
-### First-Slice Critical-Path Claim Families
+### First-Slice Critical-Path Claim Kinds
 
 The `ClaimRecord` shell above is required for every claim. For the first
-bounded slice, these family-specific kernel fields are also required:
+bounded slice, these kind-specific kernel fields are also required:
 
-| `claim_family` | Family-owned kernel fields |
+| `claim_kind` | Kind-owned kernel fields |
 | --- | --- |
-| `ActivityClaim` | `provider_activity_kind`, `location_claim_ref_or_null`, `activity_leg_specs` |
-| `BalanceObservationClaim` | `location_claim_ref`, `instrument_claim_refs`, `balance_kind`, `quantity`, `observed_at_or_null`, `observed_precision_or_null` |
-| `InstrumentIdentityClaim` | `scheme`, `value`, `venue_or_null`, `kind_hint`, `display_name_or_null`, `precision_hint_or_null` |
-| `LocationClaim` | `location_ref`, `account_label_or_null`, `wallet_label_or_null` |
+| `ActivityClaim` | `provider_activity_kind`, `location_claim_ref`, `activity_leg_specs` |
+| `BalanceObservationClaim` | `location_claim_ref`, `instrument_claim_refs`, `balance_kind`, `quantity`, `observed_at`, `observed_precision` |
+| `InstrumentIdentityClaim` | `scheme`, `value`, `venue`, `kind_hint`, `display_name`, `precision_hint` |
+| `LocationClaim` | `location_ref`, `account_label`, `wallet_label` |
 | `BeneficialOwnerClaim` | `beneficial_owner_ref` |
-| `ValuationClaim` | `valuation_measure_kind`, `valuation_purpose`, `amount`, `currency`, `valued_at_or_null`, `valued_precision_or_null`, `location_claim_ref_or_null`, `instrument_claim_refs` |
+| `ValuationClaim` | `valuation_measure_kind`, `valuation_purpose`, `amount`, `currency`, `valued_at`, `valued_precision`, `location_claim_ref`, `instrument_claim_refs` |
 
 `activity_leg_specs` entry shape:
 
@@ -465,9 +466,9 @@ bounded slice, these family-specific kernel fields are also required:
 - `leg_kind`
 - `quantity`
 - `instrument_claim_refs`
-- `location_claim_ref_or_null`
-- `subtype_or_null`
-- `attributed_to_leg_slot_or_null`
+- `location_claim_ref`
+- `subtype`
+- `attributed_to_leg_slot`
 
 First-slice linkage rules:
 
@@ -478,7 +479,7 @@ First-slice linkage rules:
   optional subtype, optional attributed-leg linkage, and optional location
 - retail activity claims use `evidence_member_refs` plus the first-slice scope
   anchor `[retail_member_id, raw_row_ref]`; they do not require a retail-row
-  observation family in this pass
+  observation kind in this pass
 - statement-derived claims use both `evidence_member_refs` and
   `evidence_observation_refs`
 - `BalanceObservationClaim` must include the row observation id in
@@ -503,12 +504,12 @@ Rules:
 - `provider_operation_key` is satisfied by
   `ActivityClaim.provider_activity_kind` and must not be duplicated into a
   compatibility sidecar field
-- review markers map to shared support artifacts rather than canonical claims
+- review markers map to shared support records and sidecars rather than canonical claims
   or bridge-compat semantic payloads
 - adapter-local extras may survive only as envelope or compatibility-sidecar
   detail and never as canonical `ClaimSet` kernel meaning
-- do not add a generic `claim_payload` blob to stand in for a family table
-- no non-critical claim family may be implemented until this page or the
+- do not add a generic `claim_payload` blob to stand in for a kind table
+- no non-critical claim kind may be implemented until this page or the
   owning bounded slice page defines its kernel field table explicitly
 
 Stable ids:
@@ -518,24 +519,24 @@ Stable ids:
   may admit one or more mutually exclusive bundles
 - `bundle_id` identifies one mutually exclusive semantic bundle
 - `claim_id` identifies one semantic assertion under one bundle
-- `compilation_decision_id` identifies one compilation-decision record for one
+- `bundle_decision_id` identifies one bundle-decision record for one
   interpretation scope
-- `claim_set_id` uses component array `[evidence_set_id, claim_emitter_id]`
-- `interpretation_scope_id` uses component array `[claim_set_id, scope_anchor]`
+- `claim_set_id` uses component array `[evidence_set_id, claim_producer_id]`
+- `interpretation_scope_id` uses component array `[claim_set_id, scope_key]`
 - `bundle_id` uses component array
-  `[interpretation_scope_id, bundle_discriminator]`
-- `claim_id` uses component array `[bundle_id, claim_family, claim_anchor]`
-- `compilation_decision_id` uses component array
+  `[interpretation_scope_id, bundle_key]`
+- `claim_id` uses component array `[bundle_id, claim_kind, claim_key]`
+- `bundle_decision_id` uses component array
   `[claim_set_id, interpretation_scope_id]`
 
 Ordering:
 
 - `ClaimRecord` rows sort by tuple
-  `[bundle_id, claim_family, effective_at_or_null, effective_precision_or_null, claim_id]`
-- `InterpretationBundleRecord` rows sort by
-  `[interpretation_scope_id, bundle_discriminator, bundle_id]`
-- `CompilationDecisionRecord` rows sort by
-  `[interpretation_scope_id, compilation_decision_id]`
+  `[bundle_id, claim_kind, effective_at, effective_precision, claim_id]`
+- `ClaimBundleRecord` rows sort by
+  `[interpretation_scope_id, bundle_key, bundle_id]`
+- `BundleDecisionRecord` rows sort by
+  `[interpretation_scope_id, bundle_decision_id]`
 
 Serialization:
 
@@ -551,8 +552,8 @@ Fingerprint inputs:
 
 - product metadata
 - canonical `ClaimRecord` rows
-- canonical `InterpretationBundleRecord` rows
-- canonical `CompilationDecisionRecord` rows
+- canonical `ClaimBundleRecord` rows
+- canonical `BundleDecisionRecord` rows
 
 Must guarantee:
 
@@ -561,12 +562,12 @@ Must guarantee:
 - preserved ambiguity where one safe final interpretation is unavailable
 - claim-stage gaps and reviews may attach to `interpretation_scope_id` when
   no narrower truthful subject has resolved yet
-- family-owned kernel fields are frozen wherever this page defines them; later
+- kind-owned kernel fields are frozen wherever this page defines them; later
   writing and implementation must not invent alternate shells or generic
-  payload blobs for those families
+  payload blobs for those kinds
 - no semantic promotion of reviews, blockers, or renderer metadata into claim
-  families
-- claim-owned compilation decisions that record bundle acceptance, blocking,
+  kinds
+- claim-owned bundle decisions that record bundle acceptance, blocking,
   deferral, or supersession without carrying economic payloads
 
 Must not:
@@ -578,7 +579,7 @@ Must not:
 Handoff to `EconomicFacts`:
 
 - `ClaimSet` hands off source-local assertions, mutually exclusive bundles, and
-  compilation decisions
+  bundle decisions
 - the compiler decides which bundle can become accepted economic truth and
   which scopes remain blocked, deferred, or superseded
 
@@ -606,39 +607,39 @@ Record families:
 - `EconomicEventRecord`
   - `event_id`
   - `bundle_id`
-  - `compilation_decision_id`
-  - `event_family`
-  - `effective_at_or_null`
+  - `bundle_decision_id`
+  - `event_kind`
+  - `effective_at`
   - `recorded_at`
   - `settlement_state`
   - `lifecycle_state`
-  - `legal_owner_ref_or_null`
-  - `beneficial_owner_ref_or_null`
-  - `counterparty_ref_or_null`
-  - `supersedes_event_id_or_null`
+  - `legal_owner_ref`
+  - `beneficial_owner_ref`
+  - `counterparty_ref`
+  - `supersedes_event_id`
 - `EconomicLegRecord`
   - `leg_id`
   - `event_id`
   - `leg_role`
   - `subject_ref`
-  - `instrument_ref_or_null`
-  - `location_ref_or_null`
+  - `instrument_ref`
+  - `location_ref`
   - `quantity`
-  - `valuation_ref_or_null`
+  - `valuation_ref`
 - `ValuationRecord`
   - `valuation_id`
   - `valuation_source_ref`
   - `valuation_purpose`
   - `amount`
   - `currency`
-  - `valued_at_or_null`
-  - `valued_precision_or_null`
+  - `valued_at`
+  - `valued_precision`
   - `provenance_refs`
   - `confidence`
 
 Controlled vocabularies:
 
-- `event_family`:
+- `event_kind`:
   - `asset_movement`
   - `cash_movement`
   - `obligation_or_right`
@@ -668,24 +669,24 @@ Stable ids:
 - `leg_id` identifies one stable leg under one accepted event
 - `valuation_id` identifies one valuation record used by one or more accepted
   events or legs
-- `economic_facts_id` uses component array `[ordered_claim_set_refs]`
+- `economic_facts_id` uses component array `[claim_set_refs]`
 - `valuation_source_ref` uses `ValuationSourceRef` from
   [Target Contract Primitives](../reference/target-contract-primitives.md)
 - `event_id` uses component array `[bundle_id, event_index]`
 - `leg_id` uses component array `[event_id, leg_role, subject_ref, leg_index]`
 - `valuation_id` uses component array
-  `[valuation_source_ref, valuation_purpose, amount, currency, valued_at_or_null, valued_precision_or_null]`
+  `[valuation_source_ref, valuation_purpose, amount, currency, valued_at, valued_precision]`
 - `event_index` and `leg_index` are zero-based canonical positions in declared
   event and leg order
-- `compilation_decision_id` may be referenced for audit, but it does not define
+- `bundle_decision_id` may be referenced for audit, but it does not define
   event identity
 
 Ordering:
 
-- `EconomicEventRecord` rows sort by `effective_at_or_null`, then `recorded_at`,
+- `EconomicEventRecord` rows sort by `effective_at`, then `recorded_at`,
   then `event_id`
 - `EconomicLegRecord` rows sort by `[event_id, leg_id]`
-- `ValuationRecord` rows sort by `[valuation_purpose, valued_at_or_null, valuation_id]`
+- `ValuationRecord` rows sort by `[valuation_purpose, valued_at, valuation_id]`
 
 Serialization:
 
@@ -704,7 +705,7 @@ Fingerprint inputs:
 
 Must guarantee:
 
-- accepted event families stay jurisdiction-neutral and output-neutral
+- accepted event kinds stay jurisdiction-neutral and output-neutral
 - event identity is driven by the selected semantic bundle, not by compilation
   bookkeeping noise
 - event, leg, and valuation records carry the computation-critical
@@ -758,10 +759,10 @@ Record families:
   - `continuity_segment_id`
   - `source`
   - `subject_ref`
-  - `segment_start_at_or_null`
-  - `segment_end_at_or_null`
+  - `segment_start_at`
+  - `segment_end_at`
   - `reconciliation_status`
-  - `checkpoint_date_or_null`
+  - `checkpoint_date`
 - `LinkRecord`
   - `link_id`
   - `continuity_segment_id`
@@ -776,7 +777,7 @@ Record families:
   - `target_kind`
   - `target_as_of_at`
   - `expected_value`
-  - `observed_value_or_null`
+  - `observed_value`
   - `balance_target_status`
 - `CheckpointCandidateRecord`
   - `checkpoint_candidate_id`
@@ -784,8 +785,8 @@ Record families:
   - `subject_ref`
   - `checkpoint_date`
   - `candidate_status`
-  - `supporting_balance_target_refs`
-  - `supporting_evidence_refs`
+  - `balance_target_refs`
+  - `evidence_refs`
 
 Controlled vocabularies:
 
@@ -839,22 +840,22 @@ Stable ids:
 - `reconciliation_state_id` uses component array
   `[economic_facts_ref, continuity_segment_id]`
 - `continuity_segment_id` uses component array
-  `[source, subject_ref, segment_start_at_or_null, segment_end_at_or_null]`
+  `[source, subject_ref, segment_start_at, segment_end_at]`
 - `link_id` uses component array
   `[continuity_segment_id, link_kind, left_event_ref, right_event_ref]`
 - `balance_target_id` uses component array
   `[continuity_segment_id, subject_ref, target_kind, target_as_of_at, expected_value_fingerprint]`
 - `checkpoint_candidate_id` uses component array
-  `[continuity_segment_id, subject_ref, checkpoint_date, supporting_balance_target_refs]`
+  `[continuity_segment_id, subject_ref, checkpoint_date, balance_target_refs]`
 - `expected_value_fingerprint` is the canonical fingerprint of the
   `AssertionValue` carried in `expected_value`
-- `supporting_evidence_refs` provide audit support, but they are not part of
-  candidate identity
+- `evidence_refs` provide audit support, but they are not part of candidate
+  identity
 
 Ordering:
 
 - `ContinuitySegmentRecord` rows sort by
-  `[checkpoint_date_or_null, source, subject_ref, continuity_segment_id]`
+  `[checkpoint_date, source, subject_ref, continuity_segment_id]`
 - `LinkRecord` rows sort by
   `[continuity_segment_id, link_kind, left_event_ref, right_event_ref, link_id]`
 - `BalanceTargetRecord` rows sort by
@@ -868,8 +869,7 @@ Serialization:
 - persist product metadata once per emitted kernel
 - use stable object-key ordering
 - preserve the declared order above
-- sort `supporting_balance_target_refs` and `supporting_evidence_refs`
-  lexicographically
+- sort `balance_target_refs` and `evidence_refs` lexicographically
 
 Fingerprint inputs:
 
@@ -884,6 +884,8 @@ Must guarantee:
 - explicit completeness decisions
 - explicit continuity decisions
 - explicit missing-leg and missing-evidence surfaces
+- reconciliation-stage gaps and reviews may attach to `balance_target_id` when
+  one exact target is the truthful blocker or review scope
 - preservation of partial truth when the whole window is not yet clean
 - no rewriting of upstream economics to satisfy checks
 
@@ -923,7 +925,7 @@ Record families:
 - `CheckpointRecord`
   - `checkpoint_id`
   - `asserted_as_of_at`
-  - `ordered_checkpoint_assertion_ids`
+  - `checkpoint_assertion_ids`
 - `CheckpointAssertionRecord`
   - `checkpoint_assertion_id`
   - `checkpoint_id`
@@ -988,9 +990,9 @@ Stable ids:
 - `checkpoint_assertion_id` identifies one accepted checkpoint truth record for
   one subject and one as-of point
 - `checkpoint_run_id` uses component array
-  `[ordered_reconciliation_state_refs, asserted_as_of_at]`
+  `[reconciliation_state_refs, asserted_as_of_at]`
 - `checkpoint_id` uses component array
-  `[asserted_as_of_at, ordered_checkpoint_assertion_ids]`
+  `[asserted_as_of_at, checkpoint_assertion_ids]`
 - `checkpoint_assertion_id` uses component array
   `[assertion_kind, asserted_as_of_at, subject_ref, accepted_value_fingerprint]`
 - `accepted_value_fingerprint` is the canonical fingerprint of one
@@ -1082,7 +1084,7 @@ Record families:
   - `journal_id`
   - `entry_id`
   - `entry_kind`
-  - `effective_at_or_null`
+  - `effective_at`
   - `economic_event_refs`
   - `checkpoint_assertion_refs`
   - `journal_status`
@@ -1142,18 +1144,18 @@ Stable ids:
   `CommodityRef`, and `OriginRef` from
   [Target Contract Primitives](../reference/target-contract-primitives.md)
 - `journal_run_id` uses component array
-  `[checkpoint_ref, ordered_economic_facts_refs]`
+  `[checkpoint_ref, economic_facts_refs]`
 - `journal_id` uses component array
-  `[ordered_economic_event_refs, ordered_checkpoint_assertion_refs, ordered_entry_kinds]`
+  `[economic_event_refs, checkpoint_assertion_refs, entry_kinds]`
 - `entry_id` uses component array
-  `[journal_id, entry_kind, effective_at_or_null, economic_event_refs, checkpoint_assertion_refs]`
+  `[journal_id, entry_kind, effective_at, economic_event_refs, checkpoint_assertion_refs]`
 - `posting_id` uses component array
   `[entry_id, account_ref, commodity_ref, amount, posting_side, origin_ref]`
 - `validation_id` uses component array `[entry_id, validation_kind]`
 
 Ordering:
 
-- `JournalEntryRecord` rows sort by `[effective_at_or_null, entry_kind, entry_id]`
+- `JournalEntryRecord` rows sort by `[effective_at, entry_kind, entry_id]`
 - `PostingRecord` rows sort by
   `[entry_id, posting_side, account_ref, commodity_ref, origin_ref, posting_id]`
 - `ValidationRecord` rows sort by `[entry_id, validation_kind, validation_id]`
@@ -1217,29 +1219,29 @@ Record families:
 
 - `TaxDeterminantRecord`
   - `determinant_id`
-  - `determinant_family`
+  - `determinant_kind`
   - `tax_year`
   - `basis_pool_ref`
   - `beneficial_owner_ref`
   - `instrument_ref`
-  - `effective_at_or_null`
+  - `effective_at`
   - `quantity`
   - `direction`
-  - `valuation_ref_or_null`
-  - `counterparty_ref_or_null`
+  - `valuation_ref`
+  - `counterparty_ref`
   - `economic_event_refs`
   - `checkpoint_assertion_refs`
-  - `basis_transition_ref_or_null`
+  - `basis_transition_ref`
 - `BasisTransitionRecord`
   - `basis_transition_id`
   - `basis_pool_ref`
-  - `from_determinant_ref_or_null`
+  - `from_determinant_ref`
   - `to_determinant_ref`
   - `transition_kind`
 
 Controlled vocabularies:
 
-- `determinant_family`:
+- `determinant_kind`:
   - `acquisition`
   - `disposition`
   - `income`
@@ -1271,18 +1273,18 @@ Stable ids:
 - `determinant_id` identifies one tax determinant
 - `basis_transition_id` identifies one basis or pool transition
 - `tax_inputs_id` uses component array
-  `[checkpoint_ref, ordered_economic_facts_refs]`
+  `[checkpoint_ref, economic_facts_refs]`
 - `determinant_id` uses component array
-  `[tax_year, determinant_family, basis_pool_ref, beneficial_owner_ref, instrument_ref, effective_at_or_null, quantity, direction, economic_event_refs, checkpoint_assertion_refs]`
+  `[tax_year, determinant_kind, basis_pool_ref, beneficial_owner_ref, instrument_ref, effective_at, quantity, direction, economic_event_refs, checkpoint_assertion_refs]`
 - `basis_transition_id` uses component array
-  `[basis_pool_ref, transition_kind, from_determinant_ref_or_null, to_determinant_ref]`
+  `[basis_pool_ref, transition_kind, from_determinant_ref, to_determinant_ref]`
 
 Ordering:
 
 - `TaxDeterminantRecord` rows sort by tuple
-  `[tax_year, basis_pool_ref.tax_policy_id, basis_pool_ref.jurisdiction_or_regime, basis_pool_ref.beneficial_owner_ref, basis_pool_ref.pool_scope, determinant_family, effective_at_or_null, determinant_id]`
+  `[tax_year, basis_pool_ref.tax_policy_id, basis_pool_ref.jurisdiction_or_regime, basis_pool_ref.beneficial_owner_ref, basis_pool_ref.pool_key, determinant_kind, effective_at, determinant_id]`
 - `BasisTransitionRecord` rows sort by
-  `[basis_pool_ref.tax_policy_id, basis_pool_ref.jurisdiction_or_regime, basis_pool_ref.beneficial_owner_ref, basis_pool_ref.pool_scope, transition_kind, basis_transition_id]`
+  `[basis_pool_ref.tax_policy_id, basis_pool_ref.jurisdiction_or_regime, basis_pool_ref.beneficial_owner_ref, basis_pool_ref.pool_key, transition_kind, basis_transition_id]`
 
 Serialization:
 
@@ -1346,7 +1348,7 @@ Record families:
 - `TaxOutputRecord`
   - `tax_output_id`
   - `policy_id`
-  - `output_family`
+  - `output_kind`
   - `tax_year`
   - `tax_status`
   - `basis_pool_refs`
@@ -1355,7 +1357,7 @@ Record families:
   - `tax_output_id`
   - `basis_pool_ref`
   - `next_tax_year`
-  - `state_fingerprint_ref`
+  - `state_fingerprint`
 - `UnsupportedItemRecord`
   - `unsupported_item_id`
   - `tax_output_id`
@@ -1364,7 +1366,7 @@ Record families:
 
 Controlled vocabularies:
 
-- `output_family`:
+- `output_kind`:
   - `realized_gains_schedule`
   - `income_schedule`
   - `expense_schedule`
@@ -1393,7 +1395,7 @@ Stable ids:
 - `unsupported_item_id` identifies one persisted unsupported-item record
 - `tax_outputs_id` uses component array `[tax_inputs_ref, policy_id, tax_year]`
 - `tax_output_id` uses component array
-  `[policy_id, output_family, tax_year, basis_pool_refs]`
+  `[policy_id, output_kind, tax_year, basis_pool_refs]`
 - `carry_forward_id` uses component array
   `[tax_output_id, basis_pool_ref, next_tax_year]`
 - `unsupported_item_id` uses component array
@@ -1402,7 +1404,7 @@ Stable ids:
 Ordering:
 
 - `TaxOutputRecord` rows sort by
-  `[policy_id, tax_year, output_family, tax_output_id]`
+  `[policy_id, tax_year, output_kind, tax_output_id]`
 - `CarryForwardRecord` rows sort by
   `[tax_output_id, next_tax_year, basis_pool_ref, carry_forward_id]`
 - `UnsupportedItemRecord` rows sort by
@@ -1450,7 +1452,7 @@ The pipeline products rely on shared supporting contracts defined elsewhere:
   contract
 - [Domain Ontology](domain-ontology.md) for entity seams, refs,
   `AssertionValue`, and package ownership
-- [Gaps And Readiness](gaps-and-readiness.md) for `GapCore`,
+- [Gaps And Readiness](gaps-and-readiness.md) for `GapRecord`,
   `GapExplanation`, reviews, readiness, and `SubjectRef`
 - [Reconciliation And Tax Architecture](reconciliation-tax-architecture.md) for
   persistence rules, partitioning rules, and fast-path expectations

--- a/docs/concepts/pipeline-stage-contracts.md
+++ b/docs/concepts/pipeline-stage-contracts.md
@@ -57,6 +57,12 @@ Shared rules:
 
 ## Shared Product Rules
 
+Shared primitive and artifact authorities used by this page live in
+[Target Contract Primitives](../reference/target-contract-primitives.md) and
+[Target Product Artifacts](../reference/target-product-artifacts.md). This
+page remains the owner of stage semantics, record families, stage-owned
+vocabularies, and handoff guarantees.
+
 ### Versioning, Serialization, And Fingerprints
 
 - every target product carries a `schema_version`
@@ -80,12 +86,18 @@ Shared rules:
 - component arrays use the owning product's canonical scalar forms exactly as
   emitted; do not add hidden trimming, lowercasing, or resorting outside the
   declared tuple rules
+- canonical scalar forms, admissible anchor components, shared dataset
+  identity, reusable tuple contracts, and default target dataset packaging are
+  owned by the reference pages above rather than redefined here
 
 ### Composite Tuple Rules
 
 - `SubjectRef` serializes and sorts as `[subject_kind, subject_id]`
 - `BasisPoolRef` serializes and sorts as
   `[tax_policy_id, jurisdiction_or_regime, beneficial_owner_ref, pool_scope]`
+- plain `*_ref` and `*_refs` fields point to stable ids unless the owning page
+  explicitly names a structured tuple contract such as `SubjectRef`,
+  `BasisPoolRef`, `AccountRef`, `CommodityRef`, or `OriginRef`
 - when one stable-id recipe, ordering rule, or fingerprint input includes one
   of these composite references, use the tuple form above rather than an
   object-name shorthand
@@ -186,13 +198,14 @@ Stable ids:
 - `observation_id` uses component array
   `[member_id, observation_class, observation_anchor]`
 - `selection_group_id` is emitted by the evidence-selection stage and remains a
-  stable upstream id rather than a downstream recomputation
-- `member_class` is the stable evidence-family or member-role label emitted for
-  the member
+  stable upstream id rather than a downstream recomputation; it is a
+  decision-boundary id, not an evidence member family
+- `member_class` is the stable evidence member-family or member-role label
+  emitted for the member
 - `member_locator_identity` is the stage-owned stable locator tuple for one
   evidence member
-- `observation_class` is the stable observation family label emitted for one
-  typed observation
+- `observation_class` is the stable typed observation label emitted for one
+  observation under the owning evidence member
 - `observation_anchor` is the stable row, page, anchor, or typed observation
   locator emitted for that observation
 
@@ -312,12 +325,19 @@ Stable ids:
 - `adjudication_record_id` uses component array
   `[claim_set_id, interpretation_group_id, compilation_outcome, resolution_basis, accepted_claim_refs, rejected_claim_refs, deferred_claim_refs]`
 - `claim_emitter_id` is the stable id of the translation family or shared
-  compiler boundary that emitted the claim set
+  compiler boundary that emitted the claim set; its reusable id recipe is
+  owned by
+  [Target Contract Primitives](../reference/target-contract-primitives.md)
+- `claim_emitter_id` is product-scoped `ClaimSet` metadata, not an implicit
+  local variable or adapter-private constant
 - `claim_anchor` is the stable provider-local anchor for one asserted meaning;
-  slice-specific anchor choices live in
+  the shared admissibility rules for anchor components live in
+  [Target Contract Primitives](../reference/target-contract-primitives.md),
+  while slice-specific anchor choices live in
   [First Slice Contract](../reference/first-slice-contract.md)
 - `bundle_anchor` is the stable anchor shared by all mutually exclusive bundles
-  over the same source-local meaning
+  over the same source-local meaning; its admissibility rules also live in
+  [Target Contract Primitives](../reference/target-contract-primitives.md)
 - `bundle_discriminator` is `default` when one anchor has exactly one bundle;
   otherwise use `alt:1`, `alt:2`, and so on in canonical bundle order under
   that anchor
@@ -416,6 +436,16 @@ Record families:
   - `location_ref_or_null`
   - `quantity`
   - `valuation_ref_or_null`
+- `ValuationRecord`
+  - `valuation_id`
+  - `amount`
+  - `currency`
+  - `valuation_purpose`
+  - `valued_at_or_null`
+  - `value_precision_or_null`
+  - `source_kind`
+  - `confidence`
+  - `provenance_refs`
 
 Controlled vocabularies:
 
@@ -440,10 +470,15 @@ Controlled vocabularies:
   - `fee`
   - `rebate`
   - `withholding`
+- `valuation_purpose`:
+  - `economic`
+  - `checkpoint_support`
+  - `accounting_support`
+  - `tax_support`
+  - `market_observation`
 
 Envelope content may include:
 
-- detailed valuations
 - ownership and counterparty explanation
 - explanation of accepted identity seams
 - supporting claim traces
@@ -453,10 +488,16 @@ Stable ids:
 
 - `event_id` identifies one accepted economic event
 - `leg_id` identifies one stable leg under one accepted event
+- `valuation_id` identifies one persisted valuation kernel record
 - `event_id` uses component array `[adjudication_record_id, event_index]`
 - `leg_id` uses component array `[event_id, leg_role, subject_ref, leg_index]`
+- `valuation_id` uses component array
+  `[amount, currency, valuation_purpose, valued_at_or_null, value_precision_or_null, source_kind, confidence, provenance_refs]`
 - `event_index` and `leg_index` are zero-based canonical positions in declared
   event and leg order
+- `valuation_ref_or_null` points to `valuation_id` when a downstream stage
+  must reason from persisted valuation truth instead of rehydrating envelope
+  detail
 
 Ordering:
 
@@ -464,18 +505,22 @@ Ordering:
 - otherwise sort by `recorded_at`
 - then `event_id`
 - `EconomicLegRecord` rows sort by `[event_id, leg_id]`
+- `ValuationRecord` rows sort by `[valuation_purpose, valued_at_or_null, valuation_id]`
 
 Serialization:
 
-- serialize `EconomicEventRecord` rows and `EconomicLegRecord` rows as separate
-  ordered arrays
+- serialize `EconomicEventRecord`, `EconomicLegRecord`, and `ValuationRecord`
+  rows as separate ordered arrays
 - use stable object-key ordering
 - preserve the declared event and leg order above
+- sort `provenance_refs` lexicographically when a stronger stage-owned order is
+  not declared
 
 Fingerprint inputs:
 
 - canonical `EconomicEventRecord` rows
 - canonical `EconomicLegRecord` rows
+- canonical `ValuationRecord` rows
 - `schema_version`
 - referenced `CompilationDecisionRecord` ids
 
@@ -484,6 +529,8 @@ Must guarantee:
 - accepted event families stay jurisdiction-neutral and output-neutral
 - event and leg records carry the computation-critical determinants needed for
   later reconciliation, checkpointing, accounting, and tax
+- valuation records stay first-class kernel truth whenever later checkpoint,
+  accounting, or tax behavior depends on them
 - corrections preserve supersession lineage instead of mutating accepted
   economic truth in place
 - unresolved economic detail may remain explicit only where later stages can
@@ -498,8 +545,8 @@ Must not:
 Handoff to `ReconciliationState`:
 
 - `EconomicFacts` provides accepted economic events, economic legs, identity
-  seams, settlement links, lifecycle state, and valuation references where
-  they are already safe
+  seams, settlement links, lifecycle state, and valuation records or
+  references where they are already safe
 - it does not claim that continuity is complete, transfers are fully linked, or
   checkpoint truth is accepted
 
@@ -545,8 +592,8 @@ Record families:
   - `target_kind`
   - `target_as_of_at`
   - `target_precision`
-  - `expected_value_ref`
-  - `observed_value_ref_or_null`
+  - `expected_value`
+  - `observed_value_or_null`
   - `balance_target_status`
 - `CheckpointCandidateRecord`
   - `checkpoint_candidate_id`
@@ -603,9 +650,18 @@ Stable ids:
 - `link_id` uses component array
   `[continuity_segment_id, link_kind, left_event_ref, right_event_ref]`
 - `balance_target_id` uses component array
-  `[continuity_segment_id, subject_ref, target_kind, target_as_of_at, target_precision, expected_value_ref]`
+  `[continuity_segment_id, subject_ref, target_kind, target_as_of_at, target_precision, expected_value_fingerprint]`
 - `checkpoint_candidate_id` uses component array
   `[continuity_segment_id, subject_ref, checkpoint_date, supporting_balance_target_refs, supporting_evidence_refs]`
+- `expected_value` and `observed_value_or_null` use the shared
+  `AssertionValue` union owned by
+  [Target Contract Primitives](../reference/target-contract-primitives.md)
+- `expected_value_fingerprint` is the canonical fingerprint of one
+  `AssertionValue` and keeps stable-id recipes on admissible scalar inputs
+- reconciliation comparison values stay inline because they are
+  kernel-critical determinants, not detachable sidecars
+- `checkpoint_candidate_id` depends on supporting refs only; it does not
+  include observed-value payloads or comparison text
 
 Ordering:
 
@@ -734,8 +790,8 @@ Stable ids:
 - `checkpoint_assertion_id` uses component array
   `[assertion_kind, asserted_as_of_at, subject_ref, accepted_value_fingerprint]`
 - `accepted_value_fingerprint` is the canonical fingerprint of one
-  `CheckpointAssertionValue` variant from
-  [Domain Ontology](domain-ontology.md)
+  `AssertionValue` from
+  [Target Contract Primitives](../reference/target-contract-primitives.md)
 
 Ordering:
 
@@ -823,7 +879,7 @@ Record families:
   - `commodity_ref`
   - `amount`
   - `posting_side`
-  - `source_ref`
+  - `origin_ref`
 - `ValidationRecord`
   - `validation_id`
   - `entry_id`
@@ -867,11 +923,16 @@ Stable ids:
 - `entry_id` uses component array
   `[journal_id, entry_kind, effective_at_or_null, economic_event_refs, checkpoint_assertion_refs]`
 - `posting_id` uses component array
-  `[entry_id, account_ref, commodity_ref, amount, posting_side, source_ref]`
+  `[entry_id, account_ref, commodity_ref, amount, posting_side, origin_ref]`
 - `validation_id` uses component array `[entry_id, validation_kind]`
 - `ordered_economic_event_refs`, `ordered_checkpoint_assertion_refs`, and
   `ordered_entry_kinds` are the canonical flattened journal-level arrays
   derived from the emitted `JournalEntryRecord` rows
+- `account_ref`, `commodity_ref`, and `origin_ref` use the structured tuple
+  contracts owned by
+  [Target Contract Primitives](../reference/target-contract-primitives.md)
+- `origin_ref` points to the immediate kernel origin for the posting rather
+  than to a provider label, renderer label, or free-form source string
 
 Ordering:
 
@@ -1052,7 +1113,7 @@ Record families:
 
 - `TaxOutputRecord`
   - `tax_output_id`
-  - `policy_id`
+  - `tax_policy_id`
   - `output_family`
   - `tax_year`
   - `tax_status`
@@ -1091,16 +1152,18 @@ Stable ids:
 - `carry_forward_id` identifies one carry-forward state record
 - `unsupported_item_id` identifies one persisted unsupported-item record
 - `tax_output_id` uses component array
-  `[policy_id, output_family, tax_year, basis_pool_refs]`
+  `[tax_policy_id, output_family, tax_year, basis_pool_refs]`
 - `carry_forward_id` uses component array
   `[tax_output_id, basis_pool_ref, next_tax_year]`
 - `unsupported_item_id` uses component array
   `[tax_output_id, determinant_ref]`
+- `tax_policy_id` uses the reusable `TaxPolicyId` contract owned by
+  [Target Contract Primitives](../reference/target-contract-primitives.md)
 
 Ordering:
 
 - `TaxOutputRecord` rows sort by
-  `[policy_id, tax_year, output_family, tax_output_id]`
+  `[tax_policy_id, tax_year, output_family, tax_output_id]`
 - `CarryForwardRecord` rows sort by
   `[tax_output_id, next_tax_year, basis_pool_ref, carry_forward_id]`
 - `UnsupportedItemRecord` rows sort by
@@ -1120,7 +1183,7 @@ Fingerprint inputs:
 - canonical `UnsupportedItemRecord` rows
 - `schema_version`
 - referenced `TaxInputs` ids or fingerprints
-- selected `policy_id`
+- selected `tax_policy_id`
 
 Must guarantee:
 
@@ -1146,6 +1209,11 @@ The pipeline products rely on shared supporting contracts defined elsewhere:
 - [First Downstream Slice Contract](../reference/first-downstream-slice-contract.md)
   for the first bounded `EconomicFacts -> ReconciliationState -> Checkpoint`
   contract
+- [Target Contract Primitives](../reference/target-contract-primitives.md) for
+  canonical scalar forms, reusable tuple contracts, shared `AssertionValue`,
+  and reusable target ids
+- [Target Product Artifacts](../reference/target-product-artifacts.md) for
+  target dataset packaging, kernel filenames, and sidecar locations
 - [Domain Ontology](domain-ontology.md) for the target ontology and identity
   seams
 - [Gaps And Readiness](gaps-and-readiness.md) for `GapCore`,

--- a/docs/concepts/pipeline-stage-contracts.md
+++ b/docs/concepts/pipeline-stage-contracts.md
@@ -59,6 +59,10 @@ Shared rules:
 ### Versioning, Serialization, And Fingerprints
 
 - every target product carries a `schema_version`
+- `schema_version` is a product-level kernel field persisted once per emitted
+  product beside the ordered kernel records for that product
+- per-record kernel field lists below do not repeat `schema_version` unless one
+  product truly carries it on every record
 - readers accept only the declared supported versions for that product
 - unknown schema versions fail fast
 - compatibility is forward-only by default; do not promise long-lived in-place
@@ -378,6 +382,46 @@ The compiler owns adjudication between `ClaimSet` and `EconomicFacts`.
 - one resolution basis describing why the compiler accepted, deferred, or
   blocked the interpretation group
 
+### CompilationDecision Kernel
+
+Kernel fields:
+
+- `claim_set_id`
+- `adjudication_record_id`
+- `interpretation_group_id`
+- `compilation_outcome`
+- `accepted_claim_refs`
+- `rejected_claim_refs`
+- `deferred_claim_refs`
+- `resolution_basis`
+- `blocking_gap_refs`
+
+Stable ids:
+
+- `adjudication_record_id` uses component array
+  `[claim_set_id, interpretation_group_id, compilation_outcome, resolution_basis, accepted_claim_refs, rejected_claim_refs, deferred_claim_refs]`
+
+Controlled `resolution_basis` vocabulary:
+
+- `single_bundle_match`
+- `insufficient_identity`
+- `insufficient_temporal_precision`
+- `conflicting_claims`
+- `upstream_blocker`
+- `policy_deferred`
+- `superseded_by_later_claims`
+
+Ordering:
+
+- sort by `interpretation_group_id`
+- then `adjudication_record_id`
+
+Serialization:
+
+- serialize kernel decision records only
+- use stable object-key ordering
+- preserve sorted claim-ref and gap-ref arrays
+
 Adjudication rules:
 
 - interpretation groups are bundle-atomic
@@ -438,6 +482,10 @@ Envelope content may include:
 - `event_id` identifies one accepted economic event
 - `leg_id` identifies one stable leg under one accepted event
 - `adjudication_record_id` identifies one compiler decision record
+- `event_id` uses component array `[adjudication_record_id, event_index]`
+- `leg_id` uses component array `[event_id, leg_index]`
+- `event_index` and `leg_index` are zero-based canonical positions in declared
+  event and leg order
 
 ### EconomicFacts Ordering
 
@@ -540,6 +588,17 @@ Envelope content may include:
 - `link_id` identifies one owned transfer or settlement linkage
 - `checkpoint_candidate_id` identifies one reconciliation-owned checkpoint
   proposal
+- `continuity_segment_id` uses component array
+  `[source, subject_ref, segment_start_or_null, segment_end_or_null]`
+- `link_id` uses component array `[continuity_segment_id, link_index]`
+- `checkpoint_candidate_id` uses component array
+  `[checkpoint_date, subject_ref, continuity_segment_id, candidate_index]`
+- `reconciliation_state_id` uses component array
+  `[checkpoint_date, subject_ref, continuity_segment_id, checkpoint_candidate_id]`
+- `segment_start_or_null` and `segment_end_or_null` use canonical timestamp
+  scalars or JSON `null`
+- `link_index` and `candidate_index` are zero-based canonical positions in
+  declared order
 
 ### ReconciliationState Ordering
 
@@ -623,8 +682,12 @@ Envelope content may include:
 - `checkpoint_id` identifies one accepted checkpoint container
 - `checkpoint_assertion_id` identifies one accepted checkpoint truth record for
   one subject and one as-of point
+- `checkpoint_id` uses component array
+  `[asserted_as_of_at, ordered_checkpoint_assertion_ids]`
 - `checkpoint_assertion_id` uses component array
   `[assertion_kind, asserted_as_of_at, subject_ref.subject_kind, subject_ref.subject_id]`
+- `ordered_checkpoint_assertion_ids` is the canonical ordered list of
+  assertion ids persisted in that accepted checkpoint container
 
 ### Checkpoint Ordering
 
@@ -739,6 +802,14 @@ Envelope content may include:
 - `journal_id` identifies one accounting emission
 - `entry_id` identifies one journal entry
 - `posting_id` identifies one posting under one journal entry
+- `journal_id` uses component array
+  `[ordered_economic_event_refs, ordered_checkpoint_assertion_refs]`
+- `entry_id` uses component array `[journal_id, entry_index]`
+- `posting_id` uses component array `[entry_id, posting_index]`
+- `ordered_economic_event_refs` and `ordered_checkpoint_assertion_refs` use
+  the canonical reference ordering declared by the emitted journal product
+- `entry_index` and `posting_index` are zero-based canonical positions in
+  declared order
 
 ### Journal Ordering
 
@@ -920,6 +991,10 @@ Envelope content may include:
 ### TaxOutputs Stable Ids
 
 - `tax_output_id` identifies one policy-owned output emission
+- `tax_output_id` uses component array
+  `[policy_id, output_family, tax_year, ordered_basis_pool_refs]`
+- `ordered_basis_pool_refs` is the canonical ordered list of basis-pool tuple
+  references included in that emitted tax output
 
 ### TaxOutputs Ordering
 

--- a/docs/concepts/reconciliation-tax-architecture.md
+++ b/docs/concepts/reconciliation-tax-architecture.md
@@ -83,6 +83,8 @@ Use these pages as the detailed contract owners:
 - [Bridge To Target Mapping](bridge-to-target-mapping.md)
 - [First Slice Contract](../reference/first-slice-contract.md)
 - [First Downstream Slice Contract](../reference/first-downstream-slice-contract.md)
+- [Target Contract Primitives](../reference/target-contract-primitives.md)
+- [Target Product Artifacts](../reference/target-product-artifacts.md)
 - [Pipeline Stage Contracts](pipeline-stage-contracts.md)
 - [Domain Ontology](domain-ontology.md)
 - [Gaps And Readiness](gaps-and-readiness.md)
@@ -329,6 +331,12 @@ Must include:
   - `experimental`
   - `deferred`
 
+Wire-identity rule:
+
+- forward-looking target tax-stage docs use `tax_policy_id`
+- the exact `TaxPolicyId` wire format is owned by
+  [Target Contract Primitives](../reference/target-contract-primitives.md)
+
 ### `TaxPolicy`
 
 Consumes:
@@ -344,10 +352,10 @@ Produces:
 
 ### Selection Semantics
 
-- one run may select one or more policy ids
+- one run may select one or more `tax_policy_id` values
 - all selected policies run independently against the same input set
 - one policy's unsupported coverage does not invalidate another's results
-- unknown policy ids fail request validation immediately
+- unknown `tax_policy_id` values fail request validation immediately
 - missing explicit selection and missing configured default also fail
   validation
 - configured defaults live only at application, config, and interface

--- a/docs/concepts/reconciliation-tax-architecture.md
+++ b/docs/concepts/reconciliation-tax-architecture.md
@@ -284,14 +284,14 @@ Required partition keys:
 
 | Stage family | Required partition keys |
 | --- | --- |
-| Evidence and claims | `capture_uid`, `evidence_set_id`, `selection_group_id`, `claim_set_id`, `interpretation_scope_id` |
+| Evidence and claims | `capture_uid`, `evidence_set_id`, `selection_id`, `claim_set_id`, `interpretation_scope_id` |
 | Economic and reconciliation | `economic_facts_id`, `reconciliation_state_id`, `continuity_segment_id`, `balance_target_id`, `checkpoint_candidate_id` |
 | Checkpoint and accounting | `checkpoint_run_id`, `journal_run_id`, `checkpoint_assertion_id`, `entry_id` |
 | Tax | `tax_inputs_id`, `tax_outputs_id`, `tax_year`, `basis_pool_ref`, `determinant_id`, `basis_transition_id` |
 
 Rules:
 
-- evidence selection comparisons stay bounded to one `selection_group_id`
+- evidence selection comparisons stay bounded to one `selection_id`
 - claim adjudication stays bounded to one `interpretation_scope_id` at a time
 - economic reducers stay bounded to one `economic_facts_id` partition at a time
 - reconciliation reducers may read one continuity segment plus its explicit
@@ -314,7 +314,7 @@ high.
 
 Typical sidecar or cache surfaces include:
 
-- evidence selection-group summaries
+- evidence selection summaries
 - interpretation-scope decision summaries
 - reconciliation continuity summaries
 - checkpoint package summaries

--- a/docs/concepts/reconciliation-tax-architecture.md
+++ b/docs/concepts/reconciliation-tax-architecture.md
@@ -82,6 +82,7 @@ Use these pages as the detailed contract owners:
 - [Current Bridge Contracts](current-bridge-contracts.md)
 - [Bridge To Target Mapping](bridge-to-target-mapping.md)
 - [First Slice Contract](../reference/first-slice-contract.md)
+- [First Downstream Slice Contract](../reference/first-downstream-slice-contract.md)
 - [Pipeline Stage Contracts](pipeline-stage-contracts.md)
 - [Domain Ontology](domain-ontology.md)
 - [Gaps And Readiness](gaps-and-readiness.md)
@@ -169,7 +170,12 @@ Inner-loop calculations for:
 
 must operate on compact typed records only.
 
-Hot-path data should include:
+Hot-path data should include the compact kernel fields carried by
+`EconomicEventRecord`, `EconomicLegRecord`, `ContinuitySegmentRecord`,
+`BalanceTargetRecord`, `CheckpointAssertionRecord`, `PostingRecord`,
+`ValidationRecord`, `TaxDeterminantRecord`, and `BasisTransitionRecord`.
+
+Required hot-path content includes:
 
 - stable ids
 - timestamps and effective times
@@ -216,8 +222,8 @@ stage actually uses, including:
 | Stage family | Required partition keys |
 | --- | --- |
 | Evidence and claims | `source`, `capture_uid`, `selection_group_id`, `claim_set_id` |
-| Reconciliation | `source`, `location`, `instrument`, `continuity_segment_id`, `checkpoint_date` |
-| Tax | `tax_year`, `beneficial_owner`, `basis_pool_ref` |
+| Reconciliation | `source`, `continuity_segment_id`, `balance_target_id`, `checkpoint_candidate_id` |
+| Tax | `tax_year`, `basis_pool_ref`, `determinant_id`, `basis_transition_id` |
 
 Use derived reporting projections instead of forcing every stage to key every
 record by every dimension.

--- a/docs/concepts/reconciliation-tax-architecture.md
+++ b/docs/concepts/reconciliation-tax-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: "Reconciliation And Tax Architecture"
-summary: "Design anchor for trust gates, performance rules, tax-policy architecture, and filing-critical rollout from the current bridge toward the target pipeline."
+summary: "Design anchor for trust gates, persistence rules, performance rules, and filing-critical rollout from the current bridge toward the target pipeline."
 doc_type: concept
 audience: human
 owner: repo
@@ -12,7 +12,7 @@ This document is the implementation anchor for evolving the repo away from
 tracker-dependent historical workflows and into an independent reconciliation,
 checkpoint, accounting, and tax runtime.
 
-Use it when making structural decisions that affect normalization,
+Use it when making structural decisions that affect persistence,
 reconciliation, checkpointing, journaling, or tax computation. Treat it as a
 design contract, not as a loose idea list.
 
@@ -36,42 +36,10 @@ The system must:
   hard checkpoint
 - compute forward tax state for `2023` to `2025`
 - render a deterministic double-entry journal and require it to validate
-- surface unsupported or ambiguous truth as explicit issues, reviews, and
-  later-stage blockers
+- surface unsupported or ambiguous truth as explicit gaps, reviews, and later
+  stage blockers
 - preserve one interface-neutral application surface so future CLI, HTTP, API,
   and agent entrypoints can share the same typed workflows
-
-## Active Bridge Note
-
-The current runtime bridge centers on:
-
-- `EconomicActivityDraft`
-- `TransactionFact`
-- `balance_snapshots.csv`
-- `balance_references.csv`
-
-That bridge is:
-
-- the live implementation seam
-- the current delivery path
-- the current parity baseline
-- not the final architecture center
-
-Current operational surfaces that remain part of runtime truth:
-
-- capture-scoped source profiling
-- capture-scoped normalization
-- planner-enabled normalization
-- translation input candidates, plan, and blocking issues
-- source assembly into `working/normalized/sources/<source>/`
-- shared statement extraction
-- statement-backed balance references
-- checkpoint-owned manual balance submission scaffolding and validation
-- checkpoint location inventory rebuild
-- offline-by-default balance inspection and checking
-- optional provider hydration through separate balance-provider adapters
-- replay validation
-- oracle comparison and verification workflows
 
 ## Contract Owners
 
@@ -83,8 +51,6 @@ Use these pages as the detailed contract owners:
 - [Bridge To Target Mapping](bridge-to-target-mapping.md)
 - [First Slice Contract](../reference/first-slice-contract.md)
 - [First Downstream Slice Contract](../reference/first-downstream-slice-contract.md)
-- [Target Contract Primitives](../reference/target-contract-primitives.md)
-- [Target Product Artifacts](../reference/target-product-artifacts.md)
 - [Pipeline Stage Contracts](pipeline-stage-contracts.md)
 - [Domain Ontology](domain-ontology.md)
 - [Gaps And Readiness](gaps-and-readiness.md)
@@ -115,8 +81,8 @@ Trust and ownership rules:
 
 ### Source Boundaries
 
-- source adapters produce source-local evidence and bridge outputs today, and
-  later source-local claims
+- source adapters produce source-local evidence today and source-local claims
+  later
 - adapters may emit only safe bridge hints and safe source-local meaning
 - adapters do not own reconciliation
 - adapters do not own checkpoint acceptance
@@ -125,7 +91,8 @@ Trust and ownership rules:
 
 ### Output Boundaries
 
-- renderers consume downstream-owned products
+- renderers consume downstream-owned products or approved compatibility
+  projections
 - renderer-specific constraints stay at the edge
 - CoinTracking row rules remain output-adapter concerns only
 
@@ -137,14 +104,6 @@ Trust and ownership rules:
 - the system must still reconstruct, reconcile, checkpoint, journal, and
   compute taxes if CoinTracking tax reports disappear
 
-### Crypto Boundaries
-
-- crypto is the current filing scope
-- crypto is not the ontology center
-- crypto-specific language belongs at adapter, policy, or output edges unless
-  fundamentally required
-- the core remains broad enough for non-crypto support later
-
 ### Persistence Boundaries
 
 - persistence implements the model
@@ -155,6 +114,111 @@ Trust and ownership rules:
 - repository ports remain the persistence seam
 - active SQLite rollout is deferred until after the filing-critical path is
   stable
+
+## Authoritative Kernels Versus Compatibility Projections
+
+The target runtime uses one authoritative persisted kernel per product scope.
+
+Rules:
+
+- target products persist as canonical JSON kernels with separate sidecars
+- once a target product becomes authoritative for an in-scope family, bridge
+  CSV artifacts for that same scope become compatibility projections only
+- compatibility projections remain valid during migration, but they are never
+  peer authorities beside the target kernel
+- consumers read one authority at a time:
+  - unmigrated consumers read the derived compatibility projection
+  - migrated consumers read the target product kernel directly
+- compatibility projections must stay reproducible from authoritative kernels
+  for the duration of the compatibility window
+
+## Authoritative Persistence Model
+
+Forward-looking persistence rules:
+
+- target product kernels persist as canonical JSON documents
+- every persisted kernel carries its declared product id in metadata
+- product ids are distinct from `dataset_id`
+- upstream `*_ref` metadata fields store product ids, never `dataset_id` and
+  never raw kernel fingerprints
+- product sidecars persist separately from kernels and are keyed by
+  `dataset_id` or narrower truthful record ids
+- writes are replace-whole-partition operations, not append-in-place mutation
+  of accepted truth
+- persisted kernels are immutable snapshots for one declared partition scope
+- sidecars are regenerable from authoritative kernels plus upstream refs
+- caches and indexes are accelerators only; they are never the authority
+
+### Default Partition Scopes
+
+| Product | Default partition scope |
+| --- | --- |
+| `EvidenceSet` | capture-scoped |
+| `ClaimSet` | capture-scoped |
+| `EconomicFacts` | assembled-source-scoped |
+| `ReconciliationState` | continuity-segment-scoped under one source scope |
+| `Checkpoint` | checkpoint-run-scoped |
+| `Journal` | checkpoint-run-scoped |
+| `TaxInputs` | tax-run-scoped |
+| `TaxOutputs` | policy-and-tax-year-scoped inside one tax run |
+
+Rules:
+
+- one persisted partition owns one canonical kernel fingerprint
+- one persisted partition owns one product id aligned with that partition
+- partition boundaries are chosen by the dimensions the owning stage actually
+  reduces over
+- target products may expose derived reporting projections across several
+  partitions, but those projections do not replace the authoritative partition
+  kernels
+- `EvidenceSet`, `ClaimSet`, and `EconomicFacts` kernels each persist one
+  whole-product kernel per declared partition
+- one persisted `ReconciliationState` kernel owns one continuity-segment root
+- one persisted `Checkpoint` kernel owns one checkpoint root
+- one persisted `Journal` kernel owns one journal emission root
+- one persisted `TaxInputs` kernel owns one tax-input emission root
+- one persisted `TaxOutputs` kernel owns one policy-and-tax-year output root
+- readers use product ids or narrower record ids for target-kernel lookup;
+  `dataset_id` remains for shared support attachment and reporting only
+
+### Default Filesystem Placement
+
+Use these paths in forward-looking docs and later implementation work:
+
+- `working/normalized/captures/<capture_uid>/evidence_set.json`
+- `working/normalized/captures/<capture_uid>/claim_set.json`
+- `working/normalized/captures/<capture_uid>/support/gaps.json`
+- `working/normalized/captures/<capture_uid>/support/reviews.json`
+- `working/normalized/captures/<capture_uid>/support/readiness.json`
+- `working/normalized/sources/<source>/economic_facts.json`
+- `working/normalized/sources/<source>/bridge/facts.csv`
+- `working/normalized/sources/<source>/bridge/balance_snapshots.csv`
+- `working/normalized/sources/<source>/bridge/balance_references.csv`
+- `working/normalized/sources/<source>/reconciliation/<continuity_segment_id>/state.json`
+- `working/normalized/sources/<source>/reconciliation/<continuity_segment_id>/support/gaps.json`
+- `working/normalized/sources/<source>/reconciliation/<continuity_segment_id>/support/readiness.json`
+- `outputs/checkpoints/<checkpoint_label>/checkpoint.json`
+- `outputs/checkpoints/<checkpoint_label>/journal.json`
+- `outputs/checkpoints/<checkpoint_label>/tax_inputs.json`
+- `outputs/checkpoints/<checkpoint_label>/tax_outputs/<policy_id>/<tax_year>.json`
+
+Rules:
+
+- the external workspace remains the runtime location for evidence and emitted
+  artifacts
+- later implementation may add indexes or caches beside these kernels, but
+  must not rename the authoritative kernel paths without updating the owner
+  docs
+- current-state docs remain accurate to the live bridge until implementation
+  lands; this section owns only the target direction
+
+### Replace Semantics
+
+- writers replace the entire owned kernel for one partition on a successful run
+- a rerun may refresh or prune stage-owned sidecars under the same partition
+- reruns must not append stale kernel rows across runs
+- later accepted truth supersedes earlier accepted truth through new records and
+  explicit lineage, not through in-place mutation of an accepted kernel record
 
 ## Performance Rules
 
@@ -170,12 +234,7 @@ Inner-loop calculations for:
 - journal validation
 - tax computation
 
-must operate on compact typed records only.
-
-Hot-path data should include the compact kernel fields carried by
-`EconomicEventRecord`, `EconomicLegRecord`, `ContinuitySegmentRecord`,
-`BalanceTargetRecord`, `CheckpointAssertionRecord`, `PostingRecord`,
-`ValidationRecord`, `TaxDeterminantRecord`, and `BasisTransitionRecord`.
+must operate on compact typed kernel records only.
 
 Required hot-path content includes:
 
@@ -185,6 +244,7 @@ Required hot-path content includes:
 - location refs
 - instrument refs
 - signed quantities
+- direct assertion values where the stage owns them
 - explicit link ids
 - explicit state transitions
 - valuations where computation requires them
@@ -193,8 +253,8 @@ Required hot-path content includes:
 The hot path should not repeatedly join in:
 
 - full provenance detail
-- review records
-- large issue text
+- reviews
+- large explanation text
 - evidence metadata blobs
 - renderer metadata
 - adapter-local annotations that do not change computation
@@ -206,9 +266,8 @@ Those belong in sidecars and explanation layers.
 Reducers must use stable ordering:
 
 - effective time when present
-- otherwise event timestamp
-- then deterministic tie-break keys such as source sequence, event id, or leg
-  id
+- otherwise the product's canonical temporal key
+- then deterministic tie-break keys such as stable ids
 
 Rules:
 
@@ -219,29 +278,28 @@ Rules:
 ### Partitioning
 
 Expensive recalculation must be partitionable by the dimensions the owning
-stage actually uses, including:
+stage actually uses.
+
+Required partition keys:
 
 | Stage family | Required partition keys |
 | --- | --- |
-| Evidence and claims | `source`, `capture_uid`, `selection_group_id`, `claim_set_id` |
-| Reconciliation | `source`, `continuity_segment_id`, `balance_target_id`, `checkpoint_candidate_id` |
-| Tax | `tax_year`, `basis_pool_ref`, `determinant_id`, `basis_transition_id` |
-
-Use derived reporting projections instead of forcing every stage to key every
-record by every dimension.
-
-### Cardinality And Scope Boundaries
-
-Partition boundaries are also cardinality contracts.
+| Evidence and claims | `capture_uid`, `evidence_set_id`, `selection_group_id`, `claim_set_id`, `interpretation_scope_id` |
+| Economic and reconciliation | `economic_facts_id`, `reconciliation_state_id`, `continuity_segment_id`, `balance_target_id`, `checkpoint_candidate_id` |
+| Checkpoint and accounting | `checkpoint_run_id`, `journal_run_id`, `checkpoint_assertion_id`, `entry_id` |
+| Tax | `tax_inputs_id`, `tax_outputs_id`, `tax_year`, `basis_pool_ref`, `determinant_id`, `basis_transition_id` |
 
 Rules:
 
 - evidence selection comparisons stay bounded to one `selection_group_id`
-- claim adjudication stays bounded to one `claim_set_id` and one
-  `interpretation_group_id` at a time
+- claim adjudication stays bounded to one `interpretation_scope_id` at a time
+- economic reducers stay bounded to one `economic_facts_id` partition at a time
 - reconciliation reducers may read one continuity segment plus its explicit
   upstream references; they must not rescan unrelated full-history partitions
   per balance target
+- checkpoint reducers may read the declared `checkpoint_run_id` inputs plus
+  explicit upstream refs; they must not treat `dataset_id` as the product-join
+  key
 - tax reducers may read one tax year plus explicitly referenced carry-forward
   basis-pool state; they must not recompute unrelated years by default
 - unbounded pairwise candidate comparison outside one deterministic selection
@@ -249,219 +307,45 @@ Rules:
 - full-history rescans per target are not allowed when a bounded partition or
   reusable materialized state exists
 
-### Materialized State
+### Sidecars, Caches, And Indexes
 
-Materialized derived state is allowed where replay cost would otherwise become
-too high.
+Sidecars and caches are allowed where replay cost would otherwise become too
+high.
 
-Typical surfaces include:
+Typical sidecar or cache surfaces include:
 
-- evidence selection-group snapshots
-- interpretation-group decision snapshots
-- checkpoint state snapshots
+- evidence selection-group summaries
+- interpretation-scope decision summaries
 - reconciliation continuity summaries
-- position state snapshots where replay cost is material
-- accepted checkpoint assertions
-- tax pool and carry-forward state by tax year
-- year-open basis or pool state reused as next-year starting state
-- validated posting aggregates where useful
+- checkpoint package summaries
+- journal validation summaries
+- tax carry-forward state indexes
 
-Derived state remains replaceable and does not replace source-of-truth history.
+Rules:
 
-### Reducer Design Rules
+- sidecars are never the sole copy of business meaning
+- sidecars may be keyed by `dataset_id` or narrower truthful record ids, but
+  they do not replace product ids for kernel lookup
+- caches are always regenerable from authoritative kernels and upstream refs
+- materialized indexes are allowed only when they accelerate declared product
+  kernels rather than replacing them
 
-Prefer:
+Required hot-path indexes:
 
-- linear or near-linear reducers over sorted subject streams
-- explicit link records instead of repeated inference
-- one-time normalization of ambiguous bridge data into later-stage structures
-- reuse of prior state outputs when valid
+- `subject_ref + effective_at`
+- `continuity_segment_id`
+- `checkpoint_assertion` subject and date
+- `tax_year + basis_pool_ref`
 
-Avoid:
+## Acceptance Rules
 
-- repeated global joins across the full history
-- repeated scanning of unrelated sources or years
-- repeated evidence-level parsing during later-stage calculations
-- repeated full-history rescans per target
-- unbounded pairwise comparison across unrelated selection groups
-- dynamic policy dispatch inside tight per-record loops
+Before approving structural work in reconciliation, checkpointing, accounting,
+or tax, ask:
 
-### Tax Performance Rules
+- does the design keep one authoritative kernel per scope partition
+- can unmigrated consumers survive on compatibility projections alone
+- can migrated consumers read target products without bridge lookups
+- is every hot-path determinant present in the kernel rather than in a sidecar
+- can the stage replay deterministically from its upstream authorities
 
-Tax calculation should not recompute full acquisition history from scratch for
-every output row if bounded state is available.
-
-The design should support:
-
-- tax-year partitioning
-- carried-forward pool and state materialization
-- determinant grouping by subject and tax year
-- reuse of prior year-close state as next year-open state
-
-Policy selection should be resolved before execution, not as dynamic branching
-inside the hot loop.
-
-## Tax Policy Architecture
-
-Typed tax-policy selection is a foundation seam, not an afterthought.
-
-### Required Contracts
-
-- `TaxPolicyId`
-- `TaxPolicyDescriptor`
-- `TaxPolicy`
-- `TaxPolicyRegistry`
-- `ApplyTaxPoliciesRequest`
-- `ApplyTaxPoliciesResponse`
-
-### `TaxPolicyDescriptor`
-
-Must include:
-
-- stable id
-- display name
-- jurisdiction or regime code
-- supported years or periods
-- supported output families
-- version
-- limitations
-- status:
-  - `supported`
-  - `partial`
-  - `experimental`
-  - `deferred`
-
-Wire-identity rule:
-
-- forward-looking target tax-stage docs use `tax_policy_id`
-- the exact `TaxPolicyId` wire format is owned by
-  [Target Contract Primitives](../reference/target-contract-primitives.md)
-
-### `TaxPolicy`
-
-Consumes:
-
-- one `TaxInputs`
-- one execution context
-
-Produces:
-
-- one `TaxOutputs`
-- tax-owned gaps
-- unsupported or deferred outputs
-
-### Selection Semantics
-
-- one run may select one or more `tax_policy_id` values
-- all selected policies run independently against the same input set
-- one policy's unsupported coverage does not invalidate another's results
-- unknown `tax_policy_id` values fail request validation immediately
-- missing explicit selection and missing configured default also fail
-  validation
-- configured defaults live only at application, config, and interface
-  boundaries
-- the core must not assume one default jurisdiction
-
-### Tax-Stage Ownership
-
-Tax policy may decide:
-
-- jurisdiction-specific treatment
-- basis rules
-- carry-forward rules
-- output structure
-
-Tax policy may not decide:
-
-- source meaning
-- economic truth
-- reconciliation truth
-- checkpoint truth
-- accounting truth
-
-### MVP Tax Scope
-
-- keep the seam general
-- implement Canada MVP first
-- prioritize the filing path for `2023`, `2024`, and `2025`
-- do not build a plugin platform
-
-## Filing-Critical Acceptance Criteria
-
-The system is filing-ready only when all of these are true:
-
-- a source-backed checkpoint exists near `2026-03-23`
-- no unresolved material reconciliation issues remain
-- no unresolved material unsupported tax items remain
-- journal validation passes for supported activity
-- the forward-computed state from the `2023-08-05` historical oracle lands on
-  the source-backed checkpoint
-- `2023`, `2024`, and `2025` outputs can be reproduced from workspace evidence
-
-## Materiality And Unsupported Cases
-
-Materiality is explicit and policy-owned.
-
-Architecture rules:
-
-- do not silently suppress any non-zero drift
-- log every difference
-- allow explicit immaterial waivers only in artifacts, never in code comments
-- numeric thresholds, non-waive lists, and filing-program defaults belong to
-  checkpoint policy, tax policy, config, or delivery notes rather than this
-  architecture anchor
-- the stage contracts must preserve enough detail for those policy-owned
-  materiality decisions to remain explicit and reviewable
-
-Unsupported or ambiguous truth must produce explicit outputs and roadmap items.
-Do not guess on:
-
-- superficial loss treatment
-- capital versus business account classification
-- unsupported DeFi lifecycle cases
-- NFTs
-- bankruptcy or scam-loss workflows
-
-## External Library Policy
-
-Use directly when they are permissive and fit cleanly:
-
-- Ledger CLI as the first journal validator
-- RP2 as an architectural reference or narrow comparison source
-- `tsiemens/acb` as a scenario and formula reference
-- small MIT or Apache libraries only when the reuse is narrow and documented
-
-Use for reference only:
-
-- Beancount
-- hledger
-- GPL codebases, tests, or examples
-
-Do not:
-
-- copy GPL code into the repo
-- lightly rewrite GPL implementations and treat them as original
-- introduce heavy support libraries that fight the current typed architecture
-
-## Rollout Alignment
-
-The repo is moving from the current bridge toward the target stage contracts
-incrementally, not through a big-bang rewrite.
-
-Rollout rules:
-
-- the current bridge remains the live runtime seam until a bounded slice lands
-  a cleaner replacement
-- no dual active runtime or compatibility-wrapper lane should survive once a
-  clean replacement is ready
-- current-state docs stay accurate about live bridge terms
-- target docs stay explicit about the intended end state without claiming it is
-  already implemented
-- when work affects architecture, sequencing, or trust-gate ownership, update
-  this page together with [ROADMAP.md](../../ROADMAP.md) and
-  [Migration Sequence](../status/migration-sequence.md)
-
-The detailed implementation order lives in:
-
-- [ROADMAP.md](../../ROADMAP.md)
-- [Migration Sequence](../status/migration-sequence.md)
+If the answer to any of these is no, the design is not ready.

--- a/docs/concepts/reconciliation-tax-architecture.md
+++ b/docs/concepts/reconciliation-tax-architecture.md
@@ -80,6 +80,8 @@ This page does not re-own every lower-level contract.
 Use these pages as the detailed contract owners:
 
 - [Current Bridge Contracts](current-bridge-contracts.md)
+- [Bridge To Target Mapping](bridge-to-target-mapping.md)
+- [First Slice Contract](../reference/first-slice-contract.md)
 - [Pipeline Stage Contracts](pipeline-stage-contracts.md)
 - [Domain Ontology](domain-ontology.md)
 - [Gaps And Readiness](gaps-and-readiness.md)
@@ -211,16 +213,33 @@ Rules:
 Expensive recalculation must be partitionable by the dimensions the owning
 stage actually uses, including:
 
-- source
-- location
-- instrument
-- subject reference where applicable
-- continuity segment where applicable
-- checkpoint date where applicable
-- tax year where applicable
+| Stage family | Required partition keys |
+| --- | --- |
+| Evidence and claims | `source`, `capture_uid`, `selection_group_id`, `claim_set_id` |
+| Reconciliation | `source`, `location`, `instrument`, `continuity_segment_id`, `checkpoint_date` |
+| Tax | `tax_year`, `beneficial_owner`, `basis_pool_ref` |
 
 Use derived reporting projections instead of forcing every stage to key every
 record by every dimension.
+
+### Cardinality And Scope Boundaries
+
+Partition boundaries are also cardinality contracts.
+
+Rules:
+
+- evidence selection comparisons stay bounded to one `selection_group_id`
+- claim adjudication stays bounded to one `claim_set_id` and one
+  `interpretation_group_id` at a time
+- reconciliation reducers may read one continuity segment plus its explicit
+  upstream references; they must not rescan unrelated full-history partitions
+  per balance target
+- tax reducers may read one tax year plus explicitly referenced carry-forward
+  basis-pool state; they must not recompute unrelated years by default
+- unbounded pairwise candidate comparison outside one deterministic selection
+  group is not allowed
+- full-history rescans per target are not allowed when a bounded partition or
+  reusable materialized state exists
 
 ### Materialized State
 
@@ -229,10 +248,14 @@ too high.
 
 Typical surfaces include:
 
+- evidence selection-group snapshots
+- interpretation-group decision snapshots
 - checkpoint state snapshots
 - reconciliation continuity summaries
 - position state snapshots where replay cost is material
+- accepted checkpoint assertions
 - tax pool and carry-forward state by tax year
+- year-open basis or pool state reused as next-year starting state
 - validated posting aggregates where useful
 
 Derived state remains replaceable and does not replace source-of-truth history.
@@ -251,6 +274,8 @@ Avoid:
 - repeated global joins across the full history
 - repeated scanning of unrelated sources or years
 - repeated evidence-level parsing during later-stage calculations
+- repeated full-history rescans per target
+- unbounded pairwise comparison across unrelated selection groups
 - dynamic policy dispatch inside tight per-record loops
 
 ### Tax Performance Rules

--- a/docs/concepts/reconciliation-tax-architecture.md
+++ b/docs/concepts/reconciliation-tax-architecture.md
@@ -361,14 +361,18 @@ The system is filing-ready only when all of these are true:
 
 ## Materiality And Unsupported Cases
 
-Default materiality rules:
+Materiality is explicit and policy-owned.
+
+Architecture rules:
 
 - do not silently suppress any non-zero drift
 - log every difference
 - allow explicit immaterial waivers only in artifacts, never in code comments
-- default immaterial threshold: `<= CAD 25` per asset and `<= CAD 250`
-  aggregate
-- do not auto-waive `CAD`, `BTC`, `ETH`, or stablecoins
+- numeric thresholds, non-waive lists, and filing-program defaults belong to
+  checkpoint policy, tax policy, config, or delivery notes rather than this
+  architecture anchor
+- the stage contracts must preserve enough detail for those policy-owned
+  materiality decisions to remain explicit and reviewable
 
 Unsupported or ambiguous truth must produce explicit outputs and roadmap items.
 Do not guess on:

--- a/docs/concepts/unified-adapter-architecture.md
+++ b/docs/concepts/unified-adapter-architecture.md
@@ -10,7 +10,9 @@ related:
   - ROADMAP.md
   - docs/status/adapter-delivery-plan.md
   - docs/guides/write-an-adapter.md
+  - docs/concepts/bridge-to-target-mapping.md
   - docs/concepts/pipeline-stage-contracts.md
+  - docs/reference/first-slice-contract.md
   - docs/concepts/domain-ontology.md
   - docs/concepts/reconciliation-tax-architecture.md
   - docs/concepts/oracle-boundaries.md
@@ -246,31 +248,36 @@ Boundary note:
 
 ### 1. EvidenceSet
 
-Purpose:
+Adapter-emission purpose:
 
-- represent the evidence selected for one adapter-owned read operation
+- emit the canonical `EvidenceSet` product owned by
+  [Pipeline Stage Contracts](pipeline-stage-contracts.md)
 - preserve discovery results, family classification, provenance, and typed
-  parse outputs without making semantic commitments too early
+  parse outputs without adapter-local semantic invention
 
 Owned by:
 
 - reader facets and shared evidence orchestration
 
-Must include:
+Adapter emission must include:
 
 - adapter id
 - capture or input identity
-- manifest version and fingerprint
+- stable ids required by the canonical `EvidenceSet` kernel
+- manifest version and manifest fingerprint reference
 - evidence members with typed provenance
 - evidence family ids
 - parse diagnostics
-- deterministic member ordering
-- evidence fingerprint
+- deterministic member ordering that matches the canonical kernel order
+- an `EvidenceSet` fingerprint computed from the canonical product kernel plus
+  upstream refs, not from duplicated manifest payload blobs
 
 Must not include:
 
-- current bridge facts or downstream runtime products
+- current bridge facts
+- downstream runtime products beyond the canonical `EvidenceSet`
 - target-specific output rows
+- competing evidence-product rules that differ from the pipeline-stage owner doc
 
 Typical contents:
 
@@ -282,9 +289,12 @@ Typical contents:
 
 ### 2. ClaimSet
 
-Purpose:
+Adapter-emission purpose:
 
-- hold provider-local semantic claims before shared compilation
+- emit the canonical `ClaimSet` product owned by
+  [Pipeline Stage Contracts](pipeline-stage-contracts.md)
+- hold provider-local semantic claims before shared compilation without
+  redefining target-product meaning locally
 
 Owned by:
 
@@ -301,21 +311,24 @@ Claim types may include:
 - `ContractTermClaim`
 - `ValuationClaim`
 - `ProjectionAnnotation`
-- `EvidenceIssue`
-- `EvidenceReview`
+- `IssueCandidate`
+- `ReviewCandidate`
 
-Must include:
+Adapter emission must include:
 
 - deterministic claim ids
 - typed provenance references back to the evidence set
 - structural status for each claim
 - blocking versus advisory distinction
-- claim-set fingerprint
+- canonical claim ordering
+- a `ClaimSet` fingerprint computed from the canonical product kernel plus
+  referenced upstream ids or fingerprints, not duplicated manifest payloads
 
 Must not include:
 
 - inferred final identities that have not been resolved
 - writer-specific rows
+- competing claim-product rules that differ from the pipeline-stage owner doc
 
 ### 3. Bridge Result While The Current Path Remains Active
 
@@ -784,6 +797,8 @@ Serialization rules should:
 - avoid implicit ordering from language runtime containers
 - exclude presentation-only noise
 - include semantically relevant fields only
+- reference manifest fingerprints as upstream inputs instead of duplicating
+  manifest payload blobs into product kernels
 
 ## Assertions, Issues, And Reviews
 
@@ -1041,8 +1056,6 @@ These questions are intentionally left open for later design review:
 - Which manifest fields should be purely declarative versus code-generated?
 - How much of current timezone and precision policy belongs in manifest data
   versus provider-local code?
-- Should claim and product fingerprints include manifest fingerprints
-  directly, or reference them externally?
 
 These are implementation questions, not reasons to keep the bundled current
 contract.

--- a/docs/concepts/unified-adapter-architecture.md
+++ b/docs/concepts/unified-adapter-architecture.md
@@ -1,6 +1,6 @@
 ---
 title: "Unified Adapter Architecture"
-summary: "First-principles design anchor for the future unified adapter manifest, facets, adapter products, and deterministic verification model."
+summary: "Forward design for the future adapter manifest, facets, and verification model without re-owning target product contracts."
 doc_type: concept
 audience: human
 owner: repo
@@ -12,1087 +12,137 @@ related:
   - docs/guides/write-an-adapter.md
   - docs/concepts/bridge-to-target-mapping.md
   - docs/concepts/pipeline-stage-contracts.md
-  - docs/reference/first-slice-contract.md
   - docs/concepts/domain-ontology.md
   - docs/concepts/reconciliation-tax-architecture.md
-  - docs/concepts/oracle-boundaries.md
-  - docs/concepts/transaction-classification.md
 ---
 
-Read this document before shaping adapter changes. Use it as the forward design
-anchor for source, portfolio, and output adapter work, even while the current
-repo still runs on the older bundled adapter contracts.
+Read this document before shaping large adapter-design work. Use it as the
+forward design anchor for manifests, facets, and deterministic verification.
+This page does not own target product record families, ids, fingerprints, or
+taxonomy details. Those stay with the owner pages.
 
-This document is intentionally explicit. It is meant to be scrutinized,
-challenged, and used as a design reference during later migration work.
+## Scope And Precedence
 
-Detailed target stage contracts are owned by
-[`docs/concepts/pipeline-stage-contracts.md`](pipeline-stage-contracts.md), and
-target ontology rules are owned by
-[`docs/concepts/domain-ontology.md`](domain-ontology.md). This page focuses on
-adapter responsibilities, adapter handoffs, and adapter-local implications of
-those target contracts.
+Owner-page precedence:
 
-## Objective
+- [Pipeline Stage Contracts](pipeline-stage-contracts.md) owns target product
+  kernels, ids, ordering, and fingerprints
+- [Domain Ontology](domain-ontology.md) owns entity and ref seams
+- [Bridge To Target Mapping](bridge-to-target-mapping.md) owns migration
+  cutovers and compatibility projections
+- [Reconciliation And Tax Architecture](reconciliation-tax-architecture.md)
+  owns persistence, partitioning, and fast-path rules
+- this page owns only adapter responsibilities, manifest direction, facet
+  design, and adapter verification posture
 
-Design one future adapter architecture that:
+## Design Direction
 
-- makes adapters easier to build and reason about
-- removes avoidable behavior drift between adapters
-- centralizes deterministic workflow logic in shared services
-- keeps provider-local code focused on provider-local semantics
-- supports source, portfolio-style, and output surfaces without forcing them
-  through unrelated responsibilities
-- scales to reconciliation, checkpoint, accounting, and tax work without
-  re-centering on a tracker-specific model
+The future adapter architecture should unify around:
 
-The future design must not be shaped by the current repo layout beyond the
-actual jobs the repo must accomplish.
-
-## Why The Current Shape Is Not The End State
-
-The current runtime already contains valuable components:
-
-- shared draft compilation
-- translation-input planning
-- shared statement extraction
-- shared output-policy validation
-- shared evidence and provenance artifacts
-
-However, the current adapter shape still has one central flaw:
-
-- the source-side contract bundles too many unrelated jobs into one plugin
-  surface
-
-Today a source adapter may be expected to do all of the following:
-
-- match a source during profiling
-- classify file families
-- match and route intake files
-- validate timezone policy
-- extract location inventory
-- recognize and parse statement PDFs
-- resolve statement instrument claims
-- describe translation candidates
-- translate selected inputs or fallback inputs
-
-That bundling creates three problems:
-
-1. Adapters do too much.
-2. Capability flags do not fully narrow the actual implementation burden.
-3. Workflow behavior can drift because shared orchestration concerns stay
-   scattered across provider-local entry points.
-
-The future architecture should unify the model without creating another giant
-"do everything" interface.
-
-## Core Design Decision
-
-The future system should unify adapters around four things:
-
-- one universal manifest model
+- one manifest family
 - a small set of purpose-defined facets
-- one shared adapter product pipeline
-- one deterministic verifier model
+- deterministic adapter products that map into the core runtime pipeline
+- one shared verification model
 
-It should not unify adapters around one monolithic method surface.
+It should not unify around:
 
-This means:
+- one monolithic source-adapter interface
+- adapter-local target schemas
+- a second architecture center beside the main runtime pipeline
+- indefinite bridge wrappers or dual-contract shims
 
-- portfolio is not a special third adapter species
-- portfolio is a reader surface that emits balance, position, or statement
-  claims instead of only activity claims
-- output is not a source adapter with inverted arrows
-- output is a writer surface that consumes runtime or projection data and emits
-  target-specific artifacts
+## Adapter Responsibility Boundary
 
-## First-Principles Basis
-
-This design follows durable architecture ideas rather than repo-local
-convenience.
-
-### 1. Purpose-Defined Ports Beat Technology-Defined Layers
-
-Ports should represent a meaningful job boundary, not a technology or folder
-boundary.
-
-Implication:
-
-- "source adapter" is too broad if it means discovery, routing, parsing,
-  planning, translation, statement extraction, and location extraction
-
-### 2. Shared Intermediate Representations Reduce Drift
-
-Complex ingestion and rendering systems stay simpler when adapters do not
-translate directly from raw input to final output in one jump.
-
-Implication:
-
-- the system needs a stable sequence of intermediate products with explicit
-  invariants and verification points
-
-### 3. Determinism Must Be A Contract, Not A Hope
-
-Any surface that depends on unordered iteration, filename order, path order, or
- hidden heuristics is not trustworthy enough for reconciliation and tax work.
-
-Implication:
-
-- stable ordering, fingerprints, replacement rules, and blocking ambiguity
-  must be explicit
-
-### 4. Provenance Is A First-Class Runtime Concern
-
-Financial reconstruction requires trust in where each fact and balance
-reference came from.
-
-Implication:
-
-- provenance must remain typed in runtime models and must not be reduced to an
-  ad hoc string until artifact boundaries
-
-### 5. Assertions And Annotations Must Stay Separate
-
-Systems become fragile when structural facts, advisory notes, and review hints
-share one loose payload.
-
-Implication:
-
-- hard assertions, soft annotations, blocking issues, and review records need
-  distinct types and distinct rules
-
-### 6. Schema Evolution Needs Stable Identity
-
-Schema compatibility is simpler when every adapter product has versioned
-identity and stable fingerprints.
-
-Implication:
-
-- manifests and adapter product schemas need explicit versioning and
-  fingerprint rules
-
-## Non-Goals
-
-This architecture is not trying to:
-
-- preserve the current bundled source contract under new names
-- make every provider look identical at the semantic level
-- turn adapters into giant declarative config files with no provider-local code
-- hide unsupported behavior behind coercion or defaults
-- keep compatibility wrappers alive indefinitely
-- center the architecture on CoinTracking or any other tracker shape
-
-## Design Goals
-
-- Adapters should be thin at their entry points.
-- Provider-local code should focus on provider-local evidence and semantics.
-- Shared orchestration should live in the core planner, compiler, verifier, and
-  artifact writers.
-- Input, portfolio, and output surfaces should use one manifest family and one
-  shared terminology.
-- Every major handoff should have a deterministic fingerprint.
-- Unsupported or ambiguous data should become explicit issues or reviews.
-- Future migration should be incremental and family-based, not big-bang.
-
-## Terminology
-
-### Evidence
-
-Untouched or boundary-parsed provider material such as CSV exports, workbook
-tabs, PDFs, HTML reports, explorer exports, or future API payloads.
-
-### Claim
-
-A provider-local semantic assertion derived from evidence but not yet accepted
-as bridge or downstream runtime data.
-
-Examples:
-
-- "this row describes a trade-like activity"
-- "this statement row reports a quantity balance as of a date"
-- "this wallet export proves ownership of this chain-scoped identifier"
-
-### Runtime Data
-
-Downstream-owned runtime products such as `EconomicFacts`,
-`ReconciliationState`, `Checkpoint`, `Journal`, `TaxInputs`, and
-`TaxOutputs`.
-
-### Projection
-
-A target-specific but still structured representation derived from semantic
-data, such as a CoinTracking row model or a future journal posting set.
-
-### Artifact
-
-A serialized file, directory, or byte-oriented output written for operators,
-tools, or external systems.
-
-## Adapter Product Pipeline
-
-The future adapter system should revolve around evidence, claims, explicit
-bridge outputs while the migration remains active, and target-local rendering.
-
-Boundary note:
-
-- this document defines the adapter-scoped handoff products only
-- `docs/concepts/reconciliation-tax-architecture.md` remains the core runtime
-  architecture anchor for `EconomicFacts`, `ReconciliationState`,
-  `Checkpoint`, `Journal`, `TaxInputs`, and
-  `TaxOutputs`
-- `docs/concepts/pipeline-stage-contracts.md` owns the shared target-product
-  versioning, kernel-and-envelope, and downstream stage-contract rules that
-  adapter products must align with
-- adapter work should map into that runtime pipeline rather than creating a
-  second competing core architecture
-
-### 1. EvidenceSet
-
-Adapter-emission purpose:
-
-- emit the `EvidenceSet` product owned by
-  [Pipeline Stage Contracts](pipeline-stage-contracts.md)
-- preserve discovery results, family classification, provenance, and typed
-  parse outputs without adapter-local semantic invention
-
-Owned by:
-
-- reader facets and shared evidence orchestration
-
-Adapter emission must include:
-
-- adapter id
-- capture or input identity
-- stable ids required by the `EvidenceSet` kernel
-- manifest version and manifest fingerprint reference
-- evidence members with typed provenance
-- evidence family ids
-- parse diagnostics
-- deterministic member ordering that matches the declared kernel order
-- an `EvidenceSet` fingerprint computed from the product kernel plus
-  upstream refs, not from duplicated manifest payload blobs
-
-Must not include:
-
-- current bridge facts
-- downstream runtime products beyond `EvidenceSet`
-- target-specific output rows
-- competing evidence-product rules that differ from the pipeline-stage owner doc
-
-Typical contents:
-
-- typed CSV rows
-- workbook sheets
-- PDF-extracted balance rows
-- discovered document metadata
-- recognized evidence families
-
-### 2. ClaimSet
-
-Adapter-emission purpose:
-
-- emit the `ClaimSet` product owned by
-  [Pipeline Stage Contracts](pipeline-stage-contracts.md)
-- hold provider-local semantic claims before shared compilation without
-  redefining target-product meaning locally
-
-Owned by:
-
-- reader and translation facets
-
-Adapter emission must include:
-
-- deterministic claim ids
-- claim families chosen from the canonical minimum taxonomy owned by
-  [Pipeline Stage Contracts](pipeline-stage-contracts.md)
-- typed provenance references back to the evidence set
-- structural status for each claim
-- blocking versus advisory distinction
-- declared claim ordering
-- a `ClaimSet` fingerprint computed from the product kernel plus
-  referenced upstream ids or fingerprints, not duplicated manifest payloads
-
-Must not include:
-
-- inferred final identities that have not been resolved
-- writer-specific rows
-- competing claim-product rules that differ from the pipeline-stage owner doc
-
-### 3. Bridge Result While The Current Path Remains Active
-
-Purpose:
-
-- describe the current bridge bundle honestly while adapter migration is still
-  landing
-
-Current truth:
-
-- source adapters still return `SourceTranslationBatch`
-- that bridge bundle currently carries drafts, balance references, balance
-  reference issues, issues, reviews, and location inventory
-
-Rules:
-
-- this is a migration seam, not the future adapter architecture center
-- do not describe this bundle as if it owns `EconomicFacts`
-- adapter-side bundles must not overload "economic output" with
-  balance snapshots, balance references, issues, reviews, and location
-  inventory as if they shared one semantic meaning
-- the main runtime architecture doc owns the meaning of downstream products
-
-Target-direction naming note:
-
-- future code may move toward the name `TranslationResult`
-- current-state docs must continue using `SourceTranslationBatch` until code
-  changes land
-
-### 4. ProjectionBundle
-
-Purpose:
-
-- hold target-specific structured outputs before serialization
-
-Owned by:
-
-- writer facets and shared projection validation
-
-Examples:
-
-- CoinTracking CSV row models
-- Ledger posting sets
-- future tax package rows
-
-Must include:
-
-- target id
-- target version
-- source fingerprint
-- projection fingerprint
-- target constraint validation results
-
-### 5. ArtifactBundle
-
-Purpose:
-
-- represent serialized outputs written to disk or another delivery boundary
-
-Owned by:
-
-- shared artifact writers plus writer facets
-
-Examples:
-
-- CSV files
-- JSON plan files
-- Markdown summaries
-- future API payload packages
-
-Must include:
-
-- artifact paths or identifiers
-- media type or artifact kind
-- byte or row counts
-- artifact fingerprint
-- manifest and source fingerprint references
-
-## Why These Products Matter
-
-This pipeline gives the architecture explicit checkpoints:
-
-- evidence can be verified independently of semantics
-- claims can be verified independently of shared compilation
-- bridge or runtime data can be verified independently of target projections
-- target projections can be validated independently of final serialization
-
-That separation is the main mechanism for reducing adapter drift.
-
-## Adapter Model
-
-The future adapter system should have one universal manifest and a small set of
-optional facets.
-
-### Universal Manifest
-
-Every adapter should publish one `AdapterManifest`.
-
-The manifest is the durable contract. Facets are executable behaviors attached
-to that contract.
-
-### Manifest Responsibilities
-
-The manifest should answer:
-
-- what evidence kinds this adapter can read or write
-- what adapter or runtime products it can emit or consume
-- what facets it implements
-- which determinism guarantees it provides
-- which schema versions it supports
-- what constraints or unsupported surfaces it declares
-
-### Manifest Shape
-
-The exact field list may change, but the manifest should eventually cover at
-least the following areas.
-
-| Category | Representative fields | Purpose |
-| --- | --- | --- |
-| Identity | `adapter_id`, `display_name`, `version`, `family`, `status` | Stable adapter identity and support posture. |
-| Direction | `implemented_facets`, `reads`, `writes` | Declares whether the adapter probes, reads, translates, writes, or combines those jobs. |
-| Evidence | `accepted_evidence_kinds`, `recognized_family_ids`, `statement_kinds` | Declares what raw or parsed evidence the adapter understands. |
-| Product flow | `emits_claim_types`, `emits_bridge_types`, `consumes_runtime_types`, `emits_projection_types` | Defines product flow explicitly. |
-| Determinism | `ordering_contract`, `fingerprint_contract`, `planner_support`, `selection_modes` | Makes determinism a contract surface. |
-| Identity | `supported_identifier_schemes`, `location_identity_rules`, `instrument_claim_rules` | Declares identity expectations. |
-| Temporal and numeric policy | `timezone_policy`, `effective_time_policy`, `precision_policy` | Makes interpretation rules explicit. |
-| Constraints | `unsupported_surfaces`, `hard_requirements`, `review_triggers` | Distinguishes unsupported from merely advisory. |
-| Compatibility | `schema_version`, `compatibility_window`, `manifest_fingerprint` | Supports evolution and migration discipline. |
-
-### Facets
-
-The architecture should avoid one large interface and instead define a small
-set of purpose-defined facets.
-
-Recommended facets:
-
-| Facet | Purpose | Typical users |
-| --- | --- | --- |
-| `ProbeFacet` | Recognize evidence and describe confidence, families, and route hints. | Source, portfolio, and statement-capable adapters. |
-| `ReadFacet` | Read selected evidence and emit evidence bundles or claim bundles. | Source, portfolio, wallet, and explorer adapters. |
-| `StatementFacet` | Recognize and parse statement documents plus statement-specific identity claims. | Statement-capable platform and wallet adapters. |
-| `TranslateFacet` | Convert provider-local claims into bridge-ready outputs or compiler-ready claims when provider-local semantic mapping is required. | Source adapters with activity semantics. |
-| `WriteFacet` | Convert runtime or projection data into target artifacts. | Output adapters. |
-
-Additional rule:
-
-- portfolio is not a dedicated facet
-- portfolio behavior is expressed through `ReadFacet` and possibly
-  `StatementFacet`, because portfolio inputs are evidence readers that emit
-  balance or position claims instead of activity-heavy claims
-
-## Responsibilities By Layer
-
-### Adapter-Owned Responsibilities
-
-Adapters should own only the responsibilities that truly require provider-local
-knowledge.
+Adapters own provider-specific work only.
 
 Reader-side examples:
 
-- identifying provider-specific evidence families
-- parsing provider-specific evidence structures
+- recognizing provider-specific evidence families
+- parsing provider-specific files and documents
 - mapping provider fields into provider-local claims
-- declaring provider-specific ambiguity, precision, or semantic constraints
-- rendering provider-specific output labels or row shapes
+- surfacing provider-local ambiguity, precision, or unsupported cases
 
 Writer-side examples:
 
-- mapping runtime semantics into target-specific row models
-- handling target-specific formatting or required field population
+- mapping accepted upstream truth into target-specific row models
+- applying target-specific formatting and validation rules
 
-### Shared Core Responsibilities
+Shared core owns cross-provider workflow:
 
-The shared core should own responsibilities that must be consistent across
-providers.
-
-Examples:
-
-- evidence selection and planning
-- deterministic candidate comparison and replacement rules
-- stable ordering and fingerprint creation
-- provenance flattening at artifact boundaries
-- instrument identity resolution
-- issue and review severity conventions
-- fact compilation
-- projection validation
-- artifact writing
+- evidence selection and candidate comparison
+- stable ordering and fingerprints
+- shared issue, review, and readiness conventions
+- claim compilation into economic truth
+- bridge compatibility projection
 - replay and parity verification
+- artifact writing and output packaging
 
-### Explicit Rule
+If two adapters need the same rule and the rule is not provider-specific, it
+belongs in shared core services rather than duplicated adapter logic.
 
-If two adapters would need the same workflow rule and that rule is not
-provider-specific, it belongs in shared core services, not in duplicated
-adapter logic.
+## Manifest Direction
 
-## ProbeFacet Design
+Every future adapter should publish one manifest that answers:
 
-`ProbeFacet` should answer three questions:
+- what evidence or artifacts it reads or writes
+- which facets it implements
+- which determinism guarantees it provides
+- which compatibility window and schema versions it supports
+- which unsupported or review-worthy surfaces it declares
 
-1. Does this adapter recognize the evidence?
-2. What evidence families or statement kinds are present?
-3. What confidence and caveats apply?
+The manifest is the durable declaration. Facets are the executable behaviors
+attached to that declaration.
 
-It should not:
+## Facet Model
 
-- parse the entire provider semantic model
-- choose winning translation candidates
-- perform full translation
+Use a small set of purpose-defined facets rather than one giant contract.
 
-The probe output should be declarative.
-
-Recommended output fields:
-
-- `recognized`
-- `confidence_score`
-- `recognized_families`
-- `statement_kinds`
-- `route_hints`
-- `blocking_issues`
-- `advisory_reviews`
-
-This facet should replace the current spread of:
-
-- source matching
-- file-family classification
-- intake matching hints
-- statement-document detection
-
-while still allowing those current jobs to be implemented incrementally.
-
-## ReadFacet Design
-
-`ReadFacet` is the future home for provider-local evidence reading.
-
-Its job is to:
-
-- accept selected evidence members
-- parse them into typed evidence structures
-- emit evidence bundles and claim bundles
-
-It should not:
-
-- own cross-provider selection policy
-- infer resolved runtime instrument identity beyond provider-local claims
-- write final runtime artifacts directly
-
-Reader outputs should be deterministic for unchanged inputs.
-
-Reader ordering rules:
-
-- evidence members sorted by stable evidence ordering
-- claims sorted by stable claim key
-- diagnostics sorted by provenance plus claim or evidence id
-
-## StatementFacet Design
-
-Statements are important enough to deserve a specialized facet because they
-have distinct evidence semantics:
-
-- document recognition
-- document parsing
-- row-level balance evidence
-- row-level instrument identity claims
-
-`StatementFacet` should:
-
-- recognize statement documents
-- parse statement rows into typed statement claims
-- preserve document-level and row-level provenance
-- declare statement-specific ambiguity when quantity evidence is insufficient
-
-It should not:
-
-- silently promote valuation-only rows into quantity-backed balance references
-- bypass the shared statement extraction orchestration
-
-## TranslateFacet Design
-
-`TranslateFacet` exists because provider-local semantics still matter even
-after parsing.
-
-Its job is to:
-
-- convert provider-local claims into bridge-ready data or
-  semantic-compiler-ready claims
-- express provider-local semantic ambiguity explicitly
-
-It should not:
-
-- choose evidence members by itself
-- resolve final runtime identities through provider-local lookup tables when shared
-  resolution should own the final choice
-- write output artifacts directly
-
-This facet is closest to the current source translation behavior, but it should
-operate on claims and evidence bundles rather than on raw file-path heuristics.
-
-## WriteFacet Design
-
-`WriteFacet` is the future unified writer surface for output adapters.
-
-Its job is to:
-
-- declare what semantic or projection data it accepts
-- declare target-specific constraints
-- emit projection bundles and artifact bundles
-
-It should not:
-
-- reinterpret runtime facts semantically
-- invent missing projection metadata silently
-- coerce unsupported fact shapes into target rows
-
-This is a stricter version of the current output adapter model.
-
-## Planner And Selection Model
-
-Selection is one of the most important shared behaviors and must not remain
-adapter-local.
-
-### Design Rule
-
-The core planner owns evidence selection. Adapters describe candidates.
-
-### Candidate Model
-
-Every reader capable of overlapping or replaceable evidence should be able to
-describe candidates with:
-
-- candidate id
-- selection group
-- family id
-- member list
-- coverage window
-- freshness
-- selection mode
-- comparability
-- content fingerprint
-- description
-- notes
-
-### Selection Modes
-
-The future model should preserve the useful ideas already present:
-
-- appendable range
-- replaceable range
-- exclusive snapshot
-
-Additional rules:
-
-- candidate comparison rules must be deterministic
-- unknown coverage must block selection when it could change semantics
-- incomparable candidates must block selection unless an explicit human choice
-  exists
-- replacement must leave an auditable chain
-
-### Why Selection Must Be Shared
-
-If adapters choose winners internally:
-
-- behavior becomes non-uniform
-- replacement semantics drift
-- test coverage becomes fragmented
-- replay confidence falls
-
-## Claim Taxonomy
-
-The canonical minimum `ClaimSet` family list, stable-id recipes, and
-first-slice subset live in:
-
-- [Pipeline Stage Contracts](pipeline-stage-contracts.md) for the shared
-  repo-wide taxonomy and deterministic id rules
-- [First Slice Contract](../reference/first-slice-contract.md) for the bounded
-  Coinbase-first subset
-
-This page does not define an alternate claim-family list.
-
-## Shared Compilation Rules
-
-The compiler from claims to bridge or downstream runtime data should be shared.
-
-### Compiler Responsibilities
-
-- resolve instrument identity from claims
-- validate temporal conventions
-- validate leg shape rules
-- validate required location identity
-- separate blocking issues from advisory reviews
-- create current bridge facts, balance references, and location inventory
-
-### Compiler Rules
-
-- no bridge fact may be created when identity remains unresolved
-- no quantity-backed balance reference may be created from valuation-only
-  evidence
-- no location inventory record may be created without identifier-rooted
-  runtime location identity
-- no output hint may become a semantic fact just because a writer can use it
-
-### Why This Must Be Shared
-
-If each adapter compiles bridge facts differently:
-
-- semantic correctness becomes adapter-dependent
-- output parity becomes unstable
-- reconciliation trust is reduced
-
-## Determinism Contract
-
-Determinism must be explicit across all adapter products.
-
-### Deterministic Inputs
-
-For unchanged evidence, unchanged manifest versions, and unchanged shared-core
-versions:
-
-- selected evidence members must be identical
-- candidate and plan fingerprints must be identical
-- claim bundle fingerprints must be identical
-- bridge or runtime dataset fingerprints must be identical
-- projection bundle fingerprints must be identical
-- artifact fingerprints must be identical unless the target format includes a
-  documented nondeterministic field that is intentionally excluded
-
-### Deterministic Ordering Rules
-
-Every adapter product must declare a sort key.
-
-Examples:
-
-- evidence members sorted by stable provenance key
-- candidates sorted by selection group, coverage, freshness, and candidate id
-- claims sorted by claim family, timestamp, stable claim id, and provenance
-- facts sorted by timestamp, effective time, source, fact id
-- issues and reviews sorted by severity, kind, timestamp, provenance, id
-- projection rows sorted by target-defined stable row order
-
-### Fingerprint Rules
-
-Every adapter product should have:
-
-- a schema version
-- a stable serialization form
-- a stable fingerprint
-
-Serialization rules should:
-
-- sort object keys
-- avoid implicit ordering from language runtime containers
-- exclude presentation-only noise
-- include semantically relevant fields only
-- reference manifest fingerprints as upstream inputs instead of duplicating
-  manifest payload blobs into product kernels
-
-## Assertions, Issues, And Reviews
-
-The future design should treat diagnostic surfaces as first-class contracts.
-
-### Hard Assertions
-
-Hard assertions are required for bridge or runtime acceptance.
-
-Examples:
-
-- one resolved instrument identity
-- valid timezone semantics
-- valid quantity precision where required
-- acceptable leg shape
-
-### Blocking Issues
-
-Blocking issues stop bridge acceptance or later workflow progress.
-
-Examples:
-
-- ambiguous identity
-- unsupported precision loss
-- unknown coverage during candidate selection
-- incompatible evidence bundles in one selection group
-
-### Reviews
-
-Reviews are explicit human attention requests that do not always block the
-entire workflow.
-
-Examples:
-
-- lower-confidence fee precision on a known provider edge
-- advisory same-source same-chain portfolio evidence
-- low-confidence ownership inference
-
-### Rule
-
-Adapters must not downgrade a hard semantic failure into a review just to keep
-facts flowing.
-
-## Provenance Model
-
-Provenance is central enough to deserve explicit rules.
-
-### Runtime Rule
-
-Provenance stays typed in runtime models until artifact boundaries.
-
-### Provenance Levels
-
-The future model should distinguish:
-
-- evidence member provenance
-- parsed row or page provenance
-- claim provenance
-- bridge or runtime derivation provenance
-- artifact derivation provenance
-
-### Why Product Boundaries Matter
-
-The repo needs to answer:
-
-- which file, sheet, row, or page caused this fact
-- which evidence item supports this balance reference
-- which candidate was selected and why
-- which target row came from which fact or claim
-
-Ad hoc string fields are not enough for that.
-
-## Identity Model
-
-Identity rules should remain shared and identifier-rooted.
-
-### Instrument Identity
-
-Adapters should emit identity claims, not final resolved runtime instrument
-choices.
-
-The shared identity resolver should:
-
-- accept multiple claims
-- resolve exactly one runtime instrument or fail explicitly
-- preserve review context when ambiguity remains
-
-### Location Identity
-
-Adapters should emit identifier-rooted runtime locations.
-
-Rules:
-
-- friendly labels stay out of runtime ids
-- chain or network identity must be explicit
-- sublocations must be stable derivations of parent identity
-
-### Ownership
-
-Ownership claims should be their own claim family, not hidden in translation
-helpers.
-
-## Temporal And Numeric Policy
-
-Time and quantity interpretation must be explicit at the adapter edge, but the
-policy model should be shared.
-
-### Temporal Rules
-
-- timestamps must be timezone-aware before entering bridge or downstream
-  runtime data
-- date-only and timestamp precision must remain distinct
-- exact midnight timestamps are still timestamps if the source contract says so
-- unknown or conflicting timezone interpretation must block or review
-  explicitly based on declared policy
-
-### Numeric Rules
-
-- financial quantities remain `Decimal`
-- precision expectations may be declared by manifest or provider-local code
-- silent rounding or truncation is not acceptable on semantically important
-  quantities
-- known provider precision defects must be modeled as explicit review or issue
-  behavior
-
-## Input, Portfolio, And Output Under One Model
-
-The future design should stop treating input, portfolio, and output as
-fundamentally different architecture categories.
-
-### Input
-
-An input adapter is an adapter whose facets read evidence and emit claims,
-bridge-ready outputs, or downstream runtime data.
-
-### Portfolio
-
-A portfolio adapter is an input adapter whose primary claim types are balance,
-position, statement, or ownership claims instead of activity-heavy claims.
-
-### Output
-
-An output adapter is an adapter whose primary facet writes projection or
-artifact bundles from runtime or projection data.
-
-### Why One Adapter Model Matters
-
-The architecture stays smaller if:
-
-- one manifest model describes all adapters
-- one verifier model checks their products
-- one shared adapter vocabulary describes the flow
-
-## Migration Of Current Jobs Into Future Facets
-
-The current repo jobs should map into the future architecture as follows.
-
-| Current job | Future owner |
+| Facet | Purpose |
 | --- | --- |
-| profile matching | `ProbeFacet` plus shared selection service |
-| file-family classification | `ProbeFacet` plus manifest-declared evidence families |
-| intake matching and route hints | `ProbeFacet` plus shared intake router |
-| timezone summary | shared temporal policy service with manifest-declared expectations |
-| location inventory extraction | `ReadFacet` or `TranslateFacet` producing `OwnershipClaim` and runtime inventory through shared compilation |
-| statement matching and parsing | `StatementFacet` plus shared statement orchestration |
-| translation-input planning | shared planner using manifest and candidate descriptions |
-| activity translation | `ReadFacet` and `TranslateFacet` producing `ActivityClaim` |
-| draft compilation | shared compiler to current bridge outputs first, then `EconomicFacts` once the bridge is retired |
-| output policy validation | shared projection validator |
-| rendering | `WriteFacet` |
+| `ProbeFacet` | Recognize evidence and describe route, family, or confidence hints. |
+| `EvidenceFacet` | Read selected evidence and emit `EvidenceSet`-aligned outputs. |
+| `StatementFacet` | Recognize and parse statement documents plus statement-specific evidence detail. |
+| `ClaimFacet` | Emit provider-local semantic meaning that maps into `ClaimSet`. |
+| `WriteFacet` | Emit target-specific projections or artifacts from accepted upstream truth. |
 
-This mapping is the main path for shrinking adapter entry points.
+Portfolio behavior is not a separate species. It is evidence-reading behavior
+that emits position or balance meaning instead of activity-heavy claim sets.
 
-## Testing And Verification Model
+## Deterministic Verification Model
 
-The future adapter system needs a stronger and more uniform verification model
-than the current contract-by-contract mixture.
+Adapter verification must be a written contract, not a best-effort habit.
 
-### Required Test Layers
+Required verification properties:
 
-| Layer | Purpose |
-| --- | --- |
-| Unit tests | Provider-local parsing, semantic mapping, and edge-case decisions. |
-| Contract tests | Manifest validity, facet declarations, and product schema conformance. |
-| Golden tests | Stable evidence, claim, economic, and projection outputs on known packs. |
-| Replay tests | Re-run unchanged inputs and verify identical stable fingerprints. |
-| Negative tests | Assert blocking behavior for unsupported or ambiguous evidence. |
+- unchanged inputs preserve declared evidence-family recognition
+- unchanged inputs preserve declared ordering and fingerprints
+- unsupported or ambiguous cases surface explicitly
+- compatibility projections remain reproducible from authoritative target
+  kernels during migration
+- output adapters reject unsupported upstream shapes before serialization
 
-### Mandatory Determinism Checks
+Verification should center on adapter products and shared projections, not on
+adapter-local shell choreography.
 
-- shuffled file order must not change selected candidates
-- equivalent archive extraction order must not change claim order
-- repeated runs must preserve stable fingerprints
-- rendered writer outputs must remain stable for unchanged economic datasets
+## Migration Posture
 
-### Compatibility Checks
+The unified adapter redesign remains deferred until the filing-critical path and
+bounded first slices are stable.
 
-The future verifier should check:
+Rules during the current migration window:
 
-- manifest schema compatibility
-- adapter product schema compatibility
-- adapter support-window declarations
-- intentional breaking changes via explicit version increments
+- first-slice adapter work must emit target products through the canonical
+  owner docs, not adapter-local alternate schemas
+- adapters may emit declared compatibility sidecars for retained legacy
+  draft-or-fact reproduction during migration, but canonical target kernels
+  stay semantic-only
+- adapter docs may describe how adapters participate in `EvidenceSet`,
+  `ClaimSet`, and compatibility projections, but they may not redefine those
+  products
+- the first bounded slice must not depend on a repo-wide facet migration
+- `SourceTranslationBatch` remains honest current-state truth until its bounded
+  replacement slice lands
 
-## Scaffolding And Authoring Rules
-
-Once the future model lands, scaffolds should create:
-
-- one manifest
-- only the facets the adapter actually implements
-- provider-local modules split by real concern
-- local tests for each implemented facet
-
-Scaffolds should not create:
-
-- no-op method surfaces for unrelated jobs
-- fake fallback methods just to satisfy a bundled protocol
-- generic helper dumps
-
-## Performance And Operational Rules
-
-The future system should optimize for determinism first and performance second,
-but performance still matters.
-
-Rules:
-
-- bundle products should be stream-friendly where possible
-- large evidence collections should avoid materializing unnecessary duplicate
-  structures
-- fingerprints should be cheap enough to run in ordinary workflows
-- shared planning should avoid repeated provider-local rescans when profile
-  artifacts already contain the needed evidence facts
-
-## Security And Safety Posture
-
-The adapter system should remain safe-by-default.
-
-Rules:
-
-- adapters may read only selected evidence provided by the core workflow
-- adapters should not perform unrestricted workspace scans outside their
-  assigned evidence roots
-- network calls should remain outside ordinary adapter reading unless a
-  separate provider family explicitly owns them
-- ambiguity should never be hidden for convenience
-
-## Open Questions
-
-These questions are intentionally left open for later design review:
-
-- Should `ReadFacet` emit evidence bundles and claim bundles separately, or may
-  some adapters emit claims directly when parsing is trivial?
-- Should writer adapters consume `EconomicFacts` directly, or should all
-  writers consume a target-neutral `ProjectionBundle` first?
-- Which manifest fields should be purely declarative versus code-generated?
-- How much of current timezone and precision policy belongs in manifest data
-  versus provider-local code?
-
-These are implementation questions, not reasons to keep the bundled current
-contract.
-
-## Migration Principles
-
-When this architecture is implemented later, migration should follow these
-rules:
-
-- adapter product and bridge-mapping contracts may advance during shared
-  foundations when the first target-stage slice needs them
-- migrate by adapter family, not all at once
-- do not preserve permanent dual contracts
-- keep each checkpoint reviewable
-- let filing-critical adapters migrate first only after the filing path is
-  stable
-- remove obsolete seams once the new family path is verified
-
-## Practical Near-Term Guidance
-
-Until the future architecture lands:
-
-- keep current adapter changes moving toward these product and facet
-  boundaries
-- extract shared workflow logic when it is clearly cross-provider
-- avoid adding new adapter-local orchestration that the future shared planner,
-  compiler, or verifier should own
-- keep current fixes filing-first while still using this document as the
-  direction of travel
-
-## Design Summary
-
-The future adapter architecture should be:
-
-- manifest-centered
-- facet-based
-- intermediate-representation driven
-- deterministic by contract
-- provenance-rich
-- issue-forward
-- migration-friendly
-
-It should not be:
-
-- monolithic
-- filename-order driven
-- tracker-centered
-- adapter-local workflow heavy
-- tolerant of hidden ambiguity
-
-## External Design References
-
-These references support the design posture in this document.
-
-- Alistair Cockburn, Hexagonal Architecture:
-  <https://alistair.cockburn.us/hexagonal-architecture>
-- MLIR Dialect Conversion:
-  <https://mlir.llvm.org/docs/DialectConversion/>
-- Apache Avro Specification:
-  <https://avro.apache.org/docs/1.12.0/specification/>
-- Apache Beam coder determinism:
-  <https://beam.apache.org/releases/pydoc/2.10.0/apache_beam.coders.coders.html>
-- RFC 8785 JSON Canonicalization Scheme:
-  <https://www.rfc-editor.org/rfc/rfc8785>
-- W3C PROV-DM:
-  <https://www.w3.org/standards/history/prov-dm/>
-- JSON Schema Draft 2020-12:
-  <https://json-schema.org/draft/2020-12>
+Use [Adapter Delivery Plan](../status/adapter-delivery-plan.md) for timing and
+priority decisions. Use this page only for the future adapter shape once that
+work becomes active.

--- a/docs/concepts/unified-adapter-architecture.md
+++ b/docs/concepts/unified-adapter-architecture.md
@@ -250,7 +250,7 @@ Boundary note:
 
 Adapter-emission purpose:
 
-- emit the canonical `EvidenceSet` product owned by
+- emit the `EvidenceSet` product owned by
   [Pipeline Stage Contracts](pipeline-stage-contracts.md)
 - preserve discovery results, family classification, provenance, and typed
   parse outputs without adapter-local semantic invention
@@ -263,19 +263,19 @@ Adapter emission must include:
 
 - adapter id
 - capture or input identity
-- stable ids required by the canonical `EvidenceSet` kernel
+- stable ids required by the `EvidenceSet` kernel
 - manifest version and manifest fingerprint reference
 - evidence members with typed provenance
 - evidence family ids
 - parse diagnostics
-- deterministic member ordering that matches the canonical kernel order
-- an `EvidenceSet` fingerprint computed from the canonical product kernel plus
+- deterministic member ordering that matches the declared kernel order
+- an `EvidenceSet` fingerprint computed from the product kernel plus
   upstream refs, not from duplicated manifest payload blobs
 
 Must not include:
 
 - current bridge facts
-- downstream runtime products beyond the canonical `EvidenceSet`
+- downstream runtime products beyond `EvidenceSet`
 - target-specific output rows
 - competing evidence-product rules that differ from the pipeline-stage owner doc
 
@@ -291,7 +291,7 @@ Typical contents:
 
 Adapter-emission purpose:
 
-- emit the canonical `ClaimSet` product owned by
+- emit the `ClaimSet` product owned by
   [Pipeline Stage Contracts](pipeline-stage-contracts.md)
 - hold provider-local semantic claims before shared compilation without
   redefining target-product meaning locally
@@ -320,8 +320,8 @@ Adapter emission must include:
 - typed provenance references back to the evidence set
 - structural status for each claim
 - blocking versus advisory distinction
-- canonical claim ordering
-- a `ClaimSet` fingerprint computed from the canonical product kernel plus
+- declared claim ordering
+- a `ClaimSet` fingerprint computed from the product kernel plus
   referenced upstream ids or fingerprints, not duplicated manifest payloads
 
 Must not include:

--- a/docs/concepts/unified-adapter-architecture.md
+++ b/docs/concepts/unified-adapter-architecture.md
@@ -238,6 +238,9 @@ Boundary note:
   architecture anchor for `EconomicFacts`, `ReconciliationState`,
   `Checkpoint`, `Journal`, `TaxInputs`, and
   `TaxOutputs`
+- `docs/concepts/pipeline-stage-contracts.md` owns the shared target-product
+  versioning, kernel-and-envelope, and downstream stage-contract rules that
+  adapter products must align with
 - adapter work should map into that runtime pipeline rather than creating a
   second competing core architecture
 
@@ -1049,6 +1052,8 @@ contract.
 When this architecture is implemented later, migration should follow these
 rules:
 
+- adapter product and bridge-mapping contracts may advance during shared
+  foundations when the first target-stage slice needs them
 - migrate by adapter family, not all at once
 - do not preserve permanent dual contracts
 - keep each checkpoint reviewable

--- a/docs/concepts/unified-adapter-architecture.md
+++ b/docs/concepts/unified-adapter-architecture.md
@@ -300,23 +300,11 @@ Owned by:
 
 - reader and translation facets
 
-Claim types may include:
-
-- `ActivityClaim`
-- `BalanceObservationClaim`
-- `OwnershipClaim`
-- `LocationClaim`
-- `StatementClaim`
-- `InstrumentIdentityClaim`
-- `ContractTermClaim`
-- `ValuationClaim`
-- `ProjectionAnnotation`
-- `IssueCandidate`
-- `ReviewCandidate`
-
 Adapter emission must include:
 
 - deterministic claim ids
+- claim families chosen from the canonical minimum taxonomy owned by
+  [Pipeline Stage Contracts](pipeline-stage-contracts.md)
 - typed provenance references back to the evidence set
 - structural status for each claim
 - blocking versus advisory distinction
@@ -697,31 +685,15 @@ If adapters choose winners internally:
 
 ## Claim Taxonomy
 
-The future architecture should separate provider-local claims by job.
+The canonical minimum `ClaimSet` family list, stable-id recipes, and
+first-slice subset live in:
 
-Recommended claim families:
+- [Pipeline Stage Contracts](pipeline-stage-contracts.md) for the shared
+  repo-wide taxonomy and deterministic id rules
+- [First Slice Contract](../reference/first-slice-contract.md) for the bounded
+  Coinbase-first subset
 
-| Claim family | Purpose |
-| --- | --- |
-| `ActivityClaim` | A provider-local economic activity candidate with raw semantic details. |
-| `BalanceObservationClaim` | A quantity-backed balance or position observation tied to evidence. |
-| `OwnershipClaim` | A claim that a location identifier is controlled or owned. |
-| `LocationClaim` | A provider-local claim about where activity, balances, or positions are held. |
-| `StatementClaim` | A parsed statement row or document-level claim. |
-| `InstrumentIdentityClaim` | One provider-local identity assertion for an asset or instrument. |
-| `ContractTermClaim` | A provider-local claim about instrument or position terms that later economic compilation may need. |
-| `ValuationClaim` | A provider-local valuation observation with purpose, time, and provenance. |
-| `ProjectionAnnotation` | Output-oriented metadata that is not itself a bridge or downstream runtime fact. |
-| `IssueCandidate` | A blocking or informational problem requiring shared issue assembly. |
-| `ReviewCandidate` | A review-needed case requiring shared review assembly. |
-
-These claim families let the core compiler distinguish:
-
-- hard semantic assertions
-- evidence observations
-- identity claims
-- output hints
-- workflow diagnostics
+This page does not define an alternate claim-family list.
 
 ## Shared Compilation Rules
 

--- a/docs/concepts/unified-adapter-architecture.md
+++ b/docs/concepts/unified-adapter-architecture.md
@@ -39,7 +39,7 @@ Owner-page precedence:
 
 The future adapter architecture should unify around:
 
-- one manifest family
+- one manifest model
 - a small set of purpose-defined facets
 - deterministic adapter products that map into the core runtime pipeline
 - one shared verification model
@@ -57,7 +57,7 @@ Adapters own provider-specific work only.
 
 Reader-side examples:
 
-- recognizing provider-specific evidence families
+- recognizing provider-specific evidence kinds
 - parsing provider-specific files and documents
 - mapping provider fields into provider-local claims
 - surfacing provider-local ambiguity, precision, or unsupported cases
@@ -99,7 +99,7 @@ Use a small set of purpose-defined facets rather than one giant contract.
 
 | Facet | Purpose |
 | --- | --- |
-| `ProbeFacet` | Recognize evidence and describe route, family, or confidence hints. |
+| `ProbeFacet` | Recognize evidence and describe route, kind, or confidence hints. |
 | `EvidenceFacet` | Read selected evidence and emit `EvidenceSet`-aligned outputs. |
 | `StatementFacet` | Recognize and parse statement documents plus statement-specific evidence detail. |
 | `ClaimFacet` | Emit provider-local semantic meaning that maps into `ClaimSet`. |
@@ -114,7 +114,7 @@ Adapter verification must be a written contract, not a best-effort habit.
 
 Required verification properties:
 
-- unchanged inputs preserve declared evidence-family recognition
+- unchanged inputs preserve declared evidence-kind recognition
 - unchanged inputs preserve declared ordering and fingerprints
 - unsupported or ambiguous cases surface explicitly
 - compatibility projections remain reproducible from authoritative target

--- a/docs/reference/first-downstream-slice-contract.md
+++ b/docs/reference/first-downstream-slice-contract.md
@@ -1,0 +1,188 @@
+---
+title: "First Downstream Slice Contract"
+summary: "Bounded contract for the first Coinbase-first EconomicFacts, ReconciliationState, and Checkpoint increment."
+doc_type: reference
+audience: human
+owner: repo
+status: active
+nav_order: 16
+related:
+  - docs/reference/first-slice-contract.md
+  - docs/concepts/pipeline-stage-contracts.md
+  - docs/concepts/reconciliation-tax-architecture.md
+  - docs/status/migration-sequence.md
+  - ROADMAP.md
+---
+
+Use this page when implementing or reviewing the first bounded downstream slice
+after the default Coinbase-first `EvidenceSet` and `ClaimSet` increment. This
+document freezes scope, ids, fingerprints, replay, parity, and allowed drift
+for the first `EconomicFacts -> ReconciliationState -> Checkpoint` landing
+path.
+
+## Slice Scope
+
+The first downstream slice is:
+
+- the Coinbase-first family already bounded by
+  [First Slice Contract](first-slice-contract.md)
+- accepted `EconomicEventRecord` and `EconomicLegRecord` emission for supported
+  Coinbase retail activity and recognized statement-backed balance observations
+- bounded `ReconciliationState` emission for continuity segments, exact balance
+  targets, and checkpoint candidates over those in-scope economic facts
+- bounded `Checkpoint` emission for statement-backed position-quantity
+  assertions
+- continued interoperability with current `TransactionFact`,
+  `balance_snapshots.csv`, `balance_references.csv`, balance
+  inspect/check/summarize flows, and `cointracking_csv`
+
+The slice is not:
+
+- a broad downstream migration for every source family
+- a replacement for `Journal`, `TaxInputs`, or `TaxOutputs`
+- a claim that cross-source transfer pairing is already solved
+- a claim that operator-only checkpoint inputs satisfy filing-ready truth
+
+## In-Scope Record Families
+
+The slice may emit only these downstream kernel families:
+
+| Product | Record family | In-scope constraints |
+| --- | --- | --- |
+| `EconomicFacts` | `EconomicEventRecord` | only `asset_movement`, `cash_movement`, `fee_or_rebate`, and `correction` event families |
+| `EconomicFacts` | `EconomicLegRecord` | only `holding_change`, `cash_change`, `fee`, and `rebate` leg roles |
+| `ReconciliationState` | `ContinuitySegmentRecord` | one segment per Coinbase-held position subject and one checkpoint date |
+| `ReconciliationState` | `BalanceTargetRecord` | only `target_kind = exact_balance` |
+| `ReconciliationState` | `CheckpointCandidateRecord` | only candidates supported by in-scope exact-balance targets and statement evidence |
+| `Checkpoint` | `CheckpointRecord` | accepted container for in-scope checkpoint assertions only |
+| `Checkpoint` | `CheckpointAssertionRecord` | only `assertion_kind = position_quantity` |
+
+`LinkRecord` remains out of scope for this bounded slice. The first downstream
+slice may emit no `LinkRecord` rows and still be complete.
+
+## Bridge Interop Outputs
+
+The slice must continue to produce the current bridge interop outputs without
+inventing new bridge-only schemas:
+
+- compiled `TransactionFact` records
+- `balance_snapshots.csv`
+- `balance_references.csv`
+- current balance inspect/check/summarize outputs through the active
+  application surface
+- `cointracking_csv` rows through current renderer boundaries
+
+## Id And Fingerprint Rules
+
+Stable-id format:
+
+- use the stable-id recipes owned by
+  [Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md)
+- do not create slice-specific alternate id formats
+- slice-specific bounds narrow which families and enum values are allowed, not
+  how ids and fingerprints are computed
+
+Slice-specific rules:
+
+- `EconomicEventRecord` ids must remain stable on unchanged first-slice claim
+  inputs and unchanged compilation decisions
+- `EconomicLegRecord` ids must remain stable on unchanged accepted event
+  structure, leg roles, subject refs, quantities, and valuation refs
+- `ContinuitySegmentRecord` subjects in this slice are limited to one Coinbase
+  position subject per segment; do not mix multiple positions into one segment
+- `BalanceTargetRecord` ids in this slice are limited to one exact
+  statement-backed target per subject and as-of time
+- `CheckpointCandidateRecord` ids in this slice must derive only from in-scope
+  balance-target refs and statement-backed evidence refs
+- `CheckpointAssertionRecord` ids in this slice must include the accepted-value
+  fingerprint exactly as owned by
+  [Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md)
+
+In-scope checkpoint vocabularies for the slice:
+
+- `trust_level`:
+  - `analysis_ready`
+  - `filing_ready`
+- `acceptance_basis`:
+  - `source_document`
+  - `reconciled_continuity`
+- `evidence_class`:
+  - `statement_balance`
+- `continuity_proof`:
+  - `direct_observation`
+  - `reconciled_rollforward`
+
+Not allowed in this slice:
+
+- `operator_assertion`
+- `adopted_opening_state`
+- `platform_balance`
+- `wallet_snapshot`
+- `inventory_proof`
+- `partial_continuity`
+
+## Parity Gates
+
+Unchanged first-slice inputs must preserve all of the following:
+
+- accepted economic event ids and ordering
+- accepted economic leg ids, ordering, and quantities
+- `ContinuitySegmentRecord` ids and ordering
+- `BalanceTargetRecord` ids, ordering, and statuses
+- `CheckpointCandidateRecord` ids, ordering, and statuses
+- `CheckpointAssertionRecord` ids, ordering, and accepted values
+- compiled `TransactionFact` ordering and semantics
+- `balance_snapshots.csv` content for in-scope evidence
+- `balance_references.csv` content for in-scope evidence
+- current balance inspect/check/summarize output for in-scope evidence
+- `cointracking_csv` row ordering and field values
+
+## Replay Gates
+
+The slice is replay-safe only when repeated runs on unchanged evidence preserve:
+
+- identical accepted `EconomicEventRecord` and `EconomicLegRecord` fingerprints
+- identical `ContinuitySegmentRecord`, `BalanceTargetRecord`, and
+  `CheckpointCandidateRecord` fingerprints
+- identical `CheckpointRecord` and `CheckpointAssertionRecord` fingerprints
+- identical compiled bridge fact fingerprints
+- identical `balance_snapshots.csv` and `balance_references.csv` content for
+  in-scope evidence
+- identical balance inspect/check/summarize output for supported slice
+  subjects
+- identical `cointracking_csv` output for supported bridge facts
+
+Replay checks must also prove that incidental input ordering changes do not
+change event ids, leg ids, continuity segment ids, balance target ids,
+checkpoint candidate ids, checkpoint assertion ids, or rendered output.
+
+## Allowed Drift
+
+Not allowed:
+
+- drift in accepted event or leg kernel fields
+- drift in continuity-segment, balance-target, checkpoint-candidate, or
+  checkpoint-assertion kernel ids
+- quantity, accepted-value, or checkpoint-trust drift
+- bridge-output drift on unchanged in-scope evidence
+- balance inspect/check/summarize drift on unchanged in-scope evidence
+
+Allowed only when kernel ids, statuses, and fingerprints stay unchanged:
+
+- richer explanation text
+- additional non-kernel gap or readiness sidecars
+- additional non-kernel envelope fields
+- additional comparison detail that does not change product meaning
+
+## Explicitly Out Of Scope
+
+This bounded downstream slice does not:
+
+- emit `LinkRecord` rows as a required success condition
+- widen beyond the Coinbase-first family already bounded by
+  [First Slice Contract](first-slice-contract.md)
+- make operator-only checkpoint acceptance part of the filing path
+- use adopted opening state as an accepted checkpoint basis
+- define runtime `Journal`, `TaxInputs`, or `TaxOutputs`
+- require broad balance-provider hydration or cross-source transfer pairing
+- authorize a repo-wide adapter-family migration before the bounded slice lands

--- a/docs/reference/first-downstream-slice-contract.md
+++ b/docs/reference/first-downstream-slice-contract.md
@@ -9,6 +9,7 @@ nav_order: 16
 related:
   - docs/reference/first-slice-contract.md
   - docs/concepts/pipeline-stage-contracts.md
+  - docs/reference/target-contract-primitives.md
   - docs/concepts/reconciliation-tax-architecture.md
   - docs/status/migration-sequence.md
   - ROADMAP.md
@@ -51,11 +52,12 @@ The slice may emit only these downstream kernel families:
 | --- | --- | --- |
 | `EconomicFacts` | `EconomicEventRecord` | only `asset_movement`, `cash_movement`, `fee_or_rebate`, and `correction` event families |
 | `EconomicFacts` | `EconomicLegRecord` | only `holding_change`, `cash_change`, `fee`, and `rebate` leg roles |
+| `EconomicFacts` | `ValuationRecord` | zero rows by default; `valuation_ref_or_null` stays empty unless a later parity-preserving slice widens valuation support |
 | `ReconciliationState` | `ContinuitySegmentRecord` | one segment per Coinbase-held position subject and one checkpoint date |
-| `ReconciliationState` | `BalanceTargetRecord` | only `target_kind = exact_balance` |
+| `ReconciliationState` | `BalanceTargetRecord` | only `target_kind = exact_balance`, with inline `expected_value` and `observed_value_or_null` using `AssertionValue` |
 | `ReconciliationState` | `CheckpointCandidateRecord` | only candidates supported by in-scope exact-balance targets and statement evidence |
 | `Checkpoint` | `CheckpointRecord` | accepted container for in-scope checkpoint assertions only |
-| `Checkpoint` | `CheckpointAssertionRecord` | only `assertion_kind = position_quantity` |
+| `Checkpoint` | `CheckpointAssertionRecord` | only `assertion_kind = position_quantity`, with `accepted_value` using `AssertionValue` |
 
 `LinkRecord` remains out of scope for this bounded slice. The first downstream
 slice may emit no `LinkRecord` rows and still be complete.
@@ -88,15 +90,20 @@ Slice-specific rules:
   inputs and unchanged compilation decisions
 - `EconomicLegRecord` ids must remain stable on unchanged accepted event
   structure, leg roles, subject refs, quantities, and valuation refs
+- `valuation_ref_or_null` stays empty for the default Coinbase-first downstream
+  slice unless a later parity-preserving slice explicitly widens valuation
+  support
 - `ContinuitySegmentRecord` subjects in this slice are limited to one Coinbase
   position subject per segment; do not mix multiple positions into one segment
 - `BalanceTargetRecord` ids in this slice are limited to one exact
-  statement-backed target per subject and as-of time
+  statement-backed target per subject and as-of time, with `expected_value`
+  and `observed_value_or_null` using the shared `AssertionValue` contract from
+  [Target Contract Primitives](target-contract-primitives.md)
 - `CheckpointCandidateRecord` ids in this slice must derive only from in-scope
   balance-target refs and statement-backed evidence refs
 - `CheckpointAssertionRecord` ids in this slice must include the accepted-value
   fingerprint exactly as owned by
-  [Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md)
+  [Target Contract Primitives](target-contract-primitives.md)
 
 In-scope checkpoint vocabularies for the slice:
 

--- a/docs/reference/first-downstream-slice-contract.md
+++ b/docs/reference/first-downstream-slice-contract.md
@@ -1,6 +1,6 @@
 ---
 title: "First Downstream Slice Contract"
-summary: "Bounded contract for the first Coinbase-first EconomicFacts, ReconciliationState, and Checkpoint increment."
+summary: "Bounded contract for the first Coinbase-first EconomicFacts, ReconciliationState, and Checkpoint slice, including selected-bundle event identity and bridge compatibility projections."
 doc_type: reference
 audience: human
 owner: repo
@@ -9,17 +9,16 @@ nav_order: 16
 related:
   - docs/reference/first-slice-contract.md
   - docs/concepts/pipeline-stage-contracts.md
-  - docs/reference/target-contract-primitives.md
+  - docs/concepts/domain-ontology.md
   - docs/concepts/reconciliation-tax-architecture.md
   - docs/status/migration-sequence.md
   - ROADMAP.md
 ---
 
 Use this page when implementing or reviewing the first bounded downstream slice
-after the default Coinbase-first `EvidenceSet` and `ClaimSet` increment. This
-document freezes scope, ids, fingerprints, replay, parity, and allowed drift
-for the first `EconomicFacts -> ReconciliationState -> Checkpoint` landing
-path.
+after the default Coinbase-first `EvidenceSet -> ClaimSet` landing path. This
+document freezes scope, ids, parity, replay, and allowed drift for the first
+`EconomicFacts -> ReconciliationState -> Checkpoint` increment.
 
 ## Slice Scope
 
@@ -27,13 +26,13 @@ The first downstream slice is:
 
 - the Coinbase-first family already bounded by
   [First Slice Contract](first-slice-contract.md)
-- accepted `EconomicEventRecord` and `EconomicLegRecord` emission for supported
-  Coinbase retail activity and recognized statement-backed balance observations
+- accepted `EconomicFacts` emission for supported Coinbase retail activity and
+  recognized statement-backed balance observations
 - bounded `ReconciliationState` emission for continuity segments, exact balance
   targets, and checkpoint candidates over those in-scope economic facts
 - bounded `Checkpoint` emission for statement-backed position-quantity
   assertions
-- continued interoperability with current `TransactionFact`,
+- continued compatibility with current `TransactionFact`,
   `balance_snapshots.csv`, `balance_references.csv`, balance
   inspect/check/summarize flows, and `cointracking_csv`
 
@@ -52,60 +51,141 @@ The slice may emit only these downstream kernel families:
 | --- | --- | --- |
 | `EconomicFacts` | `EconomicEventRecord` | only `asset_movement`, `cash_movement`, `fee_or_rebate`, and `correction` event families |
 | `EconomicFacts` | `EconomicLegRecord` | only `holding_change`, `cash_change`, `fee`, and `rebate` leg roles |
-| `EconomicFacts` | `ValuationRecord` | zero rows by default; `valuation_ref_or_null` stays empty unless a later parity-preserving slice widens valuation support |
-| `ReconciliationState` | `ContinuitySegmentRecord` | one segment per Coinbase-held position subject and one checkpoint date |
-| `ReconciliationState` | `BalanceTargetRecord` | only `target_kind = exact_balance`, with inline `expected_value` and `observed_value_or_null` using `AssertionValue` |
+| `EconomicFacts` | `ValuationRecord` | zero rows by default; valuations land only when an unchanged parity slice proves they are required |
+| `ReconciliationState` | `ContinuitySegmentRecord` | one segment per in-scope Coinbase position subject and bounded time span |
+| `ReconciliationState` | `BalanceTargetRecord` | only `target_kind = exact_balance`, with direct `expected_value` and `observed_value_or_null` using `AssertionValue` |
 | `ReconciliationState` | `CheckpointCandidateRecord` | only candidates supported by in-scope exact-balance targets and statement evidence |
 | `Checkpoint` | `CheckpointRecord` | accepted container for in-scope checkpoint assertions only |
-| `Checkpoint` | `CheckpointAssertionRecord` | only `assertion_kind = position_quantity`, with `accepted_value` using `AssertionValue` |
+| `Checkpoint` | `CheckpointAssertionRecord` | only `assertion_kind = position_quantity`, with direct `accepted_value` using `AssertionValue` |
 
-`LinkRecord` remains out of scope for this bounded slice. The first downstream
-slice may emit no `LinkRecord` rows and still be complete.
+`LinkRecord` remains out of scope for this bounded slice.
 
-## Bridge Interop Outputs
+## Position And Subject Restrictions
 
-The slice must continue to produce the current bridge interop outputs without
-inventing new bridge-only schemas:
+The first downstream slice freezes one bounded position identity shape:
 
-- compiled `TransactionFact` records
-- `balance_snapshots.csv`
-- `balance_references.csv`
-- current balance inspect/check/summarize outputs through the active
-  application surface
-- `cointracking_csv` rows through current renderer boundaries
+- `PositionRef = [beneficial_owner_ref, location_ref, instrument_ref, null, "custodial_spot_balance"]`
+
+Rules:
+
+- `beneficial_owner_ref` comes from in-scope `BeneficialOwnerClaim` output
+- `location_ref` comes from in-scope `LocationClaim` output
+- `instrument_ref` comes from in-scope `InstrumentIdentityClaim` output
+- `contract_ref_or_null` stays `null` for this slice
+- one continuity segment covers one `PositionRef`; do not mix positions into one
+  segment
+- when `SubjectRef` is needed for downstream attachment, the subject kind for
+  this slice is `position`, pointing at the stable `PositionRef` identity
+
+## Product Metadata And Compilation Inputs
+
+In-scope product metadata fields:
+
+- `EconomicFacts` carries `economic_facts_id`, `schema_version`, and
+  `claim_set_refs`
+- `ReconciliationState` carries `reconciliation_state_id`,
+  `schema_version`, and `economic_facts_ref`
+- `Checkpoint` carries `checkpoint_run_id`, `schema_version`,
+  `reconciliation_state_refs`, and `asserted_as_of_at`
+
+Compilation-input rules:
+
+- downstream compilation consumes canonical `InterpretationBundleRecord`,
+  `ClaimRecord`, `CompilationDecisionRecord`, and `evidence_observation_refs`
+  from authoritative `ClaimSet` kernels
+- downstream compilation must not depend on `EconomicActivityDraft`,
+  `SourceTranslationBatch`, or undeclared bridge hints as peer semantic inputs
+- upstream `*_ref` metadata fields store target product ids, never `dataset_id`
+  and never raw kernel fingerprints
+
+## Kernel Cardinality And Ownership
+
+Slice cardinality rules:
+
+- one or more accepted `EconomicEventRecord` rows may be emitted from one
+  accepted bundle
+- one or more `EconomicLegRecord` rows may be emitted under one `event_id`
+- zero `ValuationRecord` rows are expected by default in this slice
+- one `ContinuitySegmentRecord` exists per in-scope `PositionRef` and bounded
+  segment time span
+- one or more `BalanceTargetRecord` rows may exist under one
+  `continuity_segment_id`
+- one or more `CheckpointCandidateRecord` rows may exist under one
+  `continuity_segment_id`
+- one or more `CheckpointAssertionRecord` rows may exist under one
+  `CheckpointRecord`
+
+Ownership rules:
+
+- `event_id` is derived from the selected semantic bundle, not from
+  adjudication bookkeeping
+- `compilation_decision_id` may be referenced for audit, but it does not define
+  event identity
+- `BalanceTargetRecord` carries direct `AssertionValue` payloads and must not
+  point to undefined value refs or sidecars for hot-path meaning
+- `CheckpointCandidateRecord` identity is based on supporting balance-target
+  refs, not incidental evidence-ref churn
+- `CheckpointAssertionRecord` carries direct accepted truth and does not inherit
+  authority from bridge balance references
 
 ## Id And Fingerprint Rules
 
-Stable-id format:
-
-- use the stable-id recipes owned by
-  [Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md)
-- do not create slice-specific alternate id formats
-- slice-specific bounds narrow which families and enum values are allowed, not
-  how ids and fingerprints are computed
+Use the stable-id and fingerprint rules from
+[Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md) unchanged.
+This slice freezes the in-scope bounds and the first position identity shape.
 
 Slice-specific rules:
 
-- `EconomicEventRecord` ids must remain stable on unchanged first-slice claim
-  inputs and unchanged compilation decisions
-- `EconomicLegRecord` ids must remain stable on unchanged accepted event
-  structure, leg roles, subject refs, quantities, and valuation refs
-- `valuation_ref_or_null` stays empty for the default Coinbase-first downstream
-  slice unless a later parity-preserving slice explicitly widens valuation
-  support
-- `ContinuitySegmentRecord` subjects in this slice are limited to one Coinbase
-  position subject per segment; do not mix multiple positions into one segment
-- `BalanceTargetRecord` ids in this slice are limited to one exact
-  statement-backed target per subject and as-of time, with `expected_value`
-  and `observed_value_or_null` using the shared `AssertionValue` contract from
-  [Target Contract Primitives](target-contract-primitives.md)
-- `CheckpointCandidateRecord` ids in this slice must derive only from in-scope
-  balance-target refs and statement-backed evidence refs
-- `CheckpointAssertionRecord` ids in this slice must include the accepted-value
-  fingerprint exactly as owned by
-  [Target Contract Primitives](target-contract-primitives.md)
+- `economic_facts_id = [ordered_claim_set_refs]`
+- `event_id = [bundle_id, event_index]`
+- `leg_id = [event_id, leg_role, subject_ref, leg_index]`
+- `valuation_id = [valuation_source_ref, valuation_purpose, amount, currency, valued_at_or_null, valued_precision_or_null]`
+- `reconciliation_state_id = [economic_facts_ref, continuity_segment_id]`
+- `continuity_segment_id = [source, subject_ref, segment_start_at_or_null, segment_end_at_or_null]`
+- `balance_target_id = [continuity_segment_id, subject_ref, target_kind, target_as_of_at, expected_value_fingerprint]`
+- `checkpoint_candidate_id = [continuity_segment_id, subject_ref, checkpoint_date, supporting_balance_target_refs]`
+- `checkpoint_run_id = [ordered_reconciliation_state_refs, asserted_as_of_at]`
+- `checkpoint_assertion_id = [assertion_kind, asserted_as_of_at, subject_ref, accepted_value_fingerprint]`
 
-In-scope checkpoint vocabularies for the slice:
+Not allowed in this slice:
+
+- event identity based on `compilation_decision_id` or rejected-bundle lists
+- `expected_value_ref`
+- `observed_value_ref_or_null`
+- candidate ids that include raw evidence-ref lists as identity components
+
+## Bridge Compatibility Projections
+
+For in-scope subjects, the authoritative products after the slice are:
+
+- `EconomicFacts` for accepted economic meaning
+- `ReconciliationState` for continuity segments and balance targets
+- `Checkpoint` for accepted checkpoint truth
+
+Required derived compatibility projections:
+
+- `TransactionFact` and related fact CSV outputs derived from `EconomicFacts`
+  plus declared upstream claim compatibility sidecars when legacy hint
+  reproduction still needs them
+- `balance_snapshots.csv` derived from `ReconciliationState`
+- `balance_references.csv` derived from `ReconciliationState`, `Checkpoint`,
+  and declared support sidecars
+- balance inspect/check/summarize outputs preserved through the active bridge
+  compatibility surface until that application layer is repointed
+- `cointracking_csv` preserved through the active output compatibility path
+
+Compatibility rule:
+
+- compatibility projections remain required during the migration window
+- they are not authoritative for in-scope economic, reconciliation, or
+  checkpoint truth once the target products exist
+- retained legacy hint reproduction must come from declared compatibility
+  sidecars, not from `EconomicActivityDraft`, `SourceTranslationBatch`, or
+  bridge facts as peer semantic authorities
+
+## In-Scope Checkpoint Vocabulary
+
+The first downstream slice allows only:
 
 - `trust_level`:
   - `analysis_ready`
@@ -132,31 +212,29 @@ Not allowed in this slice:
 
 Unchanged first-slice inputs must preserve all of the following:
 
-- accepted economic event ids and ordering
-- accepted economic leg ids, ordering, and quantities
+- accepted event ids and ordering
+- accepted leg ids, ordering, and quantities
 - `ContinuitySegmentRecord` ids and ordering
 - `BalanceTargetRecord` ids, ordering, and statuses
 - `CheckpointCandidateRecord` ids, ordering, and statuses
 - `CheckpointAssertionRecord` ids, ordering, and accepted values
-- compiled `TransactionFact` ordering and semantics
+- compiled `TransactionFact` ordering and semantics for in-scope evidence
 - `balance_snapshots.csv` content for in-scope evidence
 - `balance_references.csv` content for in-scope evidence
-- current balance inspect/check/summarize output for in-scope evidence
+- balance inspect/check/summarize output for in-scope evidence
 - `cointracking_csv` row ordering and field values
 
 ## Replay Gates
 
 The slice is replay-safe only when repeated runs on unchanged evidence preserve:
 
-- identical accepted `EconomicEventRecord` and `EconomicLegRecord` fingerprints
-- identical `ContinuitySegmentRecord`, `BalanceTargetRecord`, and
-  `CheckpointCandidateRecord` fingerprints
-- identical `CheckpointRecord` and `CheckpointAssertionRecord` fingerprints
-- identical compiled bridge fact fingerprints
+- identical `EconomicFacts` kernel fingerprints
+- identical `ReconciliationState` kernel fingerprints
+- identical `Checkpoint` kernel fingerprints
+- identical compiled bridge-fact fingerprints for in-scope evidence
 - identical `balance_snapshots.csv` and `balance_references.csv` content for
   in-scope evidence
-- identical balance inspect/check/summarize output for supported slice
-  subjects
+- identical balance inspect/check/summarize output for supported slice subjects
 - identical `cointracking_csv` output for supported bridge facts
 
 Replay checks must also prove that incidental input ordering changes do not
@@ -167,18 +245,17 @@ checkpoint candidate ids, checkpoint assertion ids, or rendered output.
 
 Not allowed:
 
-- drift in accepted event or leg kernel fields
+- drift in accepted economic kernel fields
 - drift in continuity-segment, balance-target, checkpoint-candidate, or
-  checkpoint-assertion kernel ids
-- quantity, accepted-value, or checkpoint-trust drift
+  checkpoint-assertion ids
+- quantity, accepted-value, trust-level, or acceptance-basis drift
 - bridge-output drift on unchanged in-scope evidence
 - balance inspect/check/summarize drift on unchanged in-scope evidence
 
 Allowed only when kernel ids, statuses, and fingerprints stay unchanged:
 
 - richer explanation text
-- additional non-kernel gap or readiness sidecars
-- additional non-kernel envelope fields
+- additional non-kernel gap, review, or readiness sidecars
 - additional comparison detail that does not change product meaning
 
 ## Explicitly Out Of Scope

--- a/docs/reference/first-downstream-slice-contract.md
+++ b/docs/reference/first-downstream-slice-contract.md
@@ -24,7 +24,7 @@ document freezes scope, ids, parity, replay, and allowed drift for the first
 
 The first downstream slice is:
 
-- the Coinbase-first family already bounded by
+- the Coinbase-first slice already bounded by
   [First Slice Contract](first-slice-contract.md)
 - accepted `EconomicFacts` emission for supported Coinbase retail activity and
   recognized statement-backed balance observations
@@ -38,7 +38,7 @@ The first downstream slice is:
 
 The slice is not:
 
-- a broad downstream migration for every source family
+- a broad downstream migration for every source
 - a replacement for `Journal`, `TaxInputs`, or `TaxOutputs`
 - a claim that cross-source transfer pairing is already solved
 - a claim that operator-only checkpoint inputs satisfy filing-ready truth
@@ -49,11 +49,11 @@ The slice may emit only these downstream kernel families:
 
 | Product | Record family | In-scope constraints |
 | --- | --- | --- |
-| `EconomicFacts` | `EconomicEventRecord` | only `asset_movement`, `cash_movement`, `fee_or_rebate`, and `correction` event families |
+| `EconomicFacts` | `EconomicEventRecord` | only `asset_movement`, `cash_movement`, `fee_or_rebate`, and `correction` event kinds |
 | `EconomicFacts` | `EconomicLegRecord` | only `holding_change`, `cash_change`, `fee`, and `rebate` leg roles |
 | `EconomicFacts` | `ValuationRecord` | zero rows by default; valuations land only when an unchanged parity slice proves they are required |
 | `ReconciliationState` | `ContinuitySegmentRecord` | one segment per in-scope Coinbase position subject and bounded time span |
-| `ReconciliationState` | `BalanceTargetRecord` | only `target_kind = exact_balance`, with direct `expected_value` and `observed_value_or_null` using `AssertionValue` |
+| `ReconciliationState` | `BalanceTargetRecord` | only `target_kind = exact_balance`, with direct `expected_value` and `observed_value` using `AssertionValue` |
 | `ReconciliationState` | `CheckpointCandidateRecord` | only candidates supported by in-scope exact-balance targets and statement evidence |
 | `Checkpoint` | `CheckpointRecord` | accepted container for in-scope checkpoint assertions only |
 | `Checkpoint` | `CheckpointAssertionRecord` | only `assertion_kind = position_quantity`, with direct `accepted_value` using `AssertionValue` |
@@ -71,7 +71,7 @@ Rules:
 - `beneficial_owner_ref` comes from in-scope `BeneficialOwnerClaim` output
 - `location_ref` comes from in-scope `LocationClaim` output
 - `instrument_ref` comes from in-scope `InstrumentIdentityClaim` output
-- `contract_ref_or_null` stays `null` for this slice
+- `contract_ref` stays `null` for this slice
 - one continuity segment covers one `PositionRef`; do not mix positions into one
   segment
 - when `SubjectRef` is needed for downstream attachment, the subject kind for
@@ -90,8 +90,8 @@ In-scope product metadata fields:
 
 Compilation-input rules:
 
-- downstream compilation consumes canonical `InterpretationBundleRecord`,
-  `ClaimRecord`, `CompilationDecisionRecord`, and `evidence_observation_refs`
+- downstream compilation consumes canonical `ClaimBundleRecord`,
+  `ClaimRecord`, `BundleDecisionRecord`, and `evidence_observation_refs`
   from authoritative `ClaimSet` kernels
 - downstream compilation must not depend on `EconomicActivityDraft`,
   `SourceTranslationBatch`, or undeclared bridge hints as peer semantic inputs
@@ -119,7 +119,7 @@ Ownership rules:
 
 - `event_id` is derived from the selected semantic bundle, not from
   adjudication bookkeeping
-- `compilation_decision_id` may be referenced for audit, but it does not define
+- `bundle_decision_id` may be referenced for audit, but it does not define
   event identity
 - `BalanceTargetRecord` carries direct `AssertionValue` payloads and must not
   point to undefined value refs or sidecars for hot-path meaning
@@ -136,22 +136,22 @@ This slice freezes the in-scope bounds and the first position identity shape.
 
 Slice-specific rules:
 
-- `economic_facts_id = [ordered_claim_set_refs]`
+- `economic_facts_id = [claim_set_refs]`
 - `event_id = [bundle_id, event_index]`
 - `leg_id = [event_id, leg_role, subject_ref, leg_index]`
-- `valuation_id = [valuation_source_ref, valuation_purpose, amount, currency, valued_at_or_null, valued_precision_or_null]`
+- `valuation_id = [valuation_source_ref, valuation_purpose, amount, currency, valued_at, valued_precision]`
 - `reconciliation_state_id = [economic_facts_ref, continuity_segment_id]`
-- `continuity_segment_id = [source, subject_ref, segment_start_at_or_null, segment_end_at_or_null]`
+- `continuity_segment_id = [source, subject_ref, segment_start_at, segment_end_at]`
 - `balance_target_id = [continuity_segment_id, subject_ref, target_kind, target_as_of_at, expected_value_fingerprint]`
-- `checkpoint_candidate_id = [continuity_segment_id, subject_ref, checkpoint_date, supporting_balance_target_refs]`
-- `checkpoint_run_id = [ordered_reconciliation_state_refs, asserted_as_of_at]`
+- `checkpoint_candidate_id = [continuity_segment_id, subject_ref, checkpoint_date, balance_target_refs]`
+- `checkpoint_run_id = [reconciliation_state_refs, asserted_as_of_at]`
 - `checkpoint_assertion_id = [assertion_kind, asserted_as_of_at, subject_ref, accepted_value_fingerprint]`
 
 Not allowed in this slice:
 
-- event identity based on `compilation_decision_id` or rejected-bundle lists
+- event identity based on `bundle_decision_id` or rejected-bundle lists
 - `expected_value_ref`
-- `observed_value_ref_or_null`
+- `observed_value_ref`
 - candidate ids that include raw evidence-ref lists as identity components
 
 ## Bridge Compatibility Projections
@@ -263,10 +263,10 @@ Allowed only when kernel ids, statuses, and fingerprints stay unchanged:
 This bounded downstream slice does not:
 
 - emit `LinkRecord` rows as a required success condition
-- widen beyond the Coinbase-first family already bounded by
+- widen beyond the Coinbase-first slice already bounded by
   [First Slice Contract](first-slice-contract.md)
 - make operator-only checkpoint acceptance part of the filing path
 - use adopted opening state as an accepted checkpoint basis
 - define runtime `Journal`, `TaxInputs`, or `TaxOutputs`
 - require broad balance-provider hydration or cross-source transfer pairing
-- authorize a repo-wide adapter-family migration before the bounded slice lands
+- authorize a repo-wide adapter migration before the bounded slice lands

--- a/docs/reference/first-slice-contract.md
+++ b/docs/reference/first-slice-contract.md
@@ -1,0 +1,205 @@
+---
+title: "First Slice Contract"
+summary: "Bounded contract for the default Coinbase-first proto-EvidenceSet and proto-ClaimSet slice."
+doc_type: reference
+audience: human
+owner: repo
+status: active
+nav_order: 15
+related:
+  - docs/concepts/bridge-to-target-mapping.md
+  - docs/concepts/pipeline-stage-contracts.md
+  - docs/status/adapter-delivery-plan.md
+  - ROADMAP.md
+---
+
+Use this page when implementing or reviewing the default first vertical slice.
+This document freezes scope, ids, fingerprints, replay, parity, and allowed
+drift for the bounded Coinbase-first landing path.
+
+## Slice Scope
+
+The default first slice is:
+
+- planner-enabled Coinbase retail CSV evidence selection
+- recognized Coinbase statement-backed balance observation flow
+- bounded proto-`EvidenceSet` and proto-`ClaimSet` emission for that family
+- continued interoperability with current `SourceTranslationBatch`,
+  `TransactionFact`, `balance_references.csv`, and `cointracking_csv`
+
+The slice is not:
+
+- the actual filing adapter inventory for `2023` to `2025`
+- a repo-wide claim migration
+- a broad unified-adapter facet rollout
+- a replacement for `EconomicFacts`, `ReconciliationState`, or `Checkpoint`
+
+## Evidence Families
+
+The slice recognizes only these evidence families:
+
+| Evidence family | Meaning | Required kernel role |
+| --- | --- | --- |
+| `coinbase_retail_export` | planner-selected Coinbase retail CSV member chosen for translation | selected, superseded, or blocked planner member |
+| `coinbase_statement_document` | recognized Coinbase statement PDF document used for statement-backed quantity observation | selected evidence member with document identity |
+| `coinbase_statement_balance_row` | one parsed statement quantity row from a recognized Coinbase statement document | evidence observation keyed to the owning document and row anchor |
+| `coinbase_translation_selection_group` | deterministic planner decision boundary for one retail export family selection | bounded `selection_group_id` for the slice |
+
+## Claim Families
+
+The first slice may emit only these claim families:
+
+| Claim family | Meaning in the slice |
+| --- | --- |
+| `ActivityClaim` | provider-local activity assertion derived from selected Coinbase retail rows |
+| `BalanceObservationClaim` | quantity-backed balance or as-of observation derived from recognized statement rows |
+| `InstrumentIdentityClaim` | provider-local asset identity assertion tied to one activity or statement observation |
+| `LocationClaim` | provider-local claim about the Coinbase-held location or sub-location in scope |
+| `ValuationClaim` | valuation observation preserved when downstream behavior depends on it |
+| `ProjectionAnnotation` | output-oriented metadata that is not accepted economic truth |
+| `IssueCandidate` | blocking pre-economic diagnostic candidate for later issue or gap assembly |
+| `ReviewCandidate` | advisory pre-economic review candidate |
+
+## Kernel Schemas
+
+### Proto-`EvidenceSet`
+
+Kernel fields for the bounded slice:
+
+- `evidence_set_id`
+- `source`
+- `adapter_id`
+- `capture_uid`
+- `member_id`
+- `selection_group_id`
+- `observation_id`
+- `selection_status`
+- `manifest_fingerprint_ref`
+- `plan_fingerprint_ref`
+
+Required status vocabulary:
+
+- `selected`
+- `superseded`
+- `blocked`
+
+### Proto-`ClaimSet`
+
+Kernel fields for the bounded slice:
+
+- `claim_set_id`
+- `claim_id`
+- `claim_family`
+- `claim_status`
+- `interpretation_group_id`
+- `evidence_member_refs`
+- `effective_at`
+- `effective_precision`
+- `provenance_refs`
+
+Required status vocabulary:
+
+- `asserted`
+- `blocked`
+- `advisory`
+- `superseded`
+
+### Bridge Interop Outputs
+
+The slice must continue to produce the current bridge interop outputs without
+inventing new bridge-only schemas:
+
+- `SourceTranslationBatch`
+- compiled `TransactionFact` records
+- `balance_references.csv`
+- `cointracking_csv` rows through current renderer boundaries
+
+## Id And Fingerprint Rules
+
+Id rules:
+
+- `evidence_set_id` is deterministic from `source`, `adapter_id`, `capture_uid`,
+  and one stable `selection_group_id`
+- `member_id` is deterministic from evidence provenance, member identity, and
+  the selected evidence family
+- `observation_id` is deterministic from `member_id` plus the row, page, or
+  anchor identity for the observation
+- `claim_set_id` is deterministic from `evidence_set_id` plus the claim-emitting
+  translation family for the slice
+- `claim_id` is deterministic from `claim_family`, provider-local operation or
+  row grouping identity, and `interpretation_group_id`
+- `interpretation_group_id` is deterministic from one mutually exclusive claim
+  bundle; independent bundles must not share a group id
+
+Fingerprint rules:
+
+- kernel fingerprints use canonical UTF-8 JSON serialization with stable object
+  key order and declared array order, hashed with SHA-256
+- product fingerprints include semantically relevant upstream ids or
+  fingerprint references, not duplicated upstream payload blobs
+- manifest fingerprints are referenced as upstream inputs; they are not
+  duplicated into the emitted product kernel
+- sidecars, explanations, and reviews use separate fingerprints when persisted
+  independently
+
+## Parity Gates
+
+Unchanged evidence must preserve all of the following:
+
+- selected evidence membership
+- superseded and blocked candidate membership
+- evidence member ids and observation ids
+- claim ids and claim ordering
+- timestamps and temporal precision
+- quantities and sign
+- bridge leg shapes
+- balance reference kinds
+- compiled `TransactionFact` ordering and semantics
+- `cointracking_csv` row ordering and field values
+
+## Replay Gates
+
+The slice is replay-safe only when repeated runs on unchanged evidence preserve:
+
+- identical planner-selected, superseded, and blocked partitions
+- identical statement recognition outcomes
+- identical proto-`EvidenceSet` and proto-`ClaimSet` kernel fingerprints
+- identical compiled bridge fact fingerprints
+- identical `balance_references.csv` content for in-scope evidence
+- identical `cointracking_csv` output for supported bridge facts
+
+Replay checks must also prove that incidental input ordering changes do not
+change selected evidence membership, claim order, compiled bridge facts, or
+rendered output.
+
+## Allowed Drift
+
+Not allowed:
+
+- kernel-field drift in selected evidence membership
+- kernel-field drift in claim ids or order
+- timestamp or precision drift
+- quantity drift
+- leg-shape drift
+- balance-reference-kind drift
+- compiled bridge fact drift
+- `cointracking_csv` row drift
+
+Allowed only when kernel ids, statuses, and fingerprints stay unchanged:
+
+- richer explanation text
+- additional non-kernel envelope fields
+- additional sidecar detail that does not change product meaning
+
+## Explicitly Out Of Scope
+
+This bounded slice does not:
+
+- pin the real filing workspace adapter inventory for `2023` to `2025`
+- widen beyond the Coinbase retail export family and recognized Coinbase
+  statement balance observations
+- define final `EconomicFacts`, `ReconciliationState`, `Checkpoint`,
+  `Journal`, or `TaxInputs` runtime products
+- force a repo-wide adapter-facet migration
+- authorize broad target package scaffolding before the Phase 0 contract lock
+  completes

--- a/docs/reference/first-slice-contract.md
+++ b/docs/reference/first-slice-contract.md
@@ -140,6 +140,22 @@ Stable-id format:
 
 Slice-specific component arrays:
 
+- `coinbase_retail_export` uses `member_class = "coinbase_retail_export"` and
+  `member_locator_identity = [raw_file, raw_member_ref_or_null]`
+- retail planner-decision observations use
+  `observation_class = "selection_decision"` and
+  `observation_anchor = [selection_status]`
+- `coinbase_statement_document` uses
+  `member_class = "coinbase_statement_document"` and
+  `member_locator_identity = [raw_file, raw_member_ref_or_null]`
+- document-identity observations use
+  `observation_class = "document_identity"` and
+  `observation_anchor = ["document"]`
+- `coinbase_statement_balance_row` is an observation class under the owning
+  `coinbase_statement_document` member, not a second member family
+- statement balance observations use
+  `observation_class = "coinbase_statement_balance_row"` and
+  `observation_anchor = [row_anchor]`
 - retail activity `claim_id` uses
   `[claim_set_id, "ActivityClaim", raw_file, raw_row_ref, interpretation_group_id]`
 - statement-derived `claim_id` uses
@@ -167,6 +183,8 @@ Fingerprint rules:
   fingerprint references, not duplicated upstream payload blobs
 - manifest fingerprints are referenced as upstream inputs; they are not
   duplicated into the emitted product kernel
+- compiled bridge fact fingerprints use the bridge replay contract owned by
+  [Current Bridge Contracts](../concepts/current-bridge-contracts.md)
 - sidecars, explanations, and reviews use separate fingerprints when persisted
   independently
 

--- a/docs/reference/first-slice-contract.md
+++ b/docs/reference/first-slice-contract.md
@@ -1,6 +1,6 @@
 ---
 title: "First Slice Contract"
-summary: "Bounded contract for the default Coinbase-first proto-EvidenceSet and proto-ClaimSet increment."
+summary: "Bounded contract for the default Coinbase-first EvidenceSet and ClaimSet slice, including cardinality, ids, replay gates, and bridge compatibility projections."
 doc_type: reference
 audience: human
 owner: repo
@@ -9,225 +9,271 @@ nav_order: 15
 related:
   - docs/concepts/bridge-to-target-mapping.md
   - docs/concepts/pipeline-stage-contracts.md
-  - docs/reference/target-contract-primitives.md
+  - docs/concepts/domain-ontology.md
+  - docs/concepts/gaps-and-readiness.md
   - docs/status/adapter-delivery-plan.md
   - ROADMAP.md
 ---
 
 Use this page when implementing or reviewing the default first vertical slice.
-This document freezes scope, ids, fingerprints, replay, parity, and allowed
-drift for the bounded Coinbase-first landing path.
+This document freezes scope, cardinality, ids, parity, replay, and allowed drift
+for the bounded Coinbase-first `EvidenceSet -> ClaimSet` landing path.
 
 ## Slice Scope
 
 The default first slice is:
 
 - planner-enabled Coinbase retail CSV evidence selection
-- recognized Coinbase statement-backed balance observation flow
-- bounded proto-`EvidenceSet` and proto-`ClaimSet` emission for that family
-- continued interoperability with current `SourceTranslationBatch`,
+- recognized Coinbase statement document selection
+- statement-backed balance-row observations under selected statement documents
+- bounded `EvidenceSet` emission for that family
+- bounded `ClaimSet` emission for that family
+- continued compatibility with current `translation_input_plan.json`,
+  `EconomicActivityDraft`, `SourceTranslationBatch`, compiled
   `TransactionFact`, `balance_references.csv`, and `cointracking_csv`
 
 The slice is not:
 
 - the actual filing adapter inventory for `2023` to `2025`
 - a repo-wide claim migration
-- a broad unified-adapter facet rollout
 - a replacement for `EconomicFacts`, `ReconciliationState`, or `Checkpoint`
+- a broad unified-adapter facet rollout
 
-## Evidence Member Families
+## `EvidenceSet` Coverage
 
-Planner candidate inventory from `translation_input_candidates.json` remains
-`EvidenceSet` envelope or selection-sidecar reasoning as owned by
-[Bridge To Target Mapping](../concepts/bridge-to-target-mapping.md). The
-bounded slice kernel uses the selected, superseded, and blocked plan records.
+The bounded slice may emit only these evidence member families:
 
-The slice recognizes only these evidence member families:
-
-| Evidence member family | Meaning | Required kernel role |
-| --- | --- | --- |
-| `coinbase_retail_export` | Coinbase retail CSV member recorded by one selected, superseded, or blocked planner decision | selected, superseded, or blocked plan member |
-| `coinbase_statement_document` | recognized Coinbase statement PDF document used for statement-backed quantity observation | selected evidence member with document identity |
-
-## Observation Classes
-
-The slice recognizes only these typed observation classes:
-
-| Observation class | Meaning | Owning member family |
-| --- | --- | --- |
-| `selection_decision` | deterministic selected, superseded, or blocked planner decision preserved as an evidence observation | `coinbase_retail_export` |
-| `document_identity` | recognized statement document identity preserved under the selected statement document member | `coinbase_statement_document` |
-| `coinbase_statement_balance_row` | one parsed statement quantity row keyed to the owning recognized statement document and row anchor | `coinbase_statement_document` |
-
-`coinbase_statement_balance_row` is an observation class only. It is not an
-evidence member family for this slice.
-
-## Selection Groups
-
-The slice freezes one bounded selection-group vocabulary:
-
-| `selection_group_id` | Meaning |
+| Evidence member family | Meaning |
 | --- | --- |
-| `coinbase:retail_export` | deterministic planner decision boundary for one Coinbase retail export family selection |
+| `coinbase_retail_export` | one Coinbase retail CSV member under planner-controlled selection |
+| `coinbase_statement_document` | one recognized Coinbase statement PDF document under per-document selection |
 
-## Claim Families
+The bounded slice may emit only these observation families:
 
-The shared minimum claim taxonomy is owned by
-[Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md). This
-bounded slice may emit only the subset below; `OwnershipClaim`,
-`StatementClaim`, and `ContractTermClaim` remain canonical shared families but
-stay out of scope for the default slice.
+| Observation family | Meaning | Owning member family |
+| --- | --- | --- |
+| `document_identity` | statement document identity and recognition payload preserved under the selected document member | `coinbase_statement_document` |
+| `coinbase_statement_balance_row` | one parsed statement quantity row keyed to the owning statement document and row anchor | `coinbase_statement_document` |
 
-The first slice may emit only these claim families:
+Frozen family-specific observation fields:
+
+| Observation family | Frozen kernel fields |
+| --- | --- |
+| `document_identity` | `statement_kind`, `document_effective_at_or_null`, `document_effective_precision_or_null`, `statement_as_of_at_or_null`, `statement_as_of_precision_or_null` |
+| `coinbase_statement_balance_row` | `account_label_or_null`, `wallet_label_or_null`, `balance_kind`, `asset_symbol`, `quantity_or_null`, `observed_at_or_null`, `observed_precision_or_null`, `notes_or_null`, `staked_quantity_text_or_null`, `value_amount_text_or_null`, `value_currency_or_null`, `price_amount_text_or_null`, `price_currency_or_null` |
+
+Observation-field rules:
+
+- there is no retail-row observation family in this bounded pass
+- `document_identity.statement_kind` uses the recognized statement-adapter kind
+  for the selected document member
+- `document_identity.statement_as_of_at_or_null` and
+  `document_effective_at_or_null` lift the current parsed statement times, and
+  the paired `*_precision_or_null` fields follow the repo-wide temporal
+  precision contract
+- `coinbase_statement_balance_row` lifts account, wallet, balance kind, asset,
+  quantity, as-of time, and optional note or valuation text directly from the
+  current statement-row contract
+- `document_identity` may leave shell `observed_at_or_null` or
+  `observed_precision_or_null` empty when the family-specific document timing
+  fields carry the truthful time meaning
+- no generic observation payload blob is allowed for in-scope families
+
+The bounded slice uses only these selection-group anchors:
+
+| `selection_group_anchor` | Meaning |
+| --- | --- |
+| `["planner", "coinbase:retail_export"]` | deterministic planner decision boundary for Coinbase retail export selection |
+| `["statement_document", member_locator_identity]` | deterministic inclusion decision for one recognized statement document |
+
+`translation_input_candidates.json` remains envelope or sidecar reasoning only.
+It does not become a canonical kernel record family.
+
+## `ClaimSet` Coverage
+
+The bounded slice may emit only this in-scope subset of canonical claim
+families:
 
 | Claim family | Meaning in the slice |
 | --- | --- |
 | `ActivityClaim` | provider-local activity assertion derived from selected Coinbase retail rows |
-| `BalanceObservationClaim` | quantity-backed balance or as-of observation derived from recognized statement rows |
-| `InstrumentIdentityClaim` | provider-local asset identity assertion tied to one activity or statement observation |
-| `LocationClaim` | provider-local claim about the Coinbase-held location or sub-location in scope |
-| `ValuationClaim` | valuation observation preserved when downstream behavior depends on it |
-| `ProjectionAnnotation` | output-oriented metadata that is not accepted economic truth |
-| `IssueCandidate` | blocking pre-economic diagnostic candidate for later issue or gap assembly |
-| `ReviewCandidate` | advisory pre-economic review candidate |
+| `BalanceObservationClaim` | quantity-backed balance observation derived from recognized statement rows |
+| `InstrumentIdentityClaim` | asset identity assertion tied to one activity or statement observation |
+| `LocationClaim` | assertion about the Coinbase-held location or sub-location in scope |
+| `BeneficialOwnerClaim` | assertion for the beneficial owner needed by downstream position identity |
+| `ValuationClaim` | canonically defined now but zero-row by default in this bounded slice |
 
-## Kernel Schemas
+Out of scope for this slice:
 
-### Proto-`EvidenceSet`
+- `LegalOwnerClaim`
+- `CounterpartyClaim`
+- `StatementClaim`
+- `ContractTermClaim`
 
-Kernel fields for the bounded slice:
+`ProjectionAnnotation`, `IssueCandidate`, and `ReviewCandidate` are not
+canonical claim families and are never emitted by this slice.
 
-- `evidence_set_id`
-- `source`
-- `adapter_id`
-- `capture_uid`
-- `member_id`
-- `selection_group_id`
-- `observation_id`
-- `selection_status`
-- `manifest_fingerprint_ref`
-- `plan_fingerprint_ref`
+Frozen family-specific claim fields:
 
-Required status vocabulary:
+| Claim family | Frozen kernel fields |
+| --- | --- |
+| `ActivityClaim` | `provider_activity_kind`, `location_claim_ref_or_null`, `activity_leg_specs` |
+| `BalanceObservationClaim` | `location_claim_ref`, `instrument_claim_refs`, `balance_kind`, `quantity`, `observed_at_or_null`, `observed_precision_or_null` |
+| `InstrumentIdentityClaim` | `scheme`, `value`, `venue_or_null`, `kind_hint`, `display_name_or_null`, `precision_hint_or_null` |
+| `LocationClaim` | `location_ref`, `account_label_or_null`, `wallet_label_or_null` |
+| `BeneficialOwnerClaim` | `beneficial_owner_ref` |
+| `ValuationClaim` | `valuation_measure_kind`, `valuation_purpose`, `amount`, `currency`, `valued_at_or_null`, `valued_precision_or_null`, `location_claim_ref_or_null`, `instrument_claim_refs` |
 
-- `selected`
-- `superseded`
-- `blocked`
+`activity_leg_specs` entry shape:
 
-### Proto-`ClaimSet`
+- `leg_slot`
+- `leg_kind`
+- `quantity`
+- `instrument_claim_refs`
+- `location_claim_ref_or_null`
+- `subtype_or_null`
+- `attributed_to_leg_slot_or_null`
 
-Kernel fields for the bounded slice:
+Claim-field and linkage rules:
 
-- `claim_set_id`
-- `claim_id`
-- `claim_family`
-- `claim_status`
-- `interpretation_group_id`
-- `evidence_member_refs`
-- `effective_at`
-- `effective_precision`
-- `provenance_refs`
+- `ActivityClaim.provider_activity_kind` is the canonical home for the current
+  Coinbase retail transaction type in this bounded slice
+- `activity_leg_specs` lift ordered leg meaning from the current draft-leg
+  contract, including sign, subtype, optional attributed-leg linkage, and
+  optional location
+- retail activity claims use `evidence_member_refs` plus
+  `[retail_member_id, raw_row_ref]` interpretation-scope anchors
+- statement-derived claims use both `evidence_member_refs` and
+  `evidence_observation_refs`
+- `BalanceObservationClaim` must include the row observation id and may also
+  include the paired `document_identity` observation id
+- `ValuationClaim` remains zero-row by default until a later owner-doc pass
+  freezes canonical numeric statement valuation inputs
+- no generic claim payload blob is allowed for in-scope families
 
-Required status vocabulary:
+## Kernel Cardinality And Ownership
 
-- `asserted`
-- `blocked`
-- `advisory`
-- `superseded`
+Slice cardinality rules:
 
-### Bridge Interop Outputs
+- one `EvidenceSet` is emitted per
+  `[source, adapter_id, capture_uid, selection_plan_fingerprint]`
+- one `SelectionDecisionRecord` exists per `selection_group_id`
+- one or more `EvidenceMemberRecord` rows may belong to one
+  `selection_group_id`
+- zero or more `EvidenceObservationRecord` rows may belong to one `member_id`
+- one `ClaimSet` is emitted per `[evidence_set_id, claim_emitter_id]`
+- one `interpretation_scope_id` exists per provider-local semantic scope
+- one or more `InterpretationBundleRecord` rows may exist per
+  `interpretation_scope_id`
+- one `CompilationDecisionRecord` exists per `interpretation_scope_id`
+- one or more `ClaimRecord` rows may exist per `bundle_id`
 
-The slice must continue to produce the current bridge interop outputs without
-inventing new bridge-only schemas:
+Ownership rules:
 
-- `SourceTranslationBatch`
-- compiled `TransactionFact` records
-- `balance_references.csv`
-- `cointracking_csv` rows through current renderer boundaries
+- `SelectionDecisionRecord` owns decision basis and blocking-gap refs only
+- `EvidenceMemberRecord` owns selected, superseded, or blocked membership
+- `CompilationDecisionRecord` remains claim-owned and records bundle selection,
+  deferral, blocking, or supersession only
+- claim-stage gaps and reviews may attach to `interpretation_scope_id` when
+  no narrower truthful subject has resolved yet
+- `CompilationDecisionRecord` must not carry event payloads, leg payloads, or
+  other economic facts
+
+## Bridge Compatibility Projections
+
+For in-scope evidence, the first slice changes authority but preserves bridge
+compatibility.
+
+Authoritative products after the slice:
+
+- `EvidenceSet` for evidence selection and typed observations
+- `ClaimSet` for source-local semantic meaning
+
+Required derived compatibility projections:
+
+- `translation_input_plan.json` derived from `EvidenceSet`
+- `EconomicActivityDraft` derived from `ClaimSet` plus declared compatibility
+  sidecars keyed by `claim_id` or `bundle_id`
+- `SourceTranslationBatch` derived from `ClaimSet` plus declared
+  compatibility sidecars and shared support sidecars
+- compiled `TransactionFact` rows preserved for current bridge consumers
+- `balance_references.csv` preserved for current downstream compatibility
+- `cointracking_csv` preserved through the active bridge/output path
+
+Compatibility rule:
+
+- bridge projections remain required during the compatibility window
+- bridge projections are not authoritative for in-scope target meaning once
+  `EvidenceSet` and `ClaimSet` exist
+
+Declared compatibility-sidecar boundary:
+
+- legacy bridge-only fields such as `economic_kind`, `projection_hint`,
+  `accounting_intent_hint`, `tax_treatment_hint`, `description`,
+  `tx_hash_or_null`, `operation_group_id_or_null`, `confidence`, and `status`
+  stay outside canonical `ClaimSet`
+- `provider_operation_key` stays satisfied by
+  `ActivityClaim.provider_activity_kind` and is not duplicated as a
+  compatibility-only claim field
 
 ## Id And Fingerprint Rules
 
-Stable-id format:
+Use the stable-id and fingerprint rules from
+[Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md) unchanged.
+This slice only freezes the admissible anchors and bounded vocabularies.
 
-- use the stable-id recipe, canonical scalar forms, and anchor admissibility
-  rules owned by
-  [Target Contract Primitives](target-contract-primitives.md) and reused by
-  [Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md)
-- use the shared `evidence_set_id`, `member_id`, `observation_id`, and
-  `claim_set_id` component recipes unchanged
-- for the default slice, `selection_group_id` for Coinbase retail export
-  planning is the current deterministic planner group id `coinbase:retail_export`
-- for the default slice, `claim_emitter_id` is the reusable primitives-page id
-  over `[source, adapter_id, "bridge-claim-compiler"]`
+Slice-specific identity rules:
 
-Slice-specific component arrays:
+- `claim_emitter_id` is the shared emitter id over
+  `[source, adapter_id, "bridge-claim-compiler"]`
+- `evidence_set_id` intentionally changes when
+  `selection_plan_fingerprint` changes, because the authoritative capture-level
+  evidence emission changed
+- `member_locator_identity` for `coinbase_retail_export` is
+  `[raw_file, raw_member_ref_or_null]`
+- `member_locator_identity` for `coinbase_statement_document` is
+  `[raw_file, raw_member_ref_or_null]`
+- `observation_anchor` for `document_identity` is `["document"]`
+- `observation_anchor` for `coinbase_statement_balance_row` is `[row_anchor]`
+- `retail_member_id` means the `member_id` of the selected
+  `coinbase_retail_export` member
+- `document_member_id` means the `member_id` of the selected
+  `coinbase_statement_document` member
+- `raw_row_ref` means the stable retail-row reference preserved by the current
+  Coinbase retail bridge inputs for one selected CSV row
+- `row_anchor` means the stable statement-row anchor preserved on the
+  `coinbase_statement_balance_row` observation
 
-- `coinbase_retail_export` uses `member_class = "coinbase_retail_export"` and
-  `member_locator_identity = [raw_file, raw_member_ref_or_null]`
-- retail planner-decision observations use
-  `observation_class = "selection_decision"` and
-  `observation_anchor = [selection_status]`
-- `coinbase_statement_document` uses
-  `member_class = "coinbase_statement_document"` and
-  `member_locator_identity = [raw_file, raw_member_ref_or_null]`
-- document-identity observations use
-  `observation_class = "document_identity"` and
-  `observation_anchor = ["document"]`
-- `coinbase_statement_balance_row` is an observation class under the owning
-  `coinbase_statement_document` member, not a second member family
-- statement balance observations use
-  `observation_class = "coinbase_statement_balance_row"` and
-  `observation_anchor = [row_anchor]`
-- retail activity `claim_id` uses
-  `[claim_set_id, "ActivityClaim", raw_file, raw_row_ref, interpretation_group_id]`
-- statement-derived `claim_id` uses
-  `[claim_set_id, claim_family, document_member_id, row_anchor, interpretation_group_id]`
-- retail activity `interpretation_group_id` uses
-  `[claim_set_id, raw_file, raw_row_ref, bundle_discriminator]`
-- statement-derived `interpretation_group_id` uses
-  `[claim_set_id, document_member_id, row_anchor, bundle_discriminator]`
-- the slice-specific `claim_anchor` arrays above are admissible shared anchors
-  under [Target Contract Primitives](target-contract-primitives.md)
-- the slice-specific `bundle_anchor` arrays above are likewise admissible
-  shared anchors and do not redefine the repo-wide anchor rules
-- for the default slice, the provider operation identity for one retail
-  activity claim is the Coinbase retail row anchor `[raw_file, raw_row_ref]`
-- `document_member_id` is the `member_id` for one recognized
-  `coinbase_statement_document`
-- `row_anchor` is the stable row anchor emitted for one recognized
-  `coinbase_statement_balance_row`
-- `bundle_discriminator` follows the shared rule from
-  [Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md):
-  `default` for one bundle under one anchor, otherwise `alt:1`, `alt:2`, and
-  so on in canonical bundle order
+Slice-specific interpretation-scope anchors:
 
-Fingerprint rules:
+- retail activity scope uses `[retail_member_id, raw_row_ref]`
+- statement balance scope uses `[document_member_id, row_anchor]`
 
-- kernel fingerprints use stable UTF-8 JSON serialization with stable object
-  key order and declared array order, hashed with SHA-256
-- product fingerprints include semantically relevant upstream ids or
-  fingerprint references, not duplicated upstream payload blobs
-- manifest fingerprints are referenced as upstream inputs; they are not
-  duplicated into the emitted product kernel
-- compiled bridge fact fingerprints use the bridge replay contract owned by
-  [Current Bridge Contracts](../concepts/current-bridge-contracts.md)
-- sidecars, explanations, and reviews use separate fingerprints when persisted
-  independently
+Slice-specific claim-anchor rule:
+
+- `claim_anchor` uses `[scope_anchor, claim_family, claim_slot]`
+- `claim_slot` is `0` when only one claim of that family exists in the bundle
+- repeated same-family claims use `1`, `2`, and so on in canonical order
+
+Bundle rule:
+
+- `bundle_discriminator` is `default` when the scope has one bundle
+- alternative bundles use `alt:1`, `alt:2`, and so on in canonical bundle
+  order
 
 ## Parity Gates
 
 Unchanged evidence must preserve all of the following:
 
-- selected evidence membership
-- superseded and blocked candidate membership
-- evidence member ids and observation ids
-- claim ids and claim ordering
+- selected, superseded, and blocked evidence membership
+- `selection_group_id`, `member_id`, and `observation_id`
+- `claim_id`, `bundle_id`, and `compilation_decision_id`
+- claim ordering and bundle ordering
 - timestamps and temporal precision
 - quantities and sign
-- bridge leg shapes
-- balance reference kinds
-- compiled `TransactionFact` ordering and semantics
-- `cointracking_csv` row ordering and field values
+- compiled `TransactionFact` ordering and semantics for in-scope evidence
+- `balance_references.csv` content for in-scope evidence
+- `cointracking_csv` row ordering and field values for supported projections
 
 ## Replay Gates
 
@@ -235,13 +281,13 @@ The slice is replay-safe only when repeated runs on unchanged evidence preserve:
 
 - identical planner-selected, superseded, and blocked partitions
 - identical statement recognition outcomes
-- identical proto-`EvidenceSet` and proto-`ClaimSet` kernel fingerprints
-- identical compiled bridge fact fingerprints
+- identical `EvidenceSet` and `ClaimSet` kernel fingerprints
+- identical derived bridge-fact fingerprints for in-scope evidence
 - identical `balance_references.csv` content for in-scope evidence
 - identical `cointracking_csv` output for supported bridge facts
 
 Replay checks must also prove that incidental input ordering changes do not
-change selected evidence membership, claim order, compiled bridge facts, or
+change evidence selection, claim order, bundle order, compilation decisions, or
 rendered output.
 
 ## Allowed Drift
@@ -249,29 +295,28 @@ rendered output.
 Not allowed:
 
 - kernel-field drift in selected evidence membership
-- kernel-field drift in claim ids or order
+- kernel-field drift in ids, statuses, ordering, or bundle structure
 - timestamp or precision drift
 - quantity drift
-- leg-shape drift
-- balance-reference-kind drift
-- compiled bridge fact drift
-- `cointracking_csv` row drift
+- derived bridge-fact drift on unchanged in-scope evidence
+- `balance_references.csv` or `cointracking_csv` drift on unchanged in-scope
+  evidence
 
 Allowed only when kernel ids, statuses, and fingerprints stay unchanged:
 
 - richer explanation text
 - additional non-kernel envelope fields
-- additional sidecar detail that does not change product meaning
+- additional support sidecar detail that does not change product meaning
 
 ## Explicitly Out Of Scope
 
 This bounded slice does not:
 
 - pin the real filing workspace adapter inventory for `2023` to `2025`
-- widen beyond the Coinbase retail export family and recognized Coinbase
-  statement balance observations
-- define final `EconomicFacts`, `ReconciliationState`, `Checkpoint`,
-  `Journal`, or `TaxInputs` runtime products
-- force a repo-wide adapter-facet migration
-- authorize broad target package scaffolding before the Phase 0 contract lock
-  completes
+- widen beyond Coinbase retail exports and recognized Coinbase statement
+  balance observations
+- define runtime `EconomicFacts`, `ReconciliationState`, `Checkpoint`,
+  `Journal`, or `TaxInputs`
+- authorize broad target package scaffolding before the contract-lock pass is
+  complete
+- require a repo-wide adapter-facet migration before the bounded slice lands

--- a/docs/reference/first-slice-contract.md
+++ b/docs/reference/first-slice-contract.md
@@ -1,6 +1,6 @@
 ---
 title: "First Slice Contract"
-summary: "Bounded contract for the default Coinbase-first proto-EvidenceSet and proto-ClaimSet slice."
+summary: "Bounded contract for the default Coinbase-first proto-EvidenceSet and proto-ClaimSet increment."
 doc_type: reference
 audience: human
 owner: repo
@@ -133,7 +133,7 @@ Id rules:
 
 Fingerprint rules:
 
-- kernel fingerprints use canonical UTF-8 JSON serialization with stable object
+- kernel fingerprints use stable UTF-8 JSON serialization with stable object
   key order and declared array order, hashed with SHA-256
 - product fingerprints include semantically relevant upstream ids or
   fingerprint references, not duplicated upstream payload blobs

--- a/docs/reference/first-slice-contract.md
+++ b/docs/reference/first-slice-contract.md
@@ -36,16 +36,27 @@ The slice is not:
 
 ## Evidence Families
 
+Planner candidate inventory from `translation_input_candidates.json` remains
+`EvidenceSet` envelope or selection-sidecar reasoning as owned by
+[Bridge To Target Mapping](../concepts/bridge-to-target-mapping.md). The
+bounded slice kernel uses the selected, superseded, and blocked plan records.
+
 The slice recognizes only these evidence families:
 
 | Evidence family | Meaning | Required kernel role |
 | --- | --- | --- |
-| `coinbase_retail_export` | planner-selected Coinbase retail CSV member chosen for translation | selected, superseded, or blocked planner member |
+| `coinbase_retail_export` | Coinbase retail CSV member recorded by one selected, superseded, or blocked planner decision | selected, superseded, or blocked plan member |
 | `coinbase_statement_document` | recognized Coinbase statement PDF document used for statement-backed quantity observation | selected evidence member with document identity |
 | `coinbase_statement_balance_row` | one parsed statement quantity row from a recognized Coinbase statement document | evidence observation keyed to the owning document and row anchor |
 | `coinbase_translation_selection_group` | deterministic planner decision boundary for one retail export family selection | bounded `selection_group_id` for the slice |
 
 ## Claim Families
+
+The shared minimum claim taxonomy is owned by
+[Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md). This
+bounded slice may emit only the subset below; `OwnershipClaim`,
+`StatementClaim`, and `ContractTermClaim` remain canonical shared families but
+stay out of scope for the default slice.
 
 The first slice may emit only these claim families:
 
@@ -116,20 +127,37 @@ inventing new bridge-only schemas:
 
 ## Id And Fingerprint Rules
 
-Id rules:
+Stable-id format:
 
-- `evidence_set_id` is deterministic from `source`, `adapter_id`, `capture_uid`,
-  and one stable `selection_group_id`
-- `member_id` is deterministic from evidence provenance, member identity, and
-  the selected evidence family
-- `observation_id` is deterministic from `member_id` plus the row, page, or
-  anchor identity for the observation
-- `claim_set_id` is deterministic from `evidence_set_id` plus the claim-emitting
-  translation family for the slice
-- `claim_id` is deterministic from `claim_family`, provider-local operation or
-  row grouping identity, and `interpretation_group_id`
-- `interpretation_group_id` is deterministic from one mutually exclusive claim
-  bundle; independent bundles must not share a group id
+- use the stable-id recipe owned by
+  [Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md):
+  `<kind>:<sha256(lowercase-hex)>` over one canonical UTF-8 JSON array of
+  ordered components
+- use the shared `evidence_set_id`, `member_id`, `observation_id`, and
+  `claim_set_id` component recipes unchanged
+- for the default slice, `selection_group_id` for Coinbase retail export
+  planning is the current deterministic planner group id `coinbase:retail_export`
+
+Slice-specific component arrays:
+
+- retail activity `claim_id` uses
+  `[claim_set_id, "ActivityClaim", raw_file, raw_row_ref, interpretation_group_id]`
+- statement-derived `claim_id` uses
+  `[claim_set_id, claim_family, document_member_id, row_anchor, interpretation_group_id]`
+- retail activity `interpretation_group_id` uses
+  `[claim_set_id, raw_file, raw_row_ref, bundle_discriminator]`
+- statement-derived `interpretation_group_id` uses
+  `[claim_set_id, document_member_id, row_anchor, bundle_discriminator]`
+- for the default slice, the provider operation identity for one retail
+  activity claim is the Coinbase retail row anchor `[raw_file, raw_row_ref]`
+- `document_member_id` is the `member_id` for one recognized
+  `coinbase_statement_document`
+- `row_anchor` is the stable row anchor emitted for one recognized
+  `coinbase_statement_balance_row`
+- `bundle_discriminator` follows the shared rule from
+  [Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md):
+  `default` for one bundle under one anchor, otherwise `alt:1`, `alt:2`, and
+  so on in canonical bundle order
 
 Fingerprint rules:
 

--- a/docs/reference/first-slice-contract.md
+++ b/docs/reference/first-slice-contract.md
@@ -26,8 +26,8 @@ The default first slice is:
 - planner-enabled Coinbase retail CSV evidence selection
 - recognized Coinbase statement document selection
 - statement-backed balance-row observations under selected statement documents
-- bounded `EvidenceSet` emission for that family
-- bounded `ClaimSet` emission for that family
+- bounded `EvidenceSet` emission for that slice
+- bounded `ClaimSet` emission for that slice
 - continued compatibility with current `translation_input_plan.json`,
   `EconomicActivityDraft`, `SourceTranslationBatch`, compiled
   `TransactionFact`, `balance_references.csv`, and `cointracking_csv`
@@ -41,50 +41,50 @@ The slice is not:
 
 ## `EvidenceSet` Coverage
 
-The bounded slice may emit only these evidence member families:
+The bounded slice may emit only these evidence member kinds:
 
-| Evidence member family | Meaning |
+| Evidence member kind | Meaning |
 | --- | --- |
 | `coinbase_retail_export` | one Coinbase retail CSV member under planner-controlled selection |
 | `coinbase_statement_document` | one recognized Coinbase statement PDF document under per-document selection |
 
-The bounded slice may emit only these observation families:
+The bounded slice may emit only these observation kinds:
 
-| Observation family | Meaning | Owning member family |
+| Observation kind | Meaning | Owning member kind |
 | --- | --- | --- |
 | `document_identity` | statement document identity and recognition payload preserved under the selected document member | `coinbase_statement_document` |
 | `coinbase_statement_balance_row` | one parsed statement quantity row keyed to the owning statement document and row anchor | `coinbase_statement_document` |
 
-Frozen family-specific observation fields:
+Frozen kind-specific observation fields:
 
-| Observation family | Frozen kernel fields |
+| Observation kind | Frozen kernel fields |
 | --- | --- |
-| `document_identity` | `statement_kind`, `document_effective_at_or_null`, `document_effective_precision_or_null`, `statement_as_of_at_or_null`, `statement_as_of_precision_or_null` |
-| `coinbase_statement_balance_row` | `account_label_or_null`, `wallet_label_or_null`, `balance_kind`, `asset_symbol`, `quantity_or_null`, `observed_at_or_null`, `observed_precision_or_null`, `notes_or_null`, `staked_quantity_text_or_null`, `value_amount_text_or_null`, `value_currency_or_null`, `price_amount_text_or_null`, `price_currency_or_null` |
+| `document_identity` | `statement_kind`, `document_effective_at`, `document_effective_precision`, `statement_as_of_at`, `statement_as_of_precision` |
+| `coinbase_statement_balance_row` | `account_label`, `wallet_label`, `balance_kind`, `asset_symbol`, `quantity`, `observed_at`, `observed_precision`, `notes`, `staked_quantity_text`, `value_amount_text`, `value_currency`, `price_amount_text`, `price_currency` |
 
 Observation-field rules:
 
-- there is no retail-row observation family in this bounded pass
+- there is no retail-row observation kind in this bounded pass
 - `document_identity.statement_kind` uses the recognized statement-adapter kind
   for the selected document member
-- `document_identity.statement_as_of_at_or_null` and
-  `document_effective_at_or_null` lift the current parsed statement times, and
-  the paired `*_precision_or_null` fields follow the repo-wide temporal
+- `document_identity.statement_as_of_at` and `document_effective_at` lift the
+  current parsed statement times, and the paired `*_precision` fields follow
+  the repo-wide temporal
   precision contract
 - `coinbase_statement_balance_row` lifts account, wallet, balance kind, asset,
   quantity, as-of time, and optional note or valuation text directly from the
   current statement-row contract
-- `document_identity` may leave shell `observed_at_or_null` or
-  `observed_precision_or_null` empty when the family-specific document timing
+- `document_identity` may leave shell `observed_at` or
+  `observed_precision` empty when the kind-specific document timing
   fields carry the truthful time meaning
-- no generic observation payload blob is allowed for in-scope families
+- no generic observation payload blob is allowed for in-scope kinds
 
-The bounded slice uses only these selection-group anchors:
+The bounded slice uses only these selection keys:
 
-| `selection_group_anchor` | Meaning |
+| `selection_key` | Meaning |
 | --- | --- |
 | `["planner", "coinbase:retail_export"]` | deterministic planner decision boundary for Coinbase retail export selection |
-| `["statement_document", member_locator_identity]` | deterministic inclusion decision for one recognized statement document |
+| `["statement_document", member_locator]` | deterministic inclusion decision for one recognized statement document |
 
 `translation_input_candidates.json` remains envelope or sidecar reasoning only.
 It does not become a canonical kernel record family.
@@ -92,9 +92,9 @@ It does not become a canonical kernel record family.
 ## `ClaimSet` Coverage
 
 The bounded slice may emit only this in-scope subset of canonical claim
-families:
+kinds:
 
-| Claim family | Meaning in the slice |
+| Claim kind | Meaning in the slice |
 | --- | --- |
 | `ActivityClaim` | provider-local activity assertion derived from selected Coinbase retail rows |
 | `BalanceObservationClaim` | quantity-backed balance observation derived from recognized statement rows |
@@ -110,19 +110,19 @@ Out of scope for this slice:
 - `StatementClaim`
 - `ContractTermClaim`
 
-`ProjectionAnnotation`, `IssueCandidate`, and `ReviewCandidate` are not
-canonical claim families and are never emitted by this slice.
+Bridge or output annotation payloads and gap or review helper payloads are not
+canonical claim kinds and are never emitted by this slice.
 
-Frozen family-specific claim fields:
+Frozen kind-specific claim fields:
 
-| Claim family | Frozen kernel fields |
+| Claim kind | Frozen kernel fields |
 | --- | --- |
-| `ActivityClaim` | `provider_activity_kind`, `location_claim_ref_or_null`, `activity_leg_specs` |
-| `BalanceObservationClaim` | `location_claim_ref`, `instrument_claim_refs`, `balance_kind`, `quantity`, `observed_at_or_null`, `observed_precision_or_null` |
-| `InstrumentIdentityClaim` | `scheme`, `value`, `venue_or_null`, `kind_hint`, `display_name_or_null`, `precision_hint_or_null` |
-| `LocationClaim` | `location_ref`, `account_label_or_null`, `wallet_label_or_null` |
+| `ActivityClaim` | `provider_activity_kind`, `location_claim_ref`, `activity_leg_specs` |
+| `BalanceObservationClaim` | `location_claim_ref`, `instrument_claim_refs`, `balance_kind`, `quantity`, `observed_at`, `observed_precision` |
+| `InstrumentIdentityClaim` | `scheme`, `value`, `venue`, `kind_hint`, `display_name`, `precision_hint` |
+| `LocationClaim` | `location_ref`, `account_label`, `wallet_label` |
 | `BeneficialOwnerClaim` | `beneficial_owner_ref` |
-| `ValuationClaim` | `valuation_measure_kind`, `valuation_purpose`, `amount`, `currency`, `valued_at_or_null`, `valued_precision_or_null`, `location_claim_ref_or_null`, `instrument_claim_refs` |
+| `ValuationClaim` | `valuation_measure_kind`, `valuation_purpose`, `amount`, `currency`, `valued_at`, `valued_precision`, `location_claim_ref`, `instrument_claim_refs` |
 
 `activity_leg_specs` entry shape:
 
@@ -130,9 +130,9 @@ Frozen family-specific claim fields:
 - `leg_kind`
 - `quantity`
 - `instrument_claim_refs`
-- `location_claim_ref_or_null`
-- `subtype_or_null`
-- `attributed_to_leg_slot_or_null`
+- `location_claim_ref`
+- `subtype`
+- `attributed_to_leg_slot`
 
 Claim-field and linkage rules:
 
@@ -149,34 +149,33 @@ Claim-field and linkage rules:
   include the paired `document_identity` observation id
 - `ValuationClaim` remains zero-row by default until a later owner-doc pass
   freezes canonical numeric statement valuation inputs
-- no generic claim payload blob is allowed for in-scope families
+- no generic claim payload blob is allowed for in-scope kinds
 
 ## Kernel Cardinality And Ownership
 
 Slice cardinality rules:
 
 - one `EvidenceSet` is emitted per
-  `[source, adapter_id, capture_uid, selection_plan_fingerprint]`
-- one `SelectionDecisionRecord` exists per `selection_group_id`
+  `[source, adapter_id, capture_uid, selection_fingerprint]`
+- one `SelectionRecord` exists per `selection_id`
 - one or more `EvidenceMemberRecord` rows may belong to one
-  `selection_group_id`
+  `selection_id`
 - zero or more `EvidenceObservationRecord` rows may belong to one `member_id`
-- one `ClaimSet` is emitted per `[evidence_set_id, claim_emitter_id]`
+- one `ClaimSet` is emitted per `[evidence_set_id, claim_producer_id]`
 - one `interpretation_scope_id` exists per provider-local semantic scope
-- one or more `InterpretationBundleRecord` rows may exist per
-  `interpretation_scope_id`
-- one `CompilationDecisionRecord` exists per `interpretation_scope_id`
+- one or more `ClaimBundleRecord` rows may exist per `interpretation_scope_id`
+- one `BundleDecisionRecord` exists per `interpretation_scope_id`
 - one or more `ClaimRecord` rows may exist per `bundle_id`
 
 Ownership rules:
 
-- `SelectionDecisionRecord` owns decision basis and blocking-gap refs only
+- `SelectionRecord` owns selection basis and blocking-gap refs only
 - `EvidenceMemberRecord` owns selected, superseded, or blocked membership
-- `CompilationDecisionRecord` remains claim-owned and records bundle selection,
+- `BundleDecisionRecord` remains claim-owned and records bundle selection,
   deferral, blocking, or supersession only
 - claim-stage gaps and reviews may attach to `interpretation_scope_id` when
   no narrower truthful subject has resolved yet
-- `CompilationDecisionRecord` must not carry event payloads, leg payloads, or
+- `BundleDecisionRecord` must not carry event payloads, leg payloads, or
   other economic facts
 
 ## Bridge Compatibility Projections
@@ -220,21 +219,20 @@ Declared compatibility-sidecar boundary:
 
 Use the stable-id and fingerprint rules from
 [Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md) unchanged.
-This slice only freezes the admissible anchors and bounded vocabularies.
+This slice only freezes the admissible keys and bounded vocabularies.
 
 Slice-specific identity rules:
 
-- `claim_emitter_id` is the shared emitter id over
-  `[source, adapter_id, "bridge-claim-compiler"]`
-- `evidence_set_id` intentionally changes when
-  `selection_plan_fingerprint` changes, because the authoritative capture-level
-  evidence emission changed
-- `member_locator_identity` for `coinbase_retail_export` is
-  `[raw_file, raw_member_ref_or_null]`
-- `member_locator_identity` for `coinbase_statement_document` is
-  `[raw_file, raw_member_ref_or_null]`
-- `observation_anchor` for `document_identity` is `["document"]`
-- `observation_anchor` for `coinbase_statement_balance_row` is `[row_anchor]`
+- `claim_producer_id` is the shared producer id over
+  `[source, adapter_id, "claim-compiler"]`
+- `evidence_set_id` intentionally changes when `selection_fingerprint`
+  changes, because the authoritative capture-level evidence emission changed
+- `member_locator` for `coinbase_retail_export` is
+  `[raw_file, raw_member_ref]`
+- `member_locator` for `coinbase_statement_document` is
+  `[raw_file, raw_member_ref]`
+- `observation_key` for `document_identity` is `["document"]`
+- `observation_key` for `coinbase_statement_balance_row` is `[row_anchor]`
 - `retail_member_id` means the `member_id` of the selected
   `coinbase_retail_export` member
 - `document_member_id` means the `member_id` of the selected
@@ -244,20 +242,20 @@ Slice-specific identity rules:
 - `row_anchor` means the stable statement-row anchor preserved on the
   `coinbase_statement_balance_row` observation
 
-Slice-specific interpretation-scope anchors:
+Slice-specific interpretation-scope keys:
 
 - retail activity scope uses `[retail_member_id, raw_row_ref]`
 - statement balance scope uses `[document_member_id, row_anchor]`
 
-Slice-specific claim-anchor rule:
+Slice-specific claim-key rule:
 
-- `claim_anchor` uses `[scope_anchor, claim_family, claim_slot]`
-- `claim_slot` is `0` when only one claim of that family exists in the bundle
-- repeated same-family claims use `1`, `2`, and so on in canonical order
+- `claim_key` uses `[scope_key, claim_kind, claim_slot]`
+- `claim_slot` is `0` when only one claim of that kind exists in the bundle
+- repeated same-kind claims use `1`, `2`, and so on in canonical order
 
 Bundle rule:
 
-- `bundle_discriminator` is `default` when the scope has one bundle
+- `bundle_key` is `default` when the scope has one bundle
 - alternative bundles use `alt:1`, `alt:2`, and so on in canonical bundle
   order
 
@@ -266,8 +264,8 @@ Bundle rule:
 Unchanged evidence must preserve all of the following:
 
 - selected, superseded, and blocked evidence membership
-- `selection_group_id`, `member_id`, and `observation_id`
-- `claim_id`, `bundle_id`, and `compilation_decision_id`
+- `selection_id`, `member_id`, and `observation_id`
+- `claim_id`, `bundle_id`, and `bundle_decision_id`
 - claim ordering and bundle ordering
 - timestamps and temporal precision
 - quantities and sign
@@ -287,7 +285,7 @@ The slice is replay-safe only when repeated runs on unchanged evidence preserve:
 - identical `cointracking_csv` output for supported bridge facts
 
 Replay checks must also prove that incidental input ordering changes do not
-change evidence selection, claim order, bundle order, compilation decisions, or
+change evidence selection, claim order, bundle order, bundle decisions, or
 rendered output.
 
 ## Allowed Drift

--- a/docs/reference/first-slice-contract.md
+++ b/docs/reference/first-slice-contract.md
@@ -9,6 +9,7 @@ nav_order: 15
 related:
   - docs/concepts/bridge-to-target-mapping.md
   - docs/concepts/pipeline-stage-contracts.md
+  - docs/reference/target-contract-primitives.md
   - docs/status/adapter-delivery-plan.md
   - ROADMAP.md
 ---
@@ -34,21 +35,40 @@ The slice is not:
 - a broad unified-adapter facet rollout
 - a replacement for `EconomicFacts`, `ReconciliationState`, or `Checkpoint`
 
-## Evidence Families
+## Evidence Member Families
 
 Planner candidate inventory from `translation_input_candidates.json` remains
 `EvidenceSet` envelope or selection-sidecar reasoning as owned by
 [Bridge To Target Mapping](../concepts/bridge-to-target-mapping.md). The
 bounded slice kernel uses the selected, superseded, and blocked plan records.
 
-The slice recognizes only these evidence families:
+The slice recognizes only these evidence member families:
 
-| Evidence family | Meaning | Required kernel role |
+| Evidence member family | Meaning | Required kernel role |
 | --- | --- | --- |
 | `coinbase_retail_export` | Coinbase retail CSV member recorded by one selected, superseded, or blocked planner decision | selected, superseded, or blocked plan member |
 | `coinbase_statement_document` | recognized Coinbase statement PDF document used for statement-backed quantity observation | selected evidence member with document identity |
-| `coinbase_statement_balance_row` | one parsed statement quantity row from a recognized Coinbase statement document | evidence observation keyed to the owning document and row anchor |
-| `coinbase_translation_selection_group` | deterministic planner decision boundary for one retail export family selection | bounded `selection_group_id` for the slice |
+
+## Observation Classes
+
+The slice recognizes only these typed observation classes:
+
+| Observation class | Meaning | Owning member family |
+| --- | --- | --- |
+| `selection_decision` | deterministic selected, superseded, or blocked planner decision preserved as an evidence observation | `coinbase_retail_export` |
+| `document_identity` | recognized statement document identity preserved under the selected statement document member | `coinbase_statement_document` |
+| `coinbase_statement_balance_row` | one parsed statement quantity row keyed to the owning recognized statement document and row anchor | `coinbase_statement_document` |
+
+`coinbase_statement_balance_row` is an observation class only. It is not an
+evidence member family for this slice.
+
+## Selection Groups
+
+The slice freezes one bounded selection-group vocabulary:
+
+| `selection_group_id` | Meaning |
+| --- | --- |
+| `coinbase:retail_export` | deterministic planner decision boundary for one Coinbase retail export family selection |
 
 ## Claim Families
 
@@ -129,14 +149,16 @@ inventing new bridge-only schemas:
 
 Stable-id format:
 
-- use the stable-id recipe owned by
-  [Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md):
-  `<kind>:<sha256(lowercase-hex)>` over one canonical UTF-8 JSON array of
-  ordered components
+- use the stable-id recipe, canonical scalar forms, and anchor admissibility
+  rules owned by
+  [Target Contract Primitives](target-contract-primitives.md) and reused by
+  [Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md)
 - use the shared `evidence_set_id`, `member_id`, `observation_id`, and
   `claim_set_id` component recipes unchanged
 - for the default slice, `selection_group_id` for Coinbase retail export
   planning is the current deterministic planner group id `coinbase:retail_export`
+- for the default slice, `claim_emitter_id` is the reusable primitives-page id
+  over `[source, adapter_id, "bridge-claim-compiler"]`
 
 Slice-specific component arrays:
 
@@ -164,6 +186,10 @@ Slice-specific component arrays:
   `[claim_set_id, raw_file, raw_row_ref, bundle_discriminator]`
 - statement-derived `interpretation_group_id` uses
   `[claim_set_id, document_member_id, row_anchor, bundle_discriminator]`
+- the slice-specific `claim_anchor` arrays above are admissible shared anchors
+  under [Target Contract Primitives](target-contract-primitives.md)
+- the slice-specific `bundle_anchor` arrays above are likewise admissible
+  shared anchors and do not redefine the repo-wide anchor rules
 - for the default slice, the provider operation identity for one retail
   activity claim is the Coinbase retail row anchor `[raw_file, raw_row_ref]`
 - `document_member_id` is the `member_id` for one recognized

--- a/docs/reference/repository-history.md
+++ b/docs/reference/repository-history.md
@@ -11,9 +11,9 @@ The direct root commit and pull requests `#1` through `#30` establish the
 current public baseline for TallyLot's typed runtime, docs, templates, and
 automation.
 
-That baseline sequence preserves multi-checkpoint branches as merge commits and
-single-checkpoint branches as squash commits, so the public code history is
-available directly in Git as well as on GitHub pull request pages.
+That baseline sequence preserves branches with multiple authored commits as
+merge commits and single-commit branches as squash commits, so the public code
+history is available directly in Git as well as on GitHub pull request pages.
 
 The direct root commit records why the earlier raw `tallylot-v0` export history
 is omitted from this public graph.

--- a/docs/reference/target-contract-primitives.md
+++ b/docs/reference/target-contract-primitives.md
@@ -1,0 +1,196 @@
+---
+title: "Target Contract Primitives"
+summary: "Shared scalar forms, tuple contracts, dataset ids, and reusable id helpers for forward-looking target products."
+doc_type: reference
+audience: human
+owner: repo
+status: active
+nav_order: 17
+related:
+  - docs/concepts/pipeline-stage-contracts.md
+  - docs/concepts/domain-ontology.md
+  - docs/concepts/gaps-and-readiness.md
+  - docs/reference/target-product-artifacts.md
+  - ROADMAP.md
+---
+
+Use this page when a forward-looking target contract needs a canonical scalar,
+tuple, anchor, or reusable identity rule. This page owns those shared contract
+primitives so later implementation slices do not invent local wire shapes.
+
+## Purpose And Scope
+
+This page owns:
+
+- canonical scalar forms used by forward-looking target products
+- tuple and structured-ref contracts reused across target stages
+- anchor admissibility rules for stable ids and fingerprints
+- shared dataset identity
+- reusable id helpers such as `claim_emitter_id` and `TaxPolicyId`
+- the shared `AssertionValue` union reused by reconciliation and checkpoints
+
+This page does not re-own stage semantics. Product kernels, record families,
+and stage-owned vocabularies still belong to the existing owner pages such as
+[Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md),
+[Domain Ontology](../concepts/domain-ontology.md), and
+[Gaps And Readiness](../concepts/gaps-and-readiness.md).
+
+## Canonical Scalar Forms
+
+Use these forms anywhere a target-stage contract refers to canonical emitted
+values, stable-id components, or fingerprint inputs.
+
+- `StableIdString` uses the format `<kind>:<sha256(lowercase-hex)>`.
+- `DecimalString` uses base-10 string form only:
+  - no exponent form
+  - no `-0`
+  - strip insignificant trailing fractional zeroes
+  - keep one leading `0` before a decimal point
+  - canonical zero is `0`
+- `TimestampString` uses UTC RFC 3339 with `Z`:
+  - preserve fractional seconds only when present in the canonical runtime
+    value
+  - never serialize target-product timestamps with a non-UTC offset
+- `DateString` uses `YYYY-MM-DD`.
+- `EnumString` uses the exact lowercase token published by the owning
+  vocabulary.
+- `Null` uses JSON `null`.
+
+These forms are the canonical fingerprint inputs for every target product unless
+an owning page publishes one more specific field rule.
+
+## Canonical Tuple And Anchor Rules
+
+Stable-id component arrays and fingerprint anchors may use only:
+
+- stable-id strings
+- enum strings
+- decimal strings
+- canonical date strings
+- canonical timestamp strings
+- integers
+- `null`
+- arrays composed only of the same canonical component types
+
+Anchors must never use:
+
+- prose messages
+- filesystem paths
+- human labels
+- unordered objects or maps
+- derived counts
+- display-only formatting
+
+Slice-specific pages may define exact anchor tuples, but those tuples must stay
+within this admissibility rule.
+
+## Shared Dataset Identity
+
+`dataset_id` identifies one persisted target-product dataset.
+
+Rules:
+
+- `dataset_id` uses the format `dataset:<sha256(lowercase-hex)>`
+- the component array is `[product_slug, product_fingerprint]`
+- `dataset_id` is content-addressed and independent of filesystem location
+
+Frozen `product_slug` vocabulary:
+
+- `evidence-set`
+- `claim-set`
+- `economic-facts`
+- `reconciliation-state`
+- `checkpoint`
+- `journal`
+- `tax-inputs`
+- `tax-outputs`
+
+## Claim Compiler Identity
+
+`claim_emitter_id` identifies the shared compiler or translation family that
+emitted one `ClaimSet`.
+
+Rules:
+
+- `claim_emitter_id` uses the format `claim-emitter:<sha256(lowercase-hex)>`
+- the component array is `[source, adapter_id, emitter_slug]`
+- `emitter_slug` must be kebab-case
+- the default first-slice `emitter_slug` is `bridge-claim-compiler`
+
+## AssertionValue
+
+`AssertionValue` is the shared value union reused by reconciliation and
+checkpoints.
+
+Variants:
+
+- `QuantityValue`
+  - `quantity`
+  - `subject_ref`
+  - `instrument_ref_or_null`
+  - `location_ref_or_null`
+- `MoneyValue`
+  - `amount`
+  - `currency`
+- `OwnerValue`
+  - `legal_owner_ref_or_null`
+  - `beneficial_owner_ref_or_null`
+  - `counterparty_ref_or_null`
+- `LocationValue`
+  - `location_ref`
+
+Rules:
+
+- the union remains explicit so later implementation cannot silently collapse
+  quantity, money, ownership, and location truth into one scalar convenience
+  type
+- the canonical value fingerprint uses one stable UTF-8 JSON object keyed by
+  variant name plus the canonical variant payload
+- `CheckpointAssertionRecord.accepted_value` uses this union
+- `BalanceTargetRecord.expected_value` uses this union
+- `BalanceTargetRecord.observed_value_or_null` uses this union
+
+## Journal Reference Types
+
+`AccountRef` identifies one accounting account.
+
+Rules:
+
+- `AccountRef` serializes and sorts as `[chart_id, account_code]`
+
+`CommodityRef` identifies one posting commodity.
+
+Rules:
+
+- `CommodityRef` serializes and sorts as `[commodity_kind, commodity_id]`
+
+Frozen `commodity_kind` vocabulary:
+
+- `instrument`
+- `currency`
+- `synthetic_unit`
+
+`OriginRef` identifies the immediate kernel origin for one posting.
+
+Rules:
+
+- `OriginRef` serializes and sorts as `[origin_kind, origin_id]`
+- `origin_kind` identifies the immediate accounting origin, not a human-facing
+  provider, source, or renderer label
+
+Frozen `origin_kind` vocabulary:
+
+- `economic_leg`
+- `checkpoint_assertion`
+- `adjustment_basis`
+
+## Tax Policy Identity
+
+`TaxPolicyId` identifies one selected tax policy.
+
+Rules:
+
+- `TaxPolicyId` uses the format `tax-policy:<sha256(lowercase-hex)>`
+- the component array is `[jurisdiction_or_regime, policy_slug, policy_version]`
+- `policy_slug` must be kebab-case
+- forward-looking target tax-stage docs use `tax_policy_id` for this contract

--- a/docs/reference/target-contract-primitives.md
+++ b/docs/reference/target-contract-primitives.md
@@ -32,18 +32,18 @@ Use the owner pages first:
 This page keeps only reusable helper ids and tuples that are not primary owner
 concepts elsewhere.
 
-## Claim Emitter Identity
+## Claim Producer Identity
 
-`claim_emitter_id` identifies the shared compiler or translation family that
-emitted one `ClaimSet`.
+`claim_producer_id` identifies the shared compiler or translation family that
+produced one `ClaimSet`.
 
 Rules:
 
-- `claim_emitter_id` uses the stable-id format owned by
+- `claim_producer_id` uses the stable-id format owned by
   [Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md)
-- the component array is `[source, adapter_id, emitter_slug]`
-- `emitter_slug` must be kebab-case
-- the default first-slice `emitter_slug` is `bridge-claim-compiler`
+- the component array is `[source, adapter_id, producer_slug]`
+- `producer_slug` must be kebab-case
+- the default first-slice `producer_slug` is `claim-compiler`
 
 ## Valuation Source Identity
 

--- a/docs/reference/target-contract-primitives.md
+++ b/docs/reference/target-contract-primitives.md
@@ -1,6 +1,6 @@
 ---
 title: "Target Contract Primitives"
-summary: "Shared scalar forms, tuple contracts, dataset ids, and reusable id helpers for forward-looking target products."
+summary: "Helper reference for reusable ids and tuples that complement the owner pages without redefining target product contracts."
 doc_type: reference
 audience: human
 owner: repo
@@ -10,147 +10,57 @@ related:
   - docs/concepts/pipeline-stage-contracts.md
   - docs/concepts/domain-ontology.md
   - docs/concepts/gaps-and-readiness.md
-  - docs/reference/target-product-artifacts.md
   - ROADMAP.md
 ---
 
-Use this page when a forward-looking target contract needs a canonical scalar,
-tuple, anchor, or reusable identity rule. This page owns those shared contract
-primitives so later implementation slices do not invent local wire shapes.
+Use this page as a helper reference when a target-stage implementation needs a
+reusable id helper or tuple that is not itself a stage contract. Owner pages
+take precedence.
 
-## Purpose And Scope
+## Precedence
 
-This page owns:
+Use the owner pages first:
 
-- canonical scalar forms used by forward-looking target products
-- tuple and structured-ref contracts reused across target stages
-- anchor admissibility rules for stable ids and fingerprints
-- shared dataset identity
-- reusable id helpers such as `claim_emitter_id` and `TaxPolicyId`
-- the shared `AssertionValue` union reused by reconciliation and checkpoints
+- [Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md) for
+  stable-id format, target product ids, upstream product refs, target product
+  kernels, and shared status vocabularies
+- [Domain Ontology](../concepts/domain-ontology.md) for `AssertionValue`,
+  `PositionRef`, `ContractRef`, `BasisPoolRef`, and other domain ref seams
+- [Gaps And Readiness](../concepts/gaps-and-readiness.md) for `SubjectRef`,
+  shared support attachments, and `dataset_id`
 
-This page does not re-own stage semantics. Product kernels, record families,
-and stage-owned vocabularies still belong to the existing owner pages such as
-[Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md),
-[Domain Ontology](../concepts/domain-ontology.md), and
-[Gaps And Readiness](../concepts/gaps-and-readiness.md).
+This page keeps only reusable helper ids and tuples that are not primary owner
+concepts elsewhere.
 
-## Canonical Scalar Forms
-
-Use these forms anywhere a target-stage contract refers to canonical emitted
-values, stable-id components, or fingerprint inputs.
-
-- `StableIdString` uses the format `<kind>:<sha256(lowercase-hex)>`.
-- `DecimalString` uses base-10 string form only:
-  - no exponent form
-  - no `-0`
-  - strip insignificant trailing fractional zeroes
-  - keep one leading `0` before a decimal point
-  - canonical zero is `0`
-- `TimestampString` uses UTC RFC 3339 with `Z`:
-  - preserve fractional seconds only when present in the canonical runtime
-    value
-  - never serialize target-product timestamps with a non-UTC offset
-- `DateString` uses `YYYY-MM-DD`.
-- `EnumString` uses the exact lowercase token published by the owning
-  vocabulary.
-- `Null` uses JSON `null`.
-
-These forms are the canonical fingerprint inputs for every target product unless
-an owning page publishes one more specific field rule.
-
-## Canonical Tuple And Anchor Rules
-
-Stable-id component arrays and fingerprint anchors may use only:
-
-- stable-id strings
-- enum strings
-- decimal strings
-- canonical date strings
-- canonical timestamp strings
-- integers
-- `null`
-- arrays composed only of the same canonical component types
-
-Anchors must never use:
-
-- prose messages
-- filesystem paths
-- human labels
-- unordered objects or maps
-- derived counts
-- display-only formatting
-
-Slice-specific pages may define exact anchor tuples, but those tuples must stay
-within this admissibility rule.
-
-## Shared Dataset Identity
-
-`dataset_id` identifies one persisted target-product dataset.
-
-Rules:
-
-- `dataset_id` uses the format `dataset:<sha256(lowercase-hex)>`
-- the component array is `[product_slug, product_fingerprint]`
-- `dataset_id` is content-addressed and independent of filesystem location
-
-Frozen `product_slug` vocabulary:
-
-- `evidence-set`
-- `claim-set`
-- `economic-facts`
-- `reconciliation-state`
-- `checkpoint`
-- `journal`
-- `tax-inputs`
-- `tax-outputs`
-
-## Claim Compiler Identity
+## Claim Emitter Identity
 
 `claim_emitter_id` identifies the shared compiler or translation family that
 emitted one `ClaimSet`.
 
 Rules:
 
-- `claim_emitter_id` uses the format `claim-emitter:<sha256(lowercase-hex)>`
+- `claim_emitter_id` uses the stable-id format owned by
+  [Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md)
 - the component array is `[source, adapter_id, emitter_slug]`
 - `emitter_slug` must be kebab-case
 - the default first-slice `emitter_slug` is `bridge-claim-compiler`
 
-## AssertionValue
+## Valuation Source Identity
 
-`AssertionValue` is the shared value union reused by reconciliation and
-checkpoints.
-
-Variants:
-
-- `QuantityValue`
-  - `quantity`
-  - `subject_ref`
-  - `instrument_ref_or_null`
-  - `location_ref_or_null`
-- `MoneyValue`
-  - `amount`
-  - `currency`
-- `OwnerValue`
-  - `legal_owner_ref_or_null`
-  - `beneficial_owner_ref_or_null`
-  - `counterparty_ref_or_null`
-- `LocationValue`
-  - `location_ref`
+`ValuationSourceRef` identifies the immediate source that justified one
+`ValuationRecord`.
 
 Rules:
 
-- the union remains explicit so later implementation cannot silently collapse
-  quantity, money, ownership, and location truth into one scalar convenience
-  type
-- the canonical value fingerprint uses one stable UTF-8 JSON object keyed by
-  variant name plus the canonical variant payload
-- `CheckpointAssertionRecord.accepted_value` uses this union
-- `BalanceTargetRecord.expected_value` uses this union
-- `BalanceTargetRecord.observed_value_or_null` uses this union
+- `ValuationSourceRef` serializes and sorts as `[source_kind, source_id]`
+- `source_kind` names the immediate valuation source surface, such as
+  `claim`, `evidence_observation`, or `market_reference`
+- when the source is already a target-kernel subject, `source_id` uses that
+  subject's stable id
+- when the source is an external market reference, `source_id` uses the
+  stage-owned stable market anchor rather than renderer-local prose
 
-## Journal Reference Types
+## Accounting Reference Tuples
 
 `AccountRef` identifies one accounting account.
 
@@ -175,8 +85,9 @@ Frozen `commodity_kind` vocabulary:
 Rules:
 
 - `OriginRef` serializes and sorts as `[origin_kind, origin_id]`
-- `origin_kind` identifies the immediate accounting origin, not a human-facing
-  provider, source, or renderer label
+- `origin_kind` identifies the immediate accounting origin, not a provider or
+  renderer label
+- `PostingRecord.origin_ref` uses `OriginRef`
 
 Frozen `origin_kind` vocabulary:
 
@@ -190,7 +101,13 @@ Frozen `origin_kind` vocabulary:
 
 Rules:
 
-- `TaxPolicyId` uses the format `tax-policy:<sha256(lowercase-hex)>`
+- `TaxPolicyId` uses the stable-id format owned by
+  [Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md)
 - the component array is `[jurisdiction_or_regime, policy_slug, policy_version]`
 - `policy_slug` must be kebab-case
-- forward-looking target tax-stage docs use `tax_policy_id` for this contract
+
+## Reminder
+
+Do not implement target product ids, upstream product refs, `dataset_id`,
+`AssertionValue`, `SubjectRef`, or target product kernel structure from this
+page. Those contracts live on their owner pages.

--- a/docs/reference/target-product-artifacts.md
+++ b/docs/reference/target-product-artifacts.md
@@ -1,148 +1,49 @@
 ---
 title: "Target Product Artifacts"
-summary: "Forward-looking dataset packaging, kernel filenames, and persistence layout for target pipeline products."
+summary: "Helper reference that points to the owner pages for target persistence, partitions, and bounded slice artifact expectations."
 doc_type: reference
 audience: human
 owner: repo
 status: active
 nav_order: 18
 related:
-  - docs/reference/target-contract-primitives.md
   - docs/concepts/pipeline-stage-contracts.md
-  - docs/concepts/workspace-model.md
-  - docs/status/migration-sequence.md
+  - docs/concepts/reconciliation-tax-architecture.md
+  - docs/reference/first-slice-contract.md
+  - docs/reference/first-downstream-slice-contract.md
   - ROADMAP.md
 ---
 
-Use this page when a forward-looking target product needs a persisted dataset
-layout, kernel filename, or sidecar location. This page owns the target product
-artifact contract only.
+Use this page as a routing reference when you need target artifact guidance.
+It does not define a second artifact contract.
 
-## Purpose And Current-State Note
+## Precedence
 
-This page defines the target product artifact contract for forward-looking
-pipeline datasets.
+Use these pages as the authoritative sources:
 
-Rules:
+- [Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md) for
+  target product kernels, record families, ids, and fingerprints
+- [Reconciliation And Tax Architecture](../concepts/reconciliation-tax-architecture.md)
+  for persistence model, partition scopes, default filesystem placement,
+  sidecars, replace semantics, caches, and indexes
+- [First Slice Contract](first-slice-contract.md) and
+  [First Downstream Slice Contract](first-downstream-slice-contract.md) for
+  bounded-slice artifact and compatibility expectations
 
-- this page does not claim these datasets are already live runtime truth
-- current bridge artifacts remain under `working/normalized/...` until later
-  implementation slices replace them
-- target product identity comes from ids and fingerprints, not from artifact
-  paths
+## Artifact Rules
 
-## Default Workspace Root
+When persisting target products:
 
-The forward-looking default target dataset root is:
+- persist one authoritative kernel per declared scope partition
+- keep product ids in kernel metadata and keep those product ids distinct from
+  `dataset_id`
+- keep bridge CSVs and bridge bundles as compatibility projections only once a
+  target product is authoritative for that scope
+- keep provenance, explanations, reviews, comparison traces, and other
+  non-kernel detail in sidecars
+- treat caches and indexes as regenerable accelerators, not as business truth
 
-- `working/pipeline/<product-slug>/<dataset_id>/`
+## Reminder
 
-Rules:
-
-- the path is not part of dataset identity
-- interfaces and application services may still support explicit output roots
-- dataset identity always comes from stable ids and fingerprints, not from a
-  chosen output directory
-
-## Dataset Directory Layout
-
-Every persisted target dataset uses this layout:
-
-- `dataset.json`
-- `kernel/`
-- `envelopes/`
-- `sidecars/`
-
-Rules:
-
-- only `kernel/` participates in product fingerprints unless an owning page says
-  otherwise
-- `envelopes/` and `sidecars/` are referenceable but excluded from kernel
-  fingerprints by default
-- kernel records are the replay and reducer authority; envelopes and sidecars
-  add explanation, provenance, and stage-local comparison detail
-
-## `dataset.json` Contract
-
-Required fields:
-
-- `product`
-- `product_slug`
-- `dataset_id`
-- `schema_version`
-- `product_fingerprint`
-- `upstream_dataset_ids`
-- `generated_at`
-- `kernel_files`
-- `envelope_files`
-- `sidecar_files`
-
-Optional fields:
-
-- `product_metadata`
-
-Rules:
-
-- `product_metadata` is only for product-scoped inputs used in id recipes but
-  not repeated in every row
-- the initial allowed example is `ClaimSet` storing `claim_emitter_id` in
-  `product_metadata`
-
-## Kernel File Naming
-
-Freeze these kernel filenames:
-
-- `EvidenceSet`
-  - `kernel/evidence-records.json`
-- `ClaimSet`
-  - `kernel/claim-records.json`
-  - `kernel/compilation-decision-records.json`
-- `EconomicFacts`
-  - `kernel/economic-event-records.json`
-  - `kernel/economic-leg-records.json`
-  - `kernel/valuation-records.json`
-- `ReconciliationState`
-  - `kernel/continuity-segment-records.json`
-  - `kernel/link-records.json`
-  - `kernel/balance-target-records.json`
-  - `kernel/checkpoint-candidate-records.json`
-- `Checkpoint`
-  - `kernel/checkpoint-records.json`
-  - `kernel/checkpoint-assertion-records.json`
-- `Journal`
-  - `kernel/journal-entry-records.json`
-  - `kernel/posting-records.json`
-  - `kernel/validation-records.json`
-- `TaxInputs`
-  - `kernel/tax-determinant-records.json`
-  - `kernel/basis-transition-records.json`
-- `TaxOutputs`
-  - `kernel/tax-output-records.json`
-  - `kernel/carry-forward-records.json`
-  - `kernel/unsupported-item-records.json`
-
-## Sidecar And Envelope Rules
-
-Freeze these shared sidecar filenames:
-
-- `sidecars/gaps.json`
-- `sidecars/readiness.json`
-- `sidecars/reviews.json`
-
-Rules:
-
-- `reviews.json` is stage-local payload, not a shared cross-stage kernel
-- richer provenance, explanations, and comparison detail live under
-  `envelopes/` keyed by stable ids
-- sidecars may be added only when they do not replace kernel business meaning
-
-## Immutability And Discovery
-
-Rules:
-
-- dataset directories are immutable once written because `dataset_id` is
-  content-addressed
-- “latest” pointers, working indexes, and workflow discovery helpers are
-  interface or application concerns, not product-contract fields
-- downstream stages consume upstream dataset ids and record ids, not filesystem
-  walks over sibling directories
+Do not implement target persistence from this page alone. The authoritative
+placement, product-id, and storage rules live on the owner pages listed above.

--- a/docs/reference/target-product-artifacts.md
+++ b/docs/reference/target-product-artifacts.md
@@ -1,0 +1,148 @@
+---
+title: "Target Product Artifacts"
+summary: "Forward-looking dataset packaging, kernel filenames, and persistence layout for target pipeline products."
+doc_type: reference
+audience: human
+owner: repo
+status: active
+nav_order: 18
+related:
+  - docs/reference/target-contract-primitives.md
+  - docs/concepts/pipeline-stage-contracts.md
+  - docs/concepts/workspace-model.md
+  - docs/status/migration-sequence.md
+  - ROADMAP.md
+---
+
+Use this page when a forward-looking target product needs a persisted dataset
+layout, kernel filename, or sidecar location. This page owns the target product
+artifact contract only.
+
+## Purpose And Current-State Note
+
+This page defines the target product artifact contract for forward-looking
+pipeline datasets.
+
+Rules:
+
+- this page does not claim these datasets are already live runtime truth
+- current bridge artifacts remain under `working/normalized/...` until later
+  implementation slices replace them
+- target product identity comes from ids and fingerprints, not from artifact
+  paths
+
+## Default Workspace Root
+
+The forward-looking default target dataset root is:
+
+- `working/pipeline/<product-slug>/<dataset_id>/`
+
+Rules:
+
+- the path is not part of dataset identity
+- interfaces and application services may still support explicit output roots
+- dataset identity always comes from stable ids and fingerprints, not from a
+  chosen output directory
+
+## Dataset Directory Layout
+
+Every persisted target dataset uses this layout:
+
+- `dataset.json`
+- `kernel/`
+- `envelopes/`
+- `sidecars/`
+
+Rules:
+
+- only `kernel/` participates in product fingerprints unless an owning page says
+  otherwise
+- `envelopes/` and `sidecars/` are referenceable but excluded from kernel
+  fingerprints by default
+- kernel records are the replay and reducer authority; envelopes and sidecars
+  add explanation, provenance, and stage-local comparison detail
+
+## `dataset.json` Contract
+
+Required fields:
+
+- `product`
+- `product_slug`
+- `dataset_id`
+- `schema_version`
+- `product_fingerprint`
+- `upstream_dataset_ids`
+- `generated_at`
+- `kernel_files`
+- `envelope_files`
+- `sidecar_files`
+
+Optional fields:
+
+- `product_metadata`
+
+Rules:
+
+- `product_metadata` is only for product-scoped inputs used in id recipes but
+  not repeated in every row
+- the initial allowed example is `ClaimSet` storing `claim_emitter_id` in
+  `product_metadata`
+
+## Kernel File Naming
+
+Freeze these kernel filenames:
+
+- `EvidenceSet`
+  - `kernel/evidence-records.json`
+- `ClaimSet`
+  - `kernel/claim-records.json`
+  - `kernel/compilation-decision-records.json`
+- `EconomicFacts`
+  - `kernel/economic-event-records.json`
+  - `kernel/economic-leg-records.json`
+  - `kernel/valuation-records.json`
+- `ReconciliationState`
+  - `kernel/continuity-segment-records.json`
+  - `kernel/link-records.json`
+  - `kernel/balance-target-records.json`
+  - `kernel/checkpoint-candidate-records.json`
+- `Checkpoint`
+  - `kernel/checkpoint-records.json`
+  - `kernel/checkpoint-assertion-records.json`
+- `Journal`
+  - `kernel/journal-entry-records.json`
+  - `kernel/posting-records.json`
+  - `kernel/validation-records.json`
+- `TaxInputs`
+  - `kernel/tax-determinant-records.json`
+  - `kernel/basis-transition-records.json`
+- `TaxOutputs`
+  - `kernel/tax-output-records.json`
+  - `kernel/carry-forward-records.json`
+  - `kernel/unsupported-item-records.json`
+
+## Sidecar And Envelope Rules
+
+Freeze these shared sidecar filenames:
+
+- `sidecars/gaps.json`
+- `sidecars/readiness.json`
+- `sidecars/reviews.json`
+
+Rules:
+
+- `reviews.json` is stage-local payload, not a shared cross-stage kernel
+- richer provenance, explanations, and comparison detail live under
+  `envelopes/` keyed by stable ids
+- sidecars may be added only when they do not replace kernel business meaning
+
+## Immutability And Discovery
+
+Rules:
+
+- dataset directories are immutable once written because `dataset_id` is
+  content-addressed
+- “latest” pointers, working indexes, and workflow discovery helpers are
+  interface or application concerns, not product-contract fields
+- downstream stages consume upstream dataset ids and record ids, not filesystem
+  walks over sibling directories

--- a/docs/standards/commits.md
+++ b/docs/standards/commits.md
@@ -1,6 +1,6 @@
 ---
 title: "Commit Standards"
-summary: "Conventional Commit, checkpoint, and PR body rules for stable repo history."
+summary: "Conventional Commit subjects, reviewable commit boundaries, and PR body rules for stable repo history."
 doc_type: standard
 audience: human
 owner: repo
@@ -9,8 +9,8 @@ nav_order: 30
 ---
 
 Use Conventional Commits for all authored commits. Keep commit history small,
-cohesive, and checkpoint-oriented. Every authored commit must stay bounded to
-one reviewable slice. When a task spans more than one separable slice, land it
+cohesive, and reviewable. Every authored commit must stay bounded to one
+reviewable change. When a task spans more than one separable change, land it
 as multiple bounded checkpoint commits instead of one umbrella commit.
 
 Use Conventional Commit subjects and the structured body sections for merge
@@ -44,7 +44,7 @@ Subject rules:
 - lowercase type
 - required lowercase kebab-case scope
 - non-empty imperative summary
-- summary names a concrete repo surface or behavior
+- summary names a concrete repo area or behavior
 - maximum 72 characters for the full subject line
 - no trailing period
 - do not use generic summaries such as `cleanup`, `misc fixes`, or
@@ -108,14 +108,14 @@ Standard footers are allowed, including `BREAKING CHANGE:`.
 
 ## Pull Request Merge Strategy Standard
 
-`main` is a merge-commit branch by default. Preserve multi-checkpoint pull
-requests with merge commits so the reviewed checkpoint history remains visible
-in Git. Use squash merges only for the narrow single-checkpoint exception.
+`main` is a merge-commit branch by default. Preserve pull requests with
+multiple authored commits as merge commits so the reviewed commit history
+remains visible in Git. Use squash merges only for the narrow single-commit
+exception.
 
-Treat the pull request title and description as the review record that governs
-merge and mainline history for every PR. For the single-checkpoint exception,
-that same metadata also becomes the generated squash commit that lands on
-`main`.
+Treat the pull request title and description as the primary review record
+for every PR. For the single-commit exception, that same metadata also
+becomes the generated squash commit that lands on `main`.
 
 Protected-branch rule:
 
@@ -123,7 +123,7 @@ Protected-branch rule:
 - do not push directly to `main`
 - do not use branch-protection bypass or force-push for normal delivery
 - do not rewrite a merged `main` commit when the original pull request must
-  remain attached to the landing commit; open a new pull request repair instead
+  remain attached to the merged commit; open a new pull request repair instead
 - if a protected-branch repair exception is explicitly requested, limit that
   exception to the exact repair action, verify the remote branch tip
   immediately afterward, and restore PR-only flow before continuing
@@ -132,7 +132,7 @@ PR title rules:
 
 - use the same Conventional Commit subject format required for authored commits
 - keep the title history-ready on its own because it remains the PR headline
-  and, for a single-checkpoint PR, the squash subject becomes
+  and, for a single-commit PR, the squash subject becomes
   `<pr title> (#<pr number>)`
 - do not use generic titles such as `update branch`, `cleanup`, or `misc fixes`
 
@@ -166,7 +166,7 @@ PR body rules:
   from the active PR
 - keep authored commit messages on `Why:`, `What:`, and `Checks:` without
   issue-closing keywords unless the user explicitly requests otherwise
-- for a one-commit PR, still list that single checkpoint under
+- for a one-commit PR, still list that single commit under
   `Included checkpoints:`
 
 Merge method rules:
@@ -174,23 +174,23 @@ Merge method rules:
 - if `Included checkpoints:` lists more than one commit, the PR must merge with
   a merge commit
 - if `Included checkpoints:` lists exactly one commit, the PR must squash merge
-- do not squash multi-checkpoint PRs
-- do not create a merge commit for a single-checkpoint PR unless the user
+- do not squash PRs with multiple authored commits
+- do not create a merge commit for a single-commit PR unless the user
   explicitly requests a one-off repair in the current thread
-- when merging a multi-checkpoint PR, override GitHub's default merge subject
+- when merging a PR with multiple authored commits, override GitHub's default merge subject
   with a deterministic subject that keeps the PR number visible instead of
-  landing `Merge pull request ...`
+  producing `Merge pull request ...`
 - for a merge commit, use `<pr title> (#<pr number>)` as the merge subject and
   keep the merge body in the same `Why:`, `What:`, `Checks:`,
   `Included checkpoints:` format as the PR body so the mainline commit record
   matches the reviewed PR record
 - if a repair PR supersedes an older pull request, add the repo's neutral
   duplicate/superseded label to the older PR as the primary marker before
-  closing the repair loop
+  closing the older PR
 - use a neutral comment on the older PR only when the repo has no suitable
   label or the user explicitly asks for explanatory prose
 
-For a single-checkpoint PR, the GitHub-generated squash commit on `main` may
+For a single-commit PR, the GitHub-generated squash commit on `main` may
 retain the validated `Included checkpoints:` and `Follow-ups:` sections from
 the PR body. Treat that as allowed for the generated mainline commit record,
 even though authored checkpoint commits should only use `Why:`, `What:`, and
@@ -227,8 +227,8 @@ working agreement, not optional guidance to ignore once a change is stable.
 
 A stable checkpoint means:
 
-- the commit covers one bounded reviewable slice
-- the change slice is coherent and reviewable
+- the commit covers one bounded reviewable change
+- the change is coherent and reviewable
 - the tree is internally consistent
 - relevant checks have passed
 - the commit has actually been created before the task is closed
@@ -239,10 +239,10 @@ Heuristics:
 - medium multi-part task: usually 1 to 3 commits by concern
 - larger risky refactor: split only where rollback or review value is real
 - broad but separable docs or repo-structure refactor: checkpoint each stable
-  slice instead of batching everything into one umbrella commit
+  change instead of batching everything into one umbrella commit
 
 For large scopes, the default end state is still bounded commits. Do not wait
-until the end of the branch and then collapse several reviewable slices into
+until the end of the branch and then collapse several reviewable changes into
 one authored commit just because the broader task was related.
 
 Do not batch unrelated fixes together. Do not split one bounded change into a
@@ -256,7 +256,7 @@ or fixup-based consolidation for that limited cleanup only, and update the
 amended commit message so `Why:`, `What:`, and `Checks:` remain accurate for
 the final commit content. Do not use repeated amend cycles to grow one broad
 commit that should be split into separate stable checkpoints.
-For multi-slice refactors, use designated checkpoint commits whenever the slice
+For multi-part refactors, use designated checkpoint commits whenever the change
 already leaves the tree coherent, linked, and narrow-check verified. A giant
 single-commit rewrite is only acceptable when the change cannot be reviewed or
 validated incrementally.
@@ -302,7 +302,7 @@ In practice that means:
 - control-plane or workflow changes run the targeted guard tests selected by
   the planner
 - production-code changes may still escalate to the broader Python quality
-  suite when the planner marks that surface as relevant
+  suite when the planner marks that change area as relevant
 - commit-message validation stays in the separate `commit-msg` hook
 
 Standard final verification still means running:
@@ -326,7 +326,7 @@ make pr-review-full
 
 Use `tools.run_quality_gates` as the default final local
 verification command. Use `tools.run_pr_review_checks --mode full` when
-changing CI, packaging, release, or other workflow surfaces where the local
+changing CI, packaging, release, or other workflow areas where the local
 verification pass should mirror the final non-draft PR suite before handoff.
 Add `--pr-title`
 plus `--pr-body-file` when you also want the full review run to validate the
@@ -350,8 +350,8 @@ make tool TOOL=run_pr_review_checks ARGS='--mode full --pr-title "$$(cat /tmp/pr
 
 `pylint`, full-repo `ruff`, and the full `pytest` suite still belong primarily
 to the shared quality and PR-review runners. The commit-time hook should stay
-change-sensitive so docs-only and similarly narrow slices do not rerun
-irrelevant Python scanners, even though some staged code or workflow surfaces
+change-sensitive so docs-only and similarly narrow changes do not rerun
+irrelevant Python scanners, even though some staged code or workflow areas
 may still escalate to broader checks.
 
 Do not describe `mypy` or `pyright` as covering `pylint` findings. Type checks

--- a/docs/standards/commits.md
+++ b/docs/standards/commits.md
@@ -112,9 +112,10 @@ Standard footers are allowed, including `BREAKING CHANGE:`.
 requests with merge commits so the reviewed checkpoint history remains visible
 in Git. Use squash merges only for the narrow single-checkpoint exception.
 
-Treat the pull request title and description as the canonical review record
-for every PR. For the single-checkpoint exception, that same metadata also
-becomes the generated squash commit that lands on `main`.
+Treat the pull request title and description as the review record that governs
+merge and mainline history for every PR. For the single-checkpoint exception,
+that same metadata also becomes the generated squash commit that lands on
+`main`.
 
 Protected-branch rule:
 

--- a/docs/standards/delivery-guardrails.md
+++ b/docs/standards/delivery-guardrails.md
@@ -8,7 +8,7 @@ status: active
 nav_order: 40
 ---
 
-Use this document when delivery safety, branch protection, PR landing, merge
+Use this document when delivery safety, branch protection, PR merge behavior, merge
 metadata, or agent-default Git behavior is part of the task.
 
 This standard exists to prevent a repeat of failures where policy was known in
@@ -19,9 +19,9 @@ structure, authoring rules, and baseline context from `AGENTS.md`,
 `docs/README.md`, `docs/status/current-state.md`,
 `docs/reference/repository-history.md`, `tools/docs_maintenance/cli.py`, and
 `tools/docs_maintenance/metadata.py` so new material lands in the right repo
-surface and follows the repo's documentation metadata rules.
-Use the repo-local workflow for the active surface on that reload path and pair
-it with the `markdown` skill when the task edits Markdown or docs surfaces.
+area and follows the repo's documentation metadata rules.
+Use the repo-local workflow for the active area on that reload path and pair
+it with the `markdown` skill when the task edits Markdown or docs files.
 When the task changes GitHub-side delivery controls, run
 `make audit-delivery-guardrails`
 before and after the change so the local CODEOWNERS state and the live remote
@@ -42,19 +42,19 @@ when the higher-layer control is available.
 
 ## Default Delivery Posture
 
-- protected branches are PR-only landing surfaces
+- protected branches are PR-only branches
 - pull requests open as draft by default
 - a PR becomes ready for review only after the full issue-finding hardening
   loop yields no new meaningful findings
 - direct pushes to `main` are forbidden except for an explicit one-time repair
   requested in the current thread
 - a merged `main` commit must not be rewritten when the original PR record
-  needs to remain attached to the landing commit
+  needs to remain attached to the merged commit
 - multi-checkpoint PRs land with a merge commit using
   `<pr title> (#<pr number>)`
 - single-checkpoint PRs land with squash merge
 - replaced PRs use the repo's neutral duplicate or superseded label as the
-  primary closeout marker
+  primary closure marker
 - comments on replaced PRs are fallback-only, not the default
 - PRs are never closed autonomously without explicit user instruction
 
@@ -65,7 +65,7 @@ when the higher-layer control is available.
 Prefer GitHub controls that reject bad actions before they land:
 
 - rulesets or branch protection that require pull requests
-- required status checks pinned to their owning app, not only named by context
+- required status checks pinned to their responsible app, not only named by context
 - required reviews
 - blocked force pushes on protected branches
 - stale-review dismissal or last-push review requirements when the repo wants
@@ -111,9 +111,9 @@ Control-plane files include:
 
 Current-state note:
 
-- these `repo_support/**` paths are current live control-plane surfaces today
+- these `repo_support/**` paths are current live control-plane files today
 - later implementation may rename that dev-only shared support boundary under
-  `dev_support/`, but until that slice lands the current live paths remain the
+  `dev_support/`, but until that change lands the current live paths remain the
   enforcement truth
 
 If a repo policy depends on a platform-native control that is not enabled, call
@@ -137,7 +137,7 @@ machine-checkable guard instead of only adding more prose.
 
 ### 3. Repo Standards And Checklists
 
-Use standards docs and checkpoint routes to explain:
+Use standards docs and implementation routes to explain:
 
 - why the rule exists
 - what exact behavior is required
@@ -149,7 +149,7 @@ Standards work itself must verify whether a rule belongs in human docs, agent
 routing, or repo-native automation before adding a new document or route.
 
 PR review is a repeatable procedure, not an improvised pass. Review starts from
-the changed surface groups in the current PR diff:
+the changed file groups in the current PR diff:
 
 - `human_docs`
   - paths: `README.md`, `CHANGELOG.md`, and `docs/**` except
@@ -173,13 +173,13 @@ the changed surface groups in the current PR diff:
     terminology, documentation and control-plane alignment
 - `ci_or_release`
   - paths: `.github/actions/**`, `.github/workflows/**`, and the repo's
-    delivery planner, workflow helpers, and workflow-sensitive config surfaces
+    delivery planner, workflow helpers, and workflow-sensitive config files
   - review domains: workflow correctness, delivery enforcement, metadata parity
 
 Verification selection is deterministic and atomic:
 
-- review domains are the union across every applicable surface group
-- `tools.audit_pr_review` reports changed paths, grouped surfaces, review
+- review domains are the union across every applicable file group
+- `tools.audit_pr_review` reports changed paths, grouped file groups, review
   domains, the selected verification mode, selected checks, suppressed checks,
   and any unmapped paths
 - pull-request CI is draft-aware:
@@ -201,8 +201,8 @@ Verification selection is deterministic and atomic:
 
 Each PR review pass should:
 
-- re-check prior fix surfaces first
-- use `tools.audit_pr_review` to confirm the applicable surface groups, review
+- re-check prior fixes first
+- use `tools.audit_pr_review` to confirm the applicable file groups, review
   domains, required verification family, and any unmapped paths before deciding
   the current pass found no new meaningful findings
 - treat passing `tools.run_pr_review_checks` or broader verification as review
@@ -210,23 +210,23 @@ Each PR review pass should:
   loop or decides the pass outcome
 - describe each upcoming pass as issue-finding with open outcome; do not
   pre-label the next pass as clean, final, or publish-ready
-- red-team one adjacent applicable surface group and look for up to 5 new
-  unique evidence-backed findings for the current pass
+- review one adjacent applicable file group and look for up to 5 new unique
+  evidence-backed findings for the current pass
 - repair every finding from that pass before starting the next pass
-- reload the narrow repo guidance needed for each repair surface before editing:
+- reload the narrow repo guidance needed for each repaired area before editing:
   use `AGENTS.md`, its task-routing table, and the owning roadmap,
-  architecture, migration, or delivery docs surfaced by that route or by repo
+  architecture, migration, or delivery docs identified by that route or by repo
   search hints instead of forcing one oversized preload bundle for every pass
-- run the required review checks for the repaired slice and create bounded
+- run the required review checks for the repaired change and create bounded
   checkpoint commits during the loop using the repo's normal commit rules
 - when a meaningful finding is real but should not expand the active PR, search
   existing issues first and open or link the follow-up issue before merge
 - when a pass finds fewer than 5 new findings, report only those findings and
   keep the loop moving
-- stop only after every applicable changed surface group has been revisited and
-  a full applicable-surface loop yields no new meaningful findings; if the only
+- stop only after every applicable changed file group has been revisited and
+  a full review cycle yields no new meaningful findings; if the only
   remaining item is a minor finishing touch, repair it and finish once no other
-  meaningful issues surface
+  meaningful issues appear
 - keep scratch tracking ephemeral and untracked
 
 ### 4. Agent Defaults
@@ -241,7 +241,7 @@ missing:
 - prefer neutral direct `Why:` and `What:` language
 - frame each upcoming review pass as issue-finding with open outcome rather
   than as a pre-labeled clean or final pass
-- re-check merge method and subject immediately before landing
+- re-check merge method and subject immediately before merging
 - report unresolved policy gaps instead of silently improvising
 - use the relevant safety and authoring skills up front rather than relying on
   mid-task memory
@@ -260,7 +260,7 @@ push-to-mainline CI.
   resolve PR metadata for the branch
 - the `plan-pr-review` workflow job audits the diff with
   `tools.audit_pr_review`, publishes the selected checks for transparency, and
-  keeps the human review surface routing visible while choosing planned mode
+  keeps the human review routing visible while choosing planned mode
   for draft PRs and full mode for non-draft PRs
 - the `pr-review` PR status aggregates the selected blocking checks for draft
   PR plans and the full non-duplicated blocking suite for non-draft PRs; it
@@ -278,7 +278,7 @@ push-to-mainline CI.
 Before calling delivery complete, verify and report:
 
 - which repo standards were reloaded immediately before the action
-- which applicable changed surface groups were reviewed
+- which applicable changed file groups were reviewed
 - whether the PR remained draft until the hardening procedure finished cleanly
 - whether the branch shape matched the allowed merge method
 - which checks were required and whether they passed
@@ -286,14 +286,14 @@ Before calling delivery complete, verify and report:
   linked from the PR when they stayed out of scope
 - whether any linked follow-up issue content remained privacy-safe and
   repo-scoped
-- whether the landing subject exactly matched the required format
+- whether the merge subject exactly matched the required format
 - whether older superseded PRs were labeled correctly
 - whether the final remote branch tip still matches the reviewed PR record
 - whether review requirements are truly enforced or explicitly deferred because
   the repo currently has only one single review-capable collaborator
 - whether PR-only CI enforcement required `commit-messages`, `pr-metadata`,
   and `pr-review` for mergeable pull requests
-- whether required PR-only statuses were pinned to the owning GitHub Actions
+- whether required PR-only statuses were pinned to the responsible GitHub Actions
   app instead of relying on unpinned status-context names alone
 
 ## Exception Handling

--- a/docs/standards/engineering.md
+++ b/docs/standards/engineering.md
@@ -26,7 +26,7 @@ Place code by responsibility, not by convenience:
 - `adapters/`: source and output adapters plus their adapter-local helpers.
 - `interfaces/`: thin entry points such as the CLI. Interfaces orchestrate
   services; they do not own business rules.
-- `repo_support/`: the current live shared support seam for repo-native tooling
+- `repo_support/`: the current live shared support boundary for repo-native tooling
   and repo-side tests. Keep this outside `src/tallylot/` because it is not
   production/runtime code.
 
@@ -38,9 +38,9 @@ Repo-native support boundaries:
 - `src/tallylot/` remains production/runtime code only.
 - `tools/` remains the home for repo-native entry points and task-specific
   dev-only modules.
-- `repo_support/` is the current live shared seam for repo-native tooling and
+- `repo_support/` is the current live shared support boundary for repo-native tooling and
   repo-side tests.
-- later implementation should rename that dev-only surface to `dev_support/`
+- later implementation should rename that dev-only package area to `dev_support/`
   so the boundary is explicit.
 - until that rename lands, `repo_support/` must stay narrow, typed,
   stdlib-first, and named by concept.
@@ -89,11 +89,11 @@ Default to one responsibility per module.
   `misc.py`, or another catch-all `common.py`.
 - Existing generic modules should shrink over time, not absorb more unrelated
   behavior.
-- Apply the same rule to the current live `repo_support/` surface and the later
-  target `dev_support/` surface. Shared repo-only support must be split by
-  named seam, not collected under generic support modules.
+- Apply the same rule to the current live `repo_support/` package area and the
+  later target `dev_support/` package area. Shared repo-only support must be
+  split by named boundaries, not collected under generic support modules.
 
-When a capability grows, split by stable seams:
+When a capability grows, split by stable boundaries:
 
 - `domain/`: separate models, value objects, and typed aliases by concept.
 - `application/`: organize by bounded capability packages such as
@@ -112,7 +112,7 @@ When a capability grows, split by stable seams:
   persistence, or composition-root wiring. Do not push application policy down
   here just to share code.
 - `repo_support/`: host reusable repo-only support only when it is shared by
-  multiple repo-native surfaces such as `tools/` and `tests/`. This is the
+  multiple repo-native areas such as `tools/` and `tests/`. This is the
   current live name for a later `dev_support/` target. Do not move
   production/runtime concerns here.
 
@@ -168,7 +168,7 @@ Current application of this rule:
 - Keep public names and commands simple, neutral, and ergonomic. Prefer short
   names that match the user-visible operation over long implementation labels,
   and only add qualifiers when a real naming collision or ambiguity exists.
-- Follow the same naming posture for modules, functions, classes, and commands:
+- Follow the same naming approach for modules, functions, classes, and commands:
   choose concise descriptive names over decorative jargon.
 - Reject verbose pattern-label suffixes such as `UseCase`, `Manager`, or
   `Handler` unless they disambiguate a real collision in the surrounding
@@ -181,7 +181,7 @@ Current application of this rule:
   unless the concept is genuinely adapter-local or asset-class-specific.
 - Under `adapters/sources/`, group packages by source kind before the provider:
   `platforms/<provider>/`, `wallets/<provider>/`, `explorers/<provider>/`,
-  `portfolio/<surface>/`, `generic/<contract>/`, or `stubs/<reserved>/`.
+  `portfolio/<input_kind>/`, `generic/<contract>/`, or `stubs/<reserved>/`.
 - Keep naming stable across implementation, tests, and adapter metadata.
 
 ## Refactor-First Hotspots
@@ -192,7 +192,7 @@ Split these modules before adding materially new behavior:
 - `src/tallylot/adapters/sources/platforms/binance/adapter.py`
 - `src/tallylot/adapters/sources/platforms/coinbase/adapter.py`
 
-Preserve these shared-surface package seams instead of collapsing them back
+Preserve these shared package boundaries instead of collapsing them back
 into single modules:
 
 - `src/tallylot/domain/transactions/`

--- a/docs/standards/engineering.md
+++ b/docs/standards/engineering.md
@@ -168,21 +168,70 @@ Current application of this rule:
 - Keep public names and commands simple, neutral, and ergonomic. Prefer short
   names that match the user-visible operation over long implementation labels,
   and only add qualifiers when a real naming collision or ambiguity exists.
+- For domain and contract surfaces, prefer the shortest accurate noun phrase.
+  Cut migration, workflow, or implementation adjectives before cutting the
+  owning noun that tells readers what the thing is.
 - Follow the same naming approach for modules, functions, classes, and commands:
   choose concise descriptive names over decorative jargon.
 - Reject verbose pattern-label suffixes such as `UseCase`, `Manager`, or
   `Handler` unless they disambiguate a real collision in the surrounding
   namespace.
+- Reserve suffixes precisely:
+  - `Ref` for canonical identity tuples or stable pointers
+  - `Id` and `*_id` for stable identifiers only
+  - `Record` for persisted kernel families
+  - `Explanation` for explanatory sidecars keyed to one kernel or support record
+  - `Projection` and `Sidecar` for derived or compatibility outputs
+- Prefer concrete owning nouns over abstract containers. Avoid names such as
+  `Core`, `Data`, `Info`, `Context`, `Payload`, or `Item` when `Record`,
+  `Explanation`, `Projection`, or the domain noun would say what the surface
+  actually holds.
+- Keep record-family stems and id stems aligned. Prefer `GapRecord` plus
+  `gap_id` or `ReadinessRecord` plus `readiness_id` over longer names that
+  repeat context the record family already supplies, unless a real sibling
+  family would make the shorter stem ambiguous.
+- Fingerprints are scalar values, not refs. Use `*_fingerprint` for stored
+  fingerprints and reserve `*_ref` for product ids, record ids, tuple refs, or
+  other explicit pointer shapes.
+- Prefer `*_kind` for canonical one-of vocab and variant fields. Reserve
+  `family` for prose grouping of related record types, adapters, or artifact
+  lines rather than for kernel field names.
+- Do not encode nullability in canonical target field names. Use the base noun
+  or ref name and state optionality in the field contract rather than in
+  suffixes that spell out nullability.
+- Do not encode canonical ordering or record-local support role in a target
+  field name when the enclosing contract already provides that meaning.
+  Drop redundant ordering prefixes and contextual support adjectives when the
+  record already establishes the relationship.
+- Prefer `*_key` for stable discriminators inside canonical ids, tuples, and
+  record-local identity seams. Avoid more abstract labels such as `*_anchor`
+  or redundant labels such as `*_discriminator` when the field simply holds
+  the stable key for that parent scope.
+- Prefer the base noun when a field already stores the locator or ref itself.
+  Avoid extra suffixes such as `_identity` when `member_locator` or
+  `valuation_source_ref` already says what the value holds.
+- For compatibility-only material that is not a target concept, name it by
+  boundary and role rather than promoting it to a pseudo-domain type.
+  Prefer `bridge annotation payload`, `output note sidecar`, or
+  `compatibility sidecar` over introducing a new canonical-seeming type name in
+  forward-looking docs or code.
+- Name the held thing separately from its identity seam or persistence shell:
+  `BasisPool` is a concept, `BasisPoolRef` is its ref, and
+  `BasisTransitionRecord` is a kernel row family.
 - Prefer specific names such as `csv_parser.py`, `balance_mapper.py`, or
   `issue_rules.py` over generic names.
 - Match package structure to the architecture first and the external provider
   second.
 - New core-domain and application names should avoid crypto-exclusive language
   unless the concept is genuinely adapter-local or asset-class-specific.
+- Do not bake migration qualifiers such as `bridge`, `legacy`, `current`, or
+  `compat` into canonical target-layer concepts, helper ids, or product ids
+  unless the name is intentionally current-state or adapter-local.
 - Under `adapters/sources/`, group packages by source kind before the provider:
   `platforms/<provider>/`, `wallets/<provider>/`, `explorers/<provider>/`,
   `portfolio/<input_kind>/`, `generic/<contract>/`, or `stubs/<reserved>/`.
-- Keep naming stable across implementation, tests, and adapter metadata.
+- Keep naming stable across implementation, tests, adapter metadata, and owner
+  docs.
 
 ## Refactor-First Hotspots
 

--- a/docs/standards/implementation.md
+++ b/docs/standards/implementation.md
@@ -1,6 +1,6 @@
 ---
 title: "Implementation Working Agreement"
-summary: "Execution rules for shaping, verifying, refactoring, and checkpointing repo work."
+summary: "Execution rules for shaping, verifying, refactoring, and committing repo work."
 doc_type: standard
 audience: human
 owner: repo
@@ -15,14 +15,14 @@ future sessions do not depend on repeated reminders from the user.
 This document complements:
 
 - `docs/standards/engineering.md` for placement and modularity rules
-- `docs/standards/commits.md` for commit format and checkpoint policy
+- `docs/standards/commits.md` for commit format and commit-boundary policy
 - `docs/concepts/reconciliation-tax-architecture.md` for architecture direction
 - `docs/status/migration-sequence.md` for no-big-bang migration order
 
 ## Repo-Native Tooling To Use
 
 This repo uses the external environment at `$(HOME)/.venvs/tallylot-py312`.
-Use the root `Makefile` as the standard local command surface. It prepends the
+Use the root `Makefile` as the standard local command interface. It prepends the
 external environment's `bin/` directory to `PATH`, which keeps repo commands
 machine-neutral and sandbox-safe without inline environment prefixes.
 
@@ -41,7 +41,7 @@ Prefer the repo's built-in tooling before inventing local workflows:
 - run the explicit full-suite override only when it is intentionally needed with
   `make quality-full`
   The repo starts the standard quality gates together by default, keeps the
-  fast pytest slice on 4 workers by default, and reserves phased scheduling as
+  fast pytest bundle on 4 workers by default, and reserves phased scheduling as
   an explicit alternate mode for comparison or debugging.
   Override the fast worker count only through
   `TALLYLOT_FAST_PYTEST_WORKERS`; use `0` to force serial.
@@ -55,7 +55,7 @@ Prefer the repo's built-in tooling before inventing local workflows:
   together when changing delivery policy, branch protection, or CI guardrails
   with
   `make audit-delivery-guardrails`
-- audit PR review surface coverage with
+- audit PR review file-group coverage with
   `make audit-pr-review` and run the required review checks for the current
   diff with `make pr-review`
 - run the blocking flake and order-sensitivity lane with
@@ -72,7 +72,7 @@ Prefer the repo's built-in tooling before inventing local workflows:
   `pyrightconfig.tests.json` before rerunning
 - refresh adapter golden fixtures with
   `make refresh-adapter-goldens ARGS='...'`
-- benchmark test-slice changes with
+- benchmark test-bundle changes with
   `make benchmark-tests`
 - benchmark quality-gate scheduling changes with
   `make benchmark-quality`
@@ -102,7 +102,7 @@ generated file, commit that change and rerun the gates.
 When repo-native tooling and tests need shared support:
 
 - keep production/runtime concerns out of `tools/` and the current live
-  `repo_support/` surface
+  `repo_support/` package area
 - keep shared repo-only support in the current live `repo_support/` package,
   not in ad hoc duplicated test helpers or tool-local path constants
 - keep `tools/` focused on entry points and task-specific dev modules
@@ -110,7 +110,7 @@ When repo-native tooling and tests need shared support:
   under `dev_support/`; do not expand `repo_support/` as if it were the desired
   long-term boundary
 
-## Default Coding Posture
+## Default Coding Expectations
 
 Agents should assume all of these are expected unless the task explicitly says
 otherwise:
@@ -118,11 +118,11 @@ otherwise:
 - keep the architecture aligned with
   `docs/concepts/reconciliation-tax-architecture.md`
 - for reconciliation, checkpoint, accounting, tax, or core pipeline work,
-  reload the owning roadmap and migration docs before shaping the slice:
+  reload the owning roadmap and migration docs before shaping the change:
   `ROADMAP.md` and `docs/status/migration-sequence.md`
 - read the narrow forward-looking roadmap, architecture, migration, or owning
   boundary guidance before shaping a non-trivial change
-- refactor when a clearer shared seam is already visible
+- refactor when a clearer shared boundary is already visible
 - extract shared components before copy-paste patterns harden
 - create or update tests alongside the implementation
 - commit at stable checkpoints without waiting to be reminded
@@ -133,7 +133,7 @@ otherwise:
 
 For non-trivial implementation work, use this order:
 
-1. confirm the target seam and owning layer
+1. confirm the target boundary and owning layer
 2. create or update the typed models, contracts, or artifact schemas first
 3. create or update tests that define the intended behavior
 4. implement the behavior
@@ -145,7 +145,7 @@ Do not start by patching call sites ad hoc and only later trying to discover
 the right structure.
 
 Before shaping a non-trivial fix, reload the narrow forward-looking guidance
-that owns the change surface. Prefer the intended end-state seam over a local
+that owns the change area. Prefer the intended end-state boundary over a local
 temporary patch when the repo already documents the target ownership model.
 
 For reconciliation, checkpoint, accounting, tax, and core pipeline work,
@@ -156,7 +156,7 @@ the normal minimum routing set is:
 - `docs/status/migration-sequence.md`
 
 Add `docs/concepts/oracle-boundaries.md` and
-`docs/concepts/transaction-classification.md` when the slice changes
+`docs/concepts/transaction-classification.md` when the change alters
 boundaries or semantic classification.
 
 ## Refactor Expectations
@@ -170,7 +170,7 @@ Refactor during the task when any of these are true:
 - a module is gaining a second responsibility
 - a new feature would deepen coupling across layers
 - repeated parsing, validation, or mapping rules are visible
-- tests are getting repetitive because the production seam is wrong
+- tests are getting repetitive because the production boundary is wrong
 - new work would make an existing hotspot materially worse
 
 Do not defer an obvious structural fix if the change is already in the code you
@@ -179,7 +179,7 @@ forward.
 
 ## Shared Component Rules
 
-Extract shared code only to a specific, named seam.
+Extract shared code only to a specific, named boundary.
 
 Good extractions:
 
@@ -199,12 +199,12 @@ Avoid generic sinks:
 
 For repo-native tooling and test support:
 
-- use the current live `repo_support/` package only for narrow shared seams
-  that are reused by multiple repo-native surfaces
+- use the current live `repo_support/` package only for narrow shared
+  boundaries that are reused by multiple repo-native areas
 - do not create generic `repo_support/helpers.py` or `repo_support/utils.py`
 - if only one tool owns the logic, keep it local to that tool instead of
   promoting it into `repo_support/`
-- later implementation should rename and split this dev-only support surface
+- later implementation should rename and split this dev-only support package area
   under `dev_support/` instead of treating `repo_support/` as the final name
 
 Shared components must stay owned by one layer and one concept.
@@ -233,11 +233,12 @@ Meaningful tests only:
 - do not add trivial getter or setter tests, wording-only assertions, duplicate
   coverage at multiple layers, or call-order tests unless that order is the
   contract
-- when tests become repetitive, treat that as a signal that the production seam
-  may be wrong and refactor the seam instead of piling on more near-duplicate
+- when tests become repetitive, treat that as a signal that the production
+  boundary may be wrong and refactor that boundary instead of piling on more
+  near-duplicate
   tests
 - for repo-side agent scripts and internal workflow entry points, cover
-  behavior in-process when a callable seam exists and reserve subprocess tests
+  behavior in-process when a callable entry point exists and reserve subprocess tests
   for the real launch boundary
 - avoid duplicate in-process and subprocess tests that prove the same workflow
   behavior; once behavior is covered in-process, thin launch-boundary tests may
@@ -263,9 +264,9 @@ afterthoughts.
 
 Expected behavior:
 
-- make a commit when a bounded slice is stable and verified
+- make a commit when a bounded change is stable and verified
 - keep commits cohesive and reviewable
-- prefer one commit per coherent reshape slice, not one commit per file
+- prefer one commit per coherent change, not one commit per file
 - keep each authored commit bounded to one reviewable concern with a clear
   rollback boundary
 - before a checkpoint commit is pushed, amend or fix up a small, scoped
@@ -275,12 +276,12 @@ Expected behavior:
 - do not use repeated amend cycles to grow one broad checkpoint that should be
   split into separate commits with clearer review and rollback boundaries
 - for large but separable scopes, create multiple bounded checkpoint commits
-  before closeout instead of ending on one umbrella authored commit
+  before finishing instead of ending on one umbrella authored commit
 - do not bundle unrelated fixes
 - do not wait for the user to remind you to commit once the task has reached a
   real checkpoint
 - when a refactor spans structure, routing, tooling, and tests, checkpoint each
-  stable slice that already passes the narrow checks for that slice
+  stable change that already passes the narrow checks for that change
 - when opening a PR, use a Conventional Commit title and the structured PR body
   defined in `docs/standards/commits.md` because that metadata
   stays attached to the PR record and becomes the squash commit on `main` for
@@ -290,13 +291,13 @@ Expected behavior:
   necessary now; `What:` should state the concrete repo change; and neither
   section should use rhetorical or promotional wording
 - before merging a PR or rewriting mainline history, verify whether the pull
-  request record must stay attached to the landing commit; if yes, do not
+  request record must stay attached to the merged commit; if yes, do not
   rewrite that merge commit after merge
 - if a multi-checkpoint PR merges with a merge commit, use
   `<pr title> (#<pr number>)` as the merge subject so the mainline log keeps
   the PR number visible
 - if a repair PR replaces an older pull request, mark the old PR with the
-  repo's neutral duplicate/superseded label before closing the repair loop
+  repo's neutral duplicate/superseded label before closing the older PR
 - add a neutral replacement comment only when the repo has no suitable label
   or the user explicitly asks for explanatory prose
 - when the work uncovers follow-up or out-of-scope changes that do not belong
@@ -322,18 +323,18 @@ Expected behavior:
   commands such as `rm -rf`, `git restore`, `git reset`, or `git checkout --`
   unless the user explicitly requests that cleanup in the current thread
 - keep tracked docs, templates, and control-plane artifacts neutral and durable
-- keep scratch review notes, temporary hardening ledgers, and compaction aids
+- keep scratch review notes, temporary review ledgers, and compaction aids
   untracked; recover from deterministic repo facts instead
 
 When not to commit:
 
 - the worktree is inconsistent
-- the tests for the slice are failing
+- the tests for the change are failing
 - the checkpoint would be hard to review or roll back
-- the current diff still contains multiple separable reviewable slices
+- the current diff still contains multiple separable reviewable changes
 
 Do not collapse a broad but separable refactor into one giant commit unless
-the slice truly cannot be reviewed or validated incrementally.
+the change truly cannot be reviewed or validated incrementally.
 
 ## Compaction Recovery
 
@@ -345,7 +346,7 @@ When context is lost before more edits, commits, or delivery steps:
 2. inspect the current diff and recent commits
 3. inspect current PR metadata and changed files when PR work is active
 4. reread only the narrow repo standards and start-skill docs for the active
-   surface
+   area
 5. reload the latest targeted verification results
 
 Do not rely on tracked scratch notes, phase logs, or preserved review ledgers
@@ -367,7 +368,7 @@ is:
 - verify the changed behavior at the smallest useful level first
 - then run `tools.run_quality_gates` before closing the task
 - escalate to `tools.run_pr_review_checks --mode full` when the change touches
-  CI, packaging, release, or other workflow surfaces where the local pass
+  CI, packaging, release, or other workflow areas where the local pass
   should mirror the final non-draft PR suite before handoff
 - avoid `tools.run_quality_gates --full-tests` unless you explicitly need the
   full-suite override rather than the standard agent path
@@ -379,7 +380,7 @@ is:
   verifier selection instead of a fixed pytest bundle
 
 For PR review and repair loops, use `tools.audit_pr_review` to classify the
-changed surface groups and use `tools.run_pr_review_checks` as the shared
+changed file groups and use `tools.run_pr_review_checks` as the shared
 verification entrypoint:
 
 - draft pull-request CI always runs `commit-messages` and `pr-metadata`, then
@@ -397,19 +398,19 @@ verification entrypoint:
   not decide PR or CI verification selection
 
 Coverage hotspot reports are informative review output only. Use them to pick
-the next hardening target after a full-suite run; do not treat them as a
+the next review target after a full-suite run; do not treat them as a
 replacement for correctness tests or the existing repo-wide coverage gate.
 
 If you are changing commit-time or suite-selection policy, keep the hook path
-limited to bounded checkpoint checks and use the shared quality runner or the
+limited to bounded commit checks and use the shared quality runner or the
 full PR-review runner as the single broad verification source. Benchmark with
 `tools.benchmark_tests` and `tools.benchmark_quality_gates` when you are
-proposing a different test slice or quality-gate schedule, and do not expand
+proposing a different test bundle or quality-gate schedule, and do not expand
 the hook path into a second full-suite verification pass.
 
 ## Migration Discipline
 
-When a task touches a migrating surface:
+When a task touches a migrating area:
 
 - implement on the fact-based path first
 - preserve external output projections only as needed
@@ -417,7 +418,7 @@ When a task touches a migrating surface:
 - add parity coverage before retiring older paths
 
 If the change would force a big-bang rewrite, the migration sequence is wrong.
-Split the work into a smaller compatible slice.
+Split the work into a smaller compatible increment.
 
 ## Workflow Integrity Rules
 
@@ -437,7 +438,7 @@ Keep workflow integrity rules explicit while the repo continues migrating.
 - evidence references recorded in normalized or checkpoint-supporting artifacts
   must stay source-relative and portable across workspaces
 - docs, command routes, and agent entrypoints must stay aligned with the
-  implemented runtime surface
+  implemented runtime
 
 ## Adapter And Artifact Discipline
 
@@ -466,7 +467,7 @@ Agents should not require repeated reminders to:
 - use `Decimal`
 - log unsupported or ambiguous facts explicitly
 - update roadmap and design docs when architecture changes
-- extract shared seams when duplication becomes obvious
+- extract shared boundaries when duplication becomes obvious
 - add or update tests for new behavior
 - create stable checkpoint commits
 
@@ -493,7 +494,7 @@ Pause feature work and fix the structure first when:
 Before closing non-trivial work, confirm:
 
 - the owning layer is still clear
-- shared logic is extracted to the right seam
+- shared logic is extracted to the right boundary
 - tests pin the new behavior
 - unsupported behavior is explicit
 - docs are updated if architecture or workflow changed

--- a/docs/status/adapter-delivery-plan.md
+++ b/docs/status/adapter-delivery-plan.md
@@ -178,6 +178,13 @@ Out of scope now:
 - broad parity work for adapters not used in the current filing path
 - redesigning discovery to support future adapter kinds
 
+Repo-status rule:
+
+- this repo may freeze the default Coinbase-first slice and its contract
+  boundaries
+- this repo must not pretend it already knows the actual `2023` to `2025`
+  filing adapter inventory without an external workspace source list
+
 Exit criteria:
 
 - the team can say exactly which adapters must be stable before filing
@@ -398,6 +405,9 @@ Rules:
 - no dual active runtime centers
 - no adapter-local hidden semantics beyond provider-local meaning
 - no broad family migration as a hidden prerequisite for the first slice
+- [Bridge To Target Mapping](../concepts/bridge-to-target-mapping.md) is the
+  single owner for the canonical bridge mapping; this page only records the
+  adapter-delivery implications
 
 Default bridge mapping for the first slice:
 
@@ -456,6 +466,8 @@ Default first-slice direction:
   Tier A family to land first
 - keep `cointracking_csv` projection compatibility in scope for the same slice
   where it protects filing output determinism
+- use [First Slice Contract](../reference/first-slice-contract.md) as the
+  bounded parity, replay, and allowed-drift contract for that default slice
 
 ### 5. Allow Shared Compiler And Verifier Prep
 

--- a/docs/status/adapter-delivery-plan.md
+++ b/docs/status/adapter-delivery-plan.md
@@ -37,7 +37,7 @@ Filing-critical stabilization on the current adapter boundaries.
 Allowed now:
 
 - planner determinism for filing-critical adapters
-- shared family recognition and statement extraction improvements
+- shared evidence-kind recognition and statement extraction improvements
 - explicit timezone review behavior
 - strict output-policy validation for filing outputs such as `cointracking_csv`
 - replay-grade verification for unchanged filing inputs
@@ -131,7 +131,7 @@ Prep work must not:
 
 - create a second architecture center in adapter docs
 - redefine target product kernels locally
-- force repo-wide family migration before the bounded slices land
+- force repo-wide adapter migration before the bounded slices land
 
 ## Deferred Redesign
 

--- a/docs/status/adapter-delivery-plan.md
+++ b/docs/status/adapter-delivery-plan.md
@@ -411,29 +411,19 @@ Rules:
 
 Default bridge mapping for the first increment:
 
-- proto-`EvidenceSet` kernel:
-  - selected, superseded, and blocked members from
-    `translation_input_candidates.json` and `translation_input_plan.json`
-  - typed provenance and locator identity from the current normalization-owned
-    evidence and statement paths
-  - source-local parsed observations from planner-selected input families and
-    statement extraction outputs where the increment uses them
-- proto-`ClaimSet` kernel:
-  - provider-local semantic assertions emitted after deterministic evidence
-    selection and before final draft or fact acceptance
-  - balance observation claims from statement-backed quantities and other
-    quantity-backed evidence used by the increment
-  - location, ownership, instrument, and contract-facing claims only where the
-    current adapter can already state them safely
-  - claim-owned blocking and advisory outputs derived from current
-    source-local issues and reviews when the meaning is still pre-economic
-- bridge continuity during migration:
-  - `SourceTranslationBatch` remains the honest current runtime boundary while the
-    first increment also emits bounded proto-`EvidenceSet` or proto-`ClaimSet`
-    artifacts
-  - the shared compiler remains responsible for producing current bridge outputs
-    from accepted claims until the corresponding downstream target-stage increment
-    replaces that bridge responsibility
+- [Bridge To Target Mapping](../concepts/bridge-to-target-mapping.md) owns the
+  exact planner-candidate, planner-plan, statement-evidence, and bridge-only
+  landing rules
+- [Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md) owns the
+  shared claim taxonomy plus the deterministic id, ordering, serialization, and
+  fingerprint contracts
+- [First Slice Contract](../reference/first-slice-contract.md) owns the bounded
+  Coinbase-first evidence families, claim families, replay, parity, and
+  allowed-drift rules
+- `SourceTranslationBatch` remains the honest current runtime boundary while
+  the first increment emits bounded proto-products beside it, and the shared
+  compiler keeps ownership of current bridge outputs until the downstream
+  target-stage replacement lands
 
 ### 3. Freeze Adapter Determinism And Compatibility Rules
 

--- a/docs/status/adapter-delivery-plan.md
+++ b/docs/status/adapter-delivery-plan.md
@@ -32,10 +32,13 @@ The repo should use a filing-first adapter strategy:
 - extract only those shared seams that remove current drift on the filing path
 - write down the future unified adapter design now, but migrate to it later
 
-This plan treats adapter work as two tracks:
+This plan treats adapter work as three tracks:
 
 - `now`: filing-critical hardening on the current seams
-- `roadmap`: the post-filing unified adapter interface and migration
+- `prep`: first-principles unified adapter contract and bridge-mapping work
+  needed by shared foundations and the first target-stage slice
+- `roadmap`: broader family migration into the unified adapter contract once the
+  filing path and first slice are stable
 
 Forward-looking adapter work must map into the main runtime pipeline in
 `docs/concepts/pipeline-stage-contracts.md` and the trust-gate rules in
@@ -350,10 +353,133 @@ filing workspace:
 The filing window does not require every adapter to be elegant. It requires
 the filing path to be trustworthy.
 
+## Work To Advance During Shared Foundations
+
+The `prep` track is allowed before the full adapter migration because Phase 0
+cannot safely proceed on stage contracts alone. The repo also needs adapter
+product and bridge-mapping rules that let `EvidenceSet` and `ClaimSet` land
+without creating a second architecture center or forcing a brutal later
+rewrite.
+
+### 1. Freeze Adapter Product Contracts Needed By The First Slice
+
+Write and align the minimum adapter-scoped products needed by shared
+foundations and the first vertical slice:
+
+- `EvidenceSet`
+- `ClaimSet`
+- `SourceTranslationBatch` as the current bridge seam during migration
+- any bounded bridge note needed for `ProjectionBundle` or `ArtifactBundle`
+
+Required rules:
+
+- the adapter-scoped products must map explicitly into the core runtime
+  pipeline
+- the current bridge seam remains honest current-state truth until a bounded
+  replacement slice lands
+- target-stage product ownership stays in the core architecture docs, not in
+  adapter docs
+
+### 2. Freeze Bridge Mapping From Current Seams To Proto Target Products
+
+The first target-stage slice must say exactly how current artifacts land in the
+new products.
+
+Required bridge notes:
+
+- how planner-owned candidate and selection artifacts become proto-`EvidenceSet`
+- how current translation seams, draft compilation, and claim-like diagnostics
+  become proto-`ClaimSet`
+- where the shared compiler owns meaning versus where adapters remain
+  provider-local
+
+Rules:
+
+- no dual active runtime centers
+- no adapter-local hidden semantics beyond provider-local meaning
+- no broad family migration as a hidden prerequisite for the first slice
+
+Default bridge mapping for the first slice:
+
+- proto-`EvidenceSet` kernel:
+  - selected, superseded, and blocked members from
+    `translation_input_candidates.json` and `translation_input_plan.json`
+  - typed provenance and locator identity from the current normalization-owned
+    evidence and statement seams
+  - source-local parsed observations from planner-selected input families and
+    statement extraction outputs where the slice uses them
+- proto-`ClaimSet` kernel:
+  - provider-local semantic assertions emitted after deterministic evidence
+    selection and before final draft or fact acceptance
+  - balance observation claims from statement-backed quantities and other
+    quantity-backed evidence used by the slice
+  - location, ownership, instrument, and contract-facing claims only where the
+    current adapter can already state them safely
+  - claim-owned blocking and advisory surfaces derived from current
+    source-local issues and reviews when the meaning is still pre-economic
+- bridge continuity during migration:
+  - `SourceTranslationBatch` remains the honest current runtime seam while the
+    first slice also emits bounded proto-`EvidenceSet` or proto-`ClaimSet`
+    artifacts
+  - the shared compiler remains responsible for producing current bridge outputs
+    from accepted claims until the corresponding downstream target-stage slice
+    replaces that bridge responsibility
+
+### 3. Freeze Adapter Determinism And Compatibility Rules
+
+Shared foundations need adapter determinism to be a written contract, not only
+an implementation preference.
+
+Required prep work:
+
+- declared ordering rules for adapter-scoped products
+- schema-version and compatibility rules aligned with target product rules
+- canonical serialization and fingerprint rules
+- explicit ownership of manifest fingerprints versus product fingerprints
+
+### 4. Name The First Adapter-Family Vertical Slice
+
+The first unified-adapter-facing slice should be explicit instead of implied.
+
+Required slice definition:
+
+- one adapter family
+- the evidence families and claim families in scope
+- the bridge outputs or target products it must still interoperate with
+- replay and parity gates on unchanged evidence
+- unsupported or ambiguous cases that must remain explicit
+
+Default first-slice direction:
+
+- use the planner-enabled `coinbase` retail export family plus statement-backed
+  balance observation flow unless the active filing workspace requires another
+  Tier A family to land first
+- keep `cointracking_csv` projection compatibility in scope for the same slice
+  where it protects filing output determinism
+
+### 5. Allow Shared Compiler And Verifier Prep
+
+The repo may advance shared compiler and verifier work during prep when that
+work reduces drift across the first slice.
+
+Allowed prep work:
+
+- shared claim compilation seams
+- shared product verifiers
+- shared replay and fingerprint checks
+- shared bridge-to-target comparison helpers
+
+Not allowed in prep:
+
+- repo-wide family migration
+- wrappers that keep old and new contracts alive indefinitely
+- broad facet rollout with no bounded consumer
+
 ## Work To Roadmap
 
-The `roadmap` track is the full unified adapter redesign that should happen
-after filing-critical work no longer depends on current seam stability.
+The `roadmap` track covers broader family migration and contract adoption after
+the shared foundations and first slice are stable enough that the filing path
+is not depending on unresolved adapter semantics.
 
 ### Roadmap Objective
 
@@ -372,9 +498,10 @@ provider-local semantics only.
 - keep the compiler and verifier shared
 - keep provider-local code focused on parsing, semantic mapping, and rendering
 
-### Roadmap Phase R1. Define Adapter Products
+### Roadmap Phase R1. Finish Adapter Products Beyond The First Slice
 
-Design and write the future adapter-scoped products:
+Complete and extend the future adapter-scoped products beyond the bounded
+contracts already needed for the first slice:
 
 - `EvidenceSet`
 - `ClaimSet`
@@ -398,8 +525,8 @@ Deliverables:
 
 Entry criteria:
 
-- filing-critical path is stable enough that the team can change contracts
-  without risking the tax deadline
+- shared foundations and first-slice bridge mapping are stable enough that
+  broader family migration will not re-open core contract questions
 
 ### Roadmap Phase R2. Split The Contract Into Facets
 
@@ -498,7 +625,7 @@ Retirement conditions:
 ## Decision Rules While Filing Work Is Active
 
 Use these rules to decide whether an adapter change belongs in `now` or
-`roadmap`.
+`prep` or `roadmap`.
 
 Choose `now` when:
 
@@ -508,6 +635,16 @@ Choose `now` when:
   seam
 - the change improves replay confidence on unchanged inputs
 - the change makes unsupported or ambiguous behavior explicit
+
+Choose `prep` when:
+
+- the change freezes adapter products or bridge mapping required by Phase 0
+- the change aligns current planner or translation seams with proto-
+  `EvidenceSet` or proto-`ClaimSet`
+- the change establishes shared ordering, fingerprint, or compatibility rules
+- the change enables one bounded family slice without introducing wrapper lanes
+- the change advances shared compiler or verifier seams needed by the first
+  target-stage slice
 
 Choose `roadmap` when:
 

--- a/docs/status/adapter-delivery-plan.md
+++ b/docs/status/adapter-delivery-plan.md
@@ -1,6 +1,6 @@
 ---
 title: "Adapter Delivery Plan"
-summary: "Filing-first plan for stabilizing current adapters now and deferring the unified adapter contract rewrite until after filing-critical work."
+summary: "Filing-first plan for stabilizing current adapters now and deferring the broad unified adapter redesign until the filing path and bounded first slices are stable."
 doc_type: status
 audience: human
 owner: repo
@@ -9,670 +9,138 @@ nav_order: 30
 related:
   - ROADMAP.md
   - docs/guides/write-an-adapter.md
+  - docs/concepts/unified-adapter-architecture.md
+  - docs/concepts/bridge-to-target-mapping.md
   - docs/concepts/pipeline-stage-contracts.md
-  - docs/concepts/domain-ontology.md
-  - docs/concepts/reconciliation-tax-architecture.md
   - docs/status/current-state.md
 ---
 
 Use this plan when deciding whether adapter work belongs in the current
-filing-critical window or in the later adapter-contract rewrite.
-
-The intent is to keep tax delivery primary. The repo should harden the current
-adapter path where it directly improves filing confidence, determinism, and
-repeatability, but it should defer the full unified adapter redesign until the
-filing path is stable enough to trust.
+filing-critical window or in the later unified-adapter redesign.
 
 ## Decision
 
-The repo should use a filing-first adapter strategy:
+The repo uses a filing-first adapter strategy:
 
-- harden the current adapter layer where it directly reduces filing risk
-- avoid a broad source and output adapter contract rewrite before filing
-- extract only those shared boundaries that remove current drift on the filing path
-- write down the future unified adapter design now, but migrate to it later
+- harden the current adapter path where it directly reduces filing risk
+- defer the broad unified adapter redesign until the filing path and bounded
+  first slices are stable
+- allow only the adapter prep work that the contract-lock pass and first slices
+  actually need
 
-This plan treats adapter work as three tracks:
+## Work Tracks
 
-- `now`: filing-critical hardening on the current adapter boundaries
-- `prep`: first-principles unified adapter contract and bridge-mapping work
-  needed by shared foundations and the first target-stage increment
-- `roadmap`: broader family migration into the unified adapter contract once the
-  filing path and first increment are stable
+### `now`
 
-Forward-looking adapter work must map into the main runtime pipeline in
-`docs/concepts/pipeline-stage-contracts.md` and the trust-gate rules in
-`docs/concepts/reconciliation-tax-architecture.md`. Adapter docs do not define
-their own competing meaning for `EvidenceSet`, `ClaimSet`, `EconomicFacts`,
-`ReconciliationState`, `Checkpoint`, `Journal`, `TaxInputs`, or
-`TaxOutputs`.
+Filing-critical stabilization on the current adapter boundaries.
 
-## Why This Plan Exists
+Allowed now:
 
-The current adapter layer already carries much more responsibility than a
-single translation interface suggests.
+- planner determinism for filing-critical adapters
+- shared family recognition and statement extraction improvements
+- explicit timezone review behavior
+- strict output-policy validation for filing outputs such as `cointracking_csv`
+- replay-grade verification for unchanged filing inputs
 
-Today a source adapter may be responsible for:
+Not allowed now:
 
-- source matching during profile selection
-- file-family classification during profile analysis
-- intake file matching and route selection
-- timezone validation policy
-- location inventory extraction
-- statement PDF recognition and parsing
-- statement instrument claim resolution
-- translation input planning in planner-enabled adapters
-- translation from raw evidence into shared activity drafts, issues, reviews,
-  balance references, and location inventory
+- broad facet migration
+- adapter-local alternate schemas for target products
+- long-lived wrappers or dual-write shims
 
-Today an output adapter is responsible for:
+### `prep`
 
-- declaring supported render policy and fact-shape requirements
-- rendering facts into an external artifact
+Narrow work that Phase 0 and the first bounded slices need before broad
+adapter redesign begins.
 
-This mismatch matters because the current source contract is effectively a
-bundle of unrelated jobs. That makes it easy for behavior drift to accumulate
-between adapters and makes every contract cleanup larger than it needs to be.
+Allowed prep:
 
-The repo still needs a broad redesign, but taxes depend on deterministic
-current behavior sooner than they depend on a perfect future contract.
+- bridge-to-target mapping needed for the first slice
+- adapter participation in canonical `EvidenceSet` and `ClaimSet` emission
+- shared determinism and verification helpers that remove first-slice drift
 
-## Current Adapter Scope
+Required prep rule:
 
-### Current Source-Side Jobs
+- first-slice adapter work must emit target products through the canonical
+  owner docs, not adapter-local alternate schemas
+- retained legacy hints needed for current drafts or facts may survive only in
+  declared compatibility sidecars, not in canonical `EvidenceSet` or
+  `ClaimSet` fields
 
-| Job | Current boundary | Why it matters |
-| --- | --- | --- |
-| Source selection | `match(...)` | Chooses the owning adapter for profiling and normalization. |
-| File-family recognition | `classify_profile_families(...)` | Drives deterministic family ownership before translation. |
-| Intake classification | `match_intake(...)`, `route_intake(...)` | Controls where inbound files land in the workspace. |
-| Timezone policy | `validate_profile_timezones(...)` | Prevents silent timestamp drift. |
-| Location evidence | `extract_location_inventory(...)` | Supplies owned location identity and evidence. |
-| Statement parsing | `match_statement_document(...)`, `parse_statement_document(...)` | Converts statements into quantity-backed balance evidence. |
-| Statement identity claims | `resolve_statement_instrument_claims(...)` | Resolves statement rows to shared instrument identities. |
-| Translation planning | `describe_translation_inputs(...)`, `translate_selected_inputs(...)` | Prevents adapter-local file winner heuristics. |
-| Translation | `translate(...)` | Produces activity drafts and evidence artifacts. |
+### `roadmap`
 
-### Current Output-Side Jobs
+Broader unified-manifest and multi-facet migration after the filing path is
+stable and the first bounded slices have proven the contract set.
 
-| Job | Current boundary | Why it matters |
-| --- | --- | --- |
-| Output policy declaration | `render_policy` | Rejects facts that the target format cannot represent safely. |
-| Rendering | `render(...)` | Produces deterministic external output artifacts. |
-
-### Current Adapters
-
-| Adapter | Kind | Current role | Default filing priority |
-| --- | --- | --- | --- |
-| `coinbase` | source platform | retail export translation, planner path, statement parsing | Tier A when the filing workspace uses Coinbase |
-| `binance` | source platform | multifamily CSV translation, intake routing, statement parsing | Tier A when the filing workspace uses Binance |
-| `shakepay` | source platform | translation, statement parsing, statement evidence | Tier A when the filing workspace uses Shakepay |
-| `wealthsimple` | source platform | translation, intake routing | Tier A when the filing workspace uses Wealthsimple |
-| `ledger_live` | source wallet | grouped-operation translation, wallet inventory | Tier A when the filing workspace uses Ledger Live |
-| `evm_explorer` | source explorer | translation, address extraction, portfolio evidence | Tier A only when explorer evidence is needed for filing |
-| `near` | source explorer | translation, location inventory | Tier A only when NEAR activity is part of filing |
-| `ronin` | source explorer | translation, location inventory | Tier A only when Ronin activity is part of filing |
-| `evm_wallet` | source wallet | wallet inventory, transaction translation | Tier A only when wallet-state evidence is needed |
-| `crypto_com` | source platform | translation, intake routing | Tier B unless required in the filing workspace |
-| `gtrade` | source platform | translation, intake routing, location inventory | Tier B unless required in the filing workspace |
-| `structured_csv` | generic source | generic structured import path | Tier B unless the filing workspace depends on it |
-| `cointracking_portfolio` | portfolio intake | intake-only routing of portfolio exports | Tier B for intake stability, not for translation |
-| `cointracking_csv` | output | filing-oriented CSV projection | Tier A because output determinism directly affects filing |
-| `cointracking_api` | output stub | reserved edge adapter | Tier C |
-| `generic_http_output` | output stub | reserved edge adapter | Tier C |
-| `platform_api_stub` | source stub | reserved non-runtime adapter | Tier C |
-| `blockchain_stub` | source stub | reserved non-runtime adapter | Tier C |
-
-### Priority Tiers
+## Priority Tiers
 
 | Tier | Meaning | Action in this plan |
 | --- | --- | --- |
-| Tier A | Required for the current filing workspace or filing output path | Harden now. |
-| Tier B | Supported but not required for the current filing window | Only touch if a shared fix naturally improves it at low cost. |
-| Tier C | Stubbed, reserved, or clearly non-filing | Do not expand now. Roadmap only. |
+| Tier A | Required for the active filing workspace or filing output path | Harden now. |
+| Tier B | Supported but not filing-critical in the active window | Touch only when a shared fix improves it cheaply. |
+| Tier C | Stubbed, reserved, or clearly non-filing | Do not expand now. |
 
-The actual Tier A set must be driven by the active filing workspace, not by a
-desire for repo-wide completeness.
+The actual Tier A set comes from the active external workspace, not from
+in-repo guesswork.
 
-## Filing-First Principles
+## Filing-Window Rules
 
-- Prefer deterministic current behavior over ambitious interface redesign.
-- Prefer shared support extraction over copy-paste repairs when the shared boundary
-  is already visible.
-- Prefer explicit issues and reviews over adapter-local guesswork.
-- Prefer content signatures, coverage metadata, and fingerprints over filename
-  or lexical path order.
-- Prefer one shared statement extraction path over adapter-local statement
-  orchestration.
-- Prefer one shared output-policy gate over format-specific silent coercion.
-- Do not widen the current source adapter contract during the filing window.
-- Do not introduce dual contracts, migration wrappers, or adapter-local
-  compatibility shims for the future design.
+- prefer deterministic current behavior over ambitious interface redesign
+- prefer shared support extraction over adapter-local workflow drift
+- prefer explicit issues and reviews over guesswork
+- do not widen the current source adapter contract during the filing window
+- do not make the unified adapter redesign a hidden prerequisite for the first
+  bounded slices
 
-## Work To Do Now
+## Filing-Critical Work To Do Now
 
-The `now` track is the work that should land before or during filing as long as
-the active filing path benefits directly.
+The filing window should focus on:
 
-### 1. Lock The Filing-Critical Adapter Set
+- locking the actual Tier A adapter set for the active workspace
+- eliminating hidden winner logic in planner-relevant adapters
+- keeping statement-backed evidence deterministic where checkpoints depend on
+  it
+- keeping timezone handling explicit
+- strengthening deterministic output validation for filing outputs
+- maintaining replay-grade verification for unchanged inputs
 
-Before additional adapter work begins, determine which current adapters are
-actually in the filing path for the active workspace.
+Exit criteria for the filing window:
 
-Required actions:
-
-- list every source used by the current filing workspace for `2023` to `2025`
-- map each source to one current adapter id
-- identify which outputs are filing-critical, beginning with
-  `cointracking_csv`
-- mark all other adapters as non-blocking for the current filing window
-
-Deliverables:
-
-- one repo-safe filing adapter set recorded in the active delivery notes or
-  issue thread
-- one explicit decision on whether each non-filing adapter is Tier B or Tier C
-
-Out of scope now:
-
-- broad parity work for adapters not used in the current filing path
-- redesigning discovery to support future adapter kinds
-
-Repo-status rule:
-
-- this repo may freeze the default Coinbase-first slice and its contract
-  boundaries
-- this repo must not pretend it already knows the actual `2023` to `2025`
-  filing adapter inventory without an external workspace source list
-
-Exit criteria:
-
-- the team can say exactly which adapters must be stable before filing
-
-### 2. Harden Shared Determinism Surfaces
-
-These shared areas reduce drift across multiple adapters and are worth
-changing during the filing window.
-
-| Work item | Why now | Concrete work | Explicitly out of scope | Exit criteria |
-| --- | --- | --- | --- | --- |
-| Translation input selection | File winner logic is one of the biggest drift sources. | Finish planner migration for filing-critical adapters, remove path-order and filename-order winning logic, keep selected, superseded, and blocked candidates explicit. | A new global adapter DSL. | Unchanged raw inputs pick the same candidates every run and emit the same plan artifacts. |
-| Deterministic ordering | Output drift can come from unordered iteration even when facts are correct. | Canonicalize ordering for candidates, selected files, drafts, issues, reviews, balance references, and rendered rows where the target format permits it. | New storage formats. | Repeated normalization and rendering runs are byte-stable or field-stable on unchanged inputs. |
-| Shared file-family recognition | Family ownership drift creates downstream translation drift. | Prefer content and schema signatures, publish stable family ids, and keep family claims in profile artifacts authoritative for translation. | Rewriting discovery around the future facet model. | Filing-critical adapters translate only recognized families and report unmatched files explicitly. |
-| Timezone handling | Silent timestamp drift directly changes tax outcomes. | Keep timezone policy explicit, centralize common timezone summaries and review patterns, and reject ambiguous timestamp interpretation. | A universal temporal framework rewrite. | Filing-critical adapters no longer silently coerce naive timestamps into facts. |
-| Statement extraction | Statement evidence is needed for checkpoint and balance trust. | Keep one shared PDF extraction path, align statement matching and instrument-claim resolution, and fail explicitly on recognized-but-empty parses. | A new statement plugin system. | Statement-backed balance evidence is deterministic across repeated runs. |
-| Identity resolution feedback | Instrument ambiguity must block fact creation consistently. | Keep draft compilation as the shared gate, standardize blocking issue and review paths, and remove adapter-local special cases where possible. | New identity domains or taxonomy expansion. | All unresolved identity paths fail the same way across filing-critical adapters. |
-| Output projection validation | Filing outputs cannot rely on renderer guesswork. | Strengthen render-policy checks and keep unsupported fact shapes explicit before rendering. | New output-contract architecture. | The renderer rejects unsupported fact shapes before writing the artifact. |
-
-### 3. Finish Planner Migration Only Where It Reduces Filing Risk
-
-Planner migration is worth doing now only when the adapter still performs
-winner-selection internally.
-
-Now:
-
-- finish planner migration for every Tier A adapter that still chooses one file
-  by filename, path order, or provider-local winner heuristics
-- keep plan artifacts mandatory before translation starts
-- ensure candidate description, coverage, freshness, selection mode, and
-  comparability are explicit
-- block ambiguous overlap instead of selecting implicitly
-
-Later:
-
-- generalize planner support into the future unified adapter contract
-- add declarative candidate schemas for every adapter kind
-
-Exit criteria:
-
-- every Tier A adapter uses either a safe planner path or an explicitly
-  accepted fallback path with no hidden winner logic
-
-### 4. Reduce Adapter-Local Orchestration In Tier A Adapters
-
-Tier A adapters should stay responsible for provider-local semantics only.
-They should not own their own mini workflow engines when a shared boundary
-already exists.
-
-Allowed extractions now:
-
-- shared file-family dispatch helpers
-- shared timezone summary builders
-- shared issue and review builders
-- shared statement extraction orchestration
-- shared draft compilation
-- shared location-id and identifier helpers
-- shared deterministic ordering helpers
-
-Avoid now:
-
-- creating another broad `helpers.py` or generic adapter utility sink
-- extracting abstractions that are only preparing for the future redesign
-- moving provider-local economic semantics into generic support too early
-
-Exit criteria:
-
-- the average Tier A adapter entry point becomes thinner without changing the
-  external contract
-
-### 5. Add Replay-Grade Verification For Tier A Adapters
-
-The filing path needs deterministic verification more than it needs a new
-contract.
-
-Required verification work:
-
-- maintain golden packs for Tier A adapters with meaningful provider cases
-- add or refresh expected fact, balance, issue, and review coverage for
-  observed row families
-- add parity checks for unchanged raw inputs
-- verify that repeated runs preserve:
-  - file completeness
-  - fact counts
-  - balance reference counts
-  - issue and review behavior unless a documented expected difference applies
-- verify that rendered filing outputs are stable on unchanged facts
-
-Recommended verification focus:
-
-- planner artifacts for planner-enabled adapters
-- statement-backed evidence for adapters with PDF support
-- grouped or multi-leg operations for complex platform and wallet adapters
-- explorer and wallet inventory behavior when location identity is filing
-  relevant
-
-Out of scope now:
-
-- repo-wide parity goldens for non-filing adapters
-- exhaustive perfection for every unsupported provider edge case
-
-Exit criteria:
-
-- unchanged filing inputs can be rerun with confidence that output drift is a
-  real signal, not adapter noise
-
-### 6. Tier A Adapter Work Matrix
-
-This matrix defines what should happen now for each likely filing-relevant
-adapter.
-
-| Adapter | Do now | Defer |
-| --- | --- | --- |
-| `coinbase` | Keep planner path authoritative, harden statement PDF extraction, ensure retail export family claims stay stable, refresh deterministic goldens. | Future facet split and declarative manifest redesign. |
-| `binance` | Keep multifamily family recognition explicit, remove hidden winner logic, harden timezone review behavior, verify statement evidence, expand row and family coverage only for observed filing inputs. | Broad cleanup for unsupported export families not in the filing workspace. |
-| `shakepay` | Keep statement-backed balances deterministic, ensure translation and statement parsers agree on instrument claims, refresh goldens for observed filing rows. | Contract redesign for statement parsing hooks. |
-| `wealthsimple` | Verify deterministic translation and intake behavior for actual filing exports, add missing edge coverage only when observed in the workspace. | Broader portfolio-style abstraction work. |
-| `ledger_live` | Harden grouped-operation translation and wallet inventory only if the filing workspace depends on it, especially for swaps and grouped operations. | General wallet-adapter redesign. |
-| `evm_explorer` | Keep address extraction, transaction translation, and same-source same-chain portfolio evidence explicit if explorer evidence is needed for filing. | General public-ledger adapter unification and provider-hydration integration. |
-| `near` | Harden only if the filing workspace includes NEAR activity. | Family-wide explorer contract redesign. |
-| `ronin` | Harden only if the filing workspace includes Ronin activity, including known fee-precision review behavior. | Family-wide explorer contract redesign. |
-| `evm_wallet` | Harden only if wallet-state or wallet inventory evidence is needed for filing. | Wallet-state contract redesign. |
-| `cointracking_csv` | Keep render-policy validation strict, verify deterministic row ordering and projection coverage for filing facts. | New writer contract or multi-target artifact pipeline. |
-
-### 7. Tier B And Tier C Handling During The Filing Window
-
-Tier B and Tier C adapters are not ignored, but they should not drive the
-shape of filing-period work.
-
-Tier B rule:
-
-- accept low-cost shared improvements when they naturally benefit Tier B
-  adapters
-- avoid adapter-specific surgery unless that adapter becomes part of the
-  current filing workspace
-
-Tier C rule:
-
-- keep stubs and reserved surfaces minimal
-- do not expand stub capabilities during the filing window
-
-### 8. Explicitly Deferred Work
-
-The following work should be roadmapped, not pulled into the filing window:
-
-- replacing the monolithic `SourceAdapter` contract with a new multi-facet
-  interface
-- unifying input, portfolio, and output adapters under one new runtime
-  contract
-- redesigning discovery around future adapter kinds
-- introducing adapter migration wrappers, compatibility shims, or dual-write
-  flows
-- creating a fully declarative adapter specification language
-- broad parity work for non-filing adapters
-- generalized balance-provider integration work beyond filing-critical needs
-
-### 9. Filing-Window Exit Criteria
-
-The `now` track is complete when all of the following are true for the active
-filing workspace:
-
-- every filing-critical source is mapped to one supported adapter
+- every filing-critical source maps to one supported adapter
 - planner-enabled Tier A adapters emit stable planning artifacts before
   translation
-- Tier A adapters no longer depend on hidden lexical winner selection
-- timestamp interpretation is explicit and stable
-- statement-backed balance evidence is deterministic where used
-- unchanged raw inputs preserve expected fact and evidence behavior
-- `cointracking_csv` rendering is stable and rejects unsupported fact shapes
-- remaining unsupported or ambiguous cases surface as explicit issues or
-  reviews
+- unchanged filing inputs preserve expected fact, evidence, issue, and review
+  behavior unless a documented product decision changes them
+- `cointracking_csv` rendering remains deterministic and rejects unsupported
+  shapes explicitly
 
-The filing window does not require every adapter to be elegant. It requires
-the filing path to be trustworthy.
+## Shared-Foundation Prep
 
-## Work To Advance During Shared Foundations
+Prep work is allowed only when it materially reduces first-slice drift.
 
-The `prep` track is allowed before the full adapter migration because Phase 0
-cannot safely proceed on stage contracts alone. The repo also needs adapter
-product and bridge-mapping rules that let `EvidenceSet` and `ClaimSet` land
-without creating a second architecture center or forcing a brutal later
-rewrite.
+Examples:
 
-### 1. Freeze Adapter Product Contracts Needed By The First Slice
+- canonical bridge-to-target mapping for planner artifacts and statement
+  evidence
+- shared verifiers for `EvidenceSet`, `ClaimSet`, and declared compatibility
+  projections
+- shared comparison helpers that prove bridge outputs are reproducible from the
+  authoritative target kernels
 
-Write and align the minimum adapter-scoped products needed by shared
-foundations and the first vertical slice:
+Prep work must not:
 
-- `EvidenceSet`
-- `ClaimSet`
-- `SourceTranslationBatch` as the current bridge seam during migration
-- any bounded bridge note needed for `ProjectionBundle` or `ArtifactBundle`
+- create a second architecture center in adapter docs
+- redefine target product kernels locally
+- force repo-wide family migration before the bounded slices land
 
-Required rules:
+## Deferred Redesign
 
-- the adapter-scoped products must map explicitly into the core runtime
-  pipeline
-- the current bridge seam remains honest current-state truth until a bounded
-  replacement slice lands
-- target-stage product ownership stays in the core architecture docs, not in
-  adapter docs
+The broader unified adapter redesign stays deferred until:
 
-### 2. Freeze Bridge Mapping From Current Boundaries To Proto Target Products
+- the filing path is stable enough to trust
+- the contract-lock owner docs are frozen
+- the first upstream and downstream bounded slices have landed cleanly
 
-The first target-stage increment must say exactly how current artifacts map into the
-new products.
-
-Required bridge notes:
-
-- how planner-owned candidate and selection artifacts become proto-`EvidenceSet`
-- how current translation boundaries, draft compilation, and claim-like diagnostics
-  become proto-`ClaimSet`
-- where the shared compiler owns meaning versus where adapters remain
-  provider-local
-
-Rules:
-
-- no dual active runtime centers
-- no adapter-local hidden semantics beyond provider-local meaning
-- no broad family migration as a hidden prerequisite for the first increment
-- [Bridge To Target Mapping](../concepts/bridge-to-target-mapping.md) is the
-  single owner for the primary bridge mapping; this page only records the
-  adapter-delivery implications
-
-Default bridge mapping for the first increment:
-
-- [Bridge To Target Mapping](../concepts/bridge-to-target-mapping.md) owns the
-  exact planner-candidate, planner-plan, statement-evidence, and bridge-only
-  landing rules
-- [Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md) owns the
-  shared claim taxonomy plus the deterministic id, ordering, serialization, and
-  fingerprint contracts
-- [First Slice Contract](../reference/first-slice-contract.md) owns the bounded
-  Coinbase-first evidence families, claim families, replay, parity, and
-  allowed-drift rules
-- `SourceTranslationBatch` remains the honest current runtime boundary while
-  the first increment emits bounded proto-products beside it, and the shared
-  compiler keeps ownership of current bridge outputs until the downstream
-  target-stage replacement lands
-
-### 3. Freeze Adapter Determinism And Compatibility Rules
-
-Shared foundations need adapter determinism to be a written contract, not only
-an implementation preference.
-
-Required prep work:
-
-- declared ordering rules for adapter-scoped products
-- schema-version and compatibility rules aligned with target product rules
-- stable serialization and fingerprint rules
-- explicit ownership of manifest fingerprints versus product fingerprints
-
-### 4. Name The First Adapter-Family Vertical Increment
-
-The first unified-adapter-facing increment should be explicit instead of implied.
-
-Required increment definition:
-
-- one adapter family
-- the evidence families and claim families in scope
-- the bridge outputs or target products it must still interoperate with
-- replay and parity gates on unchanged evidence
-- unsupported or ambiguous cases that must remain explicit
-
-Default first-increment direction:
-
-- use the planner-enabled `coinbase` retail export family plus statement-backed
-  balance observation flow unless the active filing workspace requires another
-  Tier A family to land first
-- keep `cointracking_csv` projection compatibility in scope for the same increment
-  where it protects filing output determinism
-- use [First Slice Contract](../reference/first-slice-contract.md) as the
-  bounded parity, replay, and allowed-drift contract for that default increment
-
-### 5. Allow Shared Compiler And Verifier Prep
-
-The repo may advance shared compiler and verifier work during prep when that
-work reduces drift across the first increment.
-
-Allowed prep work:
-
-- shared claim compilation boundaries
-- shared product verifiers
-- shared replay and fingerprint checks
-- shared bridge-to-target comparison helpers
-
-Not allowed in prep:
-
-- repo-wide family migration
-- wrappers that keep old and new contracts alive indefinitely
-- broad facet rollout with no bounded consumer
-
-## Work To Roadmap
-
-The `roadmap` track covers broader family migration and contract adoption after
-the shared foundations and first increment are stable enough that the filing path
-is not depending on unresolved adapter semantics.
-
-### Roadmap Objective
-
-Replace the current bundled source contract and separate output contract with a
-smaller, purpose-defined adapter architecture built around evidence, claims,
-explicit bridge boundaries during migration, deterministic verification, and
-provider-local semantics only.
-
-### Roadmap Principles
-
-- unify around explicit adapter products, not around one giant method interface
-- keep manifests declarative and authoritative
-- separate hard assertions from soft annotations
-- treat provenance as a first-class runtime concept
-- require explicit ordering and fingerprints at artifact boundaries
-- keep the compiler and verifier shared
-- keep provider-local code focused on parsing, semantic mapping, and rendering
-
-### Roadmap Phase R1. Finish Adapter Products Beyond The First Increment
-
-Complete and extend the future adapter-scoped products beyond the bounded
-contracts already needed for the first increment:
-
-- `EvidenceSet`
-- `ClaimSet`
-- `SourceTranslationBatch` as the current bridge boundary, with a target-direction
-  move toward `TranslationResult` only when code changes land
-- `ProjectionBundle`
-- `ArtifactBundle`
-
-Boundary rule:
-
-- these adapter-scoped products must map explicitly into the core runtime
-  pipeline in `docs/concepts/reconciliation-tax-architecture.md`
-- adapter planning must not become a second architecture center with competing
-  names or stage ownership
-
-Deliverables:
-
-- written contracts for each product
-- declared ordering and fingerprint rules
-- rules for which layers may create or transform each product
-
-Entry criteria:
-
-- shared foundations and first-increment bridge mapping are stable enough that
-  broader family migration will not re-open core contract questions
-
-### Roadmap Phase R2. Split The Contract Into Facets
-
-Replace the current bundled source adapter interface with a small set of
-purpose-defined facets.
-
-Planned facets:
-
-- probe or discovery facet
-- evidence reader facet
-- statement facet
-- semantic translator facet
-- artifact writer facet
-
-Goals:
-
-- allow intake-only adapters to stay intake-only
-- allow statement-capable adapters to declare only statement work
-- keep writer adapters separate from semantic readers without duplicating the
-  manifest model
-
-Non-goals:
-
-- preserving the current monolithic shape under new names
-- adding wrappers that keep both contract systems alive indefinitely
-
-### Roadmap Phase R3. Make Manifests Declarative
-
-Move more behavior description into manifests instead of open-coded adapter
-methods where the behavior is structural rather than semantic.
-
-Candidate manifest-owned data:
-
-- evidence family signatures
-- accepted artifact kinds
-- planner support and selection modes
-- statement kinds
-- ordering and serialization rules
-- determinism guarantees
-- schema version and compatibility rules
-- supported claim and artifact types
-
-Exit criteria:
-
-- a reader can understand what an adapter can do from its manifest and small
-  provider-local modules, not from a large composite entry point
-
-### Roadmap Phase R4. Unify Verification Around Adapter Products
-
-Build one verifier that checks the adapter products instead of relying on a
-mix of adapter-local conventions.
-
-Verifier goals:
-
-- replay stability on unchanged inputs
-- product fingerprint stability
-- no unordered output surfaces
-- explicit unsupported or ambiguous cases
-- artifact parity where projections exist
-
-Exit criteria:
-
-- adapter verification is centered on adapter products and deterministic
-  compiler behavior
-
-### Roadmap Phase R5. Migrate Adapter Families In Priority Order
-
-Once the future contracts exist, migrate adapter families in bounded phases.
-
-Recommended order:
-
-1. filing-critical platform adapters
-2. filing-critical writer adapters
-3. wallet and explorer adapters needed for checkpoint confidence
-4. remaining supported platform adapters
-5. generic and reserved surfaces
-
-Rules:
-
-- migrate one family at a time
-- keep each migration checkpoint reviewable
-- remove obsolete seams once the new family path is stable
-- avoid a giant umbrella migration
-
-### Roadmap Phase R6. Retire The Bundled Current Contract
-
-Only after migrated families are stable should the repo remove the current
-bundled contract shape.
-
-Retirement conditions:
-
-- no filing-critical adapter depends on the old contract
-- verification has moved to adapter products
-- docs, scaffolds, and tests all describe the new model
-
-## Decision Rules While Filing Work Is Active
-
-Use these rules to decide whether an adapter change belongs in `now` or
-`prep` or `roadmap`.
-
-Choose `now` when:
-
-- the change directly improves a filing-critical adapter or output
-- the change removes a current source of nondeterminism
-- the change moves duplicated workflow logic into an already visible shared
-  seam
-- the change improves replay confidence on unchanged inputs
-- the change makes unsupported or ambiguous behavior explicit
-
-Choose `prep` when:
-
-- the change freezes adapter products or bridge mapping required by Phase 0
-- the change aligns current planner or translation seams with proto-
-  `EvidenceSet` or proto-`ClaimSet`
-- the change establishes shared ordering, fingerprint, or compatibility rules
-- the change enables one bounded family slice without introducing wrapper lanes
-- the change advances shared compiler or verifier seams needed by the first
-  target-stage slice
-
-Choose `roadmap` when:
-
-- the change exists mainly to prepare a future interface
-- the change introduces a new abstraction layer with no filing benefit
-- the change requires dual-contract support or migration wrappers
-- the change primarily benefits non-filing adapters
-- the change expands stubs, reserved surfaces, or speculative future adapter
-  kinds
-
-When in doubt:
-
-- prefer the smaller current-contract hardening change
-- record the future design pressure in roadmap notes instead of solving it
-  prematurely in code
-
-## Relationship To The Roadmap
-
-This plan does not replace `ROADMAP.md`.
-
-`ROADMAP.md` should continue to track the long-range architecture sequence.
-This document narrows one immediate execution question that the main roadmap
-does not need to carry in detail:
-
-- what adapter work should happen before taxes
-- what adapter work should wait until after filing
-
-The broad unified adapter redesign remains a roadmap item. The current filing
-window should stabilize the path, not perfect the architecture.
+At that point, use
+[Unified Adapter Architecture](../concepts/unified-adapter-architecture.md) as
+the design anchor for broader manifest and facet work.

--- a/docs/status/adapter-delivery-plan.md
+++ b/docs/status/adapter-delivery-plan.md
@@ -29,16 +29,16 @@ The repo should use a filing-first adapter strategy:
 
 - harden the current adapter layer where it directly reduces filing risk
 - avoid a broad source and output adapter contract rewrite before filing
-- extract only those shared seams that remove current drift on the filing path
+- extract only those shared boundaries that remove current drift on the filing path
 - write down the future unified adapter design now, but migrate to it later
 
 This plan treats adapter work as three tracks:
 
-- `now`: filing-critical hardening on the current seams
+- `now`: filing-critical hardening on the current adapter boundaries
 - `prep`: first-principles unified adapter contract and bridge-mapping work
-  needed by shared foundations and the first target-stage slice
+  needed by shared foundations and the first target-stage increment
 - `roadmap`: broader family migration into the unified adapter contract once the
-  filing path and first slice are stable
+  filing path and first increment are stable
 
 Forward-looking adapter work must map into the main runtime pipeline in
 `docs/concepts/pipeline-stage-contracts.md` and the trust-gate rules in
@@ -81,7 +81,7 @@ current behavior sooner than they depend on a perfect future contract.
 
 ### Current Source-Side Jobs
 
-| Job | Current seam | Why it matters |
+| Job | Current boundary | Why it matters |
 | --- | --- | --- |
 | Source selection | `match(...)` | Chooses the owning adapter for profiling and normalization. |
 | File-family recognition | `classify_profile_families(...)` | Drives deterministic family ownership before translation. |
@@ -95,7 +95,7 @@ current behavior sooner than they depend on a perfect future contract.
 
 ### Current Output-Side Jobs
 
-| Job | Current seam | Why it matters |
+| Job | Current boundary | Why it matters |
 | --- | --- | --- |
 | Output policy declaration | `render_policy` | Rejects facts that the target format cannot represent safely. |
 | Rendering | `render(...)` | Produces deterministic external output artifacts. |
@@ -115,13 +115,13 @@ current behavior sooner than they depend on a perfect future contract.
 | `evm_wallet` | source wallet | wallet inventory, transaction translation | Tier A only when wallet-state evidence is needed |
 | `crypto_com` | source platform | translation, intake routing | Tier B unless required in the filing workspace |
 | `gtrade` | source platform | translation, intake routing, location inventory | Tier B unless required in the filing workspace |
-| `structured_csv` | generic source | generic structured import surface | Tier B unless the filing workspace depends on it |
+| `structured_csv` | generic source | generic structured import path | Tier B unless the filing workspace depends on it |
 | `cointracking_portfolio` | portfolio intake | intake-only routing of portfolio exports | Tier B for intake stability, not for translation |
 | `cointracking_csv` | output | filing-oriented CSV projection | Tier A because output determinism directly affects filing |
-| `cointracking_api` | output stub | reserved edge surface | Tier C |
-| `generic_http_output` | output stub | reserved edge surface | Tier C |
-| `platform_api_stub` | source stub | reserved non-runtime surface | Tier C |
-| `blockchain_stub` | source stub | reserved non-runtime surface | Tier C |
+| `cointracking_api` | output stub | reserved edge adapter | Tier C |
+| `generic_http_output` | output stub | reserved edge adapter | Tier C |
+| `platform_api_stub` | source stub | reserved non-runtime adapter | Tier C |
+| `blockchain_stub` | source stub | reserved non-runtime adapter | Tier C |
 
 ### Priority Tiers
 
@@ -137,7 +137,7 @@ desire for repo-wide completeness.
 ## Filing-First Principles
 
 - Prefer deterministic current behavior over ambitious interface redesign.
-- Prefer shared support extraction over copy-paste repairs when the shared seam
+- Prefer shared support extraction over copy-paste repairs when the shared boundary
   is already visible.
 - Prefer explicit issues and reviews over adapter-local guesswork.
 - Prefer content signatures, coverage metadata, and fingerprints over filename
@@ -191,14 +191,14 @@ Exit criteria:
 
 ### 2. Harden Shared Determinism Surfaces
 
-These shared surfaces reduce drift across multiple adapters and are worth
+These shared areas reduce drift across multiple adapters and are worth
 changing during the filing window.
 
 | Work item | Why now | Concrete work | Explicitly out of scope | Exit criteria |
 | --- | --- | --- | --- | --- |
 | Translation input selection | File winner logic is one of the biggest drift sources. | Finish planner migration for filing-critical adapters, remove path-order and filename-order winning logic, keep selected, superseded, and blocked candidates explicit. | A new global adapter DSL. | Unchanged raw inputs pick the same candidates every run and emit the same plan artifacts. |
 | Deterministic ordering | Output drift can come from unordered iteration even when facts are correct. | Canonicalize ordering for candidates, selected files, drafts, issues, reviews, balance references, and rendered rows where the target format permits it. | New storage formats. | Repeated normalization and rendering runs are byte-stable or field-stable on unchanged inputs. |
-| Shared file-family recognition | Family ownership drift creates downstream translation drift. | Prefer content and schema signatures, publish stable family ids, and keep family claims in profile artifacts authoritative for translation. | Rewriting discovery around the future facet model. | Filing-critical adapters translate only recognized families and surface unmatched files explicitly. |
+| Shared file-family recognition | Family ownership drift creates downstream translation drift. | Prefer content and schema signatures, publish stable family ids, and keep family claims in profile artifacts authoritative for translation. | Rewriting discovery around the future facet model. | Filing-critical adapters translate only recognized families and report unmatched files explicitly. |
 | Timezone handling | Silent timestamp drift directly changes tax outcomes. | Keep timezone policy explicit, centralize common timezone summaries and review patterns, and reject ambiguous timestamp interpretation. | A universal temporal framework rewrite. | Filing-critical adapters no longer silently coerce naive timestamps into facts. |
 | Statement extraction | Statement evidence is needed for checkpoint and balance trust. | Keep one shared PDF extraction path, align statement matching and instrument-claim resolution, and fail explicitly on recognized-but-empty parses. | A new statement plugin system. | Statement-backed balance evidence is deterministic across repeated runs. |
 | Identity resolution feedback | Instrument ambiguity must block fact creation consistently. | Keep draft compilation as the shared gate, standardize blocking issue and review paths, and remove adapter-local special cases where possible. | New identity domains or taxonomy expansion. | All unresolved identity paths fail the same way across filing-critical adapters. |
@@ -231,8 +231,8 @@ Exit criteria:
 ### 4. Reduce Adapter-Local Orchestration In Tier A Adapters
 
 Tier A adapters should stay responsible for provider-local semantics only.
-They should not own their own mini workflow engines when a shared seam already
-exists.
+They should not own their own mini workflow engines when a shared boundary
+already exists.
 
 Allowed extractions now:
 
@@ -387,15 +387,15 @@ Required rules:
 - target-stage product ownership stays in the core architecture docs, not in
   adapter docs
 
-### 2. Freeze Bridge Mapping From Current Seams To Proto Target Products
+### 2. Freeze Bridge Mapping From Current Boundaries To Proto Target Products
 
-The first target-stage slice must say exactly how current artifacts land in the
+The first target-stage increment must say exactly how current artifacts map into the
 new products.
 
 Required bridge notes:
 
 - how planner-owned candidate and selection artifacts become proto-`EvidenceSet`
-- how current translation seams, draft compilation, and claim-like diagnostics
+- how current translation boundaries, draft compilation, and claim-like diagnostics
   become proto-`ClaimSet`
 - where the shared compiler owns meaning versus where adapters remain
   provider-local
@@ -404,35 +404,35 @@ Rules:
 
 - no dual active runtime centers
 - no adapter-local hidden semantics beyond provider-local meaning
-- no broad family migration as a hidden prerequisite for the first slice
+- no broad family migration as a hidden prerequisite for the first increment
 - [Bridge To Target Mapping](../concepts/bridge-to-target-mapping.md) is the
-  single owner for the canonical bridge mapping; this page only records the
+  single owner for the primary bridge mapping; this page only records the
   adapter-delivery implications
 
-Default bridge mapping for the first slice:
+Default bridge mapping for the first increment:
 
 - proto-`EvidenceSet` kernel:
   - selected, superseded, and blocked members from
     `translation_input_candidates.json` and `translation_input_plan.json`
   - typed provenance and locator identity from the current normalization-owned
-    evidence and statement seams
+    evidence and statement paths
   - source-local parsed observations from planner-selected input families and
-    statement extraction outputs where the slice uses them
+    statement extraction outputs where the increment uses them
 - proto-`ClaimSet` kernel:
   - provider-local semantic assertions emitted after deterministic evidence
     selection and before final draft or fact acceptance
   - balance observation claims from statement-backed quantities and other
-    quantity-backed evidence used by the slice
+    quantity-backed evidence used by the increment
   - location, ownership, instrument, and contract-facing claims only where the
     current adapter can already state them safely
-  - claim-owned blocking and advisory surfaces derived from current
+  - claim-owned blocking and advisory outputs derived from current
     source-local issues and reviews when the meaning is still pre-economic
 - bridge continuity during migration:
-  - `SourceTranslationBatch` remains the honest current runtime seam while the
-    first slice also emits bounded proto-`EvidenceSet` or proto-`ClaimSet`
+  - `SourceTranslationBatch` remains the honest current runtime boundary while the
+    first increment also emits bounded proto-`EvidenceSet` or proto-`ClaimSet`
     artifacts
   - the shared compiler remains responsible for producing current bridge outputs
-    from accepted claims until the corresponding downstream target-stage slice
+    from accepted claims until the corresponding downstream target-stage increment
     replaces that bridge responsibility
 
 ### 3. Freeze Adapter Determinism And Compatibility Rules
@@ -444,14 +444,14 @@ Required prep work:
 
 - declared ordering rules for adapter-scoped products
 - schema-version and compatibility rules aligned with target product rules
-- canonical serialization and fingerprint rules
+- stable serialization and fingerprint rules
 - explicit ownership of manifest fingerprints versus product fingerprints
 
-### 4. Name The First Adapter-Family Vertical Slice
+### 4. Name The First Adapter-Family Vertical Increment
 
-The first unified-adapter-facing slice should be explicit instead of implied.
+The first unified-adapter-facing increment should be explicit instead of implied.
 
-Required slice definition:
+Required increment definition:
 
 - one adapter family
 - the evidence families and claim families in scope
@@ -459,24 +459,24 @@ Required slice definition:
 - replay and parity gates on unchanged evidence
 - unsupported or ambiguous cases that must remain explicit
 
-Default first-slice direction:
+Default first-increment direction:
 
 - use the planner-enabled `coinbase` retail export family plus statement-backed
   balance observation flow unless the active filing workspace requires another
   Tier A family to land first
-- keep `cointracking_csv` projection compatibility in scope for the same slice
+- keep `cointracking_csv` projection compatibility in scope for the same increment
   where it protects filing output determinism
 - use [First Slice Contract](../reference/first-slice-contract.md) as the
-  bounded parity, replay, and allowed-drift contract for that default slice
+  bounded parity, replay, and allowed-drift contract for that default increment
 
 ### 5. Allow Shared Compiler And Verifier Prep
 
 The repo may advance shared compiler and verifier work during prep when that
-work reduces drift across the first slice.
+work reduces drift across the first increment.
 
 Allowed prep work:
 
-- shared claim compilation seams
+- shared claim compilation boundaries
 - shared product verifiers
 - shared replay and fingerprint checks
 - shared bridge-to-target comparison helpers
@@ -490,19 +490,19 @@ Not allowed in prep:
 ## Work To Roadmap
 
 The `roadmap` track covers broader family migration and contract adoption after
-the shared foundations and first slice are stable enough that the filing path
+the shared foundations and first increment are stable enough that the filing path
 is not depending on unresolved adapter semantics.
 
 ### Roadmap Objective
 
 Replace the current bundled source contract and separate output contract with a
 smaller, purpose-defined adapter architecture built around evidence, claims,
-explicit bridge seams during migration, deterministic verification, and
+explicit bridge boundaries during migration, deterministic verification, and
 provider-local semantics only.
 
 ### Roadmap Principles
 
-- unify around explicit adapter products, not around one giant method surface
+- unify around explicit adapter products, not around one giant method interface
 - keep manifests declarative and authoritative
 - separate hard assertions from soft annotations
 - treat provenance as a first-class runtime concept
@@ -510,14 +510,14 @@ provider-local semantics only.
 - keep the compiler and verifier shared
 - keep provider-local code focused on parsing, semantic mapping, and rendering
 
-### Roadmap Phase R1. Finish Adapter Products Beyond The First Slice
+### Roadmap Phase R1. Finish Adapter Products Beyond The First Increment
 
 Complete and extend the future adapter-scoped products beyond the bounded
-contracts already needed for the first slice:
+contracts already needed for the first increment:
 
 - `EvidenceSet`
 - `ClaimSet`
-- `SourceTranslationBatch` as the current bridge seam, with a target-direction
+- `SourceTranslationBatch` as the current bridge boundary, with a target-direction
   move toward `TranslationResult` only when code changes land
 - `ProjectionBundle`
 - `ArtifactBundle`
@@ -537,7 +537,7 @@ Deliverables:
 
 Entry criteria:
 
-- shared foundations and first-slice bridge mapping are stable enough that
+- shared foundations and first-increment bridge mapping are stable enough that
   broader family migration will not re-open core contract questions
 
 ### Roadmap Phase R2. Split The Contract Into Facets

--- a/docs/status/current-state.md
+++ b/docs/status/current-state.md
@@ -1,6 +1,6 @@
 ---
 title: "Current State"
-summary: "Implemented runtime capabilities, current operational surface, and deferred areas."
+summary: "Implemented runtime capabilities, current operational capabilities, and deferred areas."
 doc_type: status
 audience: human
 owner: repo
@@ -36,14 +36,14 @@ product names `EvidenceSet`, `ClaimSet`, `EconomicFacts`,
 
 - The implemented bridge currently centers on `EconomicActivityDraft`,
   `TransactionFact`, `balance_snapshots.csv`, and `balance_references.csv`.
-- Treat that bridge as the current delivery seam, not as the final architecture
+- Treat that bridge as the current delivery boundary, not as the final architecture
   center.
 - The target pipeline products and stage contracts live in
   `docs/concepts/pipeline-stage-contracts.md`; system-level trust gates and
   rollout alignment live in
   `docs/concepts/reconciliation-tax-architecture.md` and `ROADMAP.md`.
 - MVP work should extend the current bridge incrementally where it protects the
-  filing path, while landing richer pipeline products only when a concrete next
+  filing path, while adding richer pipeline products only when a concrete next
   stage needs them.
 
 ## Current Operational Surface
@@ -81,7 +81,7 @@ The repo currently ships typed replacements for the core workflow capabilities:
 - checkpoint location inventory rebuild with evidence, issues, and summary
   artifacts
 - checkpoint PDF balance extraction for supported statement families through
-  the shared statement extraction seam
+  the shared statement extraction path
 - `application/balances` owns the shared balance capability: inspect, check,
   and summarize workflows with explicit drift, missing-side, duplicate-input,
   blocker outputs, additive cross-source corroboration sidecars, explicit
@@ -139,7 +139,7 @@ The repo currently ships typed replacements for the core workflow capabilities:
   targets whose location and asset identity are already known.
 - On-chain asset ids with immutable chain identity are the prerequisite for
   historical public-ledger provider hydration. Symbol-only token rows remain
-  explicit unsupported surfaces until immutable identity is proven.
+  explicit unsupported cases until immutable identity is proven.
 - `balance_snapshots.csv` and `balance_references.csv` are the only runtime
   balance artifacts. `balances.csv` and `balance_evidence.csv` are superseded
   generated outputs and are not runtime inputs.
@@ -152,7 +152,7 @@ The repo currently ships typed replacements for the core workflow capabilities:
 
 ## Current Migration Notes
 
-- Translation input planning is opt-in per adapter during the first slice.
+- Translation input planning is opt-in per adapter during the first increment.
 - Coinbase is the first planner-enabled adapter and now describes retail CSV
   candidates instead of choosing one file by path order.
 - Legacy adapters still use the fallback `translate(...)` path until their

--- a/docs/status/migration-sequence.md
+++ b/docs/status/migration-sequence.md
@@ -58,7 +58,9 @@ The target architecture lands as these final products:
 Owning contract pages:
 
 - [`docs/concepts/current-bridge-contracts.md`](../concepts/current-bridge-contracts.md)
+- [`docs/concepts/bridge-to-target-mapping.md`](../concepts/bridge-to-target-mapping.md)
 - [`docs/concepts/pipeline-stage-contracts.md`](../concepts/pipeline-stage-contracts.md)
+- [`docs/reference/first-slice-contract.md`](../reference/first-slice-contract.md)
 - [`docs/concepts/domain-ontology.md`](../concepts/domain-ontology.md)
 - [`docs/concepts/gaps-and-readiness.md`](../concepts/gaps-and-readiness.md)
 
@@ -75,8 +77,8 @@ These foundations are prerequisites, not later cleanup:
 - target-product versioning, compatibility, serialization, and fingerprint
   rules
 - kernel-and-envelope rules with stable rehydration joins
-- one bridge note for how current adapter seams land proto-`EvidenceSet` and
-  proto-`ClaimSet`
+- one bridge-to-target mapping page that owns how current adapter seams land in
+  proto-`EvidenceSet` and proto-`ClaimSet`
 
 Rules:
 
@@ -112,6 +114,9 @@ Default first-slice direction:
 - use the planner-enabled Coinbase retail export family plus statement-backed
   balance observation flow unless the active filing workspace requires another
   Tier A family to land first
+- use [First Slice Contract](../reference/first-slice-contract.md) as the
+  bounded default-slice contract instead of inferring extra adapter inventory
+  from the repo
 
 ## Phase Order
 
@@ -127,8 +132,8 @@ Deliver before broad code changes:
 - kernel-and-envelope rules with stable rehydration joins
 - minimum `ClaimSet`, `EconomicFacts`, `Checkpoint`, and `TaxInputs`
   vocabularies
-- one bridge note for how current planner and translation seams land proto-
-  `EvidenceSet` and proto-`ClaimSet`
+- one canonical bridge-to-target mapping for how current planner and
+  translation seams land proto-`EvidenceSet` and proto-`ClaimSet`
 - one named first vertical slice with parity and replay gates
 - clear bridge-versus-target ownership so later code slices do not re-decide
   naming or stage boundaries
@@ -139,6 +144,8 @@ Rules:
 - do not let the bridge contract masquerade as the target ontology
 - do not make broad unified-adapter family migration a hidden prerequisite for
   the first target-stage slice
+- do not start broad target package scaffolding before these contracts are
+  frozen on their owner pages
 
 ### Phase 1. Formalize `EvidenceSet`
 

--- a/docs/status/migration-sequence.md
+++ b/docs/status/migration-sequence.md
@@ -72,6 +72,11 @@ These foundations are prerequisites, not later cleanup:
 - shared `SubjectRef` rules
 - shared checkpoint-assertion direction
 - typed tax-policy selection seam
+- target-product versioning, compatibility, serialization, and fingerprint
+  rules
+- kernel-and-envelope rules with stable rehydration joins
+- one bridge note for how current adapter seams land proto-`EvidenceSet` and
+  proto-`ClaimSet`
 
 Rules:
 
@@ -85,24 +90,46 @@ Rules:
 - `EvidenceSet` formalizes deterministic evidence selection and source-local
   observations now spread across intake, profiling, and translation-input
   planning
+- current planner artifacts may serve as the first bridge landing path into
+  proto-`EvidenceSet`; broad unified-adapter family migration is not a hidden
+  prerequisite
 - `ClaimSet` becomes the place where `EconomicActivityDraft` responsibilities
   can split into source-local meaning plus preserved ambiguity
+- claim-native output may first land through one bounded adapter family or
+  shared compiler seam before any repo-wide adapter facet migration
 - `EconomicFacts` becomes the accepted economic truth that the current
   `TransactionFact` bridge only approximates today
 - `ReconciliationState` and `Checkpoint` absorb the trust-gate work currently
   expressed through bridge-era balances, links, and checkpoint scaffolding
 - `Journal`, `TaxInputs`, and `TaxOutputs` replace the remaining bridge-era
   tendency to push accounting or tax meaning downward too early
+- unified adapter product and facet work may advance during shared foundations
+  when it removes first-slice drift, but broad family migration waits until the
+  contract lock and first slice are stable
+
+Default first-slice direction:
+
+- use the planner-enabled Coinbase retail export family plus statement-backed
+  balance observation flow unless the active filing workspace requires another
+  Tier A family to land first
 
 ## Phase Order
 
-### Phase 0. Shared Foundations And Schema Lock
+### Phase 0. Shared Foundations, Contract Lock, And First-Slice Prep
 
 Deliver before broad code changes:
 
 - aligned bridge, target, ontology, and support-model docs
 - shared provenance, gaps, readiness, checkpoint assertions, identity seams,
   `SubjectRef`, and tax-policy selection contracts
+- target-product versioning, serialization, and fingerprint rules
+- checkpoint acceptance vocabularies and minimum admissibility rules
+- kernel-and-envelope rules with stable rehydration joins
+- minimum `ClaimSet`, `EconomicFacts`, `Checkpoint`, and `TaxInputs`
+  vocabularies
+- one bridge note for how current planner and translation seams land proto-
+  `EvidenceSet` and proto-`ClaimSet`
+- one named first vertical slice with parity and replay gates
 - clear bridge-versus-target ownership so later code slices do not re-decide
   naming or stage boundaries
 
@@ -110,6 +137,8 @@ Rules:
 
 - do not start broad tax-engine work before these contracts are written down
 - do not let the bridge contract masquerade as the target ontology
+- do not make broad unified-adapter family migration a hidden prerequisite for
+  the first target-stage slice
 
 ### Phase 1. Formalize `EvidenceSet`
 
@@ -118,12 +147,15 @@ Deliver:
 - deterministic selection outputs
 - explicit selected, superseded, and blocked evidence outputs
 - source-local parsed observation contracts
+- a bounded landing path from current planner artifacts into proto-`EvidenceSet`
 
 Rules:
 
 - evidence selection remains deterministic
 - evidence does not force economic meaning
 - evidence selection reasoning must survive beyond intake-time heuristics
+- the first `EvidenceSet` slice may reuse current adapter seams as long as the
+  landing contract is explicit and no second architecture center is created
 
 ### Phase 2. Introduce `ClaimSet`
 
@@ -133,6 +165,8 @@ Deliver:
 - claim-owned issues and reviews
 - explicit materially unresolved meaning
 - claim-to-economic compilation seam boundaries
+- one bounded adapter-family path for claim-native output before any broad
+  facet migration
 
 Rules:
 
@@ -141,6 +175,7 @@ Rules:
 - adapters own source-local meaning only
 - the current bridge may remain as a bounded seam during migration, but it must
   stop forcing final semantics too early
+- the first `ClaimSet` slice must not require repo-wide dual-contract support
 
 ### Phase 3. Land `EconomicFacts`
 

--- a/docs/status/migration-sequence.md
+++ b/docs/status/migration-sequence.md
@@ -8,19 +8,25 @@ status: active
 nav_order: 20
 ---
 
-Use this document to implement the next phase without a big-bang refactor. The
-goal is to move from the current bridge into the target pipeline with explicit
-parity gates, clean retirement rules, and no wrapper-lane sprawl.
+Use this document to implement the next increment without a big-bang refactor.
+The goal is to move from the current bridge into the target pipeline with
+explicit parity gates, clean retirement rules, and no wrapper-lane sprawl.
 
-## Migration Objectives
+## Roadmap Ownership
 
-- preserve current working behavior while new foundations land
-- avoid freezing the current bridge as the long-term architecture center
-- keep adapters and services shippable at every checkpoint
-- keep CoinTracking as one edge projection and oracle family, not a migration
-  anchor
-- preserve current bridge truth while establishing the target stage and
-  ontology ownership model
+`ROADMAP.md` is the only numbered implementation program of record.
+
+Use this page for:
+
+- landing rules for the next increment
+- bridge-retirement rules
+- parity and replay expectations between increments
+
+Do not use this page for:
+
+- competing phase numbers
+- alternate phase labels
+- a second copy of roadmap sequencing
 
 ## Current Bridge
 
@@ -46,14 +52,7 @@ Current live bridge contract owner:
 
 The target architecture lands as these final products:
 
-1. `EvidenceSet`
-2. `ClaimSet`
-3. `EconomicFacts`
-4. `ReconciliationState`
-5. `Checkpoint`
-6. `Journal`
-7. `TaxInputs`
-8. `TaxOutputs`
+`EvidenceSet -> ClaimSet -> EconomicFacts -> ReconciliationState -> Checkpoint -> Journal -> TaxInputs -> TaxOutputs`
 
 Owning contract pages:
 
@@ -61,6 +60,7 @@ Owning contract pages:
 - [`docs/concepts/bridge-to-target-mapping.md`](../concepts/bridge-to-target-mapping.md)
 - [`docs/concepts/pipeline-stage-contracts.md`](../concepts/pipeline-stage-contracts.md)
 - [`docs/reference/first-slice-contract.md`](../reference/first-slice-contract.md)
+- [`docs/reference/first-downstream-slice-contract.md`](../reference/first-downstream-slice-contract.md)
 - [`docs/concepts/domain-ontology.md`](../concepts/domain-ontology.md)
 - [`docs/concepts/gaps-and-readiness.md`](../concepts/gaps-and-readiness.md)
 
@@ -71,67 +71,55 @@ These foundations are prerequisites, not later cleanup:
 - shared stage contracts
 - shared ontology and identity boundaries
 - shared gap and readiness model
-- shared `SubjectRef` rules
 - shared checkpoint-assertion direction
-- typed tax-policy selection boundary
-- target-product versioning, compatibility, serialization, and fingerprint
-  rules
+- target-product versioning, serialization, and fingerprint rules
 - kernel-and-envelope rules with stable rehydration joins
-- one primary bridge-to-target mapping for how current adapter outputs map to
-  proto-`EvidenceSet` and proto-`ClaimSet`
+- one bridge-to-target mapping page that owns how current adapter outputs map
+  to proto-`EvidenceSet` and proto-`ClaimSet`
+- one bounded downstream slice page that owns the first
+  `EconomicFacts -> ReconciliationState -> Checkpoint` consumer path
 
 Rules:
 
-- no stage should invent an incompatible blocker category or readiness model
-- no stage should use `SubjectRef` as a substitute for real domain modeling
-- no stage should restate the target contracts in a competing document when an
-  owning contract page already exists
+- no stage may invent an incompatible blocker category or readiness model
+- no stage may use `SubjectRef` as a substitute for real domain modeling
+- no stage may restate target contracts in a competing document when an owning
+  contract page already exists
 
 ## Bridge-To-Target Landing Rules
 
 - [Bridge To Target Mapping](../concepts/bridge-to-target-mapping.md) owns the
   live-to-target transformation rules
-- [Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md) owns the
-  target product kernels, claim taxonomy, stable ids, ordering, serialization,
+- [Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md) own the
+  target product kernels, record families, stable ids, ordering, serialization,
   and fingerprint rules
 - [First Slice Contract](../reference/first-slice-contract.md) owns the bounded
-  Coinbase-first slice, including its replay and parity rules
+  Coinbase-first `EvidenceSet` and `ClaimSet` landing path
+- [First Downstream Slice Contract](../reference/first-downstream-slice-contract.md)
+  owns the bounded first `EconomicFacts -> ReconciliationState -> Checkpoint`
+  landing path
 - broad unified-adapter family migration remains optional prep work, not a
-  hidden prerequisite for the first bounded increment
+  hidden prerequisite for the first bounded increments
 
-Default first-increment direction:
-
-- use the planner-enabled Coinbase retail export family plus statement-backed
-  balance observation flow unless the active filing workspace requires another
-  Tier A family to land first
-- use [First Slice Contract](../reference/first-slice-contract.md) as the
-  bounded default contract for the first increment instead of inferring extra
-  adapter inventory
-  from the repo
-
-## Phase Order
-
-### Phase 0. Shared Foundations, Contract Lock, And First-Increment Prep
+## Contract Lock
 
 Deliver before broad code changes:
 
 - aligned bridge, target, ontology, and support-model docs
-- freeze the detailed contract content on the owning concept and reference
-  pages instead of restating those semantics here
-- one named first vertical increment with parity and replay gates
-- clear bridge-versus-target ownership so later code increments do not re-decide
-  naming or stage boundaries
+- frozen downstream record-family contracts and shared support artifacts
+- one named first upstream slice and one named first downstream slice
+- clear bridge-versus-target ownership so later code increments do not
+  re-decide naming, package placement, or stage boundaries
 
 Rules:
 
-- do not start broad tax-engine work before these contracts are written down
-- do not let the bridge contract masquerade as the target ontology
-- do not make broad unified-adapter family migration a hidden prerequisite for
-  the first target-stage increment
 - do not start broad target package scaffolding before these contracts are
   frozen on their owner pages
+- do not let the bridge contract masquerade as the target ontology
+- do not leave gap ids, readiness ids, checkpoint assertion ids, or downstream
+  kernel families to implementation-time judgment
 
-### Phase 1. Formalize `EvidenceSet`
+## `EvidenceSet` Increment
 
 Deliver:
 
@@ -144,12 +132,12 @@ Rules:
 
 - evidence selection remains deterministic
 - evidence does not force economic meaning
-- evidence selection reasoning must survive beyond intake-time heuristics
+- evidence-selection reasoning must survive beyond intake-time heuristics
 - the first `EvidenceSet` increment may reuse current adapter boundaries as
   long as the mapping contract is explicit and no second architecture center is
   created
 
-### Phase 2. Introduce `ClaimSet`
+## `ClaimSet` Increment
 
 Deliver:
 
@@ -165,17 +153,19 @@ Rules:
 - ambiguous rows may remain claims without being forced into final economic,
   accounting, or tax meaning
 - adapters own source-local meaning only
-- the current bridge may remain as a bounded boundary during migration, but it must
-  stop forcing final semantics too early
-- the first `ClaimSet` increment must not require repo-wide dual-contract support
+- the current bridge may remain as a bounded boundary during migration, but it
+  must stop forcing final semantics too early
+- the first `ClaimSet` increment must not require repo-wide dual-contract
+  support
 
-### Phase 3. Land `EconomicFacts`
+## `EconomicFacts` Increment
 
 Deliver:
 
-- claim-to-economic compilation boundary
-- target-directed economic models aligned to the target ontology
-- explicit identity, settlement, lifecycle, and valuation handling
+- target-directed accepted economic truth through `EconomicEventRecord` and
+  `EconomicLegRecord`
+- frozen `event_family` and `leg_role` vocabularies on the owner page
+- claim-to-economic compilation decisions with stable adjudication records
 
 Rules:
 
@@ -184,27 +174,30 @@ Rules:
 - accepted economic meaning should move away from bridge activity-label
   centrality
 
-### Phase 4. Land `ReconciliationState`
+## `ReconciliationState` Increment
 
 Deliver:
 
-- explicit reconciliation completeness and continuity outputs
+- explicit `ContinuitySegmentRecord`, `LinkRecord`, `BalanceTargetRecord`, and
+  `CheckpointCandidateRecord` contracts
+- explicit completeness and continuity outputs
 - target gap and readiness adoption where the owning stage can support it
-- transfer linkage, balance targets, and checkpoint candidacy under one
-  reconciliation-owned product
 
 Rules:
 
 - reconciliation consumes accepted economic truth plus checkpoint evidence
 - exact balance assertions are one reconciliation input, not the whole
   reconciliation product
+- the first downstream slice may keep `LinkRecord` out of scope while the
+  remainder of the reconciliation contract is still frozen
 
-### Phase 5. Land `Checkpoint`
+## `Checkpoint` Increment
 
 Deliver:
 
 - explicit checkpoint truth and acceptance basis
 - source-backed checkpoint evidence requirements
+- `CheckpointAssertionValue` plus frozen `assertion_kind` vocabulary
 - trust level and adopted opening-state handling
 - checkpoint continuity reports
 
@@ -213,36 +206,41 @@ Rules:
 - checkpoint truth remains source-backed where filing readiness requires it
 - operator-confirmed balances may support runtime progress but do not become
   filing-ready checkpoint truth by default
+- the first downstream slice requires statement-backed checkpoint evidence
+  rather than operator-only acceptance
 
-### Phase 6. Land `Journal`
+## `Journal` Increment
 
 Deliver:
 
-- internal journal model
-- posting expansion and validation
+- `JournalEntryRecord`, `PostingRecord`, and `ValidationRecord`
+- posting expansion and validation surfaces
 - accounting-owned blockers
 
 Rules:
 
 - accounting validates accepted truth
 - accounting does not repair truth
+- posting determinants required for validation stay in the kernel contract
 
-### Phase 7. Land `TaxInputs` And `TaxOutputs`
+## `Tax` Increment
 
 Deliver:
 
-- `TaxInputs`
-- selected tax-policy execution
+- `TaxDeterminantRecord` and `BasisTransitionRecord`
+- selected tax-policy execution over `TaxInputs`
 - year-partitioned carry-forward state
-- policy-owned `TaxOutputs`
+- `TaxOutputRecord`, `CarryForwardRecord`, and `UnsupportedItemRecord`
 
 Rules:
 
 - tax outputs flow from `TaxInputs` through selected tax policies
 - tax policy does not decide source meaning, reconciliation truth, or
   checkpoint truth
+- tax determinants keep effective time, quantity, direction, and basis
+  transitions in the kernel
 
-### Phase 8. Retire Superseded Bridge Outputs And Assumptions
+## Bridge Retirement
 
 Retire or demote bridge outputs and assumptions only after:
 
@@ -266,12 +264,12 @@ Do not remove an older path until all relevant gates pass:
 
 The docs and control-plane baseline for this migration is:
 
-- target stage contracts, ontology, and gap/readiness ownership are already
-  separated into focused concept pages
+- target stage contracts, ontology, and gap/readiness ownership are separated
+  into focused owner pages
 - current-state docs keep current bridge terms where accuracy requires them
-- later implementation should rename the dev-only shared repo support package area
-  from `repo_support/` to `dev_support/`, but this remains future work until
-  the corresponding implementation increment lands
-- roadmap, migration, and architecture anchors must be updated together when a
+- later implementation should rename the dev-only shared repo support package
+  area from `repo_support/` to `dev_support/`, but that remains future work
+  until the corresponding implementation increment lands
+- roadmap, migration, and architecture anchors are updated together when a
   change updates stage ownership, trust-gate sequencing, or shared support
   contracts

--- a/docs/status/migration-sequence.md
+++ b/docs/status/migration-sequence.md
@@ -59,6 +59,8 @@ Owning contract pages:
 - [`docs/concepts/current-bridge-contracts.md`](../concepts/current-bridge-contracts.md)
 - [`docs/concepts/bridge-to-target-mapping.md`](../concepts/bridge-to-target-mapping.md)
 - [`docs/concepts/pipeline-stage-contracts.md`](../concepts/pipeline-stage-contracts.md)
+- [`docs/reference/target-contract-primitives.md`](../reference/target-contract-primitives.md)
+- [`docs/reference/target-product-artifacts.md`](../reference/target-product-artifacts.md)
 - [`docs/reference/first-slice-contract.md`](../reference/first-slice-contract.md)
 - [`docs/reference/first-downstream-slice-contract.md`](../reference/first-downstream-slice-contract.md)
 - [`docs/concepts/domain-ontology.md`](../concepts/domain-ontology.md)
@@ -72,6 +74,9 @@ These foundations are prerequisites, not later cleanup:
 - shared ontology and identity boundaries
 - shared gap and readiness model
 - shared checkpoint-assertion direction
+- shared primitive contracts for scalars, tuple refs, dataset ids, and
+  reusable target value shapes
+- shared target artifact packaging and kernel filename rules
 - target-product versioning, serialization, and fingerprint rules
 - kernel-and-envelope rules with stable rehydration joins
 - one bridge-to-target mapping page that owns how current adapter outputs map
@@ -110,6 +115,10 @@ Deliver before broad code changes:
 - one named first upstream slice and one named first downstream slice
 - clear bridge-versus-target ownership so later code increments do not
   re-decide naming, package placement, or stage boundaries
+- shared primitive contracts frozen
+- target artifact packaging frozen
+- review-sidecar policy frozen
+- package landing rules frozen
 
 Rules:
 
@@ -197,7 +206,7 @@ Deliver:
 
 - explicit checkpoint truth and acceptance basis
 - source-backed checkpoint evidence requirements
-- `CheckpointAssertionValue` plus frozen `assertion_kind` vocabulary
+- `AssertionValue` plus frozen `assertion_kind` vocabulary
 - trust level and adopted opening-state handling
 - checkpoint continuity reports
 

--- a/docs/status/migration-sequence.md
+++ b/docs/status/migration-sequence.md
@@ -89,25 +89,15 @@ Rules:
 
 ## Bridge-To-Target Landing Rules
 
-- `EvidenceSet` formalizes deterministic evidence selection and source-local
-  observations now spread across intake, profiling, and translation-input
-  planning
-- current planner artifacts may serve as the first bridge path into
-  proto-`EvidenceSet`; broad unified-adapter family migration is not a hidden
-  prerequisite
-- `ClaimSet` becomes the place where `EconomicActivityDraft` responsibilities
-  can split into source-local meaning plus preserved ambiguity
-- claim-native output may first arrive through one bounded adapter family or
-  a shared compiler boundary before any repo-wide adapter facet migration
-- `EconomicFacts` becomes the accepted economic truth that the current
-  `TransactionFact` bridge only approximates today
-- `ReconciliationState` and `Checkpoint` absorb the trust-gate work currently
-  expressed through bridge-era balances, links, and checkpoint scaffolding
-- `Journal`, `TaxInputs`, and `TaxOutputs` replace the remaining bridge-era
-  tendency to push accounting or tax meaning downward too early
-- unified adapter product and facet work may advance during shared foundations
-  when it removes first-increment drift, but broad family migration waits until
-  the contract lock and first increment are stable
+- [Bridge To Target Mapping](../concepts/bridge-to-target-mapping.md) owns the
+  live-to-target transformation rules
+- [Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md) owns the
+  target product kernels, claim taxonomy, stable ids, ordering, serialization,
+  and fingerprint rules
+- [First Slice Contract](../reference/first-slice-contract.md) owns the bounded
+  Coinbase-first slice, including its replay and parity rules
+- broad unified-adapter family migration remains optional prep work, not a
+  hidden prerequisite for the first bounded increment
 
 Default first-increment direction:
 
@@ -126,15 +116,8 @@ Default first-increment direction:
 Deliver before broad code changes:
 
 - aligned bridge, target, ontology, and support-model docs
-- shared provenance, gaps, readiness, checkpoint assertions, identity seams,
-  `SubjectRef`, and tax-policy selection contracts
-- target-product versioning, serialization, and fingerprint rules
-- checkpoint acceptance vocabularies and minimum admissibility rules
-- kernel-and-envelope rules with stable rehydration joins
-- minimum `ClaimSet`, `EconomicFacts`, `Checkpoint`, and `TaxInputs`
-  vocabularies
-- one primary bridge-to-target mapping for how current planner and
-  translation paths map to proto-`EvidenceSet` and proto-`ClaimSet`
+- freeze the detailed contract content on the owning concept and reference
+  pages instead of restating those semantics here
 - one named first vertical increment with parity and replay gates
 - clear bridge-versus-target ownership so later code increments do not re-decide
   naming or stage boundaries

--- a/docs/status/migration-sequence.md
+++ b/docs/status/migration-sequence.md
@@ -1,6 +1,6 @@
 ---
 title: "Migration Sequence"
-summary: "Incremental migration order from the current bridge toward the target stage-first pipeline with parity gates and retirement rules."
+summary: "Incremental landing and retirement rules for moving from the current bridge to the target pipeline without dual authorities."
 doc_type: status
 audience: human
 owner: repo
@@ -8,277 +8,173 @@ status: active
 nav_order: 20
 ---
 
-Use this document to implement the next increment without a big-bang refactor.
-The goal is to move from the current bridge into the target pipeline with
-explicit parity gates, clean retirement rules, and no wrapper-lane sprawl.
+Use this page to sequence implementation increments without a big-bang refactor.
+This document keeps migration rules, cutover expectations, and retirement gates
+in one place. It does not re-own target product contracts or recreate roadmap
+phase detail.
 
 ## Roadmap Ownership
 
-`ROADMAP.md` is the only numbered implementation program of record.
+[ROADMAP.md](../../ROADMAP.md) is the only numbered implementation program of
+record.
 
 Use this page for:
 
-- landing rules for the next increment
-- bridge-retirement rules
-- parity and replay expectations between increments
+- migration landing rules
+- reader and writer cutover expectations
+- bridge retirement rules
+- parity and replay gates that must hold before one surface is retired
 
 Do not use this page for:
 
 - competing phase numbers
 - alternate phase labels
-- a second copy of roadmap sequencing
+- duplicate product-contract definitions
+- duplicate ontology, support-model, or persistence contracts
 
-## Current Bridge
+## Operating Rules
 
-Current bridge truth:
+Every slice must obey the following rules before code lands:
 
-- `EconomicActivityDraft`, `TransactionFact`, and the shared balance artifacts
-  are the live implementation boundary
-- that boundary is the current parity baseline
-- that boundary is not the final architecture center
+- declare the slice scope
+- name the authoritative writer for every affected scope
+- name the authoritative reader for every affected consumer
+- declare the product ids and upstream product-ref fields used by each target
+  kernel the slice introduces
+- name the derived compatibility projection for every unmigrated reader
+- name any declared compatibility sidecars needed to preserve retained legacy
+  fields for those unmigrated readers
+- name the cutover gate and retirement gate for every affected bridge surface
 
-Bridge naming rule:
+Migration-wide rules:
 
-- keep current bridge names in live bridge code until later implementation
-  increments replace them
-- do not perform large bridge renames as a prerequisite for the next bounded
-  architecture increment
+- no consumer may read a bridge surface and a target product as peer
+  authorities
+- once a target product exists for an in-scope family, that target product is
+  the authoritative persisted source for that scope
+- bridge surfaces that remain in use after that point are compatibility
+  projections only
+- unchanged bridge outputs must remain reproducible from the authoritative
+  target kernels during the compatibility window
 
-Current live bridge contract owner:
+The authoritative cutover matrix lives in
+[Bridge To Target Mapping](../concepts/bridge-to-target-mapping.md).
 
-- [`docs/concepts/current-bridge-contracts.md`](../concepts/current-bridge-contracts.md)
+## Landing Order
 
-## Target Pipeline
+### 1. Contract Lock
 
-The target architecture lands as these final products:
+Before broad implementation, freeze:
 
-`EvidenceSet -> ClaimSet -> EconomicFacts -> ReconciliationState -> Checkpoint -> Journal -> TaxInputs -> TaxOutputs`
+- target product contracts on
+  [Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md)
+- ontology and ref seams on
+  [Domain Ontology](../concepts/domain-ontology.md)
+- shared blockers, reviews, readiness, and `SubjectRef` rules on
+  [Gaps And Readiness](../concepts/gaps-and-readiness.md)
+- persistence, partitioning, and fast-path rules on
+  [Reconciliation And Tax Architecture](../concepts/reconciliation-tax-architecture.md)
+- bridge-to-target cutover rules on
+  [Bridge To Target Mapping](../concepts/bridge-to-target-mapping.md)
 
-Owning contract pages:
+Broad parallel implementation must not begin before those owner pages are
+aligned and frozen.
 
-- [`docs/concepts/current-bridge-contracts.md`](../concepts/current-bridge-contracts.md)
-- [`docs/concepts/bridge-to-target-mapping.md`](../concepts/bridge-to-target-mapping.md)
-- [`docs/concepts/pipeline-stage-contracts.md`](../concepts/pipeline-stage-contracts.md)
-- [`docs/reference/target-contract-primitives.md`](../reference/target-contract-primitives.md)
-- [`docs/reference/target-product-artifacts.md`](../reference/target-product-artifacts.md)
-- [`docs/reference/first-slice-contract.md`](../reference/first-slice-contract.md)
-- [`docs/reference/first-downstream-slice-contract.md`](../reference/first-downstream-slice-contract.md)
-- [`docs/concepts/domain-ontology.md`](../concepts/domain-ontology.md)
-- [`docs/concepts/gaps-and-readiness.md`](../concepts/gaps-and-readiness.md)
+### 2. First Upstream Slice
 
-## Shared Foundations
+Land the bounded
+[`EvidenceSet -> ClaimSet`](../reference/first-slice-contract.md) slice.
 
-These foundations are prerequisites, not later cleanup:
+Required posture:
 
-- shared stage contracts
-- shared ontology and identity boundaries
-- shared gap and readiness model
-- shared checkpoint-assertion direction
-- shared primitive contracts for scalars, tuple refs, dataset ids, and
-  reusable target value shapes
-- shared target artifact packaging and kernel filename rules
-- target-product versioning, serialization, and fingerprint rules
-- kernel-and-envelope rules with stable rehydration joins
-- one bridge-to-target mapping page that owns how current adapter outputs map
-  to proto-`EvidenceSet` and proto-`ClaimSet`
-- one bounded downstream slice page that owns the first
-  `EconomicFacts -> ReconciliationState -> Checkpoint` consumer path
+- `EvidenceSet` becomes authoritative for in-scope evidence selection
+- `ClaimSet` becomes authoritative for in-scope source-local semantics
+- `translation_input_plan.json`, `EconomicActivityDraft`, and
+  `SourceTranslationBatch` survive only as derived compatibility projections
 
-Rules:
+### 3. First Downstream Slice
 
-- no stage may invent an incompatible blocker category or readiness model
-- no stage may use `SubjectRef` as a substitute for real domain modeling
-- no stage may restate target contracts in a competing document when an owning
-  contract page already exists
+Land the bounded
+[`EconomicFacts -> ReconciliationState -> Checkpoint`](../reference/first-downstream-slice-contract.md)
+slice.
 
-## Bridge-To-Target Landing Rules
+Required posture:
 
-- [Bridge To Target Mapping](../concepts/bridge-to-target-mapping.md) owns the
-  live-to-target transformation rules
-- [Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md) own the
-  target product kernels, record families, stable ids, ordering, serialization,
-  and fingerprint rules
-- [First Slice Contract](../reference/first-slice-contract.md) owns the bounded
-  Coinbase-first `EvidenceSet` and `ClaimSet` landing path
-- [First Downstream Slice Contract](../reference/first-downstream-slice-contract.md)
-  owns the bounded first `EconomicFacts -> ReconciliationState -> Checkpoint`
-  landing path
-- broad unified-adapter family migration remains optional prep work, not a
-  hidden prerequisite for the first bounded increments
+- `EconomicFacts` becomes authoritative for in-scope accepted economic meaning
+- `ReconciliationState` becomes authoritative for in-scope continuity segments
+  and balance targets
+- `Checkpoint` becomes authoritative for in-scope accepted checkpoint truth
+- `TransactionFact`, `balance_snapshots.csv`, and `balance_references.csv`
+  survive only as derived compatibility projections for unmigrated readers
 
-## Contract Lock
+### 4. Reader Cutovers
 
-Deliver before broad code changes:
+After the bounded slices land, migrate readers one consumer surface at a time:
 
-- aligned bridge, target, ontology, and support-model docs
-- frozen downstream record-family contracts and shared support artifacts
-- one named first upstream slice and one named first downstream slice
-- clear bridge-versus-target ownership so later code increments do not
-  re-decide naming, package placement, or stage boundaries
-- shared primitive contracts frozen
-- target artifact packaging frozen
-- review-sidecar policy frozen
-- package landing rules frozen
+- evidence and claim readers move to target kernels first
+- reconciliation and checkpoint readers move next
+- balance inspect/check/summarize moves only when its application surface is
+  explicitly repointed
+- accounting and tax readers move only after their upstream products are
+  authoritative and stable
 
-Rules:
+### 5. Later Downstream Products
 
-- do not start broad target package scaffolding before these contracts are
-  frozen on their owner pages
-- do not let the bridge contract masquerade as the target ontology
-- do not leave gap ids, readiness ids, checkpoint assertion ids, or downstream
-  kernel families to implementation-time judgment
-
-## `EvidenceSet` Increment
-
-Deliver:
-
-- deterministic selection outputs
-- explicit selected, superseded, and blocked evidence outputs
-- source-local parsed observation contracts
-- a bounded path from current planner artifacts into proto-`EvidenceSet`
+Land `Journal`, `TaxInputs`, and `TaxOutputs` only after the upstream target
+products they depend on are authoritative for the relevant scope.
 
 Rules:
 
-- evidence selection remains deterministic
-- evidence does not force economic meaning
-- evidence-selection reasoning must survive beyond intake-time heuristics
-- the first `EvidenceSet` increment may reuse current adapter boundaries as
-  long as the mapping contract is explicit and no second architecture center is
-  created
+- do not let accounting repair economic or checkpoint truth
+- do not let tax decide source meaning, reconciliation completeness, or
+  checkpoint acceptance
 
-## `ClaimSet` Increment
+## Bridge Retirement Rules
 
-Deliver:
+Retire or demote a bridge surface only when all of the following are true:
 
-- claim-native contracts
-- claim-owned issues and reviews
-- explicit materially unresolved meaning
-- claim-to-economic compilation boundary rules
-- one bounded adapter-family path for claim-native output before any broad
-  facet migration
+- the slice names one authoritative writer for the affected scope
+- every active reader has a declared target reader or derived compatibility
+  projection
+- parity and replay gates for the affected slice pass on unchanged evidence
+- current-state docs are updated if the implemented live runtime surface
+  changes
 
-Rules:
+Bridge retirement is therefore:
 
-- ambiguous rows may remain claims without being forced into final economic,
-  accounting, or tax meaning
-- adapters own source-local meaning only
-- the current bridge may remain as a bounded boundary during migration, but it
-  must stop forcing final semantics too early
-- the first `ClaimSet` increment must not require repo-wide dual-contract
-  support
+- per scope, not global
+- per reader, not just per writer
+- controlled by cutover gates, not by naming preference
 
-## `EconomicFacts` Increment
+## Parity And Replay Gates
 
-Deliver:
+Do not retire an older path until all relevant gates pass:
 
-- target-directed accepted economic truth through `EconomicEventRecord` and
-  `EconomicLegRecord`
-- frozen `event_family` and `leg_role` vocabularies on the owner page
-- claim-to-economic compilation decisions with stable adjudication records
+- adapter or parser contract tests for the affected slice
+- projection parity tests for every retained compatibility surface
+- target-kernel replay checks for the authoritative product
+- reconciliation or checkpoint parity where the slice reaches those stages
+- end-to-end smoke coverage for the affected workflow
 
-Rules:
+When a compatibility projection remains active, parity must prove:
 
-- no wrapper lane beside the active runtime path
-- no bridge rename is required before the first target economic increment lands
-- accepted economic meaning should move away from bridge activity-label
-  centrality
+- the projection is reproducible from the authoritative target kernels
+- the projection preserves unchanged bridge behavior for unmigrated readers
+- the projection does not introduce new semantic authority outside the target
+  kernels
 
-## `ReconciliationState` Increment
+## Docs And Control-Plane Updates
 
-Deliver:
+When a migration slice changes architecture ownership or the live runtime
+surface, update these pages together:
 
-- explicit `ContinuitySegmentRecord`, `LinkRecord`, `BalanceTargetRecord`, and
-  `CheckpointCandidateRecord` contracts
-- explicit completeness and continuity outputs
-- target gap and readiness adoption where the owning stage can support it
+- [ROADMAP.md](../../ROADMAP.md)
+- [Architecture Overview](../concepts/architecture-overview.md)
+- [Bridge To Target Mapping](../concepts/bridge-to-target-mapping.md)
+- [Current Bridge Contracts](../concepts/current-bridge-contracts.md) if live
+  bridge truth changes
+- the owning slice reference page if the bounded slice contract changes
 
-Rules:
-
-- reconciliation consumes accepted economic truth plus checkpoint evidence
-- exact balance assertions are one reconciliation input, not the whole
-  reconciliation product
-- the first downstream slice may keep `LinkRecord` out of scope while the
-  remainder of the reconciliation contract is still frozen
-
-## `Checkpoint` Increment
-
-Deliver:
-
-- explicit checkpoint truth and acceptance basis
-- source-backed checkpoint evidence requirements
-- `AssertionValue` plus frozen `assertion_kind` vocabulary
-- trust level and adopted opening-state handling
-- checkpoint continuity reports
-
-Rules:
-
-- checkpoint truth remains source-backed where filing readiness requires it
-- operator-confirmed balances may support runtime progress but do not become
-  filing-ready checkpoint truth by default
-- the first downstream slice requires statement-backed checkpoint evidence
-  rather than operator-only acceptance
-
-## `Journal` Increment
-
-Deliver:
-
-- `JournalEntryRecord`, `PostingRecord`, and `ValidationRecord`
-- posting expansion and validation surfaces
-- accounting-owned blockers
-
-Rules:
-
-- accounting validates accepted truth
-- accounting does not repair truth
-- posting determinants required for validation stay in the kernel contract
-
-## `Tax` Increment
-
-Deliver:
-
-- `TaxDeterminantRecord` and `BasisTransitionRecord`
-- selected tax-policy execution over `TaxInputs`
-- year-partitioned carry-forward state
-- `TaxOutputRecord`, `CarryForwardRecord`, and `UnsupportedItemRecord`
-
-Rules:
-
-- tax outputs flow from `TaxInputs` through selected tax policies
-- tax policy does not decide source meaning, reconciliation truth, or
-  checkpoint truth
-- tax determinants keep effective time, quantity, direction, and basis
-  transitions in the kernel
-
-## Bridge Retirement
-
-Retire or demote bridge outputs and assumptions only after:
-
-- parity tests exist for the affected increment
-- the replacement increment has one active runtime path
-- downstream stages no longer depend on the superseded bridge-only assumptions
-- current-state docs are updated to reflect the new live truth
-
-## Parity Gates
-
-Do not remove an older path until all relevant gates pass:
-
-- adapter or parser contract tests
-- projection parity tests
-- reconciliation or checkpoint artifact parity where applicable
-- end-to-end smoke workflow for the affected slice
-- explicit docs updates so current-state truth and target-state planning remain
-  aligned
-
-## Docs And Control-Plane Migration
-
-The docs and control-plane baseline for this migration is:
-
-- target stage contracts, ontology, and gap/readiness ownership are separated
-  into focused owner pages
-- current-state docs keep current bridge terms where accuracy requires them
-- later implementation should rename the dev-only shared repo support package
-  area from `repo_support/` to `dev_support/`, but that remains future work
-  until the corresponding implementation increment lands
-- roadmap, migration, and architecture anchors are updated together when a
-  change updates stage ownership, trust-gate sequencing, or shared support
-  contracts
+Current-state docs stay truthful to implemented behavior. Forward-looking docs
+stay detailed enough that later implementation does not need to invent ids,
+reader cutovers, storage placement, or support-model boundaries.

--- a/docs/status/migration-sequence.md
+++ b/docs/status/migration-sequence.md
@@ -27,16 +27,16 @@ parity gates, clean retirement rules, and no wrapper-lane sprawl.
 Current bridge truth:
 
 - `EconomicActivityDraft`, `TransactionFact`, and the shared balance artifacts
-  are the live implementation seam
-- that seam is the current parity baseline
-- that seam is not the final architecture center
+  are the live implementation boundary
+- that boundary is the current parity baseline
+- that boundary is not the final architecture center
 
 Bridge naming rule:
 
 - keep current bridge names in live bridge code until later implementation
-  slices replace them
+  increments replace them
 - do not perform large bridge renames as a prerequisite for the next bounded
-  architecture slice
+  architecture increment
 
 Current live bridge contract owner:
 
@@ -69,20 +69,20 @@ Owning contract pages:
 These foundations are prerequisites, not later cleanup:
 
 - shared stage contracts
-- shared ontology and identity seams
+- shared ontology and identity boundaries
 - shared gap and readiness model
 - shared `SubjectRef` rules
 - shared checkpoint-assertion direction
-- typed tax-policy selection seam
+- typed tax-policy selection boundary
 - target-product versioning, compatibility, serialization, and fingerprint
   rules
 - kernel-and-envelope rules with stable rehydration joins
-- one bridge-to-target mapping page that owns how current adapter seams land in
+- one primary bridge-to-target mapping for how current adapter outputs map to
   proto-`EvidenceSet` and proto-`ClaimSet`
 
 Rules:
 
-- no stage should invent an incompatible blocker or readiness surface
+- no stage should invent an incompatible blocker category or readiness model
 - no stage should use `SubjectRef` as a substitute for real domain modeling
 - no stage should restate the target contracts in a competing document when an
   owning contract page already exists
@@ -92,13 +92,13 @@ Rules:
 - `EvidenceSet` formalizes deterministic evidence selection and source-local
   observations now spread across intake, profiling, and translation-input
   planning
-- current planner artifacts may serve as the first bridge landing path into
+- current planner artifacts may serve as the first bridge path into
   proto-`EvidenceSet`; broad unified-adapter family migration is not a hidden
   prerequisite
 - `ClaimSet` becomes the place where `EconomicActivityDraft` responsibilities
   can split into source-local meaning plus preserved ambiguity
-- claim-native output may first land through one bounded adapter family or
-  shared compiler seam before any repo-wide adapter facet migration
+- claim-native output may first arrive through one bounded adapter family or
+  a shared compiler boundary before any repo-wide adapter facet migration
 - `EconomicFacts` becomes the accepted economic truth that the current
   `TransactionFact` bridge only approximates today
 - `ReconciliationState` and `Checkpoint` absorb the trust-gate work currently
@@ -106,21 +106,22 @@ Rules:
 - `Journal`, `TaxInputs`, and `TaxOutputs` replace the remaining bridge-era
   tendency to push accounting or tax meaning downward too early
 - unified adapter product and facet work may advance during shared foundations
-  when it removes first-slice drift, but broad family migration waits until the
-  contract lock and first slice are stable
+  when it removes first-increment drift, but broad family migration waits until
+  the contract lock and first increment are stable
 
-Default first-slice direction:
+Default first-increment direction:
 
 - use the planner-enabled Coinbase retail export family plus statement-backed
   balance observation flow unless the active filing workspace requires another
   Tier A family to land first
 - use [First Slice Contract](../reference/first-slice-contract.md) as the
-  bounded default-slice contract instead of inferring extra adapter inventory
+  bounded default contract for the first increment instead of inferring extra
+  adapter inventory
   from the repo
 
 ## Phase Order
 
-### Phase 0. Shared Foundations, Contract Lock, And First-Slice Prep
+### Phase 0. Shared Foundations, Contract Lock, And First-Increment Prep
 
 Deliver before broad code changes:
 
@@ -132,10 +133,10 @@ Deliver before broad code changes:
 - kernel-and-envelope rules with stable rehydration joins
 - minimum `ClaimSet`, `EconomicFacts`, `Checkpoint`, and `TaxInputs`
   vocabularies
-- one canonical bridge-to-target mapping for how current planner and
-  translation seams land proto-`EvidenceSet` and proto-`ClaimSet`
-- one named first vertical slice with parity and replay gates
-- clear bridge-versus-target ownership so later code slices do not re-decide
+- one primary bridge-to-target mapping for how current planner and
+  translation paths map to proto-`EvidenceSet` and proto-`ClaimSet`
+- one named first vertical increment with parity and replay gates
+- clear bridge-versus-target ownership so later code increments do not re-decide
   naming or stage boundaries
 
 Rules:
@@ -143,7 +144,7 @@ Rules:
 - do not start broad tax-engine work before these contracts are written down
 - do not let the bridge contract masquerade as the target ontology
 - do not make broad unified-adapter family migration a hidden prerequisite for
-  the first target-stage slice
+  the first target-stage increment
 - do not start broad target package scaffolding before these contracts are
   frozen on their owner pages
 
@@ -154,15 +155,16 @@ Deliver:
 - deterministic selection outputs
 - explicit selected, superseded, and blocked evidence outputs
 - source-local parsed observation contracts
-- a bounded landing path from current planner artifacts into proto-`EvidenceSet`
+- a bounded path from current planner artifacts into proto-`EvidenceSet`
 
 Rules:
 
 - evidence selection remains deterministic
 - evidence does not force economic meaning
 - evidence selection reasoning must survive beyond intake-time heuristics
-- the first `EvidenceSet` slice may reuse current adapter seams as long as the
-  landing contract is explicit and no second architecture center is created
+- the first `EvidenceSet` increment may reuse current adapter boundaries as
+  long as the mapping contract is explicit and no second architecture center is
+  created
 
 ### Phase 2. Introduce `ClaimSet`
 
@@ -171,7 +173,7 @@ Deliver:
 - claim-native contracts
 - claim-owned issues and reviews
 - explicit materially unresolved meaning
-- claim-to-economic compilation seam boundaries
+- claim-to-economic compilation boundary rules
 - one bounded adapter-family path for claim-native output before any broad
   facet migration
 
@@ -180,22 +182,22 @@ Rules:
 - ambiguous rows may remain claims without being forced into final economic,
   accounting, or tax meaning
 - adapters own source-local meaning only
-- the current bridge may remain as a bounded seam during migration, but it must
+- the current bridge may remain as a bounded boundary during migration, but it must
   stop forcing final semantics too early
-- the first `ClaimSet` slice must not require repo-wide dual-contract support
+- the first `ClaimSet` increment must not require repo-wide dual-contract support
 
 ### Phase 3. Land `EconomicFacts`
 
 Deliver:
 
-- claim-to-economic compilation seam
+- claim-to-economic compilation boundary
 - target-directed economic models aligned to the target ontology
 - explicit identity, settlement, lifecycle, and valuation handling
 
 Rules:
 
 - no wrapper lane beside the active runtime path
-- no bridge rename is required before the first target economic slice lands
+- no bridge rename is required before the first target economic increment lands
 - accepted economic meaning should move away from bridge activity-label
   centrality
 
@@ -211,7 +213,7 @@ Deliver:
 Rules:
 
 - reconciliation consumes accepted economic truth plus checkpoint evidence
-- exact balance assertions are one reconciliation input surface, not the whole
+- exact balance assertions are one reconciliation input, not the whole
   reconciliation product
 
 ### Phase 5. Land `Checkpoint`
@@ -257,12 +259,12 @@ Rules:
 - tax policy does not decide source meaning, reconciliation truth, or
   checkpoint truth
 
-### Phase 8. Retire Superseded Bridge Surfaces
+### Phase 8. Retire Superseded Bridge Outputs And Assumptions
 
-Retire or demote bridge surfaces only after:
+Retire or demote bridge outputs and assumptions only after:
 
-- parity tests exist for the affected slice
-- the replacement slice has one active runtime path
+- parity tests exist for the affected increment
+- the replacement increment has one active runtime path
 - downstream stages no longer depend on the superseded bridge-only assumptions
 - current-state docs are updated to reflect the new live truth
 
@@ -284,9 +286,9 @@ The docs and control-plane baseline for this migration is:
 - target stage contracts, ontology, and gap/readiness ownership are already
   separated into focused concept pages
 - current-state docs keep current bridge terms where accuracy requires them
-- later implementation should rename the dev-only shared repo support surface
+- later implementation should rename the dev-only shared repo support package area
   from `repo_support/` to `dev_support/`, but this remains future work until
-  the corresponding implementation slice lands
+  the corresponding implementation increment lands
 - roadmap, migration, and architecture anchors must be updated together when a
-  slice changes stage ownership, trust-gate sequencing, or shared support
+  change updates stage ownership, trust-gate sequencing, or shared support
   contracts

--- a/tests/contract/test_standards_guards.py
+++ b/tests/contract/test_standards_guards.py
@@ -357,7 +357,7 @@ def test_delivery_standards_pin_merge_subject_and_repair_label_rules() -> None:
     assert "multiple bounded checkpoint commits" in commits_text
     assert "keep each authored commit bounded" in implementation_text
     assert "split it into\n   multiple bounded checkpoint commits" in checkpoint_text
-    assert "keep every authored commit bounded to one reviewable slice" in agents_text
+    assert "keep every authored commit bounded to one reviewable change" in agents_text
 
 
 def test_delivery_guardrails_doc_is_routed_and_layered() -> None:
@@ -406,7 +406,7 @@ def test_delivery_guardrails_doc_is_routed_and_layered() -> None:
     )
     assert "use the `markdown` skill if available" in agents_text
     assert (
-        "use\n  the repo-local workflow for the active surface and reload the narrow repo\n  guidance listed in this file before editing."
+        "use\n  the repo-local workflow for the active area and reload the narrow repo\n  guidance listed in this file before editing."
         in agents_text
     )
     assert "docs/standards/issues.md" in agents_text
@@ -441,9 +441,7 @@ def test_delivery_guardrails_doc_is_routed_and_layered() -> None:
     assert "always-visible PR metadata checks" in guardrails_text
     assert "full non-duplicated blocking suite" in guardrails_text
     assert "suppresses the narrower targeted pytest subset checks" in guardrails_text
-    assert (
-        "every applicable changed surface group has been revisited" in guardrails_text
-    )
+    assert "every applicable changed file group has been revisited" in guardrails_text
     assert "issue-finding with open outcome" in guardrails_text
     assert "make audit-pr-review" in hardening_route_text
     assert "tools.run_pr_review_checks" in hardening_route_text
@@ -454,7 +452,7 @@ def test_delivery_guardrails_doc_is_routed_and_layered() -> None:
         "green `tools.run_pr_review_checks` result as a no-findings"
         in hardening_route_text
     )
-    assert "issue-finding loop" in hardening_route_text
+    assert "review cycle" in hardening_route_text
     assert "invent findings to hit a quota" in hardening_route_text
     assert (
         "stop only after a full pass yields no new meaningful findings"
@@ -465,7 +463,7 @@ def test_delivery_guardrails_doc_is_routed_and_layered() -> None:
     assert "claiming a clean pass" not in hardening_route_text
     assert "final PR review" not in hardening_route_text
     assert (
-        "Continue steps 1 through 5 until every applicable changed surface group has"
+        "Continue steps 1 through 5 until every applicable changed file group has"
         in hardening_route_text
     )
 
@@ -497,7 +495,7 @@ def test_repo_local_routing_does_not_depend_on_removed_global_safety_skills() ->
     assert "issue-finding with open outcome" in hardening_route_text
     assert "AGENTS.md`, its task-routing table" in guardrails_text
     assert "checkpoint commits during the loop" in guardrails_text
-    assert "applicable surface groups" in guardrails_text
+    assert "applicable file groups" in guardrails_text
     assert (
         "Repair every finding from that pass before starting the next pass"
         in hardening_route_text

--- a/tests/unit/docs_runtime_parity/test_repo_doc_guards.py
+++ b/tests/unit/docs_runtime_parity/test_repo_doc_guards.py
@@ -176,8 +176,8 @@ def test_commit_standards_document_hybrid_pr_merge_policy() -> None:
     )
 
     assert "`main` is a merge-commit branch by default." in text
-    assert "Use squash merges only for the narrow single-checkpoint exception." in text
-    assert "do not squash multi-checkpoint PRs" in text
+    assert "Use squash merges only for the narrow single-commit" in text
+    assert "do not squash PRs with multiple authored commits" in text
     assert "non-pushed checkpoint commit may be amended" in text
     assert "single-checkpoint exception" in implementation_text
     assert "search existing open issues first" in implementation_text

--- a/tests/unit/test_repo_agent_skills.py
+++ b/tests/unit/test_repo_agent_skills.py
@@ -68,7 +68,7 @@ EXPECTED_SKILLS = {
             "docs/standards/commits.md",
             ".claude/commands/pr-review.md",
             "make audit-pr-review",
-            "applicable surface groups",
+            "applicable file groups",
             "issue-finding with open outcome",
         ),
     ),


### PR DESCRIPTION
Why:
- phase 0 implementation needs frozen contract owners, ids, replay rules, and bounded-slice references before code starts depending on them
- the architecture rewrite still left contract vocabulary and guidance drifting across roadmap, standards, and reference pages

What:
- freeze the phase 0 contract set across roadmap, concept, and reference docs, including first-slice references and target contract primitives
- tighten repo guidance and review routes so the frozen contract vocabulary becomes the active authoring baseline

Checks:
- `make pr-review`

Issue linkage:
- None: searched existing repo issues for phase 0 contract freeze and target pipeline contract docs and found no matching tracked issue

Included checkpoints:
- `docs(roadmap): lock phase 0 contract prep`
- `docs(contracts): freeze phase 0 contract owners`
- `docs(guidance): tighten repo guidance vocabulary`
- `docs(contracts): close phase 0 doc drift`
- `docs(contracts): freeze remaining phase 0 ids and replay rules`
- `docs(contracts): harden roadmap stage contracts`
- `docs(contracts): harden phase 0 contract lock`
- `docs(architecture): freeze target pipeline contracts`
- `docs(architecture): harden future-state naming contracts`
