### PR TITLE
build(delivery): prefer auto-merge handoff for ready PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,7 @@
 .github/pull_request_template.md @CrownOpsEng
 .github/CODEOWNERS @CrownOpsEng
 AGENTS.md @CrownOpsEng
+.gitmessage.txt @CrownOpsEng
 docs/standards/** @CrownOpsEng
 .claude/commands/** @CrownOpsEng
 repo_support/local_autofix.py @CrownOpsEng

--- a/.github/actions/setup-python-uv/action.yml
+++ b/.github/actions/setup-python-uv/action.yml
@@ -1,6 +1,12 @@
 name: Setup Python and uv
 description: Setup Python 3.12, restore the uv cache, and sync repo dependencies.
 
+inputs:
+  include-ci-group:
+    description: Include CI-only dependency tooling during sync.
+    required: false
+    default: "false"
+
 runs:
   using: composite
   steps:
@@ -19,7 +25,12 @@ runs:
         echo "$PROJECT_ENVIRONMENT/bin" >> "$GITHUB_PATH"
     - name: Sync dependencies
       shell: bash
-      run: uv sync --python 3.12 --frozen
+      run: |
+        SYNC_ARGS=(--python 3.12 --frozen)
+        if [ "${{ inputs.include-ci-group }}" != "true" ]; then
+          SYNC_ARGS+=(--no-group ci)
+        fi
+        uv sync "${SYNC_ARGS[@]}"
     - name: Prune uv cache
       shell: bash
       run: uv cache prune --ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/setup-python-uv
+        with:
+          include-ci-group: "true"
       - name: Run actionlint
         run: uv run python -m tools.run_review_check --check-id actionlint --trigger push_main
 

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -163,6 +163,8 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       - uses: ./.github/actions/setup-python-uv
+        with:
+          include-ci-group: "true"
       - name: Run actionlint
         run: uv run python -m tools.run_review_check --check-id actionlint --trigger pull_request
 

--- a/docs/standards/commits.md
+++ b/docs/standards/commits.md
@@ -178,6 +178,8 @@ Merge method rules:
 - do not squash PRs with multiple authored commits
 - do not create a merge commit for a single-commit PR unless the user
   explicitly requests a one-off repair in the current thread
+- once a PR is ready and its merge method plus merge metadata are correct,
+  prefer enabling auto-merge over waiting for a later manual merge click
 - when merging a PR with multiple authored commits, override GitHub's default merge subject
   with a deterministic subject that keeps the PR number visible instead of
   producing `Merge pull request ...`

--- a/docs/standards/delivery-guardrails.md
+++ b/docs/standards/delivery-guardrails.md
@@ -47,6 +47,8 @@ when the higher-layer control is available.
 - pull requests open as draft by default
 - a PR becomes ready for review only after the full issue-finding hardening
   loop yields no new meaningful findings
+- once a PR is ready and its merge method, subject, and body are correct,
+  auto-merge is the default protected-branch handoff
 - direct pushes to `main` are forbidden except for an explicit one-time repair
   requested in the current thread
 - a merged `main` commit must not be rewritten when the original PR record
@@ -69,6 +71,8 @@ Prefer GitHub controls that reject bad actions before they land:
 - required status checks pinned to their responsible app, not only named by context
 - required reviews
 - blocked force pushes on protected branches
+- repository auto-merge enabled when the repo wants GitHub to complete the
+  protected-branch handoff after checks pass
 - stale-review dismissal or last-push review requirements when the repo wants
   post-push re-approval
 - CODEOWNERS or equivalent reviewer routing for control-plane files

--- a/tests/unit/test_evaluate_review_results.py
+++ b/tests/unit/test_evaluate_review_results.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pytest import CaptureFixture
+
 from tools import evaluate_review_results
 
 
@@ -31,3 +33,41 @@ def test_blocking_missing_job_result_fails() -> None:
     )
 
     assert exit_code == 1
+
+
+def test_planner_failure_with_blank_outputs_reports_planner_result(
+    capsys: CaptureFixture[str],
+) -> None:
+    exit_code = evaluate_review_results.main(
+        [
+            "--selected-checks-json",
+            "",
+            "--nonblocking-checks-json",
+            "",
+            "--needs-json",
+            '{"plan-main-ci": {"result": "failure", "outputs": {}}}',
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "plan-main-ci: result=failure" in captured.err
+
+
+def test_blank_outputs_without_planner_failure_fail_cleanly(
+    capsys: CaptureFixture[str],
+) -> None:
+    exit_code = evaluate_review_results.main(
+        [
+            "--selected-checks-json",
+            "",
+            "--nonblocking-checks-json",
+            "[]",
+            "--needs-json",
+            '{"plan-main-ci": {"result": "success"}}',
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert "selected checks: missing workflow output" in captured.err

--- a/tests/unit/test_review_verification_workflows.py
+++ b/tests/unit/test_review_verification_workflows.py
@@ -52,6 +52,10 @@ def test_pr_review_workflow_uses_draft_aware_planner_gated_atomic_jobs() -> None
     assert "needs.build.result == 'success'" in workflow_text
     assert "needs.pytest-full.result == 'success'" in workflow_text
     assert "tools.evaluate_review_results" in workflow_text
+    actionlint_job = workflow_text.split("  actionlint:\n", maxsplit=1)[1].split(
+        "  ruff:\n", maxsplit=1
+    )[0]
+    assert 'include-ci-group: "true"' in actionlint_job
     assert "  pr-review:\n    if: ${{ always() }}\n    needs:\n" in workflow_text
     pr_review_needs = workflow_text.split("  pr-review:\n", maxsplit=1)[1].split(
         "    runs-on:", maxsplit=1
@@ -78,6 +82,10 @@ def test_main_ci_workflow_uses_planner_gated_atomic_jobs() -> None:
     assert "tools.run_review_check --check-id target-naming" in workflow_text
     assert "tools.run_review_check --check-id ci-tooling" in workflow_text
     assert "tools.evaluate_review_results" in workflow_text
+    actionlint_job = workflow_text.split("  actionlint:\n", maxsplit=1)[1].split(
+        "  ruff:\n", maxsplit=1
+    )[0]
+    assert 'include-ci-group: "true"' in actionlint_job
     main_ci_needs = workflow_text.split("  main-ci-result:\n", maxsplit=1)[1].split(
         "    runs-on:", maxsplit=1
     )[0]
@@ -96,12 +104,17 @@ def test_setup_action_pins_external_actions_and_uv_version() -> None:
     assert "astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9" in action_text
     assert 'version: "0.9.20"' in action_text
     assert "enable-cache: true" in action_text
+    assert "include-ci-group:" in action_text
+    assert 'default: "false"' in action_text
     assert 'PROJECT_ENVIRONMENT="$HOME/.venvs/tallylot-py312"' in action_text
     assert (
         'echo "UV_PROJECT_ENVIRONMENT=$PROJECT_ENVIRONMENT" >> "$GITHUB_ENV"'
         in action_text
     )
     assert 'echo "$PROJECT_ENVIRONMENT/bin" >> "$GITHUB_PATH"' in action_text
+    assert "SYNC_ARGS=(--python 3.12 --frozen)" in action_text
+    assert "SYNC_ARGS+=(--no-group ci)" in action_text
+    assert 'uv sync "${SYNC_ARGS[@]}"' in action_text
     assert "uv cache prune --ci" in action_text
 
 

--- a/tools/evaluate_review_results.py
+++ b/tools/evaluate_review_results.py
@@ -33,20 +33,65 @@ def _job_results(needs_json: str) -> Mapping[str, object]:
     return cast(Mapping[str, object], json.loads(needs_json))
 
 
-def main(argv: Sequence[str] | None = None) -> int:
-    args = _parse_args(argv)
-    selected_checks = tuple(cast(list[str], json.loads(args.selected_checks_json)))
-    nonblocking_checks = set(cast(list[str], json.loads(args.nonblocking_checks_json)))
-    needs = _job_results(args.needs_json)
+def _job_result(job_payload: object) -> str | None:
+    if not isinstance(job_payload, Mapping):
+        return None
+    job_result_payload = cast(Mapping[str, object], job_payload)
+    result_object = job_result_payload.get("result")
+    return result_object if isinstance(result_object, str) else None
 
+
+def _planner_failures(needs: Mapping[str, object]) -> tuple[str, ...]:
+    failures: list[str] = []
+    for planner_check_id in ("plan-pr-review", "plan-main-ci"):
+        planner_payload = needs.get(planner_check_id)
+        if planner_payload is None:
+            continue
+        result = _job_result(planner_payload)
+        if result == "success":
+            continue
+        failures.append(f"{planner_check_id}: result={result}")
+    return tuple(failures)
+
+
+def _parse_checks_json(
+    raw_value: str,
+    *,
+    label: str,
+    allow_blank: bool,
+) -> tuple[str, ...]:
+    if not raw_value.strip():
+        if allow_blank:
+            return ()
+        raise ValueError(f"{label}: missing workflow output")
+    try:
+        payload_object: object = json.loads(raw_value)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{label}: invalid workflow output") from exc
+    if not isinstance(payload_object, list):
+        raise ValueError(f"{label}: expected JSON array of strings")
+    payload_items = cast(list[object], payload_object)
+    payload: list[str] = []
+    for item in payload_items:
+        if not isinstance(item, str):
+            raise ValueError(f"{label}: expected JSON array of strings")
+        payload.append(item)
+    return tuple(payload)
+
+
+def _collect_check_failures(
+    *,
+    selected_checks: Sequence[str],
+    nonblocking_checks: set[str],
+    needs: Mapping[str, object],
+) -> tuple[list[str], list[str]]:
     blocking_failures: list[str] = []
     blocked_checks: list[str] = []
-
     for check_id in selected_checks:
         if check_id in {"plan-pr-review", "plan-main-ci"}:
             continue
-        job_payload = needs.get(check_id)
-        if not isinstance(job_payload, Mapping):
+        result = _job_result(needs.get(check_id))
+        if result is None:
             if check_id in nonblocking_checks:
                 print(
                     f"[non-blocking] {check_id} result=not-run-in-aggregate",
@@ -55,9 +100,6 @@ def main(argv: Sequence[str] | None = None) -> int:
                 continue
             blocking_failures.append(f"{check_id}: missing job result")
             continue
-        job_result_payload = cast(Mapping[str, object], job_payload)
-        result_object = job_result_payload.get("result")
-        result = result_object if isinstance(result_object, str) else None
         if result == "success":
             continue
         if check_id in nonblocking_checks:
@@ -65,8 +107,43 @@ def main(argv: Sequence[str] | None = None) -> int:
             continue
         if result == "skipped":
             blocked_checks.append(check_id)
-        else:
-            blocking_failures.append(f"{check_id}: result={result}")
+            continue
+        blocking_failures.append(f"{check_id}: result={result}")
+    return blocking_failures, blocked_checks
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    needs = _job_results(args.needs_json)
+    planner_failures = list(_planner_failures(needs))
+    allow_blank_outputs = bool(planner_failures)
+
+    try:
+        selected_checks = _parse_checks_json(
+            args.selected_checks_json,
+            label="selected checks",
+            allow_blank=allow_blank_outputs,
+        )
+        nonblocking_checks = set(
+            _parse_checks_json(
+                args.nonblocking_checks_json,
+                label="non-blocking checks",
+                allow_blank=allow_blank_outputs,
+            )
+        )
+    except ValueError as exc:
+        planner_failures.append(str(exc))
+        print("review verification failed:", file=sys.stderr)
+        for failure in planner_failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 1
+
+    blocking_failures, blocked_checks = _collect_check_failures(
+        selected_checks=selected_checks,
+        nonblocking_checks=nonblocking_checks,
+        needs=needs,
+    )
+    blocking_failures = planner_failures + blocking_failures
 
     if blocked_checks:
         print(


### PR DESCRIPTION
Why:
- the repo now has GitHub-side auto-merge enabled, but the tracked delivery guidance still left the default protected-branch handoff ambiguous and left one control-plane file outside CODEOWNERS
- post-merge CI planner failures were also being obscured by the aggregate review-result job, which made delivery failures harder to diagnose cleanly

What:
- default the shared GitHub bootstrap action to skip the ci dependency group and opt it back in only for actionlint jobs
- report planner failures and blank workflow outputs cleanly in review-result aggregation and pin that behavior with focused workflow tests
- add `.gitmessage.txt` to CODEOWNERS and codify auto-merge as the default handoff for ready PRs in the delivery standards

Checks:
- make audit-pr-review
- make docs-check
- make audit-delivery-guardrails
- checkpoint hook-selected verification for `fix(ci): narrow review bootstrap and planner reporting`
- checkpoint hook-selected verification for `build(delivery): codify auto-merge default handoff`

Issue linkage:
- None: no existing repo issue tracked this delivery-policy and CI hardening follow-up

Included checkpoints:
- `fix(ci): narrow review bootstrap and planner reporting`
- `build(delivery): codify auto-merge default handoff`
