### PR TITLE
docs(architecture): align staged pipeline and deferred read models

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -244,8 +244,8 @@ Fire before implementation when one of these appears:
 Response:
 
 - create only the specific needed package:
-  the reporting capability package, portfolio capability package,
-  visualization capability package, or investigation capability package
+  application/reporting/, application/portfolio/,
+  application/visualization/, or application/investigation/
 - do not pre-create all reserved families
 
 ### Trigger D. Copy Pressure Across Stage Packages

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -25,8 +25,8 @@ current adapter-edge and oracle-comparison boundaries, not canonical target
 naming.
 
 **Exception rationale:** `assessment/` stays in this roadmap only as the shared
-root for the nested `gap/`, `review/`, and `readiness/` families. It is not a
-generic assessment bucket.
+contract and sidecar root for the nested `gap/`, `review/`, and `readiness/`
+families. It is not a generic application center.
 
 ## Planning Anchors
 
@@ -45,6 +45,10 @@ These anchors drive sequencing and acceptance criteria:
   slices replace them
 - CoinTracking remains an edge adapter and oracle surface, not the runtime
   ledger model
+- broader grouped and query surfaces remain deferred until the trigger ladder
+  below fires
+- filing-critical `TaxOutputs` and narrow rendering outputs may keep derived
+  grouped output logic only for the active tax-first window
 
 ## Transition Rules
 
@@ -54,6 +58,10 @@ These anchors drive sequencing and acceptance criteria:
 - preserve current bridge truth while establishing target product ownership
 - do not let bridge compatibility views become a second architecture
   center
+- do not let shared grouped readiness or shared application assessment behavior
+  harden into the long-term architecture
+- keep broader derived read models and projections deferred until the trigger
+  ladder fires, then activate them as capability-owned application surfaces
 - do not rename live bridge symbols or repo-only support packages as a docs-only
   side effect
 - freeze short-first canonical stable ids, catalog-declared owner-local short
@@ -82,7 +90,7 @@ Must freeze:
 - `AssertionValue`, `PositionRef`, and `ContractRef`
 - shared gap, review, and readiness records and sidecars:
   `GapRecord`, `GapExplanation`, `ReviewRecord`,
-  `ReviewExplanation`, `ReadinessRecord`, `ReadinessRollupRecord`,
+  `ReviewExplanation`, `ReadinessRecord`,
   `SubjectRef = [subject_kind, subject_key]`, truthful `claim_scope_id` and `balance_target_id`
   attachments, and the downstream shared-subject seams needed for journal
   and tax records
@@ -118,12 +126,21 @@ Must freeze:
   families are already known, keeps gap/review/readiness roots explicit when
   the docs mean those families directly, and keeps the shared `assessment/` root
   split into concrete nested families
-  such as `gap/`, `review/`, and `readiness/`
+  such as `gap/`, `review/`, and `readiness/` while keeping assessment
+  behavior in the owning application slice
 - authoritative persistence model, product-owned directory stems, partition
   scopes, sidecar rules, and default filesystem placement
 - migration authority rules, compatibility views, reader cutovers, and
   retirement gates
-- package ownership and layer placement for shared functionality
+- package ownership and layer placement that keep shared assessment contracts in
+  `domain/assessment/`, keep the persisted `assessment/gap/`,
+  `assessment/review/`, and `assessment/readiness/` families as storage rules
+  only, and retire shared application assessment behavior until a specific
+  capability-owned derived read-model package is activated
+- defer broader grouped readiness, reporting, portfolio, visualization, and
+  investigation architecture until the trigger ladder below fires, allowing
+  only filing-critical product-local derived outputs, narrow rendering outputs,
+  or migration compatibility views before then
 - catalog-first target naming governance with one machine-readable naming
   authority and a blocking `target-naming` check on enforced forward-looking
   docs
@@ -139,6 +156,9 @@ Deliver:
 - explicit cutover matrix for bridge-to-target migration
 - one first upstream slice and one first downstream slice
 - explicit package ownership for `domain/` and `application/`
+- explicit defer-until-trigger rules for broader derived read models and
+  projections so the tax-first path does not have to invent long-term
+  read-model ownership early
 - explicit fast-path rule that reducers read kernels, not explanation sidecars
 - frozen critical-path field tables and product-id rules that later writing
   work can merge without deciding new structure
@@ -164,9 +184,93 @@ Exit criteria:
 - non-critical observation and claim kinds are explicitly deferred rather
   than left implicit
 - implementation placement is mechanical rather than interpretive
+- `TaxOutputs` can land without requiring a separate read-side architecture
+  first
+- no shared application assessment center or shared grouped-readiness family is
+  left as the default home for later grouped consumers
 - the first upstream slice and first downstream slice can be implemented
   without inventing
   ids, claim bundles, values, or reader cutovers
+
+## Deferred Read-Model Activation Triggers
+
+The tax-first window keeps the staged pipeline authoritative and defers
+capability-owned derived read models and projections until one of the triggers
+below fires.
+
+### Trigger A. Second Grouped Non-Compatibility Consumer
+
+Fire before implementation if the repo is about to add any grouped consumer
+beyond filing-critical `TaxOutputs`, existing narrow rendering behavior, or
+migration compatibility views.
+
+Examples:
+
+- operator-facing grouped readiness summary
+- non-tax grouped report
+- grouped dashboard dataset
+- holdings or portfolio summary
+
+Response:
+
+- introduce `docs/concepts/query-projection-architecture.md`
+- make the triggered slice first-class in architecture overview, ontology,
+  standards, and naming governance
+- do not ship the new grouped consumer inside a stage package first
+
+### Trigger B. First Persisted Derived Grouped Surface Outside Tax Outputs Or Compatibility
+
+Fire before implementation if a grouped non-authoritative surface needs durable
+persistence and is not a compatibility view or a product-local tax-output
+surface.
+
+Response:
+
+- introduce a non-authoritative projection root under
+  `working/projections/<slice>/<projection_family>/...`
+- define projection identity as slice-local and derived from authoritative refs
+  plus slice parameters
+- keep projections explicitly non-canonical and regenerable
+
+### Trigger C. First Feature That Clearly Belongs To A Reserved Family
+
+Fire before implementation when one of these appears:
+
+- cross-stage or cross-product reporting
+- portfolio tracking or holdings views
+- charts, dashboards, or visualization datasets
+- investigation or drill-down workflows that are not compatibility-only
+
+Response:
+
+- create only the specific needed package:
+  the reporting capability package, portfolio capability package,
+  visualization capability package, or investigation capability package
+- do not pre-create all reserved families
+
+### Trigger D. Copy Pressure Across Stage Packages
+
+Fire before implementation if grouped output logic would otherwise be copied
+into a second stage package or second consumer.
+
+Response:
+
+- extract to the correct capability-owned derived read-model package in the
+  same slice as the new feature
+- do not ship the duplicate first and clean it up later
+
+### Trigger E. Automatic Activation At Post-Filing Expansion
+
+If none of the earlier triggers fire first, activate the broader derived
+read-model and projection architecture at the start of `Phase 10`.
+
+Response:
+
+- add `docs/concepts/query-projection-architecture.md`
+- add the needed package families to naming governance
+- add projection persistence rules
+- update architecture overview and standards to make the capability-owned
+  derived read side explicit
 
 ## Phase 1. Land `EvidenceSet`
 
@@ -290,7 +394,8 @@ Deliver:
 
 - `JournalEntryRecord`, `PostingRecord`, and `EntryCheckRecord`
 - journal-owned blockers and entry-check rules
-- rendering orchestration over accepted upstream products
+- rendering orchestration over accepted upstream products that stays narrow and
+  downstream-facing
 
 Exit criteria:
 
@@ -310,14 +415,20 @@ Deliver:
 - selected tax-policy execution over those inputs
 - year partitioning and tax carry-forward records
 - explicit tax unsupported-input records where policy execution cannot proceed
-- filing-critical policy outputs derived from accepted upstream products rather than
-  CoinTracking tax reports
+- filing-critical policy outputs derived from accepted upstream products rather
+  than CoinTracking tax reports
+- `TaxOutputs` ownership of `policy_summary`, `supporting_schedule`,
+  `filing_form`, policy explanations, limitations, and rendered policy content
+  for the tax-first path
 
 Exit criteria:
 
 - `2023` to `2025` outputs can be produced from reconciled economics and
   accepted checkpoint truth without treating CoinTracking tax reports as the
   ledger
+- `TaxOutputs` remains a narrow tax-output exception rather than the permanent
+  home of general reporting, dashboards, portfolio views, visualization
+  datasets, or investigation workflows
 
 ## Phase 8. Repo-Only Support Reset
 
@@ -378,6 +489,8 @@ Deliver:
 - provider-backed AI implementations with explicit audit trails
 - additional productized source and output adapters beyond the current
   high-value evidence sources
+- broader capability-owned derived read models and projections if no earlier
+  trigger already activated them
 
 Exit criteria:
 
@@ -420,6 +533,9 @@ Rules:
   explicit
 - keep unsupported or deferred behavior explicit through blockers instead of
   low-confidence partial support
+- keep derived grouped outputs inside `application/tax/`,
+  `application/rendering/`, or compatibility views only while they remain
+  exclusive to the tax-first path
 - do not reintroduce wrapper lanes, migration shims, or dual active runtime
   models once a bounded replacement is ready
 - when work affects architecture, schema, or sequencing, update this file

--- a/docs/concepts/architecture-overview.md
+++ b/docs/concepts/architecture-overview.md
@@ -33,6 +33,17 @@ The primary contract pages freeze product ids, product headers, critical-path
 kernel field tables, and the compatibility sidecar boundary for retained legacy
 hint fields.
 
+Broader consumer-facing grouped or query surfaces remain intentionally deferred
+until the trigger ladder in [ROADMAP.md](../../ROADMAP.md) fires. Through the
+tax-first phases, grouped outputs may remain only as tax-output-local derived
+content, narrow rendering-derived content, or compatibility-local derived
+output rather than as a shared application center.
+
+Gap, review, and readiness remain shared contracts plus persisted sidecar
+families. They do not imply a shared application reducer center. The owning
+application slice emits and reduces its own assessment behavior until a
+specific capability-owned derived read-model package is activated.
+
 ## Layer Shape
 
 - `domain/` owns business models, refs, enums, and value objects

--- a/docs/concepts/architecture-overview.md
+++ b/docs/concepts/architecture-overview.md
@@ -38,6 +38,8 @@ until the trigger ladder in [ROADMAP.md](../../ROADMAP.md) fires. Through the
 tax-first phases, grouped outputs may remain only as tax-output-local derived
 content, narrow rendering-derived content, or compatibility-local derived
 output rather than as a shared application center.
+If no earlier trigger fires, the default activation point for broader
+capability-owned derived read models and projections is `Phase 10`.
 
 Gap, review, and readiness remain shared contracts plus persisted sidecar
 families. They do not imply a shared application reducer center. The owning

--- a/docs/concepts/bridge-to-target-mapping.md
+++ b/docs/concepts/bridge-to-target-mapping.md
@@ -90,7 +90,8 @@ No-dual-center rule:
   corresponding target product is authoritative for that scope
 - broader grouped consumers stay on authoritative kernels, compatibility views,
   or tax-output-local and rendering-local derived outputs until the roadmap
-  trigger ladder requires a dedicated capability-owned derived read-model slice
+  trigger ladder requires a dedicated capability-owned derived read-model slice;
+  if no earlier trigger fires, that activation defaults to `Phase 10`
 
 ## Cutover Matrix
 

--- a/docs/concepts/bridge-to-target-mapping.md
+++ b/docs/concepts/bridge-to-target-mapping.md
@@ -40,7 +40,7 @@ Use these pages for neighboring contracts:
   `Checkpoint`, `Journal`, `TaxInputs`, and `TaxOutputs`.
 - [Gap, Review, And Readiness](gaps-and-readiness.md) defines `GapRecord`,
   `GapExplanation`, `ReviewRecord`, `ReviewExplanation`,
-  `ReadinessRecord`, `ReadinessRollupRecord`, and `SubjectRef`.
+  `ReadinessRecord`, and `SubjectRef`.
 - this page defines how bridge surfaces move to target products without
   creating dual authorities
 
@@ -88,6 +88,9 @@ No-dual-center rule:
   migration
 - none of those surfaces may remain a second architecture center once the
   corresponding target product is authoritative for that scope
+- broader grouped consumers stay on authoritative kernels, compatibility views,
+  or tax-output-local and rendering-local derived outputs until the roadmap
+  trigger ladder requires a dedicated capability-owned derived read-model slice
 
 ## Cutover Matrix
 

--- a/docs/concepts/domain-ontology.md
+++ b/docs/concepts/domain-ontology.md
@@ -473,9 +473,6 @@ Required application ownership:
   while the live bridge still exists
 - `application/reconciliation/` for continuity, linkage, balance target
   evaluation, and checkpoint proposal records
-- `application/assessment/` for cross-stage gap, review, and readiness
-  reduction plus readiness rollups and assessment views
-
 `domain/assessment/` stays generic only because it is the shared root for the
 nested `gap/`, `review/`, and `readiness/` families plus `SubjectRef`.
 No unrelated family may be added under `domain/assessment/` without a separate
@@ -491,6 +488,29 @@ application center.
   selection, and `TaxOutputs` generation
 - `application/rendering/` for downstream rendering orchestration
 - `application/workspace/` for workspace resolution and initialization
+
+Assessment behavior stays in the owning application slice. Shared
+`domain/assessment/` contracts and persisted `assessment/gap/`,
+`assessment/review/`, and `assessment/readiness/` sidecars do not create a
+shared application assessment center.
+
+### Reserved Future Capability Families
+
+Reserve these future application families conceptually, but not as required
+package ownership yet:
+
+- a reporting family for cross-stage or cross-product reporting
+- a portfolio family for holdings and portfolio views
+- a visualization family for charts, dashboards, and visualization datasets
+- an investigation family for drill-down and investigation workflows that are
+  not compatibility-only
+
+Rules:
+
+- these families are reserved in prose only until the roadmap trigger ladder
+  requires one of them
+- do not introduce a generic read-side sink while waiting for a trigger
+- do not pre-create all reserved families when only one capability is needed
 
 Boundary rules:
 

--- a/docs/concepts/domain-ontology.md
+++ b/docs/concepts/domain-ontology.md
@@ -499,11 +499,12 @@ shared application assessment center.
 Reserve these future application families conceptually, but not as required
 package ownership yet:
 
-- a reporting family for cross-stage or cross-product reporting
-- a portfolio family for holdings and portfolio views
-- a visualization family for charts, dashboards, and visualization datasets
-- an investigation family for drill-down and investigation workflows that are
-  not compatibility-only
+- application/reporting/ for cross-stage or cross-product reporting
+- application/portfolio/ for holdings and portfolio views
+- application/visualization/ for charts, dashboards, and visualization
+  datasets
+- application/investigation/ for drill-down and investigation workflows that
+  are not compatibility-only
 
 Rules:
 

--- a/docs/concepts/gaps-and-readiness.md
+++ b/docs/concepts/gaps-and-readiness.md
@@ -20,7 +20,7 @@ and generic subject-attachment model.
 - stage-owned blockers stay explicit; no stage may invent an incompatible
   blocker surface
 - reviews stay advisory and must never become hidden blockers
-- kernel-scope readiness rollups are derived from subject-level or scope-level
+- kernel-scope grouped readiness is derived from subject-level or scope-level
   truth, not stored as the only truth
 - gap, review, and readiness records plus sidecars help stages interoperate
   without erasing stage ownership
@@ -122,8 +122,8 @@ Rules:
 
 ### `kernel_scope_id`
 
-`kernel_scope_id` is defined once for target gap, review, readiness, rollup,
-assessment-view, and sidecar attachments.
+`kernel_scope_id` is defined once for target gap, review, readiness,
+derived-output, and sidecar attachments.
 
 Rules:
 
@@ -138,8 +138,8 @@ Rules:
 - `kernel_scope_id` is never a target product id, never an upstream product
   ref, and never the primary reader key when one product id or narrower record
   id exists
-- `kernel_scope_id` is used only for shared assessment views plus gap/review/
-  readiness sidecar attachment when no narrower truthful subject or scope
+- `kernel_scope_id` is used only for gap/review/readiness sidecar attachment
+  and declared derived outputs when no narrower truthful subject or scope
   exists
 - `kernel_scope_id` must not replace `selection_id`,
   `claim_scope_id`, `continuity_segment_id`, `balance_target_id`,
@@ -148,7 +148,8 @@ Rules:
 ## Shared Stage Vocabulary
 
 Use one stage vocabulary across gap records, review records, readiness
-records, checkpoint-stage reuse, and downstream assessment views.
+records, checkpoint-stage reuse, and any later capability-owned derived
+outputs.
 
 Shared stage vocabulary:
 
@@ -163,7 +164,8 @@ Shared stage vocabulary:
 Rules:
 
 - `owner_stage` and `blocking_stages` use this vocabulary
-- readiness records and rollups use this vocabulary
+- readiness records and later capability-owned derived outputs use this
+  vocabulary
 - keep stage labels on repo-owned noun forms that match the target package and
   ownership docs
 - do not use alternate labels such as `semantic` once target-stage products
@@ -440,7 +442,7 @@ Rules:
 ## Readiness Model
 
 Readiness is subject-first, stage-specific, and reducible into derived grouped
-outputs plus assessment views.
+outputs.
 
 ### `ReadinessStatus`
 
@@ -521,11 +523,11 @@ Rules:
   - migration compatibility-local derived output
 - grouped readiness must remain reproducible from ordered readiness and gap
   records without manual status editing
-- source-grouped or operator-facing views remain assessment views or
-  compatibility views rather than canonical readiness record families
+- do not ship source-grouped or operator-facing grouped readiness as a shared
+  forward-target surface before trigger activation
 - once a grouped consumer requires a broader derived read-model surface, that
   grouped behavior moves into the owning capability instead of restoring a
-  shared readiness rollup family
+  shared grouped-readiness family
 
 ## Bridge Mapping From Issue And Review Records
 
@@ -556,9 +558,9 @@ Meaning:
 
 - one stage owns one meaning surface
 - downstream stages reference upstream records by stable ids or product ids
-- `kernel_scope_id` is allowed only for shared assessment views and sidecar
-  attachment
-  when no narrower truthful product id, scope id, or record id exists
+- `kernel_scope_id` is allowed only for declared derived outputs and sidecar
+  attachment when no narrower truthful product id, scope id, or record id
+  exists
 - downstream stages add stage-owned outputs only
 
 Keep these first-class:
@@ -598,8 +600,8 @@ Performance implication:
 - repeated full detail copies increase read amplification, join cost, and drift
   risk
 - the correct shape is stable ids or product ids plus stage-owned deltas, with
-  `kernel_scope_id` reserved for shared assessment views or sidecar attachment
-  only
+  `kernel_scope_id` reserved for declared derived outputs or sidecar
+  attachment only
 
 ## Current-To-Target Boundary
 

--- a/docs/concepts/gaps-and-readiness.md
+++ b/docs/concepts/gaps-and-readiness.md
@@ -439,8 +439,8 @@ Rules:
 
 ## Readiness Model
 
-Readiness is subject-first, stage-specific, and reducible into canonical
-rollups plus assessment views.
+Readiness is subject-first, stage-specific, and reducible into derived grouped
+outputs plus assessment views.
 
 ### `ReadinessStatus`
 
@@ -500,88 +500,32 @@ Rules:
 - subject readiness is the base truth
 - `evidence` readiness covers deterministic evidence selection and observation
   completeness before claim commitment
-- reducers work from subject readiness plus gaps, not from hand-built
-  readiness rollup rows
+- reducers work from subject readiness plus gaps, not from hand-built grouped
+  readiness rows
 - a subject may be ready for one stage and blocked for another
 - readiness points to blocking gap ids rather than hiding blockers in
   explanation text
 
-### `ReadinessRollupRecord`
+### Grouped Readiness Before Derived Read-Model Activation
 
-Purpose:
-
-- derived readiness rollup over subject readiness
-
-Fields:
-
-- `readiness_rollup_id`
-- `stage`
-- `rollup_kind`
-- `rollup_key`
-- `status`
-- `blocking_gap_ids`
-- `ready_count`
-- `partial_count`
-- `blocked_count`
-- `not_applicable_count`
-
-Controlled `rollup_kind` vocabulary:
-
-- `location`
-- `instrument`
-- `continuity_segment`
-- `as_of`
-- `tax_year`
-- `kernel_scope`
-
-Rollup-key rules:
-
-- `location` uses one `location_id`
-- `instrument` uses one `instrument_id`
-- `continuity_segment` uses one `continuity_segment_id`
-- `as_of` uses one canonical `YYYY-MM-DD` date string
-- `tax_year` uses one integer tax year
-- `kernel_scope` uses one `kernel_scope_id`
-
-Stable ids:
-
-- `readiness_rollup_id` identifies one derived readiness rollup record
-- `readiness_rollup_id` uses component array
-  `[stage, rollup_kind, rollup_key]`
-
-Ordering:
-
-- sort by tuple `[stage, rollup_kind, rollup_key]`
-- sort `blocking_gap_ids` lexicographically
-
-Serialization:
-
-- serialize readiness rollup records only
-- use stable object-key ordering
-- preserve the declared readiness rollup order above
-
-Fingerprint inputs:
-
-- readiness rollup records in canonical order
-- `schema_version`
-- sorted `blocking_gap_ids`
-- the ordered `ReadinessRecord` ids that fed the rollup
+Grouped readiness is derived behavior, not a shared canonical record family.
 
 Rules:
 
-- readiness rollup rows are derived rollup records, not the only stored truth
-- `partial` requires at least one resolved assertion plus at least one open
-  blocking gap id
-- if no required assertion has resolved yet, status is `blocked`, not
-  `partial`
-- if no blocker applies, status is `ready`, not `partial`
-- kernel-scope readiness rollups remain reproducible from ordered readiness
-  and gap records without manual status editing
-- canonical rollup kinds stay stage- and domain-oriented rather than grouping
-  by source identity
-- source-grouped views belong in assessment views or compatibility
-  views rather than in `ReadinessRollupRecord.rollup_kind`
-- stages use only the dimensions they actually own or can derive safely
+- shared readiness truth stays on ordered `ReadinessRecord` rows plus their
+  linked gap ids
+- before the roadmap trigger ladder activates broader derived read models,
+  grouped readiness may exist only as:
+  - tax-output-local derived output
+  - narrow rendering-derived output
+  - migration compatibility-local derived output
+- grouped readiness must remain reproducible from ordered readiness and gap
+  records without manual status editing
+- source-grouped or operator-facing views remain assessment views or
+  compatibility views rather than canonical readiness record families
+- once a grouped consumer requires a broader derived read-model surface, that
+  grouped behavior moves into the owning capability instead of restoring a
+  shared readiness rollup family
 
 ## Bridge Mapping From Issue And Review Records
 

--- a/docs/concepts/pipeline-stage-contracts.md
+++ b/docs/concepts/pipeline-stage-contracts.md
@@ -927,7 +927,7 @@ Stable ids:
 - `continuity_segment_id` uses component array
   `[subject_ref, segment_start_at, segment_end_at]`
 - `continuity_segment_id` is the reusable stage-local scope id for gap,
-  review, and readiness attachments plus readiness rollups;
+  review, readiness attachments, and declared derived outputs;
   `reconciliation_state_id` is the emitted product id over that scope plus its
   upstream lineage
 - `event_link_id` uses component array
@@ -981,7 +981,7 @@ Must guarantee:
 Must not:
 
 - reclassify upstream economics to make continuity easier
-- bury missing evidence inside kernel-scope readiness rollups
+- bury missing evidence inside kernel-scope grouped readiness outputs
 - use value refs that point to undefined sidecar values outside the kernel
 
 Handoff to `Checkpoint`:

--- a/docs/concepts/pipeline-stage-contracts.md
+++ b/docs/concepts/pipeline-stage-contracts.md
@@ -59,9 +59,12 @@ Every stage contract answers four questions:
 Shared rules:
 
 - every output preserves stable ids and enough upstream linkage for later audit
-- later stages may add stage-owned sidecars, rollups, and reporting
-  views, but must not
-  silently rewrite upstream product meaning to make their own outputs look tidy
+- later stages may add stage-owned sidecars and active-slice derived outputs,
+  but must not silently rewrite upstream product meaning to make their own
+  outputs look tidy
+- broader derived read models and projections activate only when the roadmap
+  trigger ladder requires them; they are not first-class target product
+  families during the tax-first phases
 - if a stage cannot support a required decision, it emits explicit blockers,
   unresolved records, or deferred records rather than inventing a fallback
 - replay and parity gates operate on kernels first and inspect sidecars
@@ -1450,6 +1453,7 @@ Owns:
   records
 - tax-policy explanations, limitations, and rendered output content
 - tax-owned blockers that survive policy execution
+- the tax-output-local grouped content needed for the active tax path only
 
 Record families:
 
@@ -1491,6 +1495,13 @@ Sidecar content:
 - filing notes and limitations
 - tax carry-forward explanation
 - tax unsupported-input explanation
+
+Scope fence:
+
+- `TaxOutputs` owns tax-policy output content for the active tax path
+- `TaxOutputs` does not become the long-term home of general reporting,
+  dashboards, portfolio views, visualization datasets, or investigation
+  workflows
 
 Product-root cardinality:
 
@@ -1568,6 +1579,6 @@ elsewhere:
   `AssertionValue`, and package ownership
 - [Gap, Review, And Readiness](gaps-and-readiness.md) for `GapRecord`,
   `GapExplanation`, `ReviewRecord`, `ReviewExplanation`,
-  `ReadinessRecord`, `ReadinessRollupRecord`, and `SubjectRef`
+  `ReadinessRecord`, and `SubjectRef`
 - [Reconciliation, Checkpoint, Journal, And Tax Architecture](reconciliation-tax-architecture.md) for
   persistence rules, partitioning rules, and fast-path expectations

--- a/docs/concepts/reconciliation-tax-architecture.md
+++ b/docs/concepts/reconciliation-tax-architecture.md
@@ -82,6 +82,10 @@ Trust and ownership rules:
   accepted checkpoint truth
 - selected tax policies decide treatment in `TaxOutputs`; they do not decide
   source meaning, reconciliation truth, checkpoint truth, or journal outcomes
+- `TaxOutputs` may own tax-policy output content needed for the active tax path,
+  but that exception does not make it the long-term home of general reporting,
+  dashboards, portfolio views, visualization datasets, or investigation
+  workflows
 
 ## Source, Output, Oracle, And Persistence Boundaries
 
@@ -157,10 +161,10 @@ Forward-looking persistence rules:
   page documents a stronger reason to differ
 - product sidecars persist separately from kernels and are keyed by
   `kernel_scope_id` or narrower truthful record ids
-- canonical readiness rollups stay stage- and domain-oriented;
-  source-grouped views stay as assessment views or
-  compatibility views rather than as gap, review, or readiness record
-  families or readiness rollups
+- grouped readiness remains derived behavior over shared readiness records;
+  source-grouped or operator-facing views stay as assessment views or
+  compatibility views rather than as canonical gap, review, or readiness
+  record families
 - target basenames use the owning product or sidecar family directly
   rather than generic names or bridge-era qualifiers
 - stable ids and helper refs keep the owning family stem once they cross
@@ -201,9 +205,10 @@ Rules:
 - migration-era workspace paths may still group later products under a
   source-scoped directory tree, but that filesystem placement does not make
   source identity part of downstream product naming or stable-id recipes
-- target products may expose derived reporting views across several
-  partitions, but those views do not replace the authoritative partition
-  kernels
+- during the tax-first phases, target products may expose only product-local
+  derived outputs, narrow rendering outputs, or compatibility views; broader
+  derived read models and projections activate only when the roadmap trigger
+  ladder fires
 - `EvidenceSet`, `ClaimSet`, and `EconomicFacts` kernels each persist one
   product kernel per declared partition
 - one persisted `ReconciliationState` kernel owns one continuity segment kernel
@@ -234,13 +239,15 @@ Use these paths in forward-looking docs and later implementation work:
   `assessment/gap/gap_explanations.json`,
   `assessment/review/review_records.json`,
   `assessment/review/review_explanations.json`,
-  `assessment/readiness/readiness_records.json`, and
-  `assessment/readiness/readiness_rollup_records.json`
+  and `assessment/readiness/readiness_records.json`
 - compatibility views live under the authoritative product they depend on,
   for example:
   - `working/products/economic_facts/<economic_facts_id>/compatibility/facts.csv`
   - `working/products/reconciliation_states/<reconciliation_state_id>/compatibility/balance_snapshots.csv`
   - `working/products/checkpoints/<checkpoint_id>/compatibility/balance_references.csv`
+- a general projections root under
+  `working/projections/<slice>/<projection_family>/...` is deferred until the
+  roadmap trigger ladder activates broader derived read models
 
 Rules:
 

--- a/docs/concepts/reconciliation-tax-architecture.md
+++ b/docs/concepts/reconciliation-tax-architecture.md
@@ -162,9 +162,9 @@ Forward-looking persistence rules:
 - product sidecars persist separately from kernels and are keyed by
   `kernel_scope_id` or narrower truthful record ids
 - grouped readiness remains derived behavior over shared readiness records;
-  source-grouped or operator-facing views stay as assessment views or
-  compatibility views rather than as canonical gap, review, or readiness
-  record families
+  before trigger activation it may appear only as tax-output-local, narrow
+  rendering-local, or compatibility-local derived output rather than as a
+  shared gap, review, or readiness record family
 - target basenames use the owning product or sidecar family directly
   rather than generic names or bridge-era qualifiers
 - stable ids and helper refs keep the owning family stem once they cross

--- a/docs/reference/target-persistence-reference.md
+++ b/docs/reference/target-persistence-reference.md
@@ -50,8 +50,9 @@ When persisting target products:
   views only once a target product is authoritative for that scope
 - keep provenance, explanations, reviews, comparison traces, and other
   non-kernel detail in sidecars
-- keep grouped readiness and other source-grouped views as assessment views or
-  compatibility views rather than as canonical shared record families
+- keep grouped readiness as tax-output-local, narrow rendering-local, or
+  compatibility-local derived output until the roadmap trigger ladder
+  activates a capability-owned read-model surface
 - keep assessment family directories and basenames aligned to the stored
   families, for example `assessment/gap/gap_records.json`,
   `assessment/review/review_records.json`,

--- a/docs/reference/target-persistence-reference.md
+++ b/docs/reference/target-persistence-reference.md
@@ -50,16 +50,18 @@ When persisting target products:
   views only once a target product is authoritative for that scope
 - keep provenance, explanations, reviews, comparison traces, and other
   non-kernel detail in sidecars
-- keep source-grouped views as assessment views or compatibility
-  views rather than as canonical readiness rollups
+- keep grouped readiness and other source-grouped views as assessment views or
+  compatibility views rather than as canonical shared record families
 - keep assessment family directories and basenames aligned to the stored
   families, for example `assessment/gap/gap_records.json`,
   `assessment/review/review_records.json`,
-  `assessment/readiness/readiness_records.json`, and
-  `assessment/readiness/readiness_rollup_records.json`
+  and `assessment/readiness/readiness_records.json`
 - `assessment/` stays generic only because it splits immediately into the
   persisted `gap/`, `review/`, and `readiness/` families; unrelated sidecars
   do not belong there
+- defer a general projections root such as
+  `working/projections/<slice>/<projection_family>/...` until the roadmap
+  trigger ladder activates broader derived read models
 - treat caches and indexes as regenerable accelerators, not as business truth
 
 ## Reminder

--- a/docs/standards/commits.md
+++ b/docs/standards/commits.md
@@ -81,7 +81,7 @@ Write `Why:` and `What:` directly:
 
 Bad `Why:` bullets are diff summaries such as:
 
-- `rename ReadinessRollupRecord`
+- `rename CheckpointProposalRecord`
 - `update naming docs`
 - `refactor commit wording`
 

--- a/docs/standards/engineering.md
+++ b/docs/standards/engineering.md
@@ -125,8 +125,8 @@ When a capability grows, split by stable boundaries:
   `application/intake/`, `application/profiling/`, `application/evidence/`,
   `application/claim/`, `application/economics/`,
   `application/compatibility/`, `application/normalization/`,
-  `application/reconciliation/`, `application/assessment/`,
-  `application/checkpoint/`, `application/journal/`, `application/tax/`, and
+  `application/reconciliation/`, `application/checkpoint/`,
+  `application/journal/`, `application/tax/`, and
   `application/rendering/`. Keep request and response contracts in
   capability-local `contracts.py` files and keep orchestration entry points in
   explicitly named use-case modules such as `build_profile.py`,
@@ -187,16 +187,34 @@ Current application of this rule:
   planned-item models, review assembly, and report rendering.
 - Normalization window and derived-balance helpers belong under
   `application/normalization/` rather than as nearby flat siblings.
-- Forward-looking cross-stage gap, review, and readiness reducers plus
-  readiness rollups and assessment views belong under
-  `application/assessment/` rather than being buried under
-  `application/reconciliation/`.
+- Shared gap, review, and readiness contracts belong under `domain/assessment/`
+  while the owning application slice keeps its own assessment behavior.
 - Forward-looking journal expansion and entry checks belong under
   `application/journal/` rather than under a broader `accounting/` umbrella or
   as extra checkpoint-side helpers.
 - Rendering belongs under `application/rendering/`; CoinTracking is one
   output adapter, not an application-center compatibility lane.
 - Dev-only oracle tooling must live outside `src/tallylot/`.
+
+### Tax-First Derived Output Exception
+
+During the active tax-first path, grouped consumer-facing output logic may stay
+inside `application/tax/` or `application/rendering/` only when it is
+exclusively needed for:
+
+- active filing outputs
+- current renderer surfaces
+- current compatibility surfaces
+
+Extraction is mandatory before implementation when any of these are true:
+
+- a second grouped non-compatibility consumer appears
+- a grouped non-authoritative surface needs durable persistence outside tax
+  outputs or compatibility
+- a feature clearly belongs to reporting, portfolio, visualization, or
+  investigation
+- grouped output logic would otherwise be copied into a second stage package or
+  consumer
 
 ## Naming Rules
 
@@ -286,9 +304,9 @@ Current application of this rule:
   those are the actual owned families. Reserve generic `assessment` for
   intentional roots or bounded field names such as `domain/assessment/`,
   `assessment/`, or `support_shape`.
-- When cross-stage support logic needs its own application boundary, give it
-  the family noun directly, such as `application/assessment/`, rather than
-  burying it under a neighboring stage package.
+- When grouped support logic outgrows stage-local ownership, extract it to the
+  specific capability-owned derived read-model package rather than to a shared
+  application sink.
 - `application/compatibility/` is acceptable only for migration-era bridge
   compatibility views and view writers. When a page or package uses that root,
   state directly that it is migration-only rather than a durable application
@@ -467,10 +485,8 @@ Stable-id namespaces are catalog-governed, not review-time judgment.
   `readiness/`, then make basenames mirror the stored record or explanation
   family. Prefer `assessment/gap/gap_records.json`,
   `assessment/review/review_records.json`,
-  `assessment/readiness/readiness_records.json`, and
-  `assessment/readiness/readiness_rollup_records.json` over one flat
-  assessment directory or shorter plurals that need directory context to
-  reveal shape.
+  and `assessment/readiness/readiness_records.json` over one flat assessment
+  directory or shorter plurals that need directory context to reveal shape.
 - In forward-looking docs and code, reserve `artifact` for current-state bridge
   outputs, oracle/reference packages, or intentionally mixed file families.
   When the storage role is known, prefer `kernel`, `sidecar`, `view`,

--- a/docs/standards/engineering.md
+++ b/docs/standards/engineering.md
@@ -216,6 +216,11 @@ Extraction is mandatory before implementation when any of these are true:
 - grouped output logic would otherwise be copied into a second stage package or
   consumer
 
+When extraction becomes mandatory, move that behavior into the specific
+capability package the feature needs, such as application/reporting/,
+application/portfolio/, application/visualization/, or
+application/investigation/, rather than into a generic shared sink.
+
 ## Naming Rules
 
 - Name modules after the bounded responsibility they own.
@@ -337,16 +342,17 @@ Extraction is mandatory before implementation when any of these are true:
   - `Summary` for reader-facing or compatibility aggregates that do not define a
     stable grouped kernel contract
   - `Sidecar` for attached non-kernel detail
-- Reserve `rollup` for canonical target-layer grouped records and their ids.
-  Reserve `summary` for current-state, presentation, or compatibility
-  aggregates that are not the canonical grouped record family. Inside
-  explanation or review sidecars, prefer concrete prose-field names such as
-  `headline`, `known_facts`, or `follow_up` over `*_summary`.
+- Reserve `rollup` for activated capability-owned grouped records and their ids
+  after the roadmap trigger ladder introduces that family. Reserve `summary`
+  for current-state, presentation, or compatibility aggregates that are not the
+  canonical grouped record family. Inside explanation or review sidecars,
+  prefer concrete prose-field names such as `headline`, `known_facts`, or
+  `follow_up` over `*_summary`.
 - Do not use bare `summary` as a target-stage controlled-vocabulary value or
   package responsibility label when a more concrete output noun would say what
   the surface holds. Prefer names such as `policy_summary`,
-  `supporting_schedule`, `filing_form`, `validation_report`, or
-  `readiness_rollup` when those are the real shapes.
+  `supporting_schedule`, `filing_form`, or `validation_report` when those are
+  the real shapes.
 - When describing the fixed top-level fields that travel with every emitted
   product kernel, prefer `product header` over the more abstract `metadata`.
   Reserve `metadata` for looser descriptive prose, not for the canonical
@@ -393,9 +399,8 @@ Stable-id namespaces are catalog-governed, not review-time judgment.
 
 - Keep scope families parallel from the id to the matching kind value. If the
   stable id is `claim_scope_id`, `checkpoint_proposal_id`, or
-  `kernel_scope_id`, the matching `scope_kind` or `rollup_kind` value should
-  be `claim_scope`, `checkpoint_proposal`, or `kernel_scope`, not a competing
-  alternate stem.
+  `kernel_scope_id`, the matching `scope_kind` value should be `claim_scope`,
+  `checkpoint_proposal`, or `kernel_scope`, not a competing alternate stem.
 - When the record-family stem needs the owning stage noun to stay clear, keep
   that same stem on descendant ids and persisted basenames. Prefer
   `tax_carry_forward_id` and `tax_carry_forward_records.json` alongside
@@ -519,18 +524,19 @@ Stable-id namespaces are catalog-governed, not review-time judgment.
   `source`. Reserve bare `source` for prose, for grouping dimensions whose
   enclosing field already states the role, or for source-scoped provider
   families where the contract is not storing the slug itself.
-- Inside canonical target rollups, use the actual grouping identifier in
-  `rollup_kind` when the key is itself a canonical identifier.
-- Keep canonical target rollup families stage- and domain-oriented. If
-  operators still need source-grouped views, expose them as assessment views or
-  compatibility views rather than as shared target `RollupRecord`
-  vocabulary members.
+- Inside activated capability-owned target rollups, use the actual grouping
+  identifier in `rollup_kind` when the key is itself a canonical identifier.
+- Keep activated capability-owned rollup families stage- and domain-oriented.
+  During the tax-first path, keep source-grouped or operator-facing aggregates
+  inside compatibility views or the allowed tax-path-local derived outputs
+  rather than as shared target `RollupRecord` vocabulary members.
 - Prefer concrete held-shape nouns over abstract container prose. Do not use
   labels such as `emission root`, `output root`, or `root truth container`
   when the actual kernel, record family, or persisted view already names what
   the surface holds.
-- When an assessment view or compatibility view truly stores the shared
-  source slug as its grouping key, prefer `source_slug` over bare `source`.
+- When a compatibility view or other declared derived view truly stores the
+  shared source slug as its grouping key, prefer `source_slug` over bare
+  `source`.
 - In canonical target-layer evidence and claim contracts, use `source_*` only
   when the field truly stores source identity or another source-derived value
   that would be ambiguous without the prefix. When the stage already supplies
@@ -667,12 +673,12 @@ Stable-id namespaces are catalog-governed, not review-time judgment.
 - When a product header carries an ordered set of upstream refs, keep any
   matching product-id component array in that same canonical order unless the
   contract page documents a stronger reason to differ.
-- Inside aggregate rollup records, use `rollup_kind` and `rollup_key` for the
-  grouping dimensions so `rollup` remains the record shape instead of becoming
-  a second generic field prefix.
-- Inside aggregate rollup records, drop repeated subject or entity nouns from
-  count fields when the rollup already establishes that context. Prefer
-  `ready_count` over `ready_subject_count`.
+- Inside activated capability-owned rollup records, use `rollup_kind` and
+  `rollup_key` for the grouping dimensions so `rollup` remains the record
+  shape instead of becoming a second generic field prefix.
+- Inside activated capability-owned rollup records, drop repeated subject or
+  entity nouns from count fields when the rollup already establishes that
+  context. Prefer `ready_count` over `ready_subject_count`.
 - Prefer `Proposal` for stage-owned pre-acceptance records that later become
   accepted truth. Reserve `Candidate` for raw search-space options or other
   unmanaged alternatives that the owning stage has not yet shaped into a
@@ -683,10 +689,11 @@ Stable-id namespaces are catalog-governed, not review-time judgment.
   as `LinkRecord` or `ValidationRecord`.
 - When owner docs or bounded-slice refs describe a stored record family in
   prose, reuse the stored family noun instead of swapping to a looser nearby
-  synonym. Prefer `entry checks`, `checkpoint proposals`, and `readiness
-  rollups` when those are the persisted families, and reserve broader prose
-  such as `validation`, `proposal`, or `summary` for the surrounding stage
-  behavior rather than for the stored shape itself.
+  synonym. Prefer `entry checks` and `checkpoint proposals` when those are the
+  persisted families, and use `rollups` only when the owner docs define an
+  activated capability-owned grouped family. Reserve broader prose such as
+  `validation`, `proposal`, or `summary` for the surrounding stage behavior
+  rather than for the stored shape itself.
 - When a stage owns a dedicated check record family, prefer that family noun in
   forward-looking prose for stage-owned persisted outputs and sidecars.
   Reserve broader `validation` wording for human review, workflow posture, or

--- a/docs/status/migration-sequence.md
+++ b/docs/status/migration-sequence.md
@@ -142,6 +142,8 @@ Rules:
 
 The roadmap trigger ladder is the authority for when broader derived read
 models and projections become mandatory.
+If no earlier trigger fires, the default activation point is `Phase 10`
+post-filing expansion.
 
 Before a trigger fires:
 

--- a/docs/status/migration-sequence.md
+++ b/docs/status/migration-sequence.md
@@ -57,6 +57,11 @@ Migration-wide rules:
   only
 - unchanged bridge outputs must remain reproducible from the authoritative
   target kernels during the compatibility window
+- do not introduce a shared application assessment center as a migration
+  shortcut; assessment behavior stays with the owning slice
+- through the tax-first phases, broader grouped or query surfaces stay on
+  authoritative kernels, declared compatibility views, or tax-output-local and
+  rendering-local derived outputs until the roadmap trigger ladder fires
 
 The authoritative cutover matrix lives in
 [Bridge To Target Mapping](../concepts/bridge-to-target-mapping.md).
@@ -118,6 +123,9 @@ After those slices land, migrate readers one consumer surface at a time:
   explicitly repointed
 - journal and tax readers move only after their upstream products are
   authoritative and stable
+- broader grouped consumers stay on tax-output-local outputs, narrow rendering
+  outputs, or compatibility views until the roadmap trigger ladder requires a
+  dedicated derived read-model slice
 
 ### 5. Later Downstream Products
 
@@ -129,6 +137,26 @@ Rules:
 - do not let `Journal` repair economic or checkpoint truth
 - do not let tax decide source meaning, reconciliation completeness, or
   checkpoint acceptance
+
+### 6. Triggered Derived Read-Model Activation
+
+The roadmap trigger ladder is the authority for when broader derived read
+models and projections become mandatory.
+
+Before a trigger fires:
+
+- keep reader cutovers on authoritative kernels or declared compatibility views
+- do not introduce general read-model package roots or projection storage
+  families early
+- keep grouped derived outputs inside `TaxOutputs` or `application/rendering/`
+  only when they remain exclusive to the active tax-first path
+
+When a trigger fires:
+
+- create only the specific capability-owned derived read-model package the new
+  feature needs
+- keep that derived surface additive and non-authoritative beside the
+  authoritative pipeline products
 
 ## Bridge Retirement Rules
 

--- a/tests/unit/docs_runtime_parity/test_repo_doc_guards.py
+++ b/tests/unit/docs_runtime_parity/test_repo_doc_guards.py
@@ -322,11 +322,13 @@ def test_forward_target_docs_use_assessment_paths_and_partition_labels() -> None
     )
 
     assert "assessment/gap/gap_records.json" in recon_text
-    assert "assessment/readiness/readiness_rollup_records.json" in recon_text
+    assert "assessment/readiness/readiness_records.json" in recon_text
+    assert "assessment/readiness/readiness_rollup_records.json" not in recon_text
     assert "checkpoint-economic-facts-lineage-scoped" in recon_text
     assert "tax-inputs-policy-year-scoped" in recon_text
     assert "checkpoint-economic-lineage-scoped" not in recon_text
     assert "tax-input-policy-year-scoped" not in recon_text
+    assert "tax-output-local derived output" in gaps_text
     assert "`kernel_scope`" in gaps_text
     assert "`product_scope`" not in gaps_text
 

--- a/tests/unit/docs_runtime_parity/test_repo_doc_guards.py
+++ b/tests/unit/docs_runtime_parity/test_repo_doc_guards.py
@@ -314,6 +314,10 @@ def test_forward_target_docs_use_kernel_scope_and_assessment_roots() -> None:
         assert "application/readiness/" not in text, (
             f"{path} still uses application/readiness/"
         )
+        assert "application/query/" not in text, f"{path} still uses application/query/"
+        assert "application/read_models/" not in text, (
+            f"{path} still uses application/read_models/"
+        )
 
 
 def test_forward_target_docs_use_assessment_paths_and_partition_labels() -> None:
@@ -323,6 +327,9 @@ def test_forward_target_docs_use_assessment_paths_and_partition_labels() -> None
     gaps_text = (docs_root() / "concepts" / "gaps-and-readiness.md").read_text(
         encoding="utf-8"
     )
+    persistence_text = (
+        docs_root() / "reference" / "target-persistence-reference.md"
+    ).read_text(encoding="utf-8")
 
     assert "assessment/gap/gap_records.json" in recon_text
     assert "assessment/readiness/readiness_records.json" in recon_text
@@ -334,6 +341,58 @@ def test_forward_target_docs_use_assessment_paths_and_partition_labels() -> None
     assert "tax-output-local derived output" in gaps_text
     assert "`kernel_scope`" in gaps_text
     assert "`product_scope`" not in gaps_text
+    assert "assessment view" not in gaps_text
+    assert "assessment views" not in gaps_text
+    assert "assessment view" not in recon_text
+    assert "assessment views" not in recon_text
+    assert "assessment view" not in persistence_text
+    assert "assessment views" not in persistence_text
+    assert "readiness rollup" not in gaps_text.lower()
+    assert "readiness rollup" not in recon_text.lower()
+    assert "readiness rollup" not in persistence_text.lower()
+
+
+def test_forward_target_docs_encode_phase_10_default_read_model_activation() -> None:
+    roadmap_text = (repo_root() / "ROADMAP.md").read_text(encoding="utf-8")
+    overview_text = (docs_root() / "concepts" / "architecture-overview.md").read_text(
+        encoding="utf-8"
+    )
+    migration_text = (docs_root() / "status" / "migration-sequence.md").read_text(
+        encoding="utf-8"
+    )
+    bridge_text = (docs_root() / "concepts" / "bridge-to-target-mapping.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "Phase 10" in roadmap_text
+    assert "Phase 10" in overview_text
+    assert "Phase 10" in migration_text
+    assert "Phase 10" in bridge_text
+    assert "default activation point" in overview_text
+    assert "default activation point" in migration_text
+    assert "activation defaults to `Phase 10`" in bridge_text
+
+
+def test_forward_target_docs_reserve_specific_read_model_package_names() -> None:
+    roadmap_text = (repo_root() / "ROADMAP.md").read_text(encoding="utf-8")
+    ontology_text = (docs_root() / "concepts" / "domain-ontology.md").read_text(
+        encoding="utf-8"
+    )
+    engineering_text = (docs_root() / "standards" / "engineering.md").read_text(
+        encoding="utf-8"
+    )
+
+    reserved_paths = (
+        "application/reporting/",
+        "application/portfolio/",
+        "application/visualization/",
+        "application/investigation/",
+    )
+
+    for reserved_path in reserved_paths:
+        assert reserved_path in roadmap_text
+        assert reserved_path in ontology_text
+        assert reserved_path in engineering_text
 
 
 def test_forward_target_docs_retire_operator_views_and_abstract_container_labels() -> (

--- a/tests/unit/docs_runtime_parity/test_repo_doc_guards.py
+++ b/tests/unit/docs_runtime_parity/test_repo_doc_guards.py
@@ -308,6 +308,9 @@ def test_forward_target_docs_use_kernel_scope_and_assessment_roots() -> None:
         assert "kernel_scope_id" in text, f"{path} must use kernel_scope_id"
         assert "product_scope_id" not in text, f"{path} still uses product_scope_id"
         assert "domain/support/" not in text, f"{path} still uses domain/support/"
+        assert "application/assessment/" not in text, (
+            f"{path} still uses application/assessment/"
+        )
         assert "application/readiness/" not in text, (
             f"{path} still uses application/readiness/"
         )

--- a/tests/unit/test_target_naming.py
+++ b/tests/unit/test_target_naming.py
@@ -87,12 +87,6 @@ def _write_catalog(
                     "id": "readiness_id",
                     "refs": [],
                 },
-                {
-                    "stem": "readiness_rollup",
-                    "record": "ReadinessRollupRecord",
-                    "id": "readiness_rollup_id",
-                    "refs": [],
-                },
             ],
             "package_paths": ["application/claim/", "domain/assessment/"],
             "standalone_directory_paths": ["compatibility/"],
@@ -113,10 +107,7 @@ def _write_catalog(
                         },
                         {
                             "stem": "readiness",
-                            "sidecars": [
-                                "readiness_records.json",
-                                "readiness_rollup_records.json",
-                            ],
+                            "sidecars": ["readiness_records.json"],
                         },
                     ],
                 },
@@ -1290,7 +1281,6 @@ def test_real_repo_catalog_covers_root_scopes_and_tooling_paths() -> None:
         "assessment/review/review_records.json",
         "assessment/review/review_explanations.json",
         "assessment/readiness/readiness_records.json",
-        "assessment/readiness/readiness_rollup_records.json",
     )
     assert catalog.reference_group_headings == (
         "### Target References",
@@ -1317,6 +1307,13 @@ def test_real_repo_catalog_covers_root_scopes_and_tooling_paths() -> None:
     assert "ValuationRecord" in record_names
     assert "JournalEntryRecord" in record_names
     assert "GapRecord" in record_names
+    assert "ReadinessRollupRecord" not in record_names
+    assert "application/assessment/" not in catalog.canonical_families.package_paths
+    retired_aliases = {
+        alias.term: alias.replacement for alias in catalog.retired_aliases
+    }
+    assert retired_aliases["application/readiness/"] == "owning application slice"
+    assert retired_aliases["application/assessment/"] == "owning application slice"
     assert "tools/target_naming.py" in catalog.tooling_paths
     assert "tests/unit/test_target_naming_parser.py" in catalog.tooling_paths
 

--- a/tests/unit/test_target_naming.py
+++ b/tests/unit/test_target_naming.py
@@ -644,7 +644,7 @@ def test_audit_allows_marked_locality_exception(tmp_path: Path) -> None:
     with override_repo_root(tmp_path):
         findings = audit_target_naming()
 
-    assert findings == ()
+    assert not findings
 
 
 def test_audit_allows_unmarked_allowed_section_locality_term(tmp_path: Path) -> None:
@@ -680,7 +680,7 @@ def test_audit_allows_unmarked_allowed_section_locality_term(tmp_path: Path) -> 
     with override_repo_root(tmp_path):
         findings = audit_target_naming()
 
-    assert findings == ()
+    assert not findings
 
 
 def test_audit_reports_missing_naming_scope_for_repo_docs(tmp_path: Path) -> None:
@@ -835,7 +835,7 @@ def test_locality_rule_ignores_terms_without_applicable_scope_rule(
     with override_repo_root(tmp_path):
         findings = audit_target_naming(paths=("docs/standards.md",))
 
-    assert findings == ()
+    assert not findings
 
 
 def test_audit_checks_locality_exceptions_inside_table_cells(tmp_path: Path) -> None:
@@ -1037,7 +1037,7 @@ def test_identifier_namespace_allows_canonical_ids_by_default(tmp_path: Path) ->
         """,
     )
 
-    assert findings == ()
+    assert not findings
 
 
 def test_identifier_namespace_requires_local_short_field_slots(
@@ -1085,7 +1085,7 @@ def test_identifier_namespace_allows_local_short_field_slots(tmp_path: Path) -> 
         """,
     )
 
-    assert findings == ()
+    assert not findings
 
 
 def test_identifier_namespace_requires_local_short_array_components(
@@ -1137,7 +1137,7 @@ def test_identifier_namespace_allows_local_short_array_components(
         """,
     )
 
-    assert findings == ()
+    assert not findings
 
 
 def test_identifier_namespace_mixes_canonical_and_local_short_regions(
@@ -1188,7 +1188,7 @@ def test_identifier_namespace_ignores_canonical_ids_without_local_slots(
         """,
     )
 
-    assert findings == ()
+    assert not findings
 
 
 def test_identifier_namespace_checks_qualified_field_suffixes(
@@ -1240,7 +1240,7 @@ def test_identifier_namespace_allows_local_short_qualified_field_suffixes(
         """,
     )
 
-    assert findings == ()
+    assert not findings
 
 
 def test_real_repo_catalog_covers_root_scopes_and_tooling_paths() -> None:
@@ -1309,11 +1309,28 @@ def test_real_repo_catalog_covers_root_scopes_and_tooling_paths() -> None:
     assert "GapRecord" in record_names
     assert "ReadinessRollupRecord" not in record_names
     assert "application/assessment/" not in catalog.canonical_families.package_paths
+    assert "application/reporting/" not in catalog.canonical_families.package_paths
+    assert "application/portfolio/" not in catalog.canonical_families.package_paths
+    assert "application/visualization/" not in catalog.canonical_families.package_paths
+    assert "application/investigation/" not in catalog.canonical_families.package_paths
+    assert "assessment view" not in catalog.canonical_tokens.phrases
+    assert "readiness rollup" not in catalog.canonical_tokens.phrases
+    assert "readiness_rollup_id" not in catalog.canonical_tokens.snake
     retired_aliases = {
         alias.term: alias.replacement for alias in catalog.retired_aliases
     }
     assert retired_aliases["application/readiness/"] == "owning application slice"
     assert retired_aliases["application/assessment/"] == "owning application slice"
+    assert (
+        retired_aliases["application/query/"]
+        == "specific capability-owned derived read-model package"
+    )
+    assert (
+        retired_aliases["application/read_models/"]
+        == "specific capability-owned derived read-model package"
+    )
+    assert retired_aliases["operator view"] == "derived view"
+    assert retired_aliases["operator views"] == "derived views"
     assert "tools/target_naming.py" in catalog.tooling_paths
     assert "tests/unit/test_target_naming_parser.py" in catalog.tooling_paths
 
@@ -1329,7 +1346,7 @@ def test_real_repo_catalog_covers_root_scopes_and_tooling_paths() -> None:
     ],
 )
 def test_real_repo_identifier_namespace_audit_passes(path: str) -> None:
-    assert audit_target_naming(paths=(path,)) == ()
+    assert not audit_target_naming(paths=(path,))
 
 
 def test_target_naming_sensitive_path_helper_covers_docs_and_control_plane() -> None:

--- a/tools/target_naming_catalog.yaml
+++ b/tools/target_naming_catalog.yaml
@@ -181,10 +181,6 @@ canonical_families:
       record: TaxOutputRecord
       id: tax_output_id
       refs: []
-    - stem: readiness_rollup
-      record: ReadinessRollupRecord
-      id: readiness_rollup_id
-      refs: []
     - stem: gap
       record: GapRecord
       id: gap_id
@@ -208,7 +204,6 @@ canonical_families:
   package_paths:
     - application/claim/
     - application/checkpoint/
-    - application/assessment/
     - application/compatibility/
     - application/economics/
     - application/evidence/
@@ -251,7 +246,6 @@ canonical_families:
         - stem: readiness
           sidecars:
             - readiness_records.json
-            - readiness_rollup_records.json
     - root: working/products
       families:
         - stem: evidence_sets
@@ -293,7 +287,6 @@ canonical_tokens:
     - PositionRef
     - PostingRecord
     - ReadinessRecord
-    - ReadinessRollupRecord
     - ClaimBundleRecord
     - ReviewExplanation
     - ReviewRecord
@@ -967,7 +960,14 @@ retired_aliases:
     allowed_paths: []
   - rule_id: body.shared_family_root
     term: application/readiness/
-    replacement: application/assessment/
+    replacement: owning application slice
+    contexts: [body, inline_code, summary]
+    allowed_scopes: [forward_target, repo_policy]
+    paths: []
+    allowed_paths: []
+  - rule_id: body.shared_family_root
+    term: application/assessment/
+    replacement: owning application slice
     contexts: [body, inline_code, summary]
     allowed_scopes: [forward_target, repo_policy]
     paths: []

--- a/tools/target_naming_catalog.yaml
+++ b/tools/target_naming_catalog.yaml
@@ -331,7 +331,6 @@ canonical_tokens:
     - kernel_scope_id
     - product_slug
     - readiness_id
-    - readiness_rollup_id
     - reconciliation_state_id
     - review_id
     - selection_id
@@ -347,12 +346,10 @@ canonical_tokens:
     - tax_unsupported_input_id
     - valuation_id
   phrases:
-    - assessment view
     - compatibility view
     - compatibility sidecar
     - entry check
     - product header
-    - readiness rollup
 
 local_id_slots:
   - canonical_id: claim_scope_id
@@ -972,16 +969,30 @@ retired_aliases:
     allowed_scopes: [forward_target, repo_policy]
     paths: []
     allowed_paths: []
+  - rule_id: body.shared_family_root
+    term: application/query/
+    replacement: specific capability-owned derived read-model package
+    contexts: [body, inline_code, summary]
+    allowed_scopes: [forward_target, repo_policy]
+    paths: []
+    allowed_paths: []
+  - rule_id: body.shared_family_root
+    term: application/read_models/
+    replacement: specific capability-owned derived read-model package
+    contexts: [body, inline_code, summary]
+    allowed_scopes: [forward_target, repo_policy]
+    paths: []
+    allowed_paths: []
   - rule_id: body.assessment_view_term
     term: operator view
-    replacement: assessment view
+    replacement: derived view
     contexts: [body, inline_code, summary]
     allowed_scopes: [forward_target, repo_policy]
     paths: []
     allowed_paths: []
   - rule_id: body.assessment_view_term
     term: operator views
-    replacement: assessment views
+    replacement: derived views
     contexts: [body, inline_code, summary]
     allowed_scopes: [forward_target, repo_policy]
     paths: []


### PR DESCRIPTION
Why:
- forward target docs currently froze a shared grouped-readiness and shared assessment shape that conflicted with the staged pipeline plus capability-owned derived read-model end state
- correcting that shape while it is still mostly doc-only is cheaper than carrying the wrong contracts into filing-first implementation and later refactors
- the review pass also needed to make the reserved post-filing package names explicit and retire generic query/read-model sink names before merge

What:
- remove canonical shared readiness rollup contracts and persistence and fence grouped readiness to filing-local, rendering-local, or compatibility-local derived outputs before trigger activation
- retire the shared application assessment sink, reserve the reporting, portfolio, visualization, and investigation package names in prose only, and defer broader derived read-model activation behind explicit triggers with Phase 10 as the default fallback
- align naming governance, parity guards, and supporting standards so stale rollup terminology and generic query/read-model sink names stay retired

Checks:
- `make audit-pr-review`
- `make docs-check`
- `make naming-check`
- `pytest --no-cov tests/unit/docs_runtime_parity/test_repo_doc_guards.py -q`
- `pytest --no-cov tests/unit/test_target_naming.py -q`
- `make pr-review`

Issue linkage:
- None: no existing tracked issue covers this forward-contract correction

Included checkpoints:
- `docs(roadmap): align tax-first rollout and read-model triggers`
- `docs(readiness): remove shared readiness rollup contracts`
- `docs(ownership): retire shared assessment application root`
- `docs(governance): align guards to the deferred read-model architecture`
- `docs(architecture): close deferred read-model contract gaps`
