### PR TITLE
docs(migration): harden contract-lock and assessment docs

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@ This file is the forward planning document for the repo.
   - [`docs/concepts/bridge-to-target-mapping.md`](docs/concepts/bridge-to-target-mapping.md)
   - [`docs/concepts/pipeline-stage-contracts.md`](docs/concepts/pipeline-stage-contracts.md)
   - [`docs/concepts/domain-ontology.md`](docs/concepts/domain-ontology.md)
-  - [`docs/concepts/gaps-and-readiness.md`](docs/concepts/gaps-and-readiness.md)
+  - [`docs/concepts/gaps-and-reviews.md`](docs/concepts/gaps-and-reviews.md)
   - [`docs/concepts/reconciliation-tax-architecture.md`](docs/concepts/reconciliation-tax-architecture.md)
   - [`docs/reference/first-upstream-slice-contract.md`](docs/reference/first-upstream-slice-contract.md)
   - [`docs/reference/first-downstream-slice-contract.md`](docs/reference/first-downstream-slice-contract.md)
@@ -25,8 +25,8 @@ current adapter-edge and oracle-comparison boundaries, not canonical target
 naming.
 
 **Exception rationale:** `assessment/` stays in this roadmap only as the shared
-contract and sidecar root for the nested `gap/`, `review/`, and `readiness/`
-families. It is not a generic application center.
+contract and sidecar root for the nested `gap/` and `review/` families. It is
+not a generic application center.
 
 ## Planning Anchors
 
@@ -91,12 +91,12 @@ Must freeze:
 - critical-path `ClaimRecord` field tables, `observation_refs`, and
   the compatibility sidecar boundary for retained legacy hint fields
 - `AssertionValue`, `PositionRef`, and `ContractRef`
-- shared gap, review, and readiness records and sidecars:
+- shared gap and review records and sidecars:
   `GapRecord`, `GapExplanation`, `ReviewRecord`,
-  `ReviewExplanation`, `ReadinessRecord`,
-  `SubjectRef = [subject_kind, subject_key]`, truthful `claim_scope_id` and `balance_target_id`
-  attachments, and the downstream shared-subject seams needed for journal
-  and tax records
+  `ReviewExplanation`, capability-owned readiness-view locality rules,
+  `SubjectRef = [subject_kind, subject_key]`, truthful `claim_scope_id` and
+  `balance_target_id` attachments, and the downstream shared-subject seams
+  needed for journal and tax records
 - product ids, upstream product-ref multiplicity, and the rule that product
   refs use product ids rather than `kernel_scope_id`
 - short-first canonical stable ids, catalog-declared owner-local short slots,
@@ -126,20 +126,20 @@ Must freeze:
   package ownership, keeps `economics` aligned across stage vocabulary,
   package ownership, and stage prose, uses singular concept roots such as
   `assertion/`, avoids umbrella roots such as `entities/` when the identity
-  families are already known, keeps gap/review/readiness roots explicit when
-  the docs mean those families directly, and keeps the shared `assessment/` root
-  split into concrete nested families
-  such as `gap/`, `review/`, and `readiness/` while keeping assessment
-  behavior in the owning application slice
+  families are already known, keeps gap/review roots explicit when the docs
+  mean those shared families directly, and keeps the shared `assessment/` root
+  split into concrete nested families such as `gap/` and `review/` while
+  keeping readiness views and other assessment behavior in the owning
+  application slice
 - authoritative persistence model, product-owned directory stems, partition
   scopes, sidecar rules, and default filesystem placement
 - migration authority rules, compatibility views, reader cutovers, and
   retirement gates
 - package ownership and layer placement that keep shared assessment contracts in
   `domain/assessment/`, keep the persisted `assessment/gap/`,
-  `assessment/review/`, and `assessment/readiness/` families as storage rules
-  only, and retire shared application assessment behavior until a specific
-  capability-owned derived read-model package is activated
+  `assessment/review/` families as storage rules only, and retire shared
+  application assessment behavior until a specific capability-owned derived
+  read-model package is activated
 - defer broader grouped readiness, reporting, portfolio, visualization, and
   investigation architecture until the trigger ladder below fires, allowing
   only filing-critical product-local derived outputs, narrow rendering outputs,
@@ -153,7 +153,7 @@ Must freeze:
 
 Deliver:
 
-- aligned contract pages for target products, ontology, gap/review/readiness
+- aligned contract pages for target products, ontology, gap/review
   records and sidecars, and
   persistence rules
 - explicit cutover matrix for bridge-to-target migration
@@ -180,7 +180,7 @@ Owner docs that must align before broad implementation begins:
 - `docs/concepts/bridge-to-target-mapping.md`
 - `docs/concepts/pipeline-stage-contracts.md`
 - `docs/concepts/domain-ontology.md`
-- `docs/concepts/gaps-and-readiness.md`
+- `docs/concepts/gaps-and-reviews.md`
 - `docs/concepts/reconciliation-tax-architecture.md`
 - `docs/reference/first-upstream-slice-contract.md`
 - `docs/reference/first-downstream-slice-contract.md`
@@ -342,8 +342,8 @@ Deliver:
   claim-bundle-decision records
 - claim fields frozen for the first upstream slice plus
   `observation_refs`
-- shared gap, review, and readiness records and sidecars attached to claim
-  scopes where needed
+- shared gap and review outputs attached to claim scopes where needed, with any
+  readiness views staying local to the claim-owning capability
 - declared compatibility views for `EconomicActivityDraft` and
   `SourceTranslationBatch`, with legacy hint fields kept outside `ClaimSet`
   kernels

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -78,6 +78,9 @@ Goal:
 Broad implementation must not begin until the contract pages freeze these
 contracts.
 
+Before that gate is satisfied, only contract-lock alignment and bounded prep
+work are allowed. Broad implementation across Phases 1 to 5 remains blocked.
+
 Must freeze:
 
 - `EvidenceSet` record families, ids, cardinality, and intentional
@@ -162,6 +165,25 @@ Deliver:
 - explicit fast-path rule that reducers read kernels, not explanation sidecars
 - frozen critical-path field tables and product-id rules that later writing
   work can merge without deciding new structure
+- a documented completion gate that names the owner docs and concrete reader
+  inventory required before broad implementation begins
+
+### Phase 0 Completion Gate
+
+Treat this checklist as the operational gate for ending Phase 0, not as a
+claim that the repo has already satisfied it.
+
+Owner docs that must align before broad implementation begins:
+
+- `ROADMAP.md`
+- `docs/status/migration-sequence.md`
+- `docs/concepts/bridge-to-target-mapping.md`
+- `docs/concepts/pipeline-stage-contracts.md`
+- `docs/concepts/domain-ontology.md`
+- `docs/concepts/gaps-and-readiness.md`
+- `docs/concepts/reconciliation-tax-architecture.md`
+- `docs/reference/first-upstream-slice-contract.md`
+- `docs/reference/first-downstream-slice-contract.md`
 
 Exit criteria:
 
@@ -191,6 +213,17 @@ Exit criteria:
 - the first upstream slice and first downstream slice can be implemented
   without inventing
   ids, claim bundles, values, or reader cutovers
+- every active bridge surface has one authoritative target owner
+- every active bridge surface has one derived compatibility rule
+- every active bridge surface names concrete current readers and concrete
+  target readers
+- no Phase 1 or Phase 2 doc claims authority over `TransactionFact`,
+  `facts.csv`, `balance_snapshots.csv`, `balance_references.csv`, or
+  `cointracking_csv`
+- `EventLinkRecord` status is aligned between this roadmap and the first
+  downstream slice contract
+- the intentional looseness of Phases 6 and later is explicit and is
+  non-blocking for Phase 0 to Phase 5 implementation
 
 ## Deferred Read-Model Activation Triggers
 
@@ -322,6 +355,13 @@ Exit criteria:
 - claim-bundle decisions remain claim-owned and do not carry economic
   truth
 
+Transition to Phase 3:
+
+- downstream bridge outputs stay on the live bridge path until
+  `EconomicFacts` exists
+- the first downstream slice is the first slice that turns those downstream
+  bridge outputs into target-derived compatibility views
+
 ## Phase 3. Land `EconomicFacts`
 
 Goal:
@@ -353,8 +393,10 @@ Goal:
 
 Deliver:
 
-- `ContinuitySegmentRecord`, `EventLinkRecord`, `BalanceTargetRecord`, and
-  `CheckpointProposalRecord`
+- `ContinuitySegmentRecord`, `BalanceTargetRecord`, and
+  `CheckpointProposalRecord` for the first downstream slice
+- `EventLinkRecord` when a later in-phase reconciliation increment needs
+  explicit event linkage rather than inferred continuity alone
 - direct `AssertionValue` fields for expected and observed balance meaning
 - fixed subject and position identity seams for in-scope reconciliation
 - bridge compatibility view for `balance_snapshots.csv`
@@ -383,6 +425,10 @@ Exit criteria:
 - accepted checkpoint truth is explicit, not an inferred side effect
 - statement-backed checkpoint acceptance is separated cleanly from manual-only
   runtime aids
+
+Phases 6 and later remain intentionally high-level in this round. This roadmap
+repair makes Phase 0 to Phase 5 implementation decision-complete without
+defining bounded slices for later downstream products yet.
 
 ## Phase 6. Land `Journal`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ persistence and migration references, and repo standards.
 - [Bridge-to-target mapping](concepts/bridge-to-target-mapping.md)
 - [Pipeline stage contracts](concepts/pipeline-stage-contracts.md)
 - [Domain ontology](concepts/domain-ontology.md)
-- [Gap, review, and readiness](concepts/gaps-and-readiness.md)
+- [Gap, review, and shared attachment](concepts/gaps-and-reviews.md)
 - [Reconciliation, checkpoint, journal, and tax architecture](concepts/reconciliation-tax-architecture.md)
 - [First upstream slice contract](reference/first-upstream-slice-contract.md)
 - [First downstream slice contract](reference/first-downstream-slice-contract.md)
@@ -52,7 +52,7 @@ Agent-specific routing and repo execution rules live in
 - [Oracle Boundaries](concepts/oracle-boundaries.md): Boundary rules for normal runtime inputs, adapter inputs and outputs, and oracle-only comparison packages.
 - [Domain Ontology](concepts/domain-ontology.md): Target economic ontology, identity seams, ref recipes, package ownership, and bridge-versus-target modeling rules.
 - [Transaction Classification](concepts/transaction-classification.md): Bridge-only classification vocabulary for the current fact-path bridge.
-- [Gap, Review, And Readiness](concepts/gaps-and-readiness.md): Shared gap, review, readiness, sidecar, and `SubjectRef` contracts for the target pipeline.
+- [Gap, Review, And Shared Attachment](concepts/gaps-and-reviews.md): Shared gap, review, sidecar, `SubjectRef`, and shared attachment contracts for the target pipeline.
 - [Workspace Model](concepts/workspace-model.md): Conceptual overview of the external workspace, seeded files, and mirrored repo guidance.
 - [Unified Adapter Architecture](concepts/unified-adapter-architecture.md): Future adapter manifest, facet, and verification model for the target runtime pipeline.
 <!-- docs-maintenance:end concepts -->

--- a/docs/concepts/architecture-overview.md
+++ b/docs/concepts/architecture-overview.md
@@ -41,10 +41,11 @@ output rather than as a shared application center.
 If no earlier trigger fires, the default activation point for broader
 capability-owned derived read models and projections is `Phase 10`.
 
-Gap, review, and readiness remain shared contracts plus persisted sidecar
-families. They do not imply a shared application reducer center. The owning
-application slice emits and reduces its own assessment behavior until a
-specific capability-owned derived read-model package is activated.
+Gap and review remain shared contracts plus persisted shared-assessment
+families. Readiness stays capability-owned derived behavior rather than shared
+assessment truth. The owning application slice emits and reduces its own
+assessment behavior until a specific capability-owned derived read-model
+package is activated.
 
 ## Layer Shape
 
@@ -68,7 +69,7 @@ These pages define the primary current-state and forward-looking contracts:
 | [Bridge To Target Mapping](bridge-to-target-mapping.md) | authoritative writer rules, compatibility views, and reader cutovers |
 | [Pipeline Stage Contracts](pipeline-stage-contracts.md) | target product kernels, ids, ordering, and handoff rules |
 | [Domain Ontology](domain-ontology.md) | identity seams, ref recipes, and package ownership |
-| [Gap, Review, And Readiness](gaps-and-readiness.md) | gap, review, readiness, and `SubjectRef` contracts plus compatibility-local bridge mappings |
+| [Gap, Review, And Shared Attachment](gaps-and-reviews.md) | gap, review, `SubjectRef`, and shared attachment contracts plus readiness locality rules |
 | [Reconciliation, Checkpoint, Journal, And Tax Architecture](reconciliation-tax-architecture.md) | reconciliation, checkpoint, journal, and tax trust gates plus persistence, partitioning, and fast-path rules |
 | [First Upstream Slice Contract](../reference/first-upstream-slice-contract.md) | first upstream `EvidenceSet -> ClaimSet` slice |
 | [First Downstream Slice Contract](../reference/first-downstream-slice-contract.md) | first downstream `EconomicFacts -> ReconciliationState -> Checkpoint` slice |
@@ -84,6 +85,6 @@ Supporting id, ref, persistence, and workspace references remain under
 - [Bridge To Target Mapping](bridge-to-target-mapping.md)
 - [Pipeline Stage Contracts](pipeline-stage-contracts.md)
 - [Domain Ontology](domain-ontology.md)
-- [Gap, Review, And Readiness](gaps-and-readiness.md)
+- [Gap, Review, And Shared Attachment](gaps-and-reviews.md)
 - [Reconciliation, Checkpoint, Journal, And Tax Architecture](reconciliation-tax-architecture.md)
 - [Current State](../status/current-state.md)

--- a/docs/concepts/bridge-to-target-mapping.md
+++ b/docs/concepts/bridge-to-target-mapping.md
@@ -92,6 +92,10 @@ No-dual-center rule:
   or tax-output-local and rendering-local derived outputs until the roadmap
   trigger ladder requires a dedicated capability-owned derived read-model slice;
   if no earlier trigger fires, that activation defaults to `Phase 10`
+- before the first downstream slice lands, `TransactionFact` and `facts.csv`
+  remain on the live bridge fact path; the first upstream slice may preserve
+  downstream parity only through that existing bridge path and must not
+  introduce a second fact-reducer lane from `ClaimSet`
 
 ## Cutover Matrix
 
@@ -105,15 +109,34 @@ compatibility-local and do not become canonical target-domain family names.
 
 | Current bridge surface | Target authoritative product(s) | Derived compatibility view | Derived compatibility sidecar | Current readers | Target readers after cutover | Cutover gate | Retirement gate |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| `translation_input_candidates.json` | `EvidenceSet` | `none` | `none` | normalization review tools and planner inspection flows | evidence review flows that read `EvidenceSet` directly | selected, superseded, and blocked membership are preserved with stable `selection_id` and `member_id` outcomes | retire once no active review flow requires the file |
-| `translation_input_plan.json` | `EvidenceSet` | `translation_input_plan.json` | `none` | translation entry points that still expect a plan file | evidence consumers and `ClaimSet` construction that read `EvidenceSet` directly | one authoritative `EvidenceSet` exists for the capture and reproduces the same selected, superseded, and blocked decisions | retire when no in-scope reader requires the plan file and parity is enforced on `EvidenceSet` instead |
-| `EconomicActivityDraft` | `ClaimSet` | `EconomicActivityDraft` | declared claim compatibility sidecars keyed by `claim_id` or `claim_bundle_id` | `SourceTranslationBatch` assembly and bridge fact projection builders | `EconomicFacts` construction that reads `ClaimSet` directly | claim field tables, `observation_refs`, claim-bundle decisions, and retained legacy claim fields are all frozen in `ClaimSet` kernels or declared compatibility sidecars | retire when no bridge fact projection builder or batch builder still consumes drafts |
-| `SourceTranslationBatch` | `ClaimSet` | `SourceTranslationBatch` | declared claim compatibility sidecars plus shared gap/review/readiness sidecars | current normalization application surface and bridge interop flows | target application paths in `application/claim/` and later `application/economics/` | in-scope readers can be pointed to `ClaimSet` or a declared compatibility view without meaning loss, and no retained batch-only field remains undefined | retire when no active runtime path reads the batch as its primary claim surface |
-| `TransactionFact` and `facts.csv` | `EconomicFacts` | `TransactionFact` and `facts.csv` | declared upstream claim compatibility sidecars when legacy hint reproduction still needs them | balance builders, output renderers, oracle comparison flows | reconciliation, checkpoint, journal, and tax paths that read `EconomicFacts` | accepted `EconomicEventRecord` and `EconomicLegRecord` parity is proven and current bridge facts are reproducible from `EconomicFacts` plus declared upstream compatibility sidecars | retire when no runtime reader depends on `TransactionFact` as economic authority |
-| `balance_snapshots.csv` | `ReconciliationState` | `balance_snapshots.csv` | `none` | balance inspect/check/summarize and downstream review workflows | reconciliation readers and later checkpoint-acceptance flows that read `ReconciliationState` | continuity segments and balance targets exist for the in-scope subjects and reproduce current snapshot results | retire when active balance surfaces read `ReconciliationState` directly |
-| `balance_references.csv` | `ReconciliationState` and `Checkpoint` | `balance_references.csv` | declared reconciliation/checkpoint compatibility sidecars | balance inspect/check/summarize and current checkpoint-reference workflows | checkpoint-acceptance flows and reconciliation readers that consume authoritative reconciliation and checkpoint records plus declared sidecars directly | direct `AssertionValue` fields, checkpoint proposal records, and `CheckpointAssertionRecord` rows reproduce the current reference content for in-scope subjects | retire when no active surface consumes the CSV as its authoritative reference input |
-| `exceptions.csv` and `IssueRecord` outputs | owning target product plus `GapRecord` and `GapExplanation` | `exceptions.csv` | `GapExplanation` | operator review and current normalization diagnostics | gap/review/readiness reducers and readiness views | the owning target stage preserves blocker scope, severity, materiality, and stage ownership | retire per stage when that stage emits target-native gaps for the same scope |
-| `normalization_reviews.csv` and `NormalizationReviewRecord` outputs | owning target product plus `ReviewRecord` and `ReviewExplanation` | `normalization_reviews.csv` | `ReviewExplanation` | operator review and current normalization diagnostics | target review and readiness views | advisory review scope and provenance are preserved without turning reviews into blockers | retire per stage when that stage emits target-native reviews for the same scope |
+| `translation_input_candidates.json` | `EvidenceSet` | `none` | `none` | `source normalize planner review and translation path` | evidence review and selection inspection from `EvidenceSet` | selected, superseded, and blocked membership are preserved with stable `selection_id` and `member_id` outcomes | retire once no active evidence review or selection inspection requires the file |
+| `translation_input_plan.json` | `EvidenceSet` | `translation_input_plan.json` | `none` | `source normalize planner review and translation path` | claim construction from `EvidenceSet` | one authoritative `EvidenceSet` exists for the capture and reproduces the same selected, superseded, and blocked decisions | retire when no in-scope reader requires the plan file and parity is enforced on `EvidenceSet` instead |
+| `EconomicActivityDraft` | `ClaimSet` | `EconomicActivityDraft` | declared claim compatibility sidecars keyed by `claim_id` or `claim_bundle_id` | `source assemble bridge projection path` | economics construction from `ClaimSet` | claim field tables, `observation_refs`, claim-bundle decisions, and retained legacy claim fields are all frozen in `ClaimSet` kernels or declared compatibility sidecars | retire when no active bridge projection path still consumes drafts |
+| `SourceTranslationBatch` | `ClaimSet` | `SourceTranslationBatch` | declared claim compatibility sidecars plus shared gap/review/readiness sidecars | `source assemble bridge projection path` | economics construction from `ClaimSet` | in-scope readers can be pointed to `ClaimSet` or a declared compatibility view without meaning loss, and no retained batch-only field remains undefined | retire when no active bridge projection path reads the batch as its primary claim surface |
+| `TransactionFact` and `facts.csv` | `EconomicFacts` | `TransactionFact` and `facts.csv` | declared upstream claim compatibility sidecars when legacy hint reproduction still needs them | `reconciliation balances check`; `cointracking_csv rendering path`; `dev-only oracle comparison path` | `reconciliation balances check` reading compatibility output derived from `EconomicFacts`; `cointracking_csv rendering path` reading compatibility output derived from `EconomicFacts`; `dev-only oracle comparison path` reading compatibility output derived from `EconomicFacts` | accepted `EconomicEventRecord` and `EconomicLegRecord` parity is proven and current bridge facts are reproducible from `EconomicFacts` plus declared upstream compatibility sidecars | retire when no active runtime capability depends on `TransactionFact` as economic authority |
+| `balance_snapshots.csv` | `ReconciliationState` | `balance_snapshots.csv` | `none` | `reconciliation balances inspect`; `reconciliation balances check`; `reconciliation balances summarize` | `reconciliation balances inspect` reading `ReconciliationState`; `reconciliation balances check` reading `ReconciliationState`; `reconciliation balances summarize` reading `ReconciliationState` | continuity segments and balance targets exist for the in-scope subjects and reproduce current snapshot results | retire when the active balance capabilities read `ReconciliationState` directly |
+| `balance_references.csv` | `ReconciliationState` and `Checkpoint` | `balance_references.csv` | declared reconciliation/checkpoint compatibility sidecars | `reconciliation balances inspect`; `reconciliation balances check`; `reconciliation balances summarize` | checkpoint acceptance reading `ReconciliationState` plus `Checkpoint`; `reconciliation balances inspect` reading compatibility output derived from `ReconciliationState` plus `Checkpoint`; `reconciliation balances check` reading compatibility output derived from `ReconciliationState` plus `Checkpoint`; `reconciliation balances summarize` reading compatibility output derived from `ReconciliationState` plus `Checkpoint` | direct `AssertionValue` fields, checkpoint proposal records, and `CheckpointAssertionRecord` rows reproduce the current reference content for in-scope subjects | retire when no active surface consumes the CSV as its authoritative reference input |
+| `exceptions.csv` and `IssueRecord` outputs | owning target product plus `GapRecord` and `GapExplanation` | `exceptions.csv` | `GapExplanation` | `operator review diagnostics` | `operator review diagnostics` reading the owning target product plus target-native gap and readiness records | the owning target stage preserves blocker scope, severity, materiality, and stage ownership | retire per stage when that stage emits target-native gaps for the same scope |
+| `normalization_reviews.csv` and `NormalizationReviewRecord` outputs | owning target product plus `ReviewRecord` and `ReviewExplanation` | `normalization_reviews.csv` | `ReviewExplanation` | `operator review diagnostics` | `operator review diagnostics` reading the owning target product plus target-native review records | advisory review scope and provenance are preserved without turning reviews into blockers | retire per stage when that stage emits target-native reviews for the same scope |
+
+Reader-label glossary:
+
+- `source normalize planner review and translation path` is the planner-enabled
+  normalization review and translation flow defined in
+  [Current State](../status/current-state.md)
+- `source assemble bridge projection path` is the `source assemble` bridge
+  projection flow that still consumes `EconomicActivityDraft` and
+  `SourceTranslationBatch`
+- `operator review diagnostics` is operator review of `exceptions.csv`,
+  `normalization_reviews.csv`, and related current diagnostics
+- `reconciliation balances inspect`, `reconciliation balances check`, and
+  `reconciliation balances summarize` are the shared balance capabilities in the
+  current application surface
+- `cointracking_csv rendering path` is the current CSV rendering path
+- `dev-only oracle comparison path` is the dev-only oracle comparison and
+  validation path
+
+These reader labels are authoritative across the migration docs.
 
 Planner review traces and statement-parse debugging outputs remain real local
 workflow artifacts, but they do not appear as canonical matrix rows until the
@@ -180,6 +203,8 @@ Required cutovers now:
   `ReconciliationState`
 - `balance_references.csv` becomes a compatibility view from
   `ReconciliationState` and `Checkpoint`
+- the first upstream slice must not introduce a second downstream fact lane
+  before the first downstream slice lands
 - current balance inspect/check/summarize remains on bridge compatibility
   views until those application surfaces are repointed to target products
 

--- a/docs/concepts/bridge-to-target-mapping.md
+++ b/docs/concepts/bridge-to-target-mapping.md
@@ -10,7 +10,7 @@ nav_order: 24
 related:
   - docs/concepts/current-bridge-contracts.md
   - docs/concepts/pipeline-stage-contracts.md
-  - docs/concepts/gaps-and-readiness.md
+  - docs/concepts/gaps-and-reviews.md
   - docs/reference/first-upstream-slice-contract.md
   - docs/reference/first-downstream-slice-contract.md
   - docs/status/migration-sequence.md
@@ -38,9 +38,9 @@ Use these pages for neighboring contracts:
   product kernels, ids, ordering, serialization, and fingerprints for
   `EvidenceSet`, `ClaimSet`, `EconomicFacts`, `ReconciliationState`,
   `Checkpoint`, `Journal`, `TaxInputs`, and `TaxOutputs`.
-- [Gap, Review, And Readiness](gaps-and-readiness.md) defines `GapRecord`,
-  `GapExplanation`, `ReviewRecord`, `ReviewExplanation`,
-  `ReadinessRecord`, and `SubjectRef`.
+- [Gap, Review, And Shared Attachment](gaps-and-reviews.md) defines
+  `GapRecord`, `GapExplanation`, `ReviewRecord`, `ReviewExplanation`,
+  `SubjectRef`, and `kernel_scope_id`.
 - this page defines how bridge surfaces move to target products without
   creating dual authorities
 
@@ -112,12 +112,15 @@ compatibility-local and do not become canonical target-domain family names.
 | `translation_input_candidates.json` | `EvidenceSet` | `none` | `none` | `source normalize planner review and translation path` | evidence review and selection inspection from `EvidenceSet` | selected, superseded, and blocked membership are preserved with stable `selection_id` and `member_id` outcomes | retire once no active evidence review or selection inspection requires the file |
 | `translation_input_plan.json` | `EvidenceSet` | `translation_input_plan.json` | `none` | `source normalize planner review and translation path` | claim construction from `EvidenceSet` | one authoritative `EvidenceSet` exists for the capture and reproduces the same selected, superseded, and blocked decisions | retire when no in-scope reader requires the plan file and parity is enforced on `EvidenceSet` instead |
 | `EconomicActivityDraft` | `ClaimSet` | `EconomicActivityDraft` | declared claim compatibility sidecars keyed by `claim_id` or `claim_bundle_id` | `source assemble bridge projection path` | economics construction from `ClaimSet` | claim field tables, `observation_refs`, claim-bundle decisions, and retained legacy claim fields are all frozen in `ClaimSet` kernels or declared compatibility sidecars | retire when no active bridge projection path still consumes drafts |
-| `SourceTranslationBatch` | `ClaimSet` | `SourceTranslationBatch` | declared claim compatibility sidecars plus shared gap/review/readiness sidecars | `source assemble bridge projection path` | economics construction from `ClaimSet` | in-scope readers can be pointed to `ClaimSet` or a declared compatibility view without meaning loss, and no retained batch-only field remains undefined | retire when no active bridge projection path reads the batch as its primary claim surface |
+| `SourceTranslationBatch` | `ClaimSet` | `SourceTranslationBatch` | declared claim compatibility sidecars | `source assemble bridge projection path` | economics construction from `ClaimSet` | in-scope readers can be pointed to `ClaimSet` or a declared compatibility view without meaning loss, and no retained batch-only field remains undefined | retire when no active bridge projection path reads the batch as its primary claim surface |
 | `TransactionFact` and `facts.csv` | `EconomicFacts` | `TransactionFact` and `facts.csv` | declared upstream claim compatibility sidecars when legacy hint reproduction still needs them | `reconciliation balances check`; `cointracking_csv rendering path`; `dev-only oracle comparison path` | `reconciliation balances check` reading compatibility output derived from `EconomicFacts`; `cointracking_csv rendering path` reading compatibility output derived from `EconomicFacts`; `dev-only oracle comparison path` reading compatibility output derived from `EconomicFacts` | accepted `EconomicEventRecord` and `EconomicLegRecord` parity is proven and current bridge facts are reproducible from `EconomicFacts` plus declared upstream compatibility sidecars | retire when no active runtime capability depends on `TransactionFact` as economic authority |
 | `balance_snapshots.csv` | `ReconciliationState` | `balance_snapshots.csv` | `none` | `reconciliation balances inspect`; `reconciliation balances check`; `reconciliation balances summarize` | `reconciliation balances inspect` reading `ReconciliationState`; `reconciliation balances check` reading `ReconciliationState`; `reconciliation balances summarize` reading `ReconciliationState` | continuity segments and balance targets exist for the in-scope subjects and reproduce current snapshot results | retire when the active balance capabilities read `ReconciliationState` directly |
 | `balance_references.csv` | `ReconciliationState` and `Checkpoint` | `balance_references.csv` | declared reconciliation/checkpoint compatibility sidecars | `reconciliation balances inspect`; `reconciliation balances check`; `reconciliation balances summarize` | checkpoint acceptance reading `ReconciliationState` plus `Checkpoint`; `reconciliation balances inspect` reading compatibility output derived from `ReconciliationState` plus `Checkpoint`; `reconciliation balances check` reading compatibility output derived from `ReconciliationState` plus `Checkpoint`; `reconciliation balances summarize` reading compatibility output derived from `ReconciliationState` plus `Checkpoint` | direct `AssertionValue` fields, checkpoint proposal records, and `CheckpointAssertionRecord` rows reproduce the current reference content for in-scope subjects | retire when no active surface consumes the CSV as its authoritative reference input |
-| `exceptions.csv` and `IssueRecord` outputs | owning target product plus `GapRecord` and `GapExplanation` | `exceptions.csv` | `GapExplanation` | `operator review diagnostics` | `operator review diagnostics` reading the owning target product plus target-native gap and readiness records | the owning target stage preserves blocker scope, severity, materiality, and stage ownership | retire per stage when that stage emits target-native gaps for the same scope |
-| `normalization_reviews.csv` and `NormalizationReviewRecord` outputs | owning target product plus `ReviewRecord` and `ReviewExplanation` | `normalization_reviews.csv` | `ReviewExplanation` | `operator review diagnostics` | `operator review diagnostics` reading the owning target product plus target-native review records | advisory review scope and provenance are preserved without turning reviews into blockers | retire per stage when that stage emits target-native reviews for the same scope |
+| `exceptions.csv` and `IssueRecord` outputs | owning target product plus `GapRecord` and `GapExplanation` | `exceptions.csv` | `none` | `operator review diagnostics` | `operator review diagnostics` reading the owning target product plus target-native gap outputs and capability-owned readiness views when needed | the owning target stage preserves blocker scope, severity, materiality, and stage ownership | retire per stage when that stage emits target-native gaps for the same scope |
+| `normalization_reviews.csv` and `NormalizationReviewRecord` outputs | owning target product plus `ReviewRecord` and `ReviewExplanation` | `normalization_reviews.csv` | `none` | `operator review diagnostics` | `operator review diagnostics` reading the owning target product plus target-native review outputs and capability-owned readiness views when needed | advisory review scope and provenance are preserved without turning reviews into blockers | retire per stage when that stage emits target-native reviews for the same scope |
+
+Shared assessment outputs named in the target-authority column stay separate
+from compatibility sidecars. They are not compatibility surfaces in disguise.
 
 Reader-label glossary:
 
@@ -182,7 +185,9 @@ Diagnostic mapping rules:
 - a bridge `NormalizationReviewRecord` maps to `ReviewRecord` plus
   `ReviewExplanation`
 - reviews remain advisory even when they share the same factual cause as a gap
-- gap, review, and readiness records and sidecars never become claim kinds
+- shared gap and review outputs never become claim kinds
+- any readiness that operators or renderers still need after cutover must stay
+  on capability-owned derived views rather than on shared assessment families
 
 ## Current First Slice Rules
 

--- a/docs/concepts/domain-ontology.md
+++ b/docs/concepts/domain-ontology.md
@@ -121,7 +121,7 @@ Implications:
   distinction matters
 - shared infrastructure may point at them generically only through the
   `SubjectRef` rules owned by
-  [Gap, Review, And Readiness](gaps-and-readiness.md)
+  [Gap, Review, And Shared Attachment](gaps-and-reviews.md)
 - the same shared-infrastructure rule applies when generic attachment is needed
   for `Instrument`, `Location`, ownership identities, counterparties, or
   `CheckpointAssertion`
@@ -408,10 +408,10 @@ Bridge-specific classification rules live in
 - keep `economics` aligned across stage vocabulary, package roots, and
   product-adjacent prose; reserve `economic` for adjective use inside the
   owned product family such as `EconomicFacts`
-- prefer explicit family names such as `gap`, `review`, and `readiness` in
-  forward-looking prose when those are the owned sidecars; reserve generic
-  `support` for the intentional shared root or bounded field names such as
-  `support_shape`
+- prefer explicit family names such as `gap` and `review`, or explicit
+  capability-owned readiness-view names, in forward-looking prose when those
+  are the owned surfaces; reserve generic `support` for the intentional shared
+  root or bounded field names such as `support_shape`
 - avoid umbrella package roots such as `entities/` once the owned identity
   families are already known
 - keep singular concept families on singular package stems such as
@@ -431,8 +431,9 @@ Bridge-specific classification rules live in
 The target package layout follows stage ownership and is not advisory.
 
 **Exception rationale:** `domain/assessment/` stays in this page only as the
-shared root for the nested `gap/`, `review/`, and `readiness/` families plus
-`SubjectRef`. It is not a generic support catch-all.
+shared root for the nested `gap/` and `review/` families plus shared
+attachment constructs such as `SubjectRef`. It is not a generic support
+catch-all.
 
 **Migration-only root rationale:** `application/compatibility/` remains a
 bridge-only migration root for derived compatibility views until those readers
@@ -450,8 +451,8 @@ Required domain ownership:
 - `domain/economics/` for events, legs, valuations, settlement status, and
   lifecycle events
 - `domain/assertion/` for `AssertionValue` and its variants
-- `domain/assessment/` as the shared root for nested `gap/`, `review/`, and
-  `readiness/` families plus `SubjectRef`
+- `domain/assessment/` as the shared root for nested `gap/` and `review/`
+  families plus shared attachment constructs such as `SubjectRef`
 - `domain/reconciliation/` for continuity segments, event links, balance
   targets, and checkpoint proposal records
 - `domain/checkpoint/` for accepted checkpoint truth
@@ -474,7 +475,8 @@ Required application ownership:
 - `application/reconciliation/` for continuity, linkage, balance target
   evaluation, and checkpoint proposal records
 `domain/assessment/` stays generic only because it is the shared root for the
-nested `gap/`, `review/`, and `readiness/` families plus `SubjectRef`.
+nested `gap/` and `review/` families plus shared attachment constructs such as
+`SubjectRef`.
 No unrelated family may be added under `domain/assessment/` without a separate
 standards decision.
 `application/compatibility/` is migration-only and must not become a durable
@@ -491,7 +493,7 @@ application center.
 
 Assessment behavior stays in the owning application slice. Shared
 `domain/assessment/` contracts and persisted `assessment/gap/`,
-`assessment/review/`, and `assessment/readiness/` sidecars do not create a
+`assessment/review/` sidecars do not create a
 shared application assessment center.
 
 ### Reserved Future Capability Families

--- a/docs/concepts/gaps-and-reviews.md
+++ b/docs/concepts/gaps-and-reviews.md
@@ -1,6 +1,6 @@
 ---
-title: "Gap, Review, And Readiness"
-summary: "Shared gap, review, readiness, sidecar, and `SubjectRef` contracts for the target pipeline."
+title: "Gap, Review, And Shared Attachment"
+summary: "Shared gap, review, sidecar, `SubjectRef`, and shared attachment contracts for the target pipeline."
 doc_type: concept
 audience: human
 owner: repo
@@ -9,21 +9,23 @@ naming_scope: forward_target
 nav_order: 45
 ---
 
-Use this page when defining shared gap, review, readiness, or `SubjectRef`
-contracts. This page defines the target cross-stage gap, review, readiness,
-and generic subject-attachment model.
+Use this page when defining shared gap, review, `SubjectRef`, or shared
+attachment contracts. This page defines the target cross-stage gap, review,
+generic subject-attachment, and shared scope-attachment model.
 
 ## Design Rules
 
-- gap, review, and readiness records stay compact and stage-neutral
+- gap and review records stay compact and stage-neutral
 - explanation-heavy detail belongs in sidecars, not in hot-path kernels
 - stage-owned blockers stay explicit; no stage may invent an incompatible
   blocker surface
 - reviews stay advisory and must never become hidden blockers
-- kernel-scope grouped readiness is derived from subject-level or scope-level
-  truth, not stored as the only truth
-- gap, review, and readiness records plus sidecars help stages interoperate
-  without erasing stage ownership
+- readiness is a capability-owned derived view, not a shared canonical record
+  family
+- grouped readiness stays on capability-owned derived outputs, not on a shared
+  assessment family
+- shared gap and review records plus sidecars help stages interoperate without
+  erasing stage ownership
 
 ## Provenance
 
@@ -37,8 +39,8 @@ Rules:
   identity
 - capture identity stays separate from human-readable labels and filesystem
   paths
-- gap, review, and readiness records and sidecars link to provenance rather
-  than embedding large repeated evidence detail directly
+- gap and review records and sidecars link to provenance rather than embedding
+  large repeated evidence detail directly
 
 ## `SubjectRef`
 
@@ -113,17 +115,16 @@ Rules:
   target when one exact target is the truthful blocker or review scope
 - `checkpoint_proposal_id` identifies one reconciliation-owned checkpoint
   proposal record before acceptance
-- `kernel_scope_id` identifies one shared gap/review/readiness attachment
-  scope over one canonical product kernel and is not a substitute for a
-  narrower scope
+- `kernel_scope_id` identifies one shared gap/review attachment scope over one
+  canonical product kernel and is not a substitute for a narrower scope
 - do not attach a gap or review to `kernel_scope` when `subject`,
   `selection`, `claim_scope`, `continuity_segment`,
   `balance_target`, or `checkpoint_proposal` would be truthful
 
 ### `kernel_scope_id`
 
-`kernel_scope_id` is defined once for target gap, review, readiness,
-derived-output, and sidecar attachments.
+`kernel_scope_id` is defined once for target gap, review, and declared
+derived-output attachments.
 
 Rules:
 
@@ -138,18 +139,16 @@ Rules:
 - `kernel_scope_id` is never a target product id, never an upstream product
   ref, and never the primary reader key when one product id or narrower record
   id exists
-- `kernel_scope_id` is used only for gap/review/readiness sidecar attachment
-  and declared derived outputs when no narrower truthful subject or scope
-  exists
+- `kernel_scope_id` is used only for gap/review sidecar attachment and
+  declared derived outputs when no narrower truthful subject or scope exists
 - `kernel_scope_id` must not replace `selection_id`,
   `claim_scope_id`, `continuity_segment_id`, `balance_target_id`,
   `checkpoint_proposal_id`, or one record id when those are truthful
 
 ## Shared Stage Vocabulary
 
-Use one stage vocabulary across gap records, review records, readiness
-records, checkpoint-stage reuse, and any later capability-owned derived
-outputs.
+Use one stage vocabulary across gap records, review records, checkpoint-stage
+reuse, and any later capability-owned derived outputs.
 
 Shared stage vocabulary:
 
@@ -164,8 +163,7 @@ Shared stage vocabulary:
 Rules:
 
 - `owner_stage` and `blocking_stages` use this vocabulary
-- readiness records and later capability-owned derived outputs use this
-  vocabulary
+- later capability-owned derived outputs use this vocabulary
 - keep stage labels on repo-owned noun forms that match the target package and
   ownership docs
 - do not use alternate labels such as `semantic` once target-stage products
@@ -174,9 +172,8 @@ Rules:
 ## Gap Model
 
 The target shared gap model splits compact blocking truth from explanation.
-`GapRecord`, `ReviewRecord`, and `ReadinessRecord` stay short because each one
-names the shared cross-stage business concept directly rather than a local
-helper wrapper.
+`GapRecord` and `ReviewRecord` stay short because each one names the shared
+cross-stage business concept directly rather than a local helper wrapper.
 
 ### `GapRecord`
 
@@ -267,7 +264,7 @@ Rules:
 - `owner_stage` identifies who owns the gap meaning
 - `blocking_stages` identifies who is blocked by the unresolved condition
 - stages may add stage-local subtyping later, but they must not redefine the
-  gap, review, and readiness contracts out of existence
+  gap and review contracts out of existence
 - non-subject scopes must still use stable ids rather than prose labels
 - `resolved` and `superseded` gaps remain valid persisted history; they are not
   deleted in place
@@ -439,95 +436,67 @@ Rules:
 - review explanation may become richer over time without changing the advisory
   record
 
-## Readiness Model
+## Readiness Locality
 
-Readiness is subject-first, stage-specific, and reducible into derived grouped
-outputs.
-
-### `ReadinessStatus`
-
-Shared status vocabulary:
-
-- `ready`
-- `blocked`
-- `partial`
-- `not_applicable`
-
-`partial` means:
-
-- some required meanings or assertions resolved
-- at least one blocking gap still open
-- the remaining uncertainty is recorded through gap ids, not prose-only
-  explanation
-
-### `ReadinessRecord`
-
-Purpose:
-
-- stage-specific readiness for one `SubjectRef`
-
-Kernel fields:
-
-- `readiness_id`
-- `subject_ref`
-- `stage`
-- `status`
-- `blocking_gap_ids`
-
-Stable ids:
-
-- `readiness_id` identifies one readiness record for one subject and
-  one stage
-- `readiness_id` uses component array `[subject_ref, stage]`
-
-Ordering:
-
-- sort by tuple `[stage, subject_ref.subject_kind, subject_ref.subject_key]`
-- sort `blocking_gap_ids` lexicographically
-
-Serialization:
-
-- serialize readiness records only
-- use stable object-key ordering
-- preserve the declared readiness order above
-
-Fingerprint inputs:
-
-- readiness records in canonical order
-- `schema_version`
-- sorted `blocking_gap_ids`
+Readiness is not a shared assessment family.
 
 Rules:
 
-- subject readiness is the base truth
-- `evidence` readiness covers deterministic evidence selection and observation
-  completeness before claim commitment
-- reducers work from subject readiness plus gaps, not from hand-built grouped
-  readiness rows
-- a subject may be ready for one stage and blocked for another
-- readiness points to blocking gap ids rather than hiding blockers in
-  explanation text
+- readiness is always a capability-owned derived view over authoritative
+  stage-owned records plus open gaps
+- readiness views may key off truthful subject ids, stage-local scope ids such
+  as `claim_scope_id`, `continuity_segment_id`, `balance_target_id`, and
+  `checkpoint_proposal_id`, or declared product-local grouping keys when the
+  owning capability defines them
+- the tax-first path may keep the frozen `TaxOutputs`-local grouped readiness
+  output owned by
+  [Pipeline Stage Contracts](pipeline-stage-contracts.md) and
+  [Reconciliation, Checkpoint, Journal, And Tax Architecture](reconciliation-tax-architecture.md)
+- compatibility-local or rendering-local readiness views may exist where live
+  readers need them, but they do not create a shared readiness record family
+- broader grouped readiness or durable projections outside tax-local or
+  compatibility-local surfaces require the roadmap trigger ladder to activate a
+  capability-owned derived read-model slice
 
-### Grouped Readiness Before Derived Read-Model Activation
+## Sidecar Taxonomy
 
-Grouped readiness is derived behavior, not a shared canonical record family.
+Use one explicit sidecar taxonomy across the target docs.
+
+Shared assessment families:
+
+- `assessment/gap/` for `GapRecord` and `GapExplanation`
+- `assessment/review/` for `ReviewRecord` and `ReviewExplanation`
+
+Product-local detail families:
+
+- provenance detail
+- comparison traces
+- annotations
+- policy notes and rendered policy detail
+- other product-owned explanatory detail that does not change the owning
+  product's kernel meaning
+
+Compatibility families:
+
+- migration-only `compatibility/` views and sidecars for retained bridge
+  readers
+
+Derived outputs, caches, and indexes:
+
+- non-authoritative grouped outputs
+- caches
+- indexes
 
 Rules:
 
-- shared readiness truth stays on ordered `ReadinessRecord` rows plus their
-  linked gap ids
-- before the roadmap trigger ladder activates broader derived read models,
-  grouped readiness may exist only as:
-  - tax-output-local derived output
-  - narrow rendering-derived output
-  - migration compatibility-local derived output
-- grouped readiness must remain reproducible from ordered readiness and gap
-  records without manual status editing
-- do not ship source-grouped or operator-facing grouped readiness as a shared
-  forward-target surface before trigger activation
-- once a grouped consumer requires a broader derived read-model surface, that
-  grouped behavior moves into the owning capability instead of restoring a
-  shared grouped-readiness family
+- shared assessment records and explanation families are declared persisted
+  outputs; they are not disposable accelerators
+- product-local detail families belong under explicit product-local family names
+  chosen by the owning product and never under `assessment/`
+- compatibility families stay migration-only and must not become a second
+  architecture center
+- derived outputs, caches, and indexes are the regenerable class; they remain
+  reproducible from authoritative kernels plus declared upstream refs
 
 ## Bridge Mapping From Issue And Review Records
 
@@ -546,7 +515,11 @@ Mapping rules:
 - `NormalizationReviewRecord` maps to one `ReviewRecord` plus one
   `ReviewExplanation` when owner stage, scope, and advisory meaning align
 - when one factual cause produces both a blocker and an advisory review, the
-  blocker lands in `GapRecord` and the review remains keyed sidecar detail
+  blocker lands in `GapRecord` and the review remains keyed shared-assessment
+  detail
+- if an operator or bridge consumer still needs readiness after cutover, define
+  it as a capability-owned derived view over target products plus shared gap
+  and review outputs rather than as a shared readiness record family
 - current bridge ids remain traceable when later stages adopt target-native gap
   or review ids
 
@@ -578,15 +551,23 @@ Keep these first-class:
 - postings
 - tax inputs and outputs
 
-Use sidecars only for:
+Use shared assessment families only for:
 
-- provenance
 - gaps
 - reviews
-- readiness
+
+Use product-local detail families for:
+
+- provenance
 - annotations
 - comparison traces
 - policy explanations
+
+Use derived outputs, caches, and indexes only for:
+
+- grouped readiness and other grouped views
+- caches
+- indexes
 
 Sidecars must never become:
 
@@ -612,7 +593,6 @@ vocabulary after cutover.
 - current `IssueRecord` and `NormalizationReviewRecord` remain live bridge
   outputs today
 - later implementation may map current bridge issues and reviews into the
-  shared gap/review/readiness contracts where stage ownership and meaning line
-  up
+  shared gap/review contracts where stage ownership and meaning line up
 - current-state docs keep current issue and review names where accuracy
   requires them

--- a/docs/concepts/pipeline-stage-contracts.md
+++ b/docs/concepts/pipeline-stage-contracts.md
@@ -114,8 +114,7 @@ Shared rules:
 - when a product id hashes ordered upstream header refs, keep the component
   array in the same canonical order as the header fields unless this page
   explicitly declares a stronger reason to differ
-- `kernel_scope_id` remains a derived gap/review/readiness and reporting
-  attachment only;
+- `kernel_scope_id` remains a derived gap/review and reporting attachment only;
   it is not a product id or upstream product ref
 
 ### Record Reference Rule
@@ -171,13 +170,13 @@ Shared rules:
 
 - every target product has one canonical kernel fingerprint
 - the shared `kernel_scope_id` contract is owned by
-  [Gap, Review, And Readiness](gaps-and-readiness.md)
+  [Gap, Review, And Shared Attachment](gaps-and-reviews.md)
 - `kernel_scope_id` is derived from the emitted kernel fingerprint after
   canonical fingerprinting; it is not part of the product header or fingerprint
   inputs
 - `kernel_scope_id` is the kernel-scope attachment id for gap, review,
-  readiness, comparison, and other declared shared sidecars when no narrower
-  truthful scope exists
+  comparison, and other declared shared sidecars when no narrower truthful
+  scope exists
 - `kernel_scope_id` is not a substitute for a narrower record id or stage-owned
   scope such as `selection_id`, `claim_scope_id`, `continuity_segment_id`,
   `balance_target_id`, or `checkpoint_proposal_id`
@@ -565,8 +564,7 @@ Rules:
 - legacy `provider_operation_key` is satisfied by
   `activity_label` on claims with `kind = activity` and must not be duplicated into a
   compatibility sidecar field
-- review markers map to shared gap/review/readiness records and sidecars
-  rather than
+- review markers map to shared gap/review records and sidecars rather than
   claim-kernel fields or compatibility sidecars that masquerade as claim
   meaning
 - adapter-local extras may survive only as non-kernel or compatibility sidecar
@@ -816,7 +814,8 @@ Owns:
 - transfer and settlement linkage
 - continuity decisions
 - balance targets and assertion outcomes
-- reconciliation-owned gaps and readiness
+- reconciliation-owned gaps plus derived readiness views over truthful local
+  scopes
 - checkpoint proposal records derived from reconciled economics plus checkpoint
   evidence
 
@@ -884,15 +883,15 @@ Controlled vocabularies:
 Reconciliation rules:
 
 - `ContinuitySegmentRecord.status` tracks completeness only; blocker posture
-  stays on reconciliation-owned gaps and readiness attached to
-  `continuity_segment_id`
+  stays on reconciliation-owned gaps plus reconciliation-owned derived
+  readiness views keyed by `continuity_segment_id`
 - `BalanceTargetRecord.observation_status` tracks whether one authoritative
   observed value exists for the target
 - `BalanceTargetRecord.comparison_outcome` is nullable and is set only when
   `observation_status = observed`
 - open blocker posture for balance targets stays on reconciliation-owned gaps
-  and readiness attached to `balance_target_id`, not on balance-target state
-  fields
+  plus reconciliation-owned derived readiness views keyed by
+  `balance_target_id`, not on balance-target state fields
 - `CheckpointProposalRecord.status` tracks current proposal posture only
 - `CheckpointProposalRecord.superseding_proposal_ref` points at a later
   `checkpoint_proposal_id` only when a proposal has been superseded, and that
@@ -904,7 +903,12 @@ Sidecar content may include:
 - continuity explanation
 - missing-leg detail
 - comparison traces
-- stage-owned gap and readiness sidecars
+- stage-owned gap sidecars
+
+Derived output surfaces may include:
+
+- reconciliation-owned readiness views keyed by truthful local scopes such as
+  `continuity_segment_id` or `balance_target_id`
 
 Product-root cardinality:
 
@@ -927,7 +931,8 @@ Stable ids:
 - `continuity_segment_id` uses component array
   `[subject_ref, segment_start_at, segment_end_at]`
 - `continuity_segment_id` is the reusable stage-local scope id for gap,
-  review, readiness attachments, and declared derived outputs;
+  review attachments, capability-owned derived readiness views, and declared
+  derived outputs;
   `reconciliation_state_id` is the emitted product id over that scope plus its
   upstream lineage
 - `event_link_id` uses component array
@@ -1063,11 +1068,11 @@ Controlled vocabularies:
   - `partial_rollforward`
 
 `trust_level` names checkpoint acceptance confidence tiers inside one accepted
-assertion. It is not the shared `ReadinessStatus` model from
-[Gap, Review, And Readiness](gaps-and-readiness.md).
+assertion. It is not a shared readiness vocabulary from
+[Gap, Review, And Shared Attachment](gaps-and-reviews.md).
 
-`trust_level` is a checkpoint trust-tier vocabulary. It is not a reuse of
-`ReadinessStatus`.
+`trust_level` is a checkpoint trust-tier vocabulary. It is not a reuse of a
+capability-owned readiness view.
 
 Sidecar content may include:
 
@@ -1487,7 +1492,8 @@ Controlled vocabularies:
   - `partial`
 
 `TaxOutputRecord.status` tracks output readiness only. Blocking tax posture
-stays on `TaxUnsupportedInputRecord` plus tax-owned gaps.
+stays on `TaxUnsupportedInputRecord` plus tax-owned gaps; it is not a shared
+readiness record.
 
 Sidecar content:
 
@@ -1495,6 +1501,35 @@ Sidecar content:
 - filing notes and limitations
 - tax carry-forward explanation
 - tax unsupported-input explanation
+
+Frozen tax-first derived output family:
+
+- optional product-local file:
+  `working/products/tax_outputs/<tax_outputs_id>/derived/tax_output_grouped_readiness.json`
+- row fields:
+  - `group_kind`
+  - `group_key`
+  - `status`
+  - `tax_output_refs`
+  - `tax_unsupported_input_refs`
+  - `blocking_gap_refs`
+
+Rules:
+
+- this file is a product-local derived output, not kernel content, shared
+  assessment output, or a compatibility sidecar
+- `group_kind` is fixed to `tax_output_kind` during the tax-first phases
+- `group_key` uses the `TaxOutputRecord.kind` vocabulary:
+  `policy_summary`, `supporting_schedule`, and `filing_form`
+- `status` is derived-only and non-editable; it is computed from
+  `TaxOutputRecord.status`, related `TaxUnsupportedInputRecord` rows, and
+  tax-owned gaps
+- `tax_output_refs`, `tax_unsupported_input_refs`, and `blocking_gap_refs`
+  sort lexicographically
+- allowed readers are filing-critical tax flows and narrow rendering flows only
+- a second grouped non-compatibility consumer, a new grouping dimension beyond
+  `tax_output_kind`, or durable grouped persistence outside this product-local
+  surface fires the roadmap trigger ladder before implementation
 
 Scope fence:
 
@@ -1563,8 +1598,8 @@ Must not:
 
 ## Shared Contract References
 
-The pipeline products rely on shared gap/review/readiness contracts defined
-elsewhere:
+The pipeline products rely on shared gap/review contracts and readiness
+locality rules defined elsewhere:
 
 - [Current Bridge Contracts](current-bridge-contracts.md) for the live bridge
   runtime truth
@@ -1577,8 +1612,8 @@ elsewhere:
   contract
 - [Domain Ontology](domain-ontology.md) for identity seams, refs,
   `AssertionValue`, and package ownership
-- [Gap, Review, And Readiness](gaps-and-readiness.md) for `GapRecord`,
-  `GapExplanation`, `ReviewRecord`, `ReviewExplanation`,
-  `ReadinessRecord`, and `SubjectRef`
+- [Gap, Review, And Shared Attachment](gaps-and-reviews.md) for `GapRecord`,
+  `GapExplanation`, `ReviewRecord`, `ReviewExplanation`, `SubjectRef`, and
+  `kernel_scope_id`
 - [Reconciliation, Checkpoint, Journal, And Tax Architecture](reconciliation-tax-architecture.md) for
   persistence rules, partitioning rules, and fast-path expectations

--- a/docs/concepts/reconciliation-tax-architecture.md
+++ b/docs/concepts/reconciliation-tax-architecture.md
@@ -57,7 +57,7 @@ Use these pages for the detailed neighboring contracts:
 - [First Downstream Slice Contract](../reference/first-downstream-slice-contract.md)
 - [Pipeline Stage Contracts](pipeline-stage-contracts.md)
 - [Domain Ontology](domain-ontology.md)
-- [Gap, Review, And Readiness](gaps-and-readiness.md)
+- [Gap, Review, And Shared Attachment](gaps-and-reviews.md)
 - [Engineering Standards](../standards/engineering.md)
 - [Transaction Classification](transaction-classification.md)
 - [Oracle Boundaries](oracle-boundaries.md)
@@ -161,10 +161,10 @@ Forward-looking persistence rules:
   page documents a stronger reason to differ
 - product sidecars persist separately from kernels and are keyed by
   `kernel_scope_id` or narrower truthful record ids
-- grouped readiness remains derived behavior over shared readiness records;
-  before trigger activation it may appear only as tax-output-local, narrow
-  rendering-local, or compatibility-local derived output rather than as a
-  shared gap, review, or readiness record family
+- grouped readiness remains capability-owned derived behavior over local
+  records plus open gaps; before trigger activation it may appear only as
+  tax-output-local, narrow rendering-local, or compatibility-local derived
+  output rather than as a shared assessment family
 - target basenames use the owning product or sidecar family directly
   rather than generic names or bridge-era qualifiers
 - stable ids and helper refs keep the owning family stem once they cross
@@ -174,7 +174,10 @@ Forward-looking persistence rules:
 - writes are replace-whole-partition operations, not append-in-place mutation
   of accepted truth
 - persisted kernels are immutable snapshots for one declared partition scope
-- sidecars are regenerable from authoritative kernels plus upstream refs
+- derived outputs, caches, and indexes are regenerable from authoritative
+  kernels plus upstream refs
+- shared assessment records and explicit product-local detail families are
+  declared persisted outputs, not disposable accelerators
 - caches and indexes are accelerators only; they are never the authority
 
 ### Default Partition Scopes
@@ -217,8 +220,8 @@ Rules:
 - one persisted `TaxInputs` kernel owns one tax input kernel
 - one persisted `TaxOutputs` kernel owns one tax output kernel
 - readers use product ids or narrower record ids for authoritative product
-  lookup; `kernel_scope_id` remains for shared reporting plus
-  gap/review/readiness attachment only
+  lookup; `kernel_scope_id` remains for shared reporting plus gap/review
+  attachment only
 
 ### Default Filesystem Placement
 
@@ -232,14 +235,15 @@ Use these paths in forward-looking docs and later implementation work:
 - `working/products/journals/<journal_id>/journal.json`
 - `working/products/tax_inputs/<tax_inputs_id>/tax_inputs.json`
 - `working/products/tax_outputs/<tax_outputs_id>/tax_outputs.json`
-- stage-owned gap, review, and readiness sidecars live beside the
-  authoritative kernel in that
-  same product directory under `assessment/gap/`, `assessment/review/`, and
-  `assessment/readiness/`, using `assessment/gap/gap_records.json`,
+- stage-owned shared assessment sidecars live beside the authoritative kernel
+  in that same product directory under `assessment/gap/` and
+  `assessment/review/`, using `assessment/gap/gap_records.json`,
   `assessment/gap/gap_explanations.json`,
-  `assessment/review/review_records.json`,
-  `assessment/review/review_explanations.json`,
-  and `assessment/readiness/readiness_records.json`
+  `assessment/review/review_records.json`, and
+  `assessment/review/review_explanations.json`
+- product-local derived outputs live under `derived/` inside the owning
+  product directory, for example:
+  - `working/products/tax_outputs/<tax_outputs_id>/derived/tax_output_grouped_readiness.json`
 - compatibility views live under the authoritative product they depend on,
   for example:
   - `working/products/economic_facts/<economic_facts_id>/compatibility/facts.csv`
@@ -361,27 +365,45 @@ Rules:
 - full-history rescans per target are not allowed when a bounded partition or
   reusable materialized state exists
 
-### Sidecars, Caches, And Indexes
+### Assessment, Product-Local Detail, Compatibility, And Derived Outputs
 
-Sidecars and caches are allowed where replay cost would otherwise become too
-high.
+The target docs use one explicit taxonomy for non-kernel persisted or rendered
+surfaces.
 
-Typical sidecar or cache surfaces include:
+Shared assessment families:
+
+- the gap family for `GapRecord` and `GapExplanation`
+- the review family for `ReviewRecord` and `ReviewExplanation`
+
+Product-local detail families:
 
 - evidence selection explanations
 - claim-scope decision explanations
 - reconciliation continuity explanations
 - checkpoint acceptance reports
 - journal entry-check reports
-- tax carry-forward record indexes
+- product-owned explanatory detail such as provenance, comparison traces,
+  annotations, or policy notes
+
+Compatibility families:
+
+- migration-only `compatibility/` views and sidecars
+
+Derived outputs, caches, and indexes:
+
+- grouped outputs such as the frozen `TaxOutputs`-local grouped readiness file
+- caches
+- indexes such as tax carry-forward record indexes
 
 Rules:
 
-- sidecars are never the sole copy of business meaning
-- sidecars may be keyed by `kernel_scope_id` or narrower truthful record ids,
-  but
-  they do not replace product ids for authoritative product lookup
-- caches are always regenerable from authoritative kernels and upstream refs
+- shared assessment outputs are declared persisted outputs and are never the
+  sole copy of product meaning
+- product-local detail families use explicit owning-product names and never
+  live under the shared assessment root
+- compatibility families stay migration-only and do not replace target product
+  lookup
+- derived outputs, caches, and indexes are the regenerable class
 - materialized indexes are allowed only when they accelerate declared product
   kernels rather than replacing them
 

--- a/docs/concepts/unified-adapter-architecture.md
+++ b/docs/concepts/unified-adapter-architecture.md
@@ -72,7 +72,7 @@ Shared runtime owns cross-adapter workflow:
 
 - evidence selection and candidate comparison
 - stable ordering and fingerprints
-- shared issue, review, and readiness conventions
+- shared gap, review, and attachment conventions
 - `EconomicFacts` construction
 - bridge compatibility view generation
 - replay and parity verification

--- a/docs/reference/first-downstream-slice-contract.md
+++ b/docs/reference/first-downstream-slice-contract.md
@@ -65,7 +65,8 @@ The slice may emit only these downstream kernel families:
 | `Checkpoint` | `CheckpointRecord` | accepted checkpoint record for assertions in this slice only |
 | `Checkpoint` | `CheckpointAssertionRecord` | only `kind = position_quantity`, with direct `accepted_value` using `AssertionValue` |
 
-`EventLinkRecord` remains out of scope for this slice.
+`EventLinkRecord` remains out of scope for this slice and may land only in a
+later in-phase reconciliation increment.
 
 ## Position And Subject Restrictions
 
@@ -176,6 +177,10 @@ For subjects in this slice, the authoritative products after the slice are:
 - `EconomicFacts` for accepted economic meaning
 - `ReconciliationState` for continuity segments and balance targets
 - `Checkpoint` for accepted checkpoint truth
+
+This is the first slice where `TransactionFact`, `facts.csv`,
+`balance_snapshots.csv`, `balance_references.csv`, balance-application outputs,
+and `cointracking_csv` compatibility are derived from target products.
 
 Required derived compatibility views:
 

--- a/docs/reference/first-downstream-slice-contract.md
+++ b/docs/reference/first-downstream-slice-contract.md
@@ -226,8 +226,8 @@ Rules:
 - `BalanceTargetRecord.comparison_outcome` is set only when
   `observation_status = observed`
 - balance-target blocker posture remains on reconciliation-owned gaps and
-  readiness attached to `balance_target_id`, not on balance-target state
-  fields
+  reconciliation-owned derived readiness views keyed by `balance_target_id`,
+  not on balance-target state fields
 - `CheckpointProposalRecord.superseding_proposal_ref` records proposal
   supersession when a later proposal replaces an earlier one
 
@@ -323,7 +323,8 @@ Not allowed:
 Allowed only when kernel ids, statuses, and fingerprints stay unchanged:
 
 - richer explanation text
-- additional non-kernel gap, review, or readiness sidecars
+- additional non-kernel gap or review sidecars
+- additional capability-owned derived readiness views
 - additional comparison detail that does not change product meaning
 
 ## Explicitly Out Of Scope

--- a/docs/reference/first-upstream-slice-contract.md
+++ b/docs/reference/first-upstream-slice-contract.md
@@ -40,8 +40,7 @@ This slice is:
 - bounded `EvidenceSet` emission for that slice
 - bounded `ClaimSet` emission for that slice
 - continued compatibility with current `translation_input_plan.json`,
-  `EconomicActivityDraft`, `SourceTranslationBatch`,
-  `TransactionFact`, `balance_references.csv`, and `cointracking_csv`
+  `EconomicActivityDraft`, and `SourceTranslationBatch`
 
 The slice is not:
 
@@ -226,15 +225,17 @@ Required derived compatibility views:
   sidecars keyed by `claim_id` or `claim_bundle_id`
 - `SourceTranslationBatch` derived from `ClaimSet` plus declared
   compatibility sidecars and shared gap/review/readiness sidecars
-- derived `TransactionFact` rows preserved for current bridge consumers
-- `balance_references.csv` preserved for current downstream compatibility
-- `cointracking_csv` preserved through the active bridge/output path
 
 Compatibility rule:
 
 - bridge views remain required during the compatibility window
 - bridge views are not authoritative for target meaning in this slice once
   `EvidenceSet` and `ClaimSet` exist
+- downstream bridge outputs remain on the live bridge path until the first
+  downstream slice makes `EconomicFacts`, `ReconciliationState`, and
+  `Checkpoint` authoritative for that scope
+- this slice must not introduce a new downstream fact builder or target-derived
+  renderer path from `ClaimSet`
 
 Declared compatibility sidecar boundary:
 
@@ -309,10 +310,6 @@ Unchanged evidence must preserve all of the following:
 - `translation_input_plan.json` content
 - `EconomicActivityDraft` ordering and content for evidence in this slice
 - `SourceTranslationBatch` content for evidence in this slice
-- derived `TransactionFact` ordering and meaning for evidence in this slice
-- `balance_references.csv` content for evidence in this slice
-- `cointracking_csv` row ordering and field values for supported
-  `cointracking_csv` rows
 
 ## Replay Gates
 
@@ -324,14 +321,11 @@ The slice is replay-safe only when repeated runs on unchanged evidence preserve:
 - identical `translation_input_plan.json` content
 - identical `EconomicActivityDraft` content for evidence in this slice
 - identical `SourceTranslationBatch` content for evidence in this slice
-- identical derived `TransactionFact` fingerprints for evidence in this slice
-- identical `balance_references.csv` content for evidence in this slice
-- identical `cointracking_csv` output for supported bridge facts
 
 Replay checks must also prove that incidental input ordering changes do not
 change evidence selection, claim order, claim-bundle order,
 claim-bundle decisions, or
-rendered output.
+claim-side compatibility output.
 
 ## Allowed Drift
 
@@ -343,9 +337,6 @@ Not allowed:
 - quantity drift
 - `translation_input_plan.json`, `EconomicActivityDraft`, or
   `SourceTranslationBatch` drift on unchanged evidence in this slice
-- derived `TransactionFact` drift on unchanged evidence in this slice
-- `balance_references.csv` or `cointracking_csv` drift on unchanged evidence in
-  this slice
 
 Allowed only when kernel ids, statuses, and fingerprints stay unchanged:
 
@@ -361,6 +352,8 @@ This slice does not:
 - pin the real filing workspace adapter inventory for `2023` to `2025`
 - widen beyond Coinbase retail exports and recognized Coinbase statement
   balance observations
+- own downstream economic or balance compatibility, which remains the first
+  downstream slice's responsibility
 - define runtime `EconomicFacts`, `ReconciliationState`, `Checkpoint`,
   `Journal`, or `TaxInputs`
 - authorize broad target package scaffolding before the contract-lock pass is

--- a/docs/reference/first-upstream-slice-contract.md
+++ b/docs/reference/first-upstream-slice-contract.md
@@ -11,7 +11,7 @@ related:
   - docs/concepts/bridge-to-target-mapping.md
   - docs/concepts/pipeline-stage-contracts.md
   - docs/concepts/domain-ontology.md
-  - docs/concepts/gaps-and-readiness.md
+  - docs/concepts/gaps-and-reviews.md
   - docs/status/adapter-delivery-plan.md
   - ROADMAP.md
 ---
@@ -128,8 +128,9 @@ Out of scope for this slice:
 - `statement_document`
 - `contract`
 
-Bridge or output annotation sidecar detail and gap, review, or readiness
-sidecar content are not claim kinds and are never emitted by this slice.
+Bridge or output annotation sidecar detail, shared gap/review outputs, and
+capability-owned readiness views are not claim kinds and are never emitted by
+this slice.
 
 Frozen kind-specific claim fields:
 
@@ -224,7 +225,7 @@ Required derived compatibility views:
 - `EconomicActivityDraft` derived from `ClaimSet` plus declared compatibility
   sidecars keyed by `claim_id` or `claim_bundle_id`
 - `SourceTranslationBatch` derived from `ClaimSet` plus declared
-  compatibility sidecars and shared gap/review/readiness sidecars
+  compatibility sidecars
 
 Compatibility rule:
 
@@ -236,6 +237,8 @@ Compatibility rule:
   `Checkpoint` authoritative for that scope
 - this slice must not introduce a new downstream fact builder or target-derived
   renderer path from `ClaimSet`
+- shared gap and review outputs, when the claim stage emits them, stay separate
+  from compatibility views and do not become compatibility sidecars
 
 Declared compatibility sidecar boundary:
 
@@ -341,9 +344,8 @@ Not allowed:
 Allowed only when kernel ids, statuses, and fingerprints stay unchanged:
 
 - richer explanation text
-- additional gap, review, readiness, or other sidecar detail that does not
-  change product
-  meaning
+- additional gap, review, capability-owned readiness-view, or other sidecar
+  detail that does not change product meaning
 
 ## Explicitly Out Of Scope
 

--- a/docs/reference/target-ids-and-refs.md
+++ b/docs/reference/target-ids-and-refs.md
@@ -10,7 +10,7 @@ nav_order: 17
 related:
   - docs/concepts/pipeline-stage-contracts.md
   - docs/concepts/domain-ontology.md
-  - docs/concepts/gaps-and-readiness.md
+  - docs/concepts/gaps-and-reviews.md
   - ROADMAP.md
 ---
 
@@ -33,8 +33,8 @@ Use the detailed contract pages first:
 - [Domain Ontology](../concepts/domain-ontology.md) for `AssertionValue`,
   `PositionRef`, `ContractRef`, `BasisPoolRef`, and other domain refs plus
   identity seams
-- [Gap, Review, And Readiness](../concepts/gaps-and-readiness.md) for `SubjectRef`,
-  shared gap/review/readiness attachments, and `kernel_scope_id`
+- [Gap, Review, And Shared Attachment](../concepts/gaps-and-reviews.md) for
+  `SubjectRef`, shared gap/review attachments, and `kernel_scope_id`
 
 This page keeps only reusable target ids and ref tuples that are not defined as
 the primary contract content elsewhere.

--- a/docs/reference/target-persistence-reference.md
+++ b/docs/reference/target-persistence-reference.md
@@ -34,8 +34,8 @@ Use these contract pages first:
 ## Persistence Rules
 
 **Exception rationale:** `assessment/` stays in this page only as the shared
-persistence root for the nested `gap/`, `review/`, and `readiness/` sidecar
-families. It is not a generic sidecar bucket.
+persistence root for the nested `gap/` and `review/` sidecar families. It is
+not a generic sidecar bucket.
 
 When persisting target products:
 
@@ -55,14 +55,17 @@ When persisting target products:
   activates a capability-owned read-model surface
 - keep assessment family directories and basenames aligned to the stored
   families, for example `assessment/gap/gap_records.json`,
-  `assessment/review/review_records.json`,
-  and `assessment/readiness/readiness_records.json`
+  `assessment/review/review_records.json`
 - `assessment/` stays generic only because it splits immediately into the
-  persisted `gap/`, `review/`, and `readiness/` families; unrelated sidecars
-  do not belong there
+  persisted `gap/` and `review/` families; unrelated sidecars do not belong
+  there
+- keep product-local derived outputs under `derived/` inside the owning
+  product directory when a contract explicitly allows them, for example
+  `working/products/tax_outputs/<tax_outputs_id>/derived/tax_output_grouped_readiness.json`
 - defer a general projections root such as
   `working/projections/<slice>/<projection_family>/...` until the roadmap
   trigger ladder activates broader derived read models
+- treat shared assessment outputs as declared persisted outputs
 - treat caches and indexes as regenerable accelerators, not as business truth
 
 ## Reminder

--- a/docs/standards/engineering.md
+++ b/docs/standards/engineering.md
@@ -17,8 +17,8 @@ current output-adapter or oracle-local edges, not canonical target naming.
 
 **Exception rationale:** When this standard names `assessment/` or
 `domain/assessment/`, it is calling out the intentional shared root for the
-nested `gap/`, `review/`, and `readiness/` families rather than endorsing a
-generic catch-all boundary.
+nested `gap/` and `review/` families plus shared attachment constructs rather
+than endorsing a generic catch-all boundary.
 
 **Migration-only root rationale:** When this standard names
 `application/compatibility/`, it is pointing to the bridge-only migration root
@@ -187,8 +187,9 @@ Current application of this rule:
   planned-item models, review assembly, and report rendering.
 - Normalization window and derived-balance helpers belong under
   `application/normalization/` rather than as nearby flat siblings.
-- Shared gap, review, and readiness contracts belong under `domain/assessment/`
-  while the owning application slice keeps its own assessment behavior.
+- Shared gap and review contracts plus shared attachment constructs belong
+  under `domain/assessment/` while the owning application slice keeps its own
+  assessment behavior and readiness views.
 - Forward-looking journal expansion and entry checks belong under
   `application/journal/` rather than under a broader `accounting/` umbrella or
   as extra checkpoint-side helpers.
@@ -298,17 +299,17 @@ application/investigation/, rather than into a generic shared sink.
   and one child-record noun.
 - When a broad shared root is genuinely needed, keep the immediate children
   concrete and mirrored. `assessment/` is acceptable only when it is split into
-  families such as `gap/`, `review/`, and `readiness/` rather than flattened
-  into one catch-all boundary.
+  families such as `gap/` and `review/` rather than flattened into one
+  catch-all boundary.
 - Apply that same rule to persisted sidecar layout. Prefer paths such as
   `assessment/gap/gap_records.json` and
-  `assessment/readiness/readiness_records.json` over one flat
-  `assessment/` directory full of unrelated sidecar families.
+  `assessment/review/review_records.json` over one flat `assessment/`
+  directory full of unrelated sidecar families.
 - In forward-looking prose, prefer explicit family names such as `gap`,
-  `review`, and `readiness` over the looser umbrella `shared assessment` when
-  those are the actual owned families. Reserve generic `assessment` for
-  intentional roots or bounded field names such as `domain/assessment/`,
-  `assessment/`, or `support_shape`.
+  `review`, or explicit capability-owned readiness-view names over the looser
+  umbrella `shared assessment` when those are the actual owned families.
+  Reserve generic `assessment` for intentional roots or bounded field names
+  such as `domain/assessment/`, `assessment/`, or `support_shape`.
 - When grouped support logic outgrows stage-local ownership, extract it to the
   specific capability-owned derived read-model package rather than to a shared
   application sink.
@@ -366,9 +367,9 @@ application/investigation/, rather than into a generic shared sink.
   boundary is already known. Prefer the explicit owner such as `domain`,
   `reconciliation`, `checkpoint`, `journal`, or `tax`.
 - Keep record-family stems and id stems aligned. Prefer `GapRecord` plus
-  `gap_id` or `ReadinessRecord` plus `readiness_id` over longer names that
-  repeat context the record family already supplies, unless a real sibling
-  family would make the shorter stem ambiguous.
+  `gap_id` or `ReviewRecord` plus `review_id` over longer names that repeat
+  context the record family already supplies, unless a real sibling family
+  would make the shorter stem ambiguous.
 - When a record-family noun would become generic out of context, keep the
   owning concept in the record-family stem even if child ids stay short.
   Prefer `EvidenceSelectionRecord` and `ClaimBundleDecisionRecord` over
@@ -461,8 +462,9 @@ Stable-id namespaces are catalog-governed, not review-time judgment.
   product from its accepted root.
 - Shared cross-stage support families that are repo-owned concepts in their own
   right may also stay short. Prefer `GapRecord`, `ReviewRecord`, and
-  `ReadinessRecord` over longer prefixed variants that add no new meaning.
-- For shared gap/review/readiness attachment over one emitted product kernel,
+  explicit capability-owned readiness-view names over longer prefixed variants
+  that add no new meaning.
+- For shared gap/review attachment over one emitted product kernel,
   prefer the explicit `kernel_scope_id` over generic names such as
   `dataset_id`.
 - Name partition scopes after the actual stable dimensions the product id
@@ -485,13 +487,12 @@ Stable-id namespaces are catalog-governed, not review-time judgment.
   sidecar family in the filename. Avoid generic names such as `state.json`,
   `data.json`, `output.json`, or `results.json` when later call sites would
   need directory context alone to tell what the file holds.
-- Inside `assessment/` directories that hold shared gap/review/readiness
-  sidecars, split the directory first into `gap/`, `review/`, and
-  `readiness/`, then make basenames mirror the stored record or explanation
-  family. Prefer `assessment/gap/gap_records.json`,
-  `assessment/review/review_records.json`,
-  and `assessment/readiness/readiness_records.json` over one flat assessment
-  directory or shorter plurals that need directory context to reveal shape.
+- Inside `assessment/` directories that hold shared gap/review sidecars, split
+  the directory first into `gap/` and `review/`, then make basenames mirror
+  the stored record or explanation family. Prefer
+  `assessment/gap/gap_records.json` and
+  `assessment/review/review_records.json` over one flat assessment directory
+  or shorter plurals that need directory context to reveal shape.
 - In forward-looking docs and code, reserve `artifact` for current-state bridge
   outputs, oracle/reference packages, or intentionally mixed file families.
   When the storage role is known, prefer `kernel`, `sidecar`, `view`,
@@ -745,9 +746,9 @@ Stable-id namespaces are catalog-governed, not review-time judgment.
   `BasisTransitionRecord` is a kernel row family.
 - When prose is naming one persisted emitted family rather than the broader
   concept, use the record-family noun. Prefer `checkpoint proposal records`,
-  `readiness records`, or `tax carry-forward records` over looser prose such as
-  `proposals`, `readiness`, or `carry-forward state` when the stored shape is
-  the point.
+  `capability-owned readiness views`, or `tax carry-forward records` over
+  looser prose such as `proposals`, `readiness`, or `carry-forward state`
+  when the stored shape is the point.
 - Prefer specific names such as `csv_parser.py`, `balance_mapper.py`, or
   `issue_rules.py` over generic names.
 - Match package structure to the architecture first and the external provider
@@ -777,7 +778,7 @@ Stable-id namespaces are catalog-governed, not review-time judgment.
 - Assessment views and compatibility views may still group by
   `source_slug` where operators need that reporting lens, but that dimension
   must not leak into downstream product ids, record ids, authoritative
-  directory stems, or canonical readiness-rollup vocabularies.
+  directory stems, or capability-owned readiness-view vocabularies.
 - When a canonical target contract must preserve a source-provided label,
   preserve the value without freezing the source noun into the field name.
   Prefer target-aligned names such as `location_label` over

--- a/docs/status/migration-sequence.md
+++ b/docs/status/migration-sequence.md
@@ -31,7 +31,7 @@ Do not use this page for:
 - competing phase numbers
 - alternate phase labels
 - duplicate product-contract definitions
-- duplicate ontology, gap/review/readiness, or persistence contracts
+- duplicate ontology, gap/review/shared-attachment, or persistence contracts
 
 ## Operating Rules
 
@@ -105,8 +105,9 @@ Before broad implementation, freeze:
   [Pipeline Stage Contracts](../concepts/pipeline-stage-contracts.md)
 - ontology and ref seams on
   [Domain Ontology](../concepts/domain-ontology.md)
-- shared gap, review, and readiness contracts plus `SubjectRef` rules on
-  [Gap, Review, And Readiness](../concepts/gaps-and-readiness.md)
+- shared gap and review contracts plus `SubjectRef`, `kernel_scope_id`, and
+  readiness-locality rules on
+  [Gap, Review, And Shared Attachment](../concepts/gaps-and-reviews.md)
 - persistence, partitioning, and fast-path rules on
   [Reconciliation, Checkpoint, Journal, And Tax Architecture](../concepts/reconciliation-tax-architecture.md)
 - bridge-to-target cutover rules on
@@ -246,4 +247,5 @@ surface, update these pages together:
 
 Current-state docs stay truthful to implemented behavior. Forward-looking docs
 stay detailed enough that later implementation does not need to invent ids,
-reader cutovers, storage placement, or gap/review/readiness boundaries.
+reader cutovers, storage placement, or gap/review/shared-attachment
+boundaries.

--- a/docs/status/migration-sequence.md
+++ b/docs/status/migration-sequence.md
@@ -39,7 +39,8 @@ Every slice must obey the following rules before code lands:
 
 - declare the slice scope
 - name the authoritative writer for every affected scope
-- name the authoritative reader for every affected consumer
+- name the authoritative reader for every affected consumer using concrete
+  current runtime capabilities rather than generic category labels
 - declare the product id and upstream product-ref fields carried in each target
   product header the slice introduces
 - name the derived compatibility view for every unmigrated reader
@@ -59,12 +60,40 @@ Migration-wide rules:
   target kernels during the compatibility window
 - do not introduce a shared application assessment center as a migration
   shortcut; assessment behavior stays with the owning slice
+- writer-only or scaffold-only commands are not current readers unless the
+  current-state docs explicitly say they consume the persisted bridge artifact
+  after it is written
+- target readers must name a capability plus the authoritative product it reads;
+  undocumented future package roots by themselves are not sufficient reader
+  labels
 - through the tax-first phases, broader grouped or query surfaces stay on
   authoritative kernels, declared compatibility views, or tax-output-local and
   rendering-local derived outputs until the roadmap trigger ladder fires
 
 The authoritative cutover matrix lives in
 [Bridge To Target Mapping](../concepts/bridge-to-target-mapping.md).
+
+## Canonical Current-Reader Inventory
+
+Use these labels consistently in this page and in
+[Bridge To Target Mapping](../concepts/bridge-to-target-mapping.md).
+
+- `source normalize planner review and translation path`: planner-enabled
+  normalization review and translation entry points that read
+  `translation_input_candidates.json` and `translation_input_plan.json`
+- `source assemble bridge projection path`: `source assemble` and its bridge
+  projection flow that still builds assembled source datasets from
+  `EconomicActivityDraft` and `SourceTranslationBatch`
+- `operator review diagnostics`: operator review of normalization issues and
+  reviews through `exceptions.csv`, `normalization_reviews.csv`, and related
+  current diagnostics
+- `reconciliation balances inspect`: the shared balance inspection capability
+- `reconciliation balances check`: the deterministic balance-check capability
+- `reconciliation balances summarize`: the shared balance summary capability
+- `cointracking_csv rendering path`: the current CSV rendering path that emits
+  `cointracking_csv`
+- `dev-only oracle comparison path`: the dev-only oracle comparison tools and
+  validation flows that compare current bridge outputs
 
 ## Landing Order
 
@@ -97,6 +126,9 @@ Required posture:
 - `ClaimSet` becomes authoritative for in-scope evidence-local meaning
 - `translation_input_plan.json`, `EconomicActivityDraft`, and
   `SourceTranslationBatch` survive only as derived compatibility views
+- downstream bridge outputs remain on the live bridge path until the first
+  downstream slice makes the downstream target products authoritative for that
+  scope
 
 ### 3. First Downstream Slice
 
@@ -112,6 +144,9 @@ Required posture:
 - `Checkpoint` becomes authoritative for in-scope accepted checkpoint truth
 - `TransactionFact`, `balance_snapshots.csv`, and `balance_references.csv`
   survive only as derived compatibility views for unmigrated readers
+
+This first downstream slice is therefore the first slice that converts
+downstream bridge surfaces into target-derived compatibility views.
 
 ### 4. Reader Cutovers
 
@@ -137,6 +172,10 @@ Rules:
 - do not let `Journal` repair economic or checkpoint truth
 - do not let tax decide source meaning, reconciliation completeness, or
   checkpoint acceptance
+
+Phases 6 and later remain intentionally high-level in this round. They are
+out of scope for this repair and do not block immediate Phase 0 to Phase 5
+implementation once the Phase 0 gate is satisfied.
 
 ### 6. Triggered Derived Read-Model Activation
 

--- a/repo_support/target_naming/rules/structure.py
+++ b/repo_support/target_naming/rules/structure.py
@@ -59,9 +59,8 @@ def structure_findings(
                     span=block.span,
                     message=f"support-root path {match.group(0)!r} is not allowed",
                     suggestion=(
-                        "use assessment/gap/, assessment/review/, or "
-                        "assessment/readiness/ "
-                        "with a mirrored family basename"
+                        "use assessment/gap/ or assessment/review/ with a "
+                        "mirrored family basename"
                     ),
                 )
             )

--- a/tests/unit/docs_runtime_parity/test_repo_doc_guards.py
+++ b/tests/unit/docs_runtime_parity/test_repo_doc_guards.py
@@ -249,7 +249,7 @@ def test_target_docs_use_neutral_upstream_kind_tokens_and_position_key_example()
 
 def test_forward_target_docs_use_subject_key_and_no_placeholder_measure_field() -> None:
     governed_paths = (
-        docs_root() / "concepts" / "gaps-and-readiness.md",
+        docs_root() / "concepts" / "gaps-and-reviews.md",
         docs_root() / "concepts" / "pipeline-stage-contracts.md",
         docs_root() / "reference" / "first-downstream-slice-contract.md",
         docs_root() / "reference" / "first-upstream-slice-contract.md",
@@ -265,14 +265,14 @@ def test_forward_target_docs_use_subject_key_and_no_placeholder_measure_field() 
 
 def test_forward_target_docs_freeze_new_titles_and_reference_grouping() -> None:
     docs_home = (docs_root() / "README.md").read_text(encoding="utf-8")
-    gaps_text = (docs_root() / "concepts" / "gaps-and-readiness.md").read_text(
+    gaps_text = (docs_root() / "concepts" / "gaps-and-reviews.md").read_text(
         encoding="utf-8"
     )
     recon_text = (
         docs_root() / "concepts" / "reconciliation-tax-architecture.md"
     ).read_text(encoding="utf-8")
 
-    assert 'title: "Gap, Review, And Readiness"' in gaps_text
+    assert 'title: "Gap, Review, And Shared Attachment"' in gaps_text
     assert (
         'title: "Reconciliation, Checkpoint, Journal, And Tax Architecture"'
         in recon_text
@@ -294,7 +294,7 @@ def test_forward_target_docs_freeze_new_titles_and_reference_grouping() -> None:
 def test_forward_target_docs_use_kernel_scope_and_assessment_roots() -> None:
     governed_paths = (
         repo_root() / "ROADMAP.md",
-        docs_root() / "concepts" / "gaps-and-readiness.md",
+        docs_root() / "concepts" / "gaps-and-reviews.md",
         docs_root() / "concepts" / "pipeline-stage-contracts.md",
         docs_root() / "concepts" / "reconciliation-tax-architecture.md",
         docs_root() / "reference" / "target-ids-and-refs.md",
@@ -324,7 +324,7 @@ def test_forward_target_docs_use_assessment_paths_and_partition_labels() -> None
     recon_text = (
         docs_root() / "concepts" / "reconciliation-tax-architecture.md"
     ).read_text(encoding="utf-8")
-    gaps_text = (docs_root() / "concepts" / "gaps-and-readiness.md").read_text(
+    gaps_text = (docs_root() / "concepts" / "gaps-and-reviews.md").read_text(
         encoding="utf-8"
     )
     persistence_text = (
@@ -332,13 +332,18 @@ def test_forward_target_docs_use_assessment_paths_and_partition_labels() -> None
     ).read_text(encoding="utf-8")
 
     assert "assessment/gap/gap_records.json" in recon_text
-    assert "assessment/readiness/readiness_records.json" in recon_text
+    assert "assessment/review/review_records.json" in recon_text
+    assert (
+        "working/products/tax_outputs/<tax_outputs_id>/derived/"
+        "tax_output_grouped_readiness.json" in recon_text
+    )
     assert "assessment/readiness/readiness_rollup_records.json" not in recon_text
+    assert "assessment/readiness/readiness_records.json" not in recon_text
     assert "checkpoint-economic-facts-lineage-scoped" in recon_text
     assert "tax-inputs-policy-year-scoped" in recon_text
     assert "checkpoint-economic-lineage-scoped" not in recon_text
     assert "tax-input-policy-year-scoped" not in recon_text
-    assert "tax-output-local derived output" in gaps_text
+    assert "Readiness is not a shared assessment family." in gaps_text
     assert "`kernel_scope`" in gaps_text
     assert "`product_scope`" not in gaps_text
     assert "assessment view" not in gaps_text
@@ -347,6 +352,10 @@ def test_forward_target_docs_use_assessment_paths_and_partition_labels() -> None
     assert "assessment views" not in recon_text
     assert "assessment view" not in persistence_text
     assert "assessment views" not in persistence_text
+    assert (
+        "working/products/tax_outputs/<tax_outputs_id>/derived/"
+        "tax_output_grouped_readiness.json" in persistence_text
+    )
     assert "readiness rollup" not in gaps_text.lower()
     assert "readiness rollup" not in recon_text.lower()
     assert "readiness rollup" not in persistence_text.lower()
@@ -426,7 +435,7 @@ def test_repo_human_docs_retire_operator_view_term() -> None:
 
 
 def test_bridge_record_names_stay_inside_compatibility_local_sections() -> None:
-    gaps_text = (docs_root() / "concepts" / "gaps-and-readiness.md").read_text(
+    gaps_text = (docs_root() / "concepts" / "gaps-and-reviews.md").read_text(
         encoding="utf-8"
     )
     bridge_text = (docs_root() / "concepts" / "bridge-to-target-mapping.md").read_text(

--- a/tests/unit/test_docs_maintenance.py
+++ b/tests/unit/test_docs_maintenance.py
@@ -274,12 +274,12 @@ def test_validate_frontmatter_rejects_provider_nouns_in_forward_looking_summary(
 
 
 def test_validate_frontmatter_rejects_noncanonical_forward_target_title() -> None:
-    path = repo_root() / "docs" / "concepts" / "gaps-and-readiness.md"
+    path = repo_root() / "docs" / "concepts" / "gaps-and-reviews.md"
     text = dedent(
         """\
         ---
         title: "Gaps And Readiness"
-        summary: "Shared gap, review, readiness, sidecar, and `SubjectRef` contracts for the target pipeline."
+        summary: "Shared gap, review, sidecar, `SubjectRef`, and shared attachment contracts for the target pipeline."
         doc_type: concept
         audience: human
         owner: repo

--- a/tests/unit/test_target_naming.py
+++ b/tests/unit/test_target_naming.py
@@ -81,12 +81,6 @@ def _write_catalog(
                     "id": "review_id",
                     "refs": [],
                 },
-                {
-                    "stem": "readiness",
-                    "record": "ReadinessRecord",
-                    "id": "readiness_id",
-                    "refs": [],
-                },
             ],
             "package_paths": ["application/claim/", "domain/assessment/"],
             "standalone_directory_paths": ["compatibility/"],
@@ -104,10 +98,6 @@ def _write_catalog(
                                 "review_records.json",
                                 "review_explanations.json",
                             ],
-                        },
-                        {
-                            "stem": "readiness",
-                            "sidecars": ["readiness_records.json"],
                         },
                     ],
                 },
@@ -1254,8 +1244,8 @@ def test_real_repo_catalog_covers_root_scopes_and_tooling_paths() -> None:
     assert catalog.scope_profiles["forward_target"].enforce_target_naming is True
     assert catalog.scope_profiles["repo_policy"].allow_anti_examples is True
     assert (
-        catalog.title_expectations["docs/concepts/gaps-and-readiness.md"]
-        == "Gap, Review, And Readiness"
+        catalog.title_expectations["docs/concepts/gaps-and-reviews.md"]
+        == "Gap, Review, And Shared Attachment"
     )
     assert (
         catalog.title_expectations["docs/concepts/reconciliation-tax-architecture.md"]
@@ -1265,7 +1255,6 @@ def test_real_repo_catalog_covers_root_scopes_and_tooling_paths() -> None:
         "compatibility/",
         "assessment/gap/",
         "assessment/review/",
-        "assessment/readiness/",
         "working/products/evidence_sets/",
         "working/products/claim_sets/",
         "working/products/economic_facts/",
@@ -1280,7 +1269,6 @@ def test_real_repo_catalog_covers_root_scopes_and_tooling_paths() -> None:
         "assessment/gap/gap_explanations.json",
         "assessment/review/review_records.json",
         "assessment/review/review_explanations.json",
-        "assessment/readiness/readiness_records.json",
     )
     assert catalog.reference_group_headings == (
         "### Target References",
@@ -1307,6 +1295,7 @@ def test_real_repo_catalog_covers_root_scopes_and_tooling_paths() -> None:
     assert "ValuationRecord" in record_names
     assert "JournalEntryRecord" in record_names
     assert "GapRecord" in record_names
+    assert "ReadinessRecord" not in record_names
     assert "ReadinessRollupRecord" not in record_names
     assert "application/assessment/" not in catalog.canonical_families.package_paths
     assert "application/reporting/" not in catalog.canonical_families.package_paths

--- a/tools/target_naming_catalog.yaml
+++ b/tools/target_naming_catalog.yaml
@@ -33,7 +33,7 @@ title_expectations:
   docs/concepts/architecture-overview.md: Architecture Overview
   docs/concepts/bridge-to-target-mapping.md: Bridge To Target Mapping
   docs/concepts/domain-ontology.md: Domain Ontology
-  docs/concepts/gaps-and-readiness.md: Gap, Review, And Readiness
+  docs/concepts/gaps-and-reviews.md: Gap, Review, And Shared Attachment
   docs/concepts/oracle-boundaries.md: Oracle Boundaries
   docs/concepts/pipeline-stage-contracts.md: Pipeline Stage Contracts
   docs/concepts/reconciliation-tax-architecture.md: Reconciliation, Checkpoint, Journal, And Tax Architecture
@@ -189,10 +189,6 @@ canonical_families:
       record: ReviewRecord
       id: review_id
       refs: []
-    - stem: readiness
-      record: ReadinessRecord
-      id: readiness_id
-      refs: []
     - stem: tax_carry_forward
       record: TaxCarryForwardRecord
       id: tax_carry_forward_id
@@ -243,9 +239,6 @@ canonical_families:
           sidecars:
             - review_records.json
             - review_explanations.json
-        - stem: readiness
-          sidecars:
-            - readiness_records.json
     - root: working/products
       families:
         - stem: evidence_sets
@@ -286,7 +279,6 @@ canonical_tokens:
     - OriginRef
     - PositionRef
     - PostingRecord
-    - ReadinessRecord
     - ClaimBundleRecord
     - ReviewExplanation
     - ReviewRecord
@@ -330,7 +322,6 @@ canonical_tokens:
     - kernel_scope
     - kernel_scope_id
     - product_slug
-    - readiness_id
     - reconciliation_state_id
     - review_id
     - selection_id
@@ -1149,7 +1140,7 @@ exceptions:
     allowed_scopes: [forward_target, repo_policy]
     allowed_paths:
       - docs/concepts/bridge-to-target-mapping.md
-      - docs/concepts/gaps-and-readiness.md
+      - docs/concepts/gaps-and-reviews.md
     allowed_section_labels: []
     allowed_terms:
       - IssueRecord


### PR DESCRIPTION
Why:
- contract-lock completion, reader cutovers, and shared assessment ownership still had conflicting signals across the forward-looking docs, which left Phase 0 to Phase 5 implementation room for incompatible interpretations
- readiness remained codified as a shared assessment record family in the repo's naming and policy layer even after the forward-looking docs narrowed it to capability-owned derived views

What:
- add a Phase 0 completion gate plus a canonical current-reader inventory and keep the first upstream slice limited to evidence and claim compatibility until the first downstream slice owns downstream bridge compatibility
- rename the shared assessment concept page to gaps-and-reviews, remove shared readiness from the canonical shared assessment contract set, and freeze the TaxOutputs-local grouped readiness locality rules
- align the target-naming catalog, adapter-architecture wording, and policy tests with the narrowed shared gap/review contract

Checks:
- make audit-pr-review
- make docs-check
- make naming-check
- make pr-review
- make audit-delivery-guardrails

Issue linkage:
- None: no existing tracked issue cleanly owned this contract-lock and assessment-hardening doc alignment branch after issue search

Included checkpoints:
- `docs(migration): harden contract-lock and cutover docs`
- `docs(assessment): narrow shared assessment contracts`
- `fix(target-naming): retire shared readiness canon`
