### PR TITLE
feat(claimset): land claimset authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ milestones on `main`.
 ### Docs And Control Plane
 
 - Reset durable contract and sequencing authority onto the owned docs and
-  removed roadmap-coupled semantic docs-audit proof from durable control-plane
+  removed planning-coupled semantic docs-audit proof from durable control-plane
   checks.
+- Moved completed `EvidenceSet` delivery truth out of future-tense planning
+  language and tightened durable doc checks against ephemeral delivery labels.
 
 ## 2026-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ milestones on `main`.
   checks.
 - Moved completed `EvidenceSet` delivery truth out of future-tense planning
   language and tightened durable doc checks against ephemeral delivery labels.
+- Added Coinbase `ClaimSet` authority, claim-stage assessment sidecars, and a
+  compatibility view back into the current normalization bridge.
 
 ## 2026-04-01
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -86,28 +86,16 @@ ongoing contracts and migration rules:
 Keep detailed completion proof, gate tables, and durable contract semantics on
 those owner docs rather than restating them here.
 
-## Phase 1. Land `EvidenceSet`
+## Phase 1. `EvidenceSet` Is Complete
 
-Goal:
+Phase 1 is complete. Its implemented runtime truth and durable references now
+live on the owner surfaces that describe the active bridge boundary and product
+outputs:
 
-- make deterministic evidence selection and typed observation capture
-  the formal first pipeline product
-
-Deliver:
-
-- capture-scoped `EvidenceSet` emission keyed by `evidence_set_id`
-- deterministic selected, superseded, and blocked evidence membership
-- typed evidence observations that survive beyond intake heuristics, including
-  field tables frozen for the first upstream slice for
-  `statement_document` and `statement_balance_row`
-- bridge compatibility view for `translation_input_plan.json`
-
-Exit criteria:
-
-- the runtime can explain why every selected evidence member won and why every
-  superseded or blocked member did not
-- evidence selection becomes authoritative through `EvidenceSet` for the
-  in-scope slice
+- [Current State](docs/status/current-state.md)
+- [Product Outputs](docs/workspace/working/products/README.md)
+- [Evidence And Claim Contract](docs/reference/evidence-claim-contract.md)
+- [CHANGELOG.md](CHANGELOG.md)
 
 ## Phase 2. Land `ClaimSet`
 

--- a/docs/concepts/architecture-overview.md
+++ b/docs/concepts/architecture-overview.md
@@ -29,6 +29,10 @@ The target runtime pipeline is:
 
 `EvidenceSet -> ClaimSet -> EconomicFacts -> ReconciliationState -> Checkpoint -> Journal -> TaxInputs -> TaxOutputs`
 
+Within that pipeline, `EvidenceSet` is already the implemented authority for
+the bounded Coinbase evidence-selection slice, while `ClaimSet` is the next
+upstream authority slice still to land.
+
 The primary contract pages freeze product ids, product headers, critical-path
 kernel field tables, and the compatibility sidecar boundary for retained legacy
 hint fields.

--- a/docs/concepts/architecture-overview.md
+++ b/docs/concepts/architecture-overview.md
@@ -29,9 +29,9 @@ The target runtime pipeline is:
 
 `EvidenceSet -> ClaimSet -> EconomicFacts -> ReconciliationState -> Checkpoint -> Journal -> TaxInputs -> TaxOutputs`
 
-Within that pipeline, `EvidenceSet` is already the implemented authority for
-the bounded Coinbase evidence-selection slice, while `ClaimSet` is the next
-upstream authority slice still to land.
+Within that pipeline, `EvidenceSet` and `ClaimSet` are already the implemented
+authorities for the bounded planner-enabled Coinbase slice. Downstream target
+products remain future work.
 
 The primary contract pages freeze product ids, product headers, critical-path
 kernel field tables, and the compatibility sidecar boundary for retained legacy
@@ -41,7 +41,8 @@ Broader consumer-facing grouped or query surfaces remain intentionally
 deferred. Through the tax-first path, grouped outputs may remain only as
 tax-output-local derived content, narrow rendering-derived content, or
 compatibility-local derived output rather than as a shared application center.
-broader derived read models and projections stay deferred until a later capability-specific increment makes them necessary.
+broader derived read models and projections stay deferred until a later
+capability-specific increment makes them necessary.
 
 Gap and review remain shared contracts plus persisted shared-assessment
 families. Readiness stays capability-owned derived behavior rather than shared

--- a/docs/reference/evidence-claim-contract.md
+++ b/docs/reference/evidence-claim-contract.md
@@ -18,7 +18,10 @@ related:
 
 Use this page when implementing or reviewing the bounded evidence-and-claim contract.
 This document freezes scope, cardinality, ids, parity, replay, and allowed
-drift for the bounded `EvidenceSet -> ClaimSet` increment.
+drift for the bounded `EvidenceSet -> ClaimSet` increment. The
+`EvidenceSet` side of that contract is already the live runtime authority for
+the in-scope evidence slice; `ClaimSet` is the remaining upstream authority
+slice in this contract.
 
 **Contract-local example:** This contract still uses Coinbase retail exports
 and recognized Coinbase statements only as bounded examples for the current

--- a/docs/status/current-state.md
+++ b/docs/status/current-state.md
@@ -74,9 +74,13 @@ The repo currently ships typed replacements for the current workflow capabilitie
   statement-observation scope, with
   `working/products/evidence_sets/<evidence_set_id>/compatibility/translation_input_plan.json`
   as the derived compatibility plan
-- the remaining bounded upstream authority gap is `ClaimSet`; downstream bridge
-  authorities for facts, balances, and checkpoints remain unchanged until the
-  later target products land
+- planner-enabled Coinbase normalization also emits
+  `working/products/claim_sets/<claim_set_id>/claim_set.json` plus deterministic
+  claim-stage assessment sidecars and
+  `compatibility/draft_projection_fields.json`, then derives the current
+  `EconomicActivityDraft` bridge outputs from that persisted `ClaimSet`
+- downstream bridge authorities for facts, balances, and checkpoints remain
+  unchanged until the later target products land
 - source assembly via `source assemble`, producing reconciliation-ready source
   datasets under `working/normalized/sources/<source>/` and rewrites its owned
   generated artifact set on rerun

--- a/docs/status/current-state.md
+++ b/docs/status/current-state.md
@@ -10,7 +10,7 @@ nav_order: 10
 ---
 
 This status page uses current implementation terms where accuracy requires
-them. Forward-looking architecture and roadmap docs use the final target
+them. Forward-looking architecture and planning docs use the final target
 product names `EvidenceSet`, `ClaimSet`, `EconomicFacts`,
 `ReconciliationState`, `Checkpoint`, `Journal`, `TaxInputs`, and
 `TaxOutputs`.
@@ -74,6 +74,9 @@ The repo currently ships typed replacements for the current workflow capabilitie
   statement-observation scope, with
   `working/products/evidence_sets/<evidence_set_id>/compatibility/translation_input_plan.json`
   as the derived compatibility plan
+- the remaining bounded upstream authority gap is `ClaimSet`; downstream bridge
+  authorities for facts, balances, and checkpoints remain unchanged until the
+  later target products land
 - source assembly via `source assemble`, producing reconciliation-ready source
   datasets under `working/normalized/sources/<source>/` and rewrites its owned
   generated artifact set on rerun

--- a/docs/status/migration-sequence.md
+++ b/docs/status/migration-sequence.md
@@ -13,9 +13,9 @@ Use this page to sequence implementation increments without a big-bang refactor.
 This page keeps migration rules, cutover expectations, and retirement gates in
 one place. It is the durable owner for sequencing, cutover, and bridge
 retirement rules. It does not redefine target product contracts or recreate
-roadmap phase detail.
+planning-document delivery detail.
 
-## Roadmap Ownership
+## Planning Document Ownership
 
 [ROADMAP.md](../../ROADMAP.md) is the only numbered implementation program of
 record. It remains planning-only and is not the durable contract or
@@ -30,8 +30,8 @@ Use this page for:
 
 Do not use this page for:
 
-- competing phase numbers
-- alternate phase labels
+- competing numbered planning labels
+- alternate planning labels
 - duplicate product-contract definitions
 - duplicate ontology, gap/review/shared-attachment, or persistence contracts
 
@@ -121,13 +121,14 @@ aligned and frozen.
 
 ### 2. Evidence And Claim Contract
 
-Land the bounded
+Keep the bounded
 [`EvidenceSet -> ClaimSet`](../reference/evidence-claim-contract.md) contract.
 
 Required posture:
 
 - `EvidenceSet` becomes authoritative for in-scope evidence selection
-- `ClaimSet` becomes authoritative for in-scope evidence-local meaning
+- `ClaimSet` is the remaining upstream authority slice for in-scope
+  evidence-local meaning
 - `translation_input_plan.json`, `EconomicActivityDraft`, and
   `SourceTranslationBatch` survive only as derived compatibility views
 - downstream bridge outputs remain on the live bridge path until the bounded
@@ -177,13 +178,13 @@ Rules:
 - do not let tax decide source meaning, reconciliation completeness, or
   checkpoint acceptance
 
-Later roadmap steps remain intentionally high-level here. They are out of
+Later planning-document steps remain intentionally high-level here. They are out of
 scope for the current contract delivery and do not block near-term
 implementation once the contract lock is satisfied.
 
 ### 6. Triggered Derived Read-Model Activation
 
-The roadmap may still plan later activation detail, but this page keeps the
+The planning document may still carry later activation detail, but this page keeps the
 durable rule: broader derived read models and projections stay deferred until
 an implemented capability-specific increment actually needs them.
 

--- a/docs/workspace/working/normalized/README.md
+++ b/docs/workspace/working/normalized/README.md
@@ -42,9 +42,14 @@ for current readers:
 - `translation_input_issues.csv`
 
 For planner-enabled Coinbase normalization, those files remain the current
-reader-facing compatibility layer. The authoritative `EvidenceSet` kernel and
-its product-local compatibility plan live under
-`working/products/evidence_sets/<evidence_set_id>/`.
+reader-facing compatibility layer. The authoritative `EvidenceSet` and
+`ClaimSet` kernels live under:
+
+- `working/products/evidence_sets/<evidence_set_id>/`
+- `working/products/claim_sets/<claim_set_id>/`
+
+For successful planner-enabled Coinbase runs, `normalization_summary.json`
+also records `claim_set_id` and `claim_set_ref`.
 
 ## Assembled Source Outputs
 

--- a/docs/workspace/working/products/README.md
+++ b/docs/workspace/working/products/README.md
@@ -18,6 +18,8 @@ Current implemented runtime surface:
   typed statement-observation scope in planner-enabled Coinbase normalization
 - `working/products/evidence_sets/<evidence_set_id>/compatibility/translation_input_plan.json`
   is the legacy planning view derived from that kernel
+- `working/products/claim_sets/` is reserved for the next bounded upstream
+  authority slice and is not emitted yet
 
 The normalized capture output under `working/normalized/captures/<capture_uid>/`
 may still mirror retained compatibility files for current readers, but the

--- a/docs/workspace/working/products/README.md
+++ b/docs/workspace/working/products/README.md
@@ -18,8 +18,15 @@ Current implemented runtime surface:
   typed statement-observation scope in planner-enabled Coinbase normalization
 - `working/products/evidence_sets/<evidence_set_id>/compatibility/translation_input_plan.json`
   is the legacy planning view derived from that kernel
-- `working/products/claim_sets/` is reserved for the next bounded upstream
-  authority slice and is not emitted yet
+- `working/products/claim_sets/<claim_set_id>/claim_set.json` is the
+  authoritative `ClaimSet` kernel for the bounded Coinbase evidence-local
+  meaning slice
+- `working/products/claim_sets/<claim_set_id>/assessment/gap/` and
+  `assessment/review/` store deterministic claim-stage gap and review sidecars,
+  even when those arrays are empty
+- `working/products/claim_sets/<claim_set_id>/compatibility/draft_projection_fields.json`
+  stores the retained bridge-only draft projection fields used to rebuild
+  `EconomicActivityDraft` and `SourceTranslationBatch`
 
 The normalized capture output under `working/normalized/captures/<capture_uid>/`
 may still mirror retained compatibility files for current readers, but the

--- a/repo_support/docs_audit/rules/policy_alignment.py
+++ b/repo_support/docs_audit/rules/policy_alignment.py
@@ -4,14 +4,69 @@ import re
 
 from repo_support.docs_audit.helpers import (
     architecture_doc_paths,
+    finding,
     joined,
     repo_text,
 )
+from repo_support.docs_audit.model import DocsAuditFinding, DocsAuditRule
 from repo_support.docs_audit.rules._common import build_rule
 from repo_support.paths import repo_root
 
+_ROADMAP_LINK_PATTERN = re.compile(r"`?ROADMAP\.md`?(?:\([^)]*\))?")
+_EPHEMERAL_DELIVERY_LABEL_PATTERN = re.compile(
+    r"\b(?:roadmap|phase(?:[ _-]?(?:\d+|zero|one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|sixteen|seventeen|eighteen|nineteen|twenty)))\b",
+    re.IGNORECASE,
+)
+_DURABLE_NON_PLANNING_SURFACE_PATHS = (
+    "CHANGELOG.md",
+    "docs/concepts/architecture-overview.md",
+    "docs/reference/evidence-claim-contract.md",
+    "docs/status/current-state.md",
+    "docs/status/migration-sequence.md",
+    "docs/workspace/working/products/README.md",
+)
+
+
+def _durable_non_planning_surface_texts() -> tuple[tuple[str, str], ...]:
+    return tuple(
+        (path, repo_text(path)) for path in _DURABLE_NON_PLANNING_SURFACE_PATHS
+    )
+
+
+def _masked_ephemeral_delivery_text(text: str) -> str:
+    return _ROADMAP_LINK_PATTERN.sub("", text)
+
+
+def _durable_non_planning_surface_findings() -> tuple[DocsAuditFinding, ...]:
+    findings: list[DocsAuditFinding] = []
+    rule_id = (
+        "policy_alignment."
+        "durable_non_planning_surfaces_do_not_use_ephemeral_delivery_labels"
+    )
+    for path, text in _durable_non_planning_surface_texts():
+        match = _EPHEMERAL_DELIVERY_LABEL_PATTERN.search(
+            _masked_ephemeral_delivery_text(text)
+        )
+        if match is None:
+            continue
+        findings.append(
+            finding(
+                rule_id,
+                path,
+                f"{path} uses forbidden roadmap/phase delivery labels: {match.group(0)}",
+            )
+        )
+    return tuple(findings)
+
 
 POLICY_ALIGNMENT_RULES = (
+    DocsAuditRule(
+        rule_id=(
+            "policy_alignment."
+            "durable_non_planning_surfaces_do_not_use_ephemeral_delivery_labels"
+        ),
+        run=_durable_non_planning_surface_findings,
+    ),
     build_rule(
         "policy_alignment.docs_do_not_reference_retired_service_or_model_buckets",
         "docs/standards/engineering.md",

--- a/src/tallylot/application/capture_paths.py
+++ b/src/tallylot/application/capture_paths.py
@@ -117,6 +117,68 @@ def evidence_set_ref(workspace_root: Path, evidence_set_id: str) -> str:
     )
 
 
+def claim_set_product_root(workspace_root: Path, claim_set_id: str) -> Path:
+    return workspace_root / "working" / "products" / "claim_sets" / claim_set_id
+
+
+def claim_set_product_file(workspace_root: Path, claim_set_id: str) -> Path:
+    return claim_set_product_root(workspace_root, claim_set_id) / "claim_set.json"
+
+
+def claim_set_gap_records_file(workspace_root: Path, claim_set_id: str) -> Path:
+    return (
+        claim_set_product_root(workspace_root, claim_set_id)
+        / "assessment"
+        / "gap"
+        / "gap_records.json"
+    )
+
+
+def claim_set_gap_explanations_file(workspace_root: Path, claim_set_id: str) -> Path:
+    return (
+        claim_set_product_root(workspace_root, claim_set_id)
+        / "assessment"
+        / "gap"
+        / "gap_explanations.json"
+    )
+
+
+def claim_set_review_records_file(workspace_root: Path, claim_set_id: str) -> Path:
+    return (
+        claim_set_product_root(workspace_root, claim_set_id)
+        / "assessment"
+        / "review"
+        / "review_records.json"
+    )
+
+
+def claim_set_review_explanations_file(workspace_root: Path, claim_set_id: str) -> Path:
+    return (
+        claim_set_product_root(workspace_root, claim_set_id)
+        / "assessment"
+        / "review"
+        / "review_explanations.json"
+    )
+
+
+def claim_set_compatibility_draft_projection_fields_file(
+    workspace_root: Path, claim_set_id: str
+) -> Path:
+    return (
+        claim_set_product_root(workspace_root, claim_set_id)
+        / "compatibility"
+        / "draft_projection_fields.json"
+    )
+
+
+def claim_set_ref(workspace_root: Path, claim_set_id: str) -> str:
+    return (
+        claim_set_product_file(workspace_root, claim_set_id)
+        .relative_to(workspace_root)
+        .as_posix()
+    )
+
+
 def default_capture_normalized_root(capture_root: Path) -> Path:
     context = require_capture_root(capture_root)
     return capture_normalized_root(

--- a/src/tallylot/application/claim/__init__.py
+++ b/src/tallylot/application/claim/__init__.py
@@ -1,0 +1,10 @@
+"""Claim-stage builders and contracts."""
+
+from .coinbase_builder import build_coinbase_claim_set
+from .contracts import CoinbaseClaimBuildResult, DraftProjectionFieldRecord
+
+__all__ = [
+    "CoinbaseClaimBuildResult",
+    "DraftProjectionFieldRecord",
+    "build_coinbase_claim_set",
+]

--- a/src/tallylot/application/claim/assessment.py
+++ b/src/tallylot/application/claim/assessment.py
@@ -1,0 +1,159 @@
+"""Claim-stage assessment mapping helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tallylot.domain.assessment import (
+    GapConfidence,
+    GapExplanation,
+    GapKind,
+    GapMateriality,
+    GapRecord,
+    GapStatus,
+    ReviewConfidence,
+    ReviewExplanation,
+    ReviewRecord,
+    ReviewStatus,
+)
+from tallylot.domain.claim import (
+    ClaimBundleDecisionBasis,
+    ClaimBundleDecisionOutcome,
+    ClaimBundleDecisionRecord,
+)
+from tallylot.domain.claim.models import (
+    stable_claim_bundle_decision_id,
+    stable_claim_scope_id,
+)
+from tallylot.domain.assessment.models import stable_gap_id, stable_review_id
+from tallylot.domain.issues import IssueRecord, NormalizationReviewRecord
+
+
+@dataclass(frozen=True)
+class ClaimIssueAssessment:
+    scope_id: str
+    bundle_decision: ClaimBundleDecisionRecord
+    gap_record: GapRecord
+    gap_explanation: GapExplanation
+    compatibility_issue: IssueRecord
+
+
+@dataclass(frozen=True)
+class ClaimReviewAssessment:
+    scope_id: str
+    review_record: ReviewRecord
+    review_explanation: ReviewExplanation
+    compatibility_review: NormalizationReviewRecord
+
+
+def map_claim_issue_to_scope(
+    *,
+    issue: IssueRecord,
+    claim_set_id: str,
+    retail_member_id: str,
+) -> ClaimIssueAssessment | None:
+    if issue.kind != "unsupported_row" or not issue.raw_row_ref:
+        return None
+    scope_id = stable_claim_scope_id(
+        claim_set_id=claim_set_id,
+        scope_key=(retail_member_id, issue.raw_row_ref),
+    )
+    gap_key = f"{issue.kind}:{issue.raw_row_ref}"
+    gap_record = GapRecord(
+        gap_id=stable_gap_id(
+            owner_stage="claim",
+            scope_kind="claim_scope",
+            scope_ref=scope_id,
+            gap_kind=GapKind.MANUAL_DECISION_REQUIRED,
+            gap_key=gap_key,
+        ),
+        owner_stage="claim",
+        blocking_stages=("claim", "economics"),
+        scope_kind="claim_scope",
+        scope_ref=scope_id,
+        subject_ref=None,
+        gap_kind=GapKind.MANUAL_DECISION_REQUIRED,
+        gap_key=gap_key,
+        status=GapStatus.OPEN,
+        materiality=GapMateriality.MATERIAL,
+        confidence=GapConfidence.HIGH,
+    )
+    return ClaimIssueAssessment(
+        scope_id=scope_id,
+        bundle_decision=ClaimBundleDecisionRecord(
+            claim_set_id=claim_set_id,
+            scope_id=scope_id,
+            decision_id=stable_claim_bundle_decision_id(scope_id=scope_id),
+            outcome=ClaimBundleDecisionOutcome.BLOCKED,
+            accepted_bundle_ref="",
+            rejected_bundle_refs=(),
+            deferred_bundle_refs=(),
+            basis=ClaimBundleDecisionBasis.UPSTREAM_GAP,
+            blocking_gap_refs=(gap_record.gap_id,),
+        ),
+        gap_record=gap_record,
+        gap_explanation=GapExplanation(
+            gap_id=gap_record.gap_id,
+            known_facts=(issue.message,),
+            missing_inputs=(),
+            possible_meanings=(),
+            required_evidence=(),
+            resolution_options=("model the unsupported retail row",),
+            next_action="review the unsupported retail row before continuing claim emission",
+            provenance_refs=(),
+        ),
+        compatibility_issue=issue,
+    )
+
+
+def map_claim_review_to_scope(
+    *,
+    review: NormalizationReviewRecord,
+    claim_set_id: str,
+    retail_member_id: str,
+) -> ClaimReviewAssessment | None:
+    if not review.raw_row_ref:
+        return None
+    scope_id = stable_claim_scope_id(
+        claim_set_id=claim_set_id,
+        scope_key=(retail_member_id, review.raw_row_ref),
+    )
+    review_key = (
+        f"{review.field_name}:{review.raw_row_ref}"
+        if review.field_name
+        else review.raw_row_ref
+    )
+    review_record = ReviewRecord(
+        review_id=stable_review_id(
+            owner_stage="claim",
+            scope_kind="claim_scope",
+            scope_ref=scope_id,
+            review_kind=review.kind,
+            review_key=review_key,
+        ),
+        owner_stage="claim",
+        scope_kind="claim_scope",
+        scope_ref=scope_id,
+        subject_ref=None,
+        review_kind=review.kind,
+        review_key=review_key,
+        status=ReviewStatus.OPEN,
+        confidence=ReviewConfidence.MEDIUM,
+        gap_ids=(),
+    )
+    return ClaimReviewAssessment(
+        scope_id=scope_id,
+        review_record=review_record,
+        review_explanation=ReviewExplanation(
+            review_id=review_record.review_id,
+            headline=review.message,
+            known_facts=tuple(
+                value
+                for value in (review.original_value, review.normalized_value)
+                if value
+            ),
+            follow_up=("review the advisory normalization note during claim emission",),
+            provenance_refs=(),
+        ),
+        compatibility_review=review,
+    )

--- a/src/tallylot/application/claim/assessment.py
+++ b/src/tallylot/application/claim/assessment.py
@@ -100,7 +100,7 @@ def map_claim_issue_to_scope(
             required_evidence=(),
             resolution_options=("model the unsupported retail row",),
             next_action="review the unsupported retail row before continuing claim emission",
-            provenance_refs=(),
+            provenance_refs=(retail_member_id,),
         ),
         compatibility_issue=issue,
     )
@@ -153,7 +153,7 @@ def map_claim_review_to_scope(
                 if value
             ),
             follow_up=("review the advisory normalization note during claim emission",),
-            provenance_refs=(),
+            provenance_refs=(retail_member_id,),
         ),
         compatibility_review=review,
     )

--- a/src/tallylot/application/claim/coinbase_builder.py
+++ b/src/tallylot/application/claim/coinbase_builder.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from tallylot.application.claim.assessment import (
     map_claim_issue_to_scope,
     map_claim_review_to_scope,
@@ -44,9 +46,11 @@ from tallylot.domain.evidence import (
 from tallylot.domain.issues import IssueRecord, NormalizationReviewRecord
 from tallylot.ports.source_profiles import SourceProfile
 from tallylot.ports.source_translation import SourceTranslationBatch
-from tallylot.application.normalization.translation_inputs.models import (
-    TranslationInputPlanningResult,
-)
+
+if TYPE_CHECKING:
+    from tallylot.application.normalization.translation_inputs.models import (
+        TranslationInputPlanningResult,
+    )
 
 
 def build_coinbase_claim_set(

--- a/src/tallylot/application/claim/coinbase_builder.py
+++ b/src/tallylot/application/claim/coinbase_builder.py
@@ -1,0 +1,207 @@
+"""Coinbase ClaimSet builder."""
+
+from __future__ import annotations
+
+from tallylot.application.claim.assessment import (
+    map_claim_issue_to_scope,
+    map_claim_review_to_scope,
+)
+from tallylot.application.claim.coinbase_retail import claims_for_draft
+from tallylot.application.claim.coinbase_statements import statement_scope_claims
+from tallylot.application.claim.contracts import (
+    CoinbaseClaimBuildResult,
+    DraftProjectionFieldRecord,
+)
+from tallylot.domain.assessment import (
+    GapExplanation,
+    GapRecord,
+    ReviewExplanation,
+    ReviewRecord,
+)
+from tallylot.domain.claim import (
+    ClaimBundleDecisionBasis,
+    ClaimBundleDecisionOutcome,
+    ClaimBundleDecisionRecord,
+    ClaimBundleRecord,
+    ClaimRecord,
+    ClaimSet,
+)
+from tallylot.domain.claim.models import (
+    canonical_claim_bundle_decision_records,
+    canonical_claim_bundle_records,
+    canonical_claim_records,
+    stable_claim_bundle_decision_id,
+    stable_claim_bundle_id,
+    stable_claim_scope_id,
+    stable_claim_set_id,
+)
+from tallylot.domain.evidence import (
+    EvidenceMemberKind,
+    EvidenceMemberRecord,
+    EvidenceMemberStatus,
+    EvidenceSet,
+)
+from tallylot.domain.issues import IssueRecord, NormalizationReviewRecord
+from tallylot.ports.source_profiles import SourceProfile
+from tallylot.ports.source_translation import SourceTranslationBatch
+from tallylot.application.normalization.translation_inputs.models import (
+    TranslationInputPlanningResult,
+)
+
+
+def build_coinbase_claim_set(
+    *,
+    profile: SourceProfile,
+    evidence_set: EvidenceSet | None,
+    evidence_set_ref: str,
+    planning_result: TranslationInputPlanningResult,
+    batch: SourceTranslationBatch,
+) -> CoinbaseClaimBuildResult | None:
+    if (
+        evidence_set is None
+        or planning_result.plan.blocked
+        or not _selected_retail_members(evidence_set)
+    ):
+        return None
+    emitter_id = f"{profile.source}:{profile.adapter_id}:claim"
+    claim_set_id = stable_claim_set_id(
+        evidence_set_id=evidence_set.evidence_set_id,
+        emitter_id=emitter_id,
+    )
+    claim_records: list[ClaimRecord] = []
+    bundle_records: list[ClaimBundleRecord] = []
+    decision_records: list[ClaimBundleDecisionRecord] = []
+    gap_records: list[GapRecord] = []
+    gap_explanations: list[GapExplanation] = []
+    review_records: list[ReviewRecord] = []
+    review_explanations: list[ReviewExplanation] = []
+    compatibility_issues: list[IssueRecord] = []
+    compatibility_reviews: list[NormalizationReviewRecord] = []
+    projection_fields: list[DraftProjectionFieldRecord] = []
+
+    retail_member_ids = _selected_retail_members(evidence_set)
+    retail_member_id_by_file = {
+        member.locator[0]: member.member_id for member in retail_member_ids
+    }
+    for draft_order, draft in enumerate(batch.drafts):
+        retail_member_id = retail_member_id_by_file.get(draft.raw_file)
+        if retail_member_id is None:
+            continue
+        scope_key = (retail_member_id, draft.raw_row_ref)
+        scope_id = stable_claim_scope_id(claim_set_id=claim_set_id, scope_key=scope_key)
+        bundle_id = stable_claim_bundle_id(scope_id=scope_id, key="default")
+        claims = claims_for_draft(
+            claim_set_id=claim_set_id,
+            scope_id=scope_id,
+            bundle_id=bundle_id,
+            scope_key=scope_key,
+            draft=draft,
+        )
+        claim_records.extend(claims)
+        bundle_records.append(
+            ClaimBundleRecord(
+                claim_set_id=claim_set_id,
+                scope_id=scope_id,
+                bundle_id=bundle_id,
+                key="default",
+                scope_key=scope_key,
+                claim_refs=tuple(claim.claim_id for claim in claims),
+            )
+        )
+        decision_records.append(
+            ClaimBundleDecisionRecord(
+                claim_set_id=claim_set_id,
+                scope_id=scope_id,
+                decision_id=stable_claim_bundle_decision_id(scope_id=scope_id),
+                outcome=ClaimBundleDecisionOutcome.ACCEPTED,
+                accepted_bundle_ref=bundle_id,
+                rejected_bundle_refs=(),
+                deferred_bundle_refs=(),
+                basis=ClaimBundleDecisionBasis.SINGLE_BUNDLE,
+                blocking_gap_refs=(),
+            )
+        )
+        projection_fields.append(
+            DraftProjectionFieldRecord(
+                claim_bundle_id=bundle_id,
+                economic_kind=draft.classification.economic_kind.value,
+                projection_hint=(
+                    ""
+                    if draft.classification.projection_hint is None
+                    else draft.classification.projection_hint.value
+                ),
+                accounting_intent_hint=draft.classification.accounting_intent_hint.value,
+                tax_treatment_hint=draft.classification.tax_treatment_hint.value,
+                description=draft.description,
+                tx_hash_or_null=draft.tx_hash,
+                operation_group_id_or_null=draft.operation_group_id,
+                confidence=draft.confidence,
+                status=draft.status,
+                draft_order=draft_order,
+            )
+        )
+    statement_claims, statement_bundles, statement_decisions = statement_scope_claims(
+        claim_set_id=claim_set_id,
+        evidence_set=evidence_set,
+    )
+    claim_records.extend(statement_claims)
+    bundle_records.extend(statement_bundles)
+    decision_records.extend(statement_decisions)
+
+    for issue in batch.issues:
+        mapping = map_claim_issue_to_scope(
+            issue=issue,
+            claim_set_id=claim_set_id,
+            retail_member_id=retail_member_id_by_file.get(issue.raw_file, ""),
+        )
+        if mapping is None:
+            continue
+        decision_records.append(mapping.bundle_decision)
+        gap_records.append(mapping.gap_record)
+        gap_explanations.append(mapping.gap_explanation)
+        compatibility_issues.append(mapping.compatibility_issue)
+    for review in batch.reviews:
+        review_mapping = map_claim_review_to_scope(
+            review=review,
+            claim_set_id=claim_set_id,
+            retail_member_id=retail_member_id_by_file.get(review.raw_file, ""),
+        )
+        if review_mapping is None:
+            continue
+        review_records.append(review_mapping.review_record)
+        review_explanations.append(review_mapping.review_explanation)
+        compatibility_reviews.append(review_mapping.compatibility_review)
+
+    claim_set = ClaimSet(
+        claim_set_id=claim_set_id,
+        evidence_set_ref=evidence_set_ref,
+        emitter_id=emitter_id,
+        claim_records=canonical_claim_records(tuple(claim_records)),
+        claim_bundle_records=canonical_claim_bundle_records(tuple(bundle_records)),
+        claim_bundle_decision_records=canonical_claim_bundle_decision_records(
+            tuple(decision_records)
+        ),
+    )
+    return CoinbaseClaimBuildResult(
+        claim_set=claim_set,
+        gap_records=tuple(gap_records),
+        gap_explanations=tuple(gap_explanations),
+        review_records=tuple(review_records),
+        review_explanations=tuple(review_explanations),
+        draft_projection_field_records=tuple(
+            sorted(projection_fields, key=lambda item: item.draft_order)
+        ),
+        compatibility_issue_records=tuple(compatibility_issues),
+        compatibility_review_records=tuple(compatibility_reviews),
+    )
+
+
+def _selected_retail_members(
+    evidence_set: EvidenceSet,
+) -> tuple[EvidenceMemberRecord, ...]:
+    return tuple(
+        member
+        for member in evidence_set.evidence_member_records
+        if member.kind is EvidenceMemberKind.RETAIL_ACTIVITY_EXPORT_FILE
+        and member.status is EvidenceMemberStatus.SELECTED
+    )

--- a/src/tallylot/application/claim/coinbase_builder.py
+++ b/src/tallylot/application/claim/coinbase_builder.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import PurePath
 from typing import TYPE_CHECKING
 
 from tallylot.application.claim.assessment import (
@@ -83,14 +84,13 @@ def build_coinbase_claim_set(
     compatibility_reviews: list[NormalizationReviewRecord] = []
     projection_fields: list[DraftProjectionFieldRecord] = []
 
-    retail_member_ids = _selected_retail_members(evidence_set)
-    retail_member_id_by_file = {
-        member.locator[0]: member.member_id for member in retail_member_ids
-    }
+    retail_member_id_by_raw_file = _selected_retail_member_ids_by_raw_file(evidence_set)
     for draft_order, draft in enumerate(batch.drafts):
-        retail_member_id = retail_member_id_by_file.get(draft.raw_file)
-        if retail_member_id is None:
-            continue
+        retail_member_id = _require_selected_retail_member_id(
+            retail_member_id_by_raw_file,
+            draft.raw_file,
+            label="draft",
+        )
         scope_key = (retail_member_id, draft.raw_row_ref)
         scope_id = stable_claim_scope_id(claim_set_id=claim_set_id, scope_key=scope_key)
         bundle_id = stable_claim_bundle_id(scope_id=scope_id, key="default")
@@ -153,25 +153,39 @@ def build_coinbase_claim_set(
     decision_records.extend(statement_decisions)
 
     for issue in batch.issues:
+        if issue.kind != "unsupported_row" or not issue.raw_row_ref:
+            continue
         mapping = map_claim_issue_to_scope(
             issue=issue,
             claim_set_id=claim_set_id,
-            retail_member_id=retail_member_id_by_file.get(issue.raw_file, ""),
+            retail_member_id=_require_selected_retail_member_id(
+                retail_member_id_by_raw_file,
+                issue.raw_file,
+                label="issue",
+            ),
         )
         if mapping is None:
-            continue
+            raise AssertionError(
+                "unsupported-row issue mapping unexpectedly returned None"
+            )
         decision_records.append(mapping.bundle_decision)
         gap_records.append(mapping.gap_record)
         gap_explanations.append(mapping.gap_explanation)
         compatibility_issues.append(mapping.compatibility_issue)
     for review in batch.reviews:
+        if not review.raw_row_ref:
+            continue
         review_mapping = map_claim_review_to_scope(
             review=review,
             claim_set_id=claim_set_id,
-            retail_member_id=retail_member_id_by_file.get(review.raw_file, ""),
+            retail_member_id=_require_selected_retail_member_id(
+                retail_member_id_by_raw_file,
+                review.raw_file,
+                label="review",
+            ),
         )
         if review_mapping is None:
-            continue
+            raise AssertionError("claim review mapping unexpectedly returned None")
         review_records.append(review_mapping.review_record)
         review_explanations.append(review_mapping.review_explanation)
         compatibility_reviews.append(review_mapping.compatibility_review)
@@ -209,3 +223,34 @@ def _selected_retail_members(
         if member.kind is EvidenceMemberKind.RETAIL_ACTIVITY_EXPORT_FILE
         and member.status is EvidenceMemberStatus.SELECTED
     )
+
+
+def _selected_retail_member_ids_by_raw_file(
+    evidence_set: EvidenceSet,
+) -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    for member in _selected_retail_members(evidence_set):
+        raw_file = PurePath(member.locator[0]).name
+        existing = mapping.get(raw_file)
+        if existing is not None and existing != member.member_id:
+            raise ValueError(
+                "claim builder found multiple selected retail members for "
+                f"raw_file {raw_file!r}"
+            )
+        mapping[raw_file] = member.member_id
+    return mapping
+
+
+def _require_selected_retail_member_id(
+    member_id_by_raw_file: dict[str, str],
+    raw_file: str,
+    *,
+    label: str,
+) -> str:
+    member_id = member_id_by_raw_file.get(raw_file)
+    if member_id is None:
+        raise ValueError(
+            f"claim builder could not map {label} raw_file {raw_file!r} "
+            "to the selected retail evidence member"
+        )
+    return member_id

--- a/src/tallylot/application/claim/coinbase_retail.py
+++ b/src/tallylot/application/claim/coinbase_retail.py
@@ -1,0 +1,176 @@
+"""Retail-draft claim builders for Coinbase."""
+
+from __future__ import annotations
+
+from tallylot.application.claim.constants import FILING_BENEFICIAL_OWNER_REF
+from tallylot.domain.claim import (
+    ClaimKind,
+    ClaimLegSpec,
+    ClaimRecord,
+    ClaimRecordStatus,
+)
+from tallylot.domain.claim.models import stable_claim_id
+from tallylot.domain.instruments import InstrumentKind
+from tallylot.domain.temporal import TemporalPrecision
+from tallylot.ports.source_translation import EconomicActivityDraft, EconomicLegDraft
+
+
+def claims_for_draft(
+    *,
+    claim_set_id: str,
+    scope_id: str,
+    bundle_id: str,
+    scope_key: tuple[str, ...],
+    draft: EconomicActivityDraft,
+) -> tuple[ClaimRecord, ...]:
+    location_claim_id = stable_claim_id(
+        bundle_id=bundle_id,
+        kind=ClaimKind.LOCATION,
+        key=(*scope_key, ClaimKind.LOCATION.value, "0"),
+    )
+    beneficial_owner_claim_id = stable_claim_id(
+        bundle_id=bundle_id,
+        kind=ClaimKind.BENEFICIAL_OWNER,
+        key=(*scope_key, ClaimKind.BENEFICIAL_OWNER.value, "0"),
+    )
+    instrument_claims: list[ClaimRecord] = []
+    instrument_claim_ids_by_leg_id: dict[str, str] = {}
+    instrument_claim_id_by_identity: dict[tuple[str, str, str, str, str], str] = {}
+    for leg in draft.legs:
+        identity = leg.instrument_identity_claims[0]
+        instrument_kind = (
+            identity.kind_hint.value
+            if identity.kind_hint is not InstrumentKind.UNKNOWN
+            else instrument_kind_for_symbol(identity.value).value
+        )
+        claim_name = identity.display_name or identity.value
+        identity_key = (
+            identity.scheme,
+            identity.value,
+            "" if identity.venue is None else identity.venue,
+            instrument_kind,
+            claim_name,
+        )
+        claim_id = instrument_claim_id_by_identity.get(identity_key)
+        if claim_id is None:
+            slot = str(len(instrument_claims))
+            claim_id = stable_claim_id(
+                bundle_id=bundle_id,
+                kind=ClaimKind.INSTRUMENT,
+                key=(*scope_key, ClaimKind.INSTRUMENT.value, slot),
+            )
+            instrument_claim_id_by_identity[identity_key] = claim_id
+            instrument_claims.append(
+                ClaimRecord(
+                    claim_set_id=claim_set_id,
+                    scope_id=scope_id,
+                    bundle_id=bundle_id,
+                    claim_id=claim_id,
+                    kind=ClaimKind.INSTRUMENT,
+                    status=ClaimRecordStatus.ASSERTED,
+                    key=(*scope_key, ClaimKind.INSTRUMENT.value, slot),
+                    member_refs=(scope_key[0],),
+                    observation_refs=(),
+                    effective_at=None,
+                    precision=None,
+                    provenance_refs=draft.provenance_refs,
+                    scheme=identity.scheme,
+                    value=identity.value,
+                    venue="" if identity.venue is None else identity.venue,
+                    instrument_kind=instrument_kind,
+                    name=claim_name,
+                )
+            )
+        instrument_claim_ids_by_leg_id[leg.leg_id] = claim_id
+    activity_claim = ClaimRecord(
+        claim_set_id=claim_set_id,
+        scope_id=scope_id,
+        bundle_id=bundle_id,
+        claim_id=stable_claim_id(
+            bundle_id=bundle_id,
+            kind=ClaimKind.ACTIVITY,
+            key=(*scope_key, ClaimKind.ACTIVITY.value, "0"),
+        ),
+        kind=ClaimKind.ACTIVITY,
+        status=ClaimRecordStatus.ASSERTED,
+        key=(*scope_key, ClaimKind.ACTIVITY.value, "0"),
+        member_refs=(scope_key[0],),
+        observation_refs=(),
+        effective_at=draft.effective_at or draft.timestamp,
+        precision=draft.effective_precision or TemporalPrecision.TIMESTAMP,
+        provenance_refs=draft.provenance_refs,
+        activity_label=activity_label(draft.provider_operation_key),
+        location_claim_ref=location_claim_id,
+        leg_specs=tuple(
+            ClaimLegSpec(
+                slot=index,
+                role=leg.leg_id,
+                quantity=leg.quantity,
+                instrument_claim_refs=(instrument_claim_ids_by_leg_id[leg.leg_id],),
+                location_claim_ref=location_claim_id,
+                subtype="" if leg.subtype is None else leg.subtype,
+                attributed_to_slot=attributed_slot(
+                    leg.attributed_to_leg_id, draft.legs
+                ),
+            )
+            for index, leg in enumerate(draft.legs)
+        ),
+    )
+    return (
+        activity_claim,
+        ClaimRecord(
+            claim_set_id=claim_set_id,
+            scope_id=scope_id,
+            bundle_id=bundle_id,
+            claim_id=beneficial_owner_claim_id,
+            kind=ClaimKind.BENEFICIAL_OWNER,
+            status=ClaimRecordStatus.ASSERTED,
+            key=(*scope_key, ClaimKind.BENEFICIAL_OWNER.value, "0"),
+            member_refs=(scope_key[0],),
+            observation_refs=(),
+            effective_at=None,
+            precision=None,
+            provenance_refs=draft.provenance_refs,
+            beneficial_owner_ref=FILING_BENEFICIAL_OWNER_REF,
+        ),
+        *instrument_claims,
+        ClaimRecord(
+            claim_set_id=claim_set_id,
+            scope_id=scope_id,
+            bundle_id=bundle_id,
+            claim_id=location_claim_id,
+            kind=ClaimKind.LOCATION,
+            status=ClaimRecordStatus.ASSERTED,
+            key=(*scope_key, ClaimKind.LOCATION.value, "0"),
+            member_refs=(scope_key[0],),
+            observation_refs=(),
+            effective_at=None,
+            precision=None,
+            provenance_refs=draft.provenance_refs,
+            location_ref=str(draft.location_id),
+            location_group_label="Coinbase",
+            location_label="Coinbase",
+        ),
+    )
+
+
+def activity_label(provider_operation_key: str) -> str:
+    return provider_operation_key.strip().lower().replace(" ", "_")
+
+
+def instrument_kind_for_symbol(symbol: str) -> InstrumentKind:
+    return (
+        InstrumentKind.FIAT
+        if symbol.strip().upper() in {"CAD", "USD"}
+        else InstrumentKind.CRYPTO
+    )
+
+
+def attributed_slot(
+    attributed_to_leg_id: str | None,
+    legs: tuple[EconomicLegDraft, ...],
+) -> int | None:
+    if attributed_to_leg_id is None:
+        return None
+    index_by_leg_id = {leg.leg_id: index for index, leg in enumerate(legs)}
+    return index_by_leg_id.get(attributed_to_leg_id)

--- a/src/tallylot/application/claim/coinbase_statements.py
+++ b/src/tallylot/application/claim/coinbase_statements.py
@@ -1,0 +1,213 @@
+"""Statement-derived claim builders for Coinbase."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from tallylot.application.claim.constants import FILING_BENEFICIAL_OWNER_REF
+from tallylot.domain.claim import (
+    ClaimBundleDecisionBasis,
+    ClaimBundleDecisionOutcome,
+    ClaimBundleDecisionRecord,
+    ClaimBundleRecord,
+    ClaimKind,
+    ClaimRecord,
+    ClaimRecordStatus,
+)
+from tallylot.domain.claim.models import (
+    canonical_claim_bundle_decision_records,
+    canonical_claim_bundle_records,
+    canonical_claim_records,
+    stable_claim_bundle_decision_id,
+    stable_claim_bundle_id,
+    stable_claim_id,
+    stable_claim_scope_id,
+)
+from tallylot.domain.evidence import (
+    EvidenceMemberKind,
+    EvidenceMemberStatus,
+    EvidenceObservationKind,
+    EvidenceSet,
+)
+
+from .coinbase_retail import instrument_kind_for_symbol
+
+
+def statement_scope_claims(
+    *,
+    claim_set_id: str,
+    evidence_set: EvidenceSet,
+) -> tuple[
+    tuple[ClaimRecord, ...],
+    tuple[ClaimBundleRecord, ...],
+    tuple[ClaimBundleDecisionRecord, ...],
+]:
+    claim_records: list[ClaimRecord] = []
+    bundle_records: list[ClaimBundleRecord] = []
+    decision_records: list[ClaimBundleDecisionRecord] = []
+    document_observation_id_by_member_id = {
+        observation.member_id: observation.observation_id
+        for observation in evidence_set.evidence_observation_records
+        if observation.kind is EvidenceObservationKind.STATEMENT_DOCUMENT
+    }
+    for member in evidence_set.evidence_member_records:
+        if (
+            member.kind is not EvidenceMemberKind.STATEMENT_DOCUMENT_FILE
+            or member.status is not EvidenceMemberStatus.SELECTED
+        ):
+            continue
+        row_observations = [
+            observation
+            for observation in evidence_set.evidence_observation_records
+            if observation.member_id == member.member_id
+            and observation.kind is EvidenceObservationKind.STATEMENT_BALANCE_ROW
+        ]
+        for observation in row_observations:
+            row_key = observation.key[-1]
+            scope_key = (member.member_id, row_key)
+            scope_id = stable_claim_scope_id(
+                claim_set_id=claim_set_id,
+                scope_key=scope_key,
+            )
+            bundle_id = stable_claim_bundle_id(scope_id=scope_id, key="default")
+            location_claim_id = stable_claim_id(
+                bundle_id=bundle_id,
+                kind=ClaimKind.LOCATION,
+                key=(*scope_key, ClaimKind.LOCATION.value, "0"),
+            )
+            instrument_claim_id = stable_claim_id(
+                bundle_id=bundle_id,
+                kind=ClaimKind.INSTRUMENT,
+                key=(*scope_key, ClaimKind.INSTRUMENT.value, "0"),
+            )
+            observation_refs = tuple(
+                ref
+                for ref in (
+                    observation.observation_id,
+                    document_observation_id_by_member_id.get(member.member_id, ""),
+                )
+                if ref
+            )
+            provenance_refs = observation_provenance_refs(observation.provenance_refs)
+            claims = (
+                ClaimRecord(
+                    claim_set_id=claim_set_id,
+                    scope_id=scope_id,
+                    bundle_id=bundle_id,
+                    claim_id=stable_claim_id(
+                        bundle_id=bundle_id,
+                        kind=ClaimKind.BALANCE,
+                        key=(*scope_key, ClaimKind.BALANCE.value, "0"),
+                    ),
+                    kind=ClaimKind.BALANCE,
+                    status=ClaimRecordStatus.ASSERTED,
+                    key=(*scope_key, ClaimKind.BALANCE.value, "0"),
+                    member_refs=(member.member_id,),
+                    observation_refs=observation_refs,
+                    effective_at=observation.observed_at,
+                    precision=observation.precision,
+                    provenance_refs=provenance_refs,
+                    location_claim_ref=location_claim_id,
+                    instrument_claim_refs=(instrument_claim_id,),
+                    balance_kind=observation.balance_kind,
+                    quantity=Decimal("0")
+                    if observation.quantity is None
+                    else observation.quantity,
+                    observed_at=observation.observed_at,
+                ),
+                ClaimRecord(
+                    claim_set_id=claim_set_id,
+                    scope_id=scope_id,
+                    bundle_id=bundle_id,
+                    claim_id=stable_claim_id(
+                        bundle_id=bundle_id,
+                        kind=ClaimKind.BENEFICIAL_OWNER,
+                        key=(*scope_key, ClaimKind.BENEFICIAL_OWNER.value, "0"),
+                    ),
+                    kind=ClaimKind.BENEFICIAL_OWNER,
+                    status=ClaimRecordStatus.ASSERTED,
+                    key=(*scope_key, ClaimKind.BENEFICIAL_OWNER.value, "0"),
+                    member_refs=(member.member_id,),
+                    observation_refs=observation_refs,
+                    effective_at=None,
+                    precision=None,
+                    provenance_refs=provenance_refs,
+                    beneficial_owner_ref=FILING_BENEFICIAL_OWNER_REF,
+                ),
+                ClaimRecord(
+                    claim_set_id=claim_set_id,
+                    scope_id=scope_id,
+                    bundle_id=bundle_id,
+                    claim_id=instrument_claim_id,
+                    kind=ClaimKind.INSTRUMENT,
+                    status=ClaimRecordStatus.ASSERTED,
+                    key=(*scope_key, ClaimKind.INSTRUMENT.value, "0"),
+                    member_refs=(member.member_id,),
+                    observation_refs=observation_refs,
+                    effective_at=None,
+                    precision=None,
+                    provenance_refs=provenance_refs,
+                    scheme="symbol",
+                    value=observation.instrument_symbol,
+                    venue="coinbase",
+                    instrument_kind=instrument_kind_for_symbol(
+                        observation.instrument_symbol
+                    ).value,
+                    name=observation.instrument_symbol,
+                ),
+                ClaimRecord(
+                    claim_set_id=claim_set_id,
+                    scope_id=scope_id,
+                    bundle_id=bundle_id,
+                    claim_id=location_claim_id,
+                    kind=ClaimKind.LOCATION,
+                    status=ClaimRecordStatus.ASSERTED,
+                    key=(*scope_key, ClaimKind.LOCATION.value, "0"),
+                    member_refs=(member.member_id,),
+                    observation_refs=observation_refs,
+                    effective_at=None,
+                    precision=None,
+                    provenance_refs=provenance_refs,
+                    location_ref=(
+                        f"coinbase:{observation.location_group_label}:"
+                        f"{observation.location_label}"
+                    ),
+                    location_group_label=observation.location_group_label,
+                    location_label=observation.location_label,
+                ),
+            )
+            claim_records.extend(claims)
+            bundle_records.append(
+                ClaimBundleRecord(
+                    claim_set_id=claim_set_id,
+                    scope_id=scope_id,
+                    bundle_id=bundle_id,
+                    key="default",
+                    scope_key=scope_key,
+                    claim_refs=tuple(claim.claim_id for claim in claims),
+                )
+            )
+            decision_records.append(
+                ClaimBundleDecisionRecord(
+                    claim_set_id=claim_set_id,
+                    scope_id=scope_id,
+                    decision_id=stable_claim_bundle_decision_id(scope_id=scope_id),
+                    outcome=ClaimBundleDecisionOutcome.ACCEPTED,
+                    accepted_bundle_ref=bundle_id,
+                    rejected_bundle_refs=(),
+                    deferred_bundle_refs=(),
+                    basis=ClaimBundleDecisionBasis.SINGLE_BUNDLE,
+                    blocking_gap_refs=(),
+                )
+            )
+    return (
+        canonical_claim_records(tuple(claim_records)),
+        canonical_claim_bundle_records(tuple(bundle_records)),
+        canonical_claim_bundle_decision_records(tuple(decision_records)),
+    )
+
+
+def observation_provenance_refs(
+    provenance_refs: tuple[tuple[str, ...], ...],
+) -> tuple[str, ...]:
+    return tuple(sorted(":".join(ref) for ref in provenance_refs))

--- a/src/tallylot/application/claim/constants.py
+++ b/src/tallylot/application/claim/constants.py
@@ -1,0 +1,3 @@
+"""Claim-stage constants."""
+
+FILING_BENEFICIAL_OWNER_REF = "filing:beneficial_owner:bounded-slice"

--- a/src/tallylot/application/claim/contracts.py
+++ b/src/tallylot/application/claim/contracts.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import cast
 
 from tallylot.domain.assessment import (
     GapExplanation,
@@ -42,6 +43,22 @@ class DraftProjectionFieldRecord:
             "status": self.status,
             "draft_order": self.draft_order,
         }
+
+    @classmethod
+    def from_payload(cls, payload: dict[str, object]) -> "DraftProjectionFieldRecord":
+        return cls(
+            claim_bundle_id=str(payload["claim_bundle_id"]),
+            economic_kind=str(payload["economic_kind"]),
+            projection_hint=str(payload["projection_hint"]),
+            accounting_intent_hint=str(payload["accounting_intent_hint"]),
+            tax_treatment_hint=str(payload["tax_treatment_hint"]),
+            description=str(payload["description"]),
+            tx_hash_or_null=str(payload["tx_hash_or_null"]),
+            operation_group_id_or_null=str(payload["operation_group_id_or_null"]),
+            confidence=str(payload["confidence"]),
+            status=str(payload["status"]),
+            draft_order=int(cast(int | str, payload["draft_order"])),
+        )
 
 
 @dataclass(frozen=True)

--- a/src/tallylot/application/claim/contracts.py
+++ b/src/tallylot/application/claim/contracts.py
@@ -1,0 +1,56 @@
+"""Claim-stage builder contracts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from tallylot.domain.assessment import (
+    GapExplanation,
+    GapRecord,
+    ReviewExplanation,
+    ReviewRecord,
+)
+from tallylot.domain.claim import ClaimSet
+from tallylot.domain.issues import IssueRecord, NormalizationReviewRecord
+
+
+@dataclass(frozen=True)
+class DraftProjectionFieldRecord:
+    claim_bundle_id: str
+    economic_kind: str
+    projection_hint: str
+    accounting_intent_hint: str
+    tax_treatment_hint: str
+    description: str
+    tx_hash_or_null: str
+    operation_group_id_or_null: str
+    confidence: str
+    status: str
+    draft_order: int
+
+    def to_payload(self) -> dict[str, object]:
+        return {
+            "claim_bundle_id": self.claim_bundle_id,
+            "economic_kind": self.economic_kind,
+            "projection_hint": self.projection_hint,
+            "accounting_intent_hint": self.accounting_intent_hint,
+            "tax_treatment_hint": self.tax_treatment_hint,
+            "description": self.description,
+            "tx_hash_or_null": self.tx_hash_or_null,
+            "operation_group_id_or_null": self.operation_group_id_or_null,
+            "confidence": self.confidence,
+            "status": self.status,
+            "draft_order": self.draft_order,
+        }
+
+
+@dataclass(frozen=True)
+class CoinbaseClaimBuildResult:
+    claim_set: ClaimSet
+    gap_records: tuple[GapRecord, ...]
+    gap_explanations: tuple[GapExplanation, ...]
+    review_records: tuple[ReviewRecord, ...]
+    review_explanations: tuple[ReviewExplanation, ...]
+    draft_projection_field_records: tuple[DraftProjectionFieldRecord, ...]
+    compatibility_issue_records: tuple[IssueRecord, ...]
+    compatibility_review_records: tuple[NormalizationReviewRecord, ...]

--- a/src/tallylot/application/compatibility/__init__.py
+++ b/src/tallylot/application/compatibility/__init__.py
@@ -4,8 +4,16 @@ from .translation_inputs import (
     build_translation_input_plan_payload,
     reconstruct_translation_input_plan,
 )
+from .claim_sets import (
+    ClaimSetCompatibilityArtifacts,
+    project_compatibility_artifacts_from_claim_set,
+    project_translation_batch_from_claim_set,
+)
 
 __all__ = [
+    "ClaimSetCompatibilityArtifacts",
     "build_translation_input_plan_payload",
+    "project_compatibility_artifacts_from_claim_set",
+    "project_translation_batch_from_claim_set",
     "reconstruct_translation_input_plan",
 ]

--- a/src/tallylot/application/compatibility/claim_sets.py
+++ b/src/tallylot/application/compatibility/claim_sets.py
@@ -1,0 +1,310 @@
+"""ClaimSet compatibility projection helpers."""
+
+# pylint: disable=too-many-arguments
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+
+from tallylot.adapters.support.drafts import economic_leg, symbol_claim
+from tallylot.application.claim.contracts import DraftProjectionFieldRecord
+from tallylot.domain.assessment import (
+    GapExplanation,
+    GapRecord,
+    ReviewExplanation,
+    ReviewRecord,
+)
+from tallylot.domain.claim import (
+    ClaimKind,
+    ClaimRecord,
+    ClaimSet,
+)
+from tallylot.domain.evidence import EvidenceMemberKind, EvidenceSet
+from tallylot.domain.issues import IssueRecord, NormalizationReviewRecord
+from tallylot.domain.types import LocationId
+from tallylot.domain.transactions import (
+    AccountingIntentHint,
+    EconomicKind,
+    FactLegPolicy,
+    LegKind,
+    ProjectionHint,
+    SINGLE_PRIMARY_ACTIVITY_POLICY,
+    TaxTreatmentHint,
+    TWO_SIDED_PRIMARY_EXCHANGE_POLICY,
+    TWO_SIDED_PRIMARY_EXCHANGE_WITH_SINGLE_CHARGE_POLICY,
+)
+from tallylot.ports.source_translation import (
+    EconomicActivityDraft,
+    SourceTranslationBatch,
+    classification,
+)
+
+
+@dataclass(frozen=True)
+class ClaimSetCompatibilityArtifacts:
+    drafts: tuple[EconomicActivityDraft, ...]
+    issues: tuple[IssueRecord, ...]
+    reviews: tuple[NormalizationReviewRecord, ...]
+
+
+def project_translation_batch_from_claim_set(
+    *,
+    claim_set: ClaimSet,
+    evidence_set: EvidenceSet,
+    draft_projection_field_records: tuple[DraftProjectionFieldRecord, ...],
+    gap_records: tuple[GapRecord, ...],
+    gap_explanations: tuple[GapExplanation, ...],
+    review_records: tuple[ReviewRecord, ...],
+    review_explanations: tuple[ReviewExplanation, ...],
+) -> SourceTranslationBatch:
+    artifacts = project_compatibility_artifacts_from_claim_set(
+        claim_set=claim_set,
+        evidence_set=evidence_set,
+        draft_projection_field_records=draft_projection_field_records,
+        gap_records=gap_records,
+        gap_explanations=gap_explanations,
+        review_records=review_records,
+        review_explanations=review_explanations,
+    )
+    return SourceTranslationBatch(
+        drafts=artifacts.drafts,
+        balance_references=(),
+        balance_reference_issues=(),
+        issues=artifacts.issues,
+        reviews=artifacts.reviews,
+        location_inventory=(),
+    )
+
+
+def project_compatibility_artifacts_from_claim_set(
+    *,
+    claim_set: ClaimSet,
+    evidence_set: EvidenceSet,
+    draft_projection_field_records: tuple[DraftProjectionFieldRecord, ...],
+    gap_records: tuple[GapRecord, ...],
+    gap_explanations: tuple[GapExplanation, ...],
+    review_records: tuple[ReviewRecord, ...],
+    review_explanations: tuple[ReviewExplanation, ...],
+) -> ClaimSetCompatibilityArtifacts:
+    drafts = tuple(
+        _draft_from_projection_record(
+            claim_set=claim_set,
+            evidence_set=evidence_set,
+            record=record,
+        )
+        for record in sorted(
+            draft_projection_field_records, key=lambda item: item.draft_order
+        )
+    )
+    return ClaimSetCompatibilityArtifacts(
+        drafts=drafts,
+        issues=_issues_from_claim_assessment(
+            evidence_set=evidence_set,
+            gap_records=gap_records,
+            gap_explanations=gap_explanations,
+        ),
+        reviews=_reviews_from_claim_assessment(
+            evidence_set=evidence_set,
+            review_records=review_records,
+            review_explanations=review_explanations,
+        ),
+    )
+
+
+def _draft_from_projection_record(
+    *,
+    claim_set: ClaimSet,
+    evidence_set: EvidenceSet,
+    record: DraftProjectionFieldRecord,
+) -> EconomicActivityDraft:
+    bundle_claims = [
+        claim
+        for claim in claim_set.claim_records
+        if claim.bundle_id == record.claim_bundle_id
+    ]
+    activity_claim = next(
+        claim for claim in bundle_claims if claim.kind is ClaimKind.ACTIVITY
+    )
+    location_claim = next(
+        claim for claim in bundle_claims if claim.kind is ClaimKind.LOCATION
+    )
+    instrument_claim_by_id = {
+        claim.claim_id: claim
+        for claim in bundle_claims
+        if claim.kind is ClaimKind.INSTRUMENT
+    }
+    raw_file = _raw_file_for_member_id(evidence_set, activity_claim.member_refs[0])
+    raw_row_ref = activity_claim.key[1]
+    legs = tuple(
+        economic_leg(
+            leg_id=spec.role,
+            kind=LegKind.CHARGE if spec.role == "fee" else LegKind.PRIMARY,
+            quantity=spec.quantity,
+            instrument=symbol_claim(
+                instrument_claim_by_id[spec.instrument_claim_refs[0]].value,
+                venue=instrument_claim_by_id[spec.instrument_claim_refs[0]].venue,
+            ),
+            subtype=spec.subtype or None,
+            attributed_to_leg_id=(
+                None
+                if spec.attributed_to_slot is None
+                else activity_claim.leg_specs[spec.attributed_to_slot].role
+            ),
+        )
+        for spec in activity_claim.leg_specs
+    )
+    return EconomicActivityDraft(
+        activity_id=_activity_id(activity_claim.activity_label, raw_row_ref),
+        source=_source_slug_from_claim_set_id(claim_set.claim_set_id),
+        adapter_id="coinbase",
+        timestamp=_activity_timestamp(activity_claim),
+        location_id=LocationId(location_claim.location_ref),
+        classification=classification(
+            economic_kind=EconomicKind(record.economic_kind),
+            projection_hint=(
+                None
+                if record.projection_hint == ""
+                else ProjectionHint(record.projection_hint)
+            ),
+            accounting_intent_hint=AccountingIntentHint(record.accounting_intent_hint),
+            tax_treatment_hint=TaxTreatmentHint(record.tax_treatment_hint),
+        ),
+        legs=legs,
+        leg_policy=_leg_policy_for_activity(activity_claim.activity_label),
+        description=record.description,
+        raw_file=raw_file,
+        raw_row_ref=raw_row_ref,
+        tx_hash=record.tx_hash_or_null,
+        provider_operation_key=_provider_operation_key(activity_claim.activity_label),
+        operation_group_id=record.operation_group_id_or_null,
+        provenance_refs=activity_claim.provenance_refs,
+        confidence=record.confidence,
+        status=record.status,
+    )
+
+
+def _issues_from_claim_assessment(
+    *,
+    evidence_set: EvidenceSet,
+    gap_records: tuple[GapRecord, ...],
+    gap_explanations: tuple[GapExplanation, ...],
+) -> tuple[IssueRecord, ...]:
+    explanation_by_gap_id = {item.gap_id: item for item in gap_explanations}
+    issues: list[IssueRecord] = []
+    for gap in gap_records:
+        if gap.gap_key.startswith("unsupported_row:") is False:
+            continue
+        explanation = explanation_by_gap_id.get(gap.gap_id)
+        member_id = (
+            ""
+            if explanation is None or not explanation.provenance_refs
+            else explanation.provenance_refs[0]
+        )
+        raw_row_ref = gap.gap_key.split(":", 1)[1]
+        issues.append(
+            IssueRecord(
+                issue_id=f"claim:{gap.gap_id}",
+                source="coinbase",
+                adapter_id="coinbase",
+                severity="high",
+                kind="unsupported_row",
+                message=""
+                if explanation is None or not explanation.known_facts
+                else explanation.known_facts[0],
+                raw_file=_raw_file_for_member_id(evidence_set, member_id),
+                raw_row_ref=raw_row_ref,
+            )
+        )
+    return tuple(issues)
+
+
+def _reviews_from_claim_assessment(
+    *,
+    evidence_set: EvidenceSet,
+    review_records: tuple[ReviewRecord, ...],
+    review_explanations: tuple[ReviewExplanation, ...],
+) -> tuple[NormalizationReviewRecord, ...]:
+    explanation_by_review_id = {item.review_id: item for item in review_explanations}
+    reviews: list[NormalizationReviewRecord] = []
+    for review in review_records:
+        explanation = explanation_by_review_id.get(review.review_id)
+        member_id = (
+            ""
+            if explanation is None or not explanation.provenance_refs
+            else explanation.provenance_refs[0]
+        )
+        reviews.append(
+            NormalizationReviewRecord(
+                review_id=review.review_id,
+                source="coinbase",
+                adapter_id="coinbase",
+                scope="claim_scope",
+                kind=review.review_kind,
+                message="" if explanation is None else explanation.headline,
+                raw_file=_raw_file_for_member_id(evidence_set, member_id),
+                raw_row_ref=review.review_key.split(":", 1)[-1],
+                field_name=(
+                    ""
+                    if ":" not in review.review_key
+                    else review.review_key.split(":", 1)[0]
+                ),
+                original_value=(
+                    ""
+                    if explanation is None or not explanation.known_facts
+                    else explanation.known_facts[0]
+                ),
+                normalized_value=(
+                    ""
+                    if explanation is None or len(explanation.known_facts) < 2
+                    else explanation.known_facts[1]
+                ),
+            )
+        )
+    return tuple(reviews)
+
+
+def _raw_file_for_member_id(evidence_set: EvidenceSet, member_id: str) -> str:
+    for member in evidence_set.evidence_member_records:
+        if (
+            member.member_id == member_id
+            and member.kind is EvidenceMemberKind.RETAIL_ACTIVITY_EXPORT_FILE
+        ):
+            return member.locator[0]
+    return ""
+
+
+def _source_slug_from_claim_set_id(claim_set_id: str) -> str:
+    return claim_set_id.split(":", 1)[0]
+
+
+def _provider_operation_key(activity_label: str) -> str:
+    if activity_label == "reward_income":
+        return "reward income"
+    return activity_label
+
+
+def _activity_id(activity_label: str, raw_row_ref: str) -> str:
+    if activity_label == "asset_migration":
+        sold_id, bought_id = raw_row_ref.split("|", 1)
+        return f"coinbase-asset-migration-{sold_id}-{bought_id}"
+    return f"coinbase-retail-{raw_row_ref}"
+
+
+def _leg_policy_for_activity(activity_label: str) -> "FactLegPolicy":
+    policy: FactLegPolicy
+    if activity_label in {"buy", "sell"}:
+        policy = TWO_SIDED_PRIMARY_EXCHANGE_WITH_SINGLE_CHARGE_POLICY
+    elif activity_label == "asset_migration":
+        policy = TWO_SIDED_PRIMARY_EXCHANGE_POLICY
+    else:
+        policy = SINGLE_PRIMARY_ACTIVITY_POLICY
+    return policy
+
+
+def _activity_timestamp(activity_claim: ClaimRecord) -> datetime:
+    if activity_claim.effective_at is None:
+        raise ValueError(
+            "activity claims must retain effective_at for compatibility projection"
+        )
+    return activity_claim.effective_at

--- a/src/tallylot/application/compatibility/claim_sets.py
+++ b/src/tallylot/application/compatibility/claim_sets.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
+from pathlib import PurePath
 
 from tallylot.adapters.support.drafts import economic_leg, symbol_claim
 from tallylot.application.claim.contracts import DraftProjectionFieldRecord
@@ -57,6 +58,8 @@ def project_translation_batch_from_claim_set(
     gap_explanations: tuple[GapExplanation, ...],
     review_records: tuple[ReviewRecord, ...],
     review_explanations: tuple[ReviewExplanation, ...],
+    compatibility_issue_records: tuple[IssueRecord, ...] | None = None,
+    compatibility_review_records: tuple[NormalizationReviewRecord, ...] | None = None,
 ) -> SourceTranslationBatch:
     artifacts = project_compatibility_artifacts_from_claim_set(
         claim_set=claim_set,
@@ -66,6 +69,8 @@ def project_translation_batch_from_claim_set(
         gap_explanations=gap_explanations,
         review_records=review_records,
         review_explanations=review_explanations,
+        compatibility_issue_records=compatibility_issue_records,
+        compatibility_review_records=compatibility_review_records,
     )
     return SourceTranslationBatch(
         drafts=artifacts.drafts,
@@ -86,6 +91,8 @@ def project_compatibility_artifacts_from_claim_set(
     gap_explanations: tuple[GapExplanation, ...],
     review_records: tuple[ReviewRecord, ...],
     review_explanations: tuple[ReviewExplanation, ...],
+    compatibility_issue_records: tuple[IssueRecord, ...] | None = None,
+    compatibility_review_records: tuple[NormalizationReviewRecord, ...] | None = None,
 ) -> ClaimSetCompatibilityArtifacts:
     drafts = tuple(
         _draft_from_projection_record(
@@ -99,15 +106,23 @@ def project_compatibility_artifacts_from_claim_set(
     )
     return ClaimSetCompatibilityArtifacts(
         drafts=drafts,
-        issues=_issues_from_claim_assessment(
-            evidence_set=evidence_set,
-            gap_records=gap_records,
-            gap_explanations=gap_explanations,
+        issues=(
+            compatibility_issue_records
+            if compatibility_issue_records is not None
+            else _issues_from_claim_assessment(
+                evidence_set=evidence_set,
+                gap_records=gap_records,
+                gap_explanations=gap_explanations,
+            )
         ),
-        reviews=_reviews_from_claim_assessment(
-            evidence_set=evidence_set,
-            review_records=review_records,
-            review_explanations=review_explanations,
+        reviews=(
+            compatibility_review_records
+            if compatibility_review_records is not None
+            else _reviews_from_claim_assessment(
+                evidence_set=evidence_set,
+                review_records=review_records,
+                review_explanations=review_explanations,
+            )
         ),
     )
 
@@ -156,7 +171,7 @@ def _draft_from_projection_record(
     )
     return EconomicActivityDraft(
         activity_id=_activity_id(activity_claim.activity_label, raw_row_ref),
-        source=_source_slug_from_claim_set_id(claim_set.claim_set_id),
+        source=_source_slug_for_member_id(evidence_set, activity_claim.member_refs[0]),
         adapter_id="coinbase",
         timestamp=_activity_timestamp(activity_claim),
         location_id=LocationId(location_claim.location_ref),
@@ -265,17 +280,29 @@ def _reviews_from_claim_assessment(
 
 
 def _raw_file_for_member_id(evidence_set: EvidenceSet, member_id: str) -> str:
+    if member_id == "":
+        return ""
     for member in evidence_set.evidence_member_records:
         if (
             member.member_id == member_id
             and member.kind is EvidenceMemberKind.RETAIL_ACTIVITY_EXPORT_FILE
         ):
-            return member.locator[0]
-    return ""
+            return PurePath(member.locator[0]).name
+    raise ValueError(
+        f"claim compatibility projection could not resolve member_id {member_id!r}"
+    )
 
 
-def _source_slug_from_claim_set_id(claim_set_id: str) -> str:
-    return claim_set_id.split(":", 1)[0]
+def _source_slug_for_member_id(evidence_set: EvidenceSet, member_id: str) -> str:
+    for member in evidence_set.evidence_member_records:
+        if (
+            member.member_id == member_id
+            and member.kind is EvidenceMemberKind.RETAIL_ACTIVITY_EXPORT_FILE
+        ):
+            return member.source_slug
+    raise ValueError(
+        f"claim compatibility projection could not resolve member_id {member_id!r}"
+    )
 
 
 def _provider_operation_key(activity_label: str) -> str:

--- a/src/tallylot/application/normalization/contracts.py
+++ b/src/tallylot/application/normalization/contracts.py
@@ -23,6 +23,8 @@ class NormalizeResponse:
     adapter_id: str
     evidence_set_id: str
     evidence_set_ref: str
+    claim_set_id: str
+    claim_set_ref: str
     fact_count: int
     balance_count: int
     issue_count: int

--- a/src/tallylot/application/normalization/normalize_source.py
+++ b/src/tallylot/application/normalization/normalize_source.py
@@ -131,6 +131,7 @@ class NormalizeSourceUseCase:
                 artifacts=self._artifacts,
                 evidence=self._evidence,
                 evidence_sets=self._evidence_sets,
+                claim_sets=self._claim_sets,
                 statement_extraction=self._statement_extraction,
             ),
         )
@@ -229,6 +230,8 @@ class NormalizeSourceUseCase:
                 translation_metrics=translation_result.metrics,
                 evidence_set_id=translation_result.evidence_set_id,
                 evidence_set_ref=translation_result.evidence_set_ref,
+                claim_set_id=translation_result.claim_set_id,
+                claim_set_ref=translation_result.claim_set_ref,
             ),
         )
         append_capture_status_record(
@@ -248,6 +251,8 @@ class NormalizeSourceUseCase:
             adapter_id=str(profile.adapter_id),
             evidence_set_id=translation_result.evidence_set_id,
             evidence_set_ref=translation_result.evidence_set_ref,
+            claim_set_id=translation_result.claim_set_id,
+            claim_set_ref=translation_result.claim_set_ref,
             fact_count=len(facts),
             balance_count=len(balance_snapshots),
             issue_count=len(outputs.issues),

--- a/src/tallylot/application/normalization/normalize_source.py
+++ b/src/tallylot/application/normalization/normalize_source.py
@@ -36,6 +36,7 @@ from tallylot.domain.issues import IssueRecord
 from tallylot.ports.adapter_contracts import AdapterCapability
 from tallylot.ports.artifacts import ArtifactStorePort
 from tallylot.ports.captures import CaptureMetadata
+from tallylot.ports.claim_sets import ClaimSetRepositoryPort
 from tallylot.ports.evidence import EvidenceRepositoryPort, LocationInventoryRecord
 from tallylot.ports.evidence_sets import EvidenceSetRepositoryPort
 from tallylot.ports.facts import FactRepositoryPort
@@ -66,6 +67,7 @@ class NormalizationDependencies:
     facts: FactRepositoryPort
     evidence: EvidenceRepositoryPort
     evidence_sets: EvidenceSetRepositoryPort
+    claim_sets: ClaimSetRepositoryPort
     artifacts: ArtifactStorePort
     statement_extraction: StatementExtractionService | None = None
 
@@ -77,6 +79,7 @@ class NormalizeSourceUseCase:
         self._facts = dependencies.facts
         self._evidence = dependencies.evidence
         self._evidence_sets = dependencies.evidence_sets
+        self._claim_sets = dependencies.claim_sets
         self._artifacts = dependencies.artifacts
         self._statement_extraction = (
             dependencies.statement_extraction

--- a/src/tallylot/application/normalization/summary.py
+++ b/src/tallylot/application/normalization/summary.py
@@ -27,34 +27,37 @@ def build_normalization_summary(
     translation_metrics: NormalizationTranslationMetrics,
     evidence_set_id: str,
     evidence_set_ref: str,
+    claim_set_id: str,
+    claim_set_ref: str,
 ) -> JsonValue:  # pylint: disable=too-many-arguments
-    return cast(
-        JsonValue,
-        {
-            "source": request.source,
-            "adapter_id": str(profile.adapter_id),
-            "evidence_set_id": evidence_set_id,
-            "evidence_set_ref": evidence_set_ref,
-            "fact_count": len(outputs.facts),
-            "snapshot_count": len(outputs.balance_snapshots),
-            "reference_count": len(outputs.balance_references),
-            "reference_issue_count": len(outputs.balance_reference_issues),
-            "issue_count": len(outputs.issues),
-            "review_count": len(outputs.reviews),
-            "review_summary": _review_summary(outputs.reviews),
-            "location_count": len(outputs.location_inventory),
-            "facts_outside_normalization_window": window_stats.facts_outside_window,
-            "issues_outside_normalization_window": window_stats.issues_outside_window,
-            "reviews_outside_normalization_window": window_stats.reviews_outside_window,
-            "normalization_window_start": request.window_start or "",
-            "normalization_window_end": request.window_end or "",
-            "translation_candidate_count": translation_metrics.translation_candidate_count,
-            "translation_selected_count": translation_metrics.translation_selected_count,
-            "translation_superseded_count": translation_metrics.translation_superseded_count,
-            "translation_blocked_count": translation_metrics.translation_blocked_count,
-            "translation_planner_used": translation_metrics.translation_planner_used,
-        },
-    )
+    payload: dict[str, object] = {
+        "source": request.source,
+        "adapter_id": str(profile.adapter_id),
+        "evidence_set_id": evidence_set_id,
+        "evidence_set_ref": evidence_set_ref,
+        "fact_count": len(outputs.facts),
+        "snapshot_count": len(outputs.balance_snapshots),
+        "reference_count": len(outputs.balance_references),
+        "reference_issue_count": len(outputs.balance_reference_issues),
+        "issue_count": len(outputs.issues),
+        "review_count": len(outputs.reviews),
+        "review_summary": _review_summary(outputs.reviews),
+        "location_count": len(outputs.location_inventory),
+        "facts_outside_normalization_window": window_stats.facts_outside_window,
+        "issues_outside_normalization_window": window_stats.issues_outside_window,
+        "reviews_outside_normalization_window": window_stats.reviews_outside_window,
+        "normalization_window_start": request.window_start or "",
+        "normalization_window_end": request.window_end or "",
+        "translation_candidate_count": translation_metrics.translation_candidate_count,
+        "translation_selected_count": translation_metrics.translation_selected_count,
+        "translation_superseded_count": translation_metrics.translation_superseded_count,
+        "translation_blocked_count": translation_metrics.translation_blocked_count,
+        "translation_planner_used": translation_metrics.translation_planner_used,
+    }
+    if str(profile.adapter_id) == "coinbase":
+        payload["claim_set_id"] = claim_set_id
+        payload["claim_set_ref"] = claim_set_ref
+    return cast(JsonValue, payload)
 
 
 def _review_summary(

--- a/src/tallylot/application/normalization/translation.py
+++ b/src/tallylot/application/normalization/translation.py
@@ -4,16 +4,26 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import cast
 
 from tallylot.application.capture_paths import (
+    claim_set_compatibility_draft_projection_fields_file,
+    claim_set_gap_explanations_file,
+    claim_set_gap_records_file,
+    claim_set_product_file,
+    claim_set_ref,
+    claim_set_review_explanations_file,
+    claim_set_review_records_file,
     evidence_set_compatibility_plan_file,
     evidence_set_product_file,
     evidence_set_ref,
 )
 from tallylot.application.compatibility import (
     build_translation_input_plan_payload,
+    project_translation_batch_from_claim_set,
     reconstruct_translation_input_plan,
 )
+from tallylot.application.claim.coinbase_builder import build_coinbase_claim_set
 from tallylot.application.evidence.evidence_sets import build_evidence_set_for_profile
 from tallylot.application.evidence.statement_extraction import (
     StatementDocumentCollectionResult,
@@ -32,11 +42,13 @@ from tallylot.application.normalization.translation_inputs.artifacts import (
 from tallylot.ports.evidence_sets import EvidenceSetRepositoryPort
 from tallylot.ports.artifacts import ArtifactStorePort
 from tallylot.ports.captures import CaptureMetadata
+from tallylot.ports.claim_sets import ClaimSetRepositoryPort
 from tallylot.ports.evidence import EvidenceRepositoryPort
 from tallylot.ports.source_adapters import SourceAdapter
 from tallylot.ports.source_profiles import SourceProfile
 from tallylot.ports.source_translation import SourceTranslationBatch
 from tallylot.ports.translation_inputs import TranslationInputPlanningAdapter
+from tallylot.domain.types import JsonValue
 
 
 @dataclass(frozen=True)
@@ -46,6 +58,8 @@ class TranslationExecutionResult:
     statement_documents: StatementDocumentCollectionResult
     evidence_set_id: str = ""
     evidence_set_ref: str = ""
+    claim_set_id: str = ""
+    claim_set_ref: str = ""
 
 
 @dataclass(frozen=True)
@@ -56,6 +70,7 @@ class TranslationExecutionContext:
     artifacts: ArtifactStorePort
     evidence: EvidenceRepositoryPort
     evidence_sets: EvidenceSetRepositoryPort
+    claim_sets: ClaimSetRepositoryPort
     statement_extraction: StatementExtractionService
 
 
@@ -170,14 +185,75 @@ def execute_translation(
             f"{context.output_dir / 'translation_input_plan.json'} and "
             f"{context.output_dir / 'translation_input_issues.csv'}"
         )
+    selected_batch = adapter.translate_selected_inputs(
+        profile,
+        raw_dir,
+        execution_plan,
+    )
+    claim_set_id = ""
+    claim_set_path_ref = ""
+    if str(profile.adapter_id) == "coinbase" and evidence_set is not None:
+        claim_build = build_coinbase_claim_set(
+            profile=profile,
+            evidence_set=evidence_set,
+            evidence_set_ref=evidence_set_path_ref,
+            planning_result=planning_result,
+            batch=selected_batch,
+        )
+        if claim_build is not None:
+            claim_set_id = claim_build.claim_set.claim_set_id
+            claim_set_path = claim_set_product_file(
+                context.workspace_root, claim_set_id
+            )
+            context.claim_sets.write_claim_set(claim_set_path, claim_build.claim_set)
+            context.artifacts.write_json(
+                claim_set_gap_records_file(context.workspace_root, claim_set_id),
+                [record.to_payload() for record in claim_build.gap_records],
+            )
+            context.artifacts.write_json(
+                claim_set_gap_explanations_file(context.workspace_root, claim_set_id),
+                [record.to_payload() for record in claim_build.gap_explanations],
+            )
+            context.artifacts.write_json(
+                claim_set_review_records_file(context.workspace_root, claim_set_id),
+                [record.to_payload() for record in claim_build.review_records],
+            )
+            context.artifacts.write_json(
+                claim_set_review_explanations_file(
+                    context.workspace_root, claim_set_id
+                ),
+                [record.to_payload() for record in claim_build.review_explanations],
+            )
+            context.artifacts.write_json(
+                claim_set_compatibility_draft_projection_fields_file(
+                    context.workspace_root,
+                    claim_set_id,
+                ),
+                cast(
+                    JsonValue,
+                    [
+                        record.to_payload()
+                        for record in claim_build.draft_projection_field_records
+                    ],
+                ),
+            )
+            persisted_claim_set = context.claim_sets.read_claim_set(claim_set_path)
+            selected_batch = project_translation_batch_from_claim_set(
+                claim_set=persisted_claim_set,
+                evidence_set=evidence_set,
+                draft_projection_field_records=claim_build.draft_projection_field_records,
+                gap_records=claim_build.gap_records,
+                gap_explanations=claim_build.gap_explanations,
+                review_records=claim_build.review_records,
+                review_explanations=claim_build.review_explanations,
+            )
+            claim_set_path_ref = claim_set_ref(context.workspace_root, claim_set_id)
     return TranslationExecutionResult(
-        batch=adapter.translate_selected_inputs(
-            profile,
-            raw_dir,
-            execution_plan,
-        ),
+        batch=selected_batch,
         statement_documents=statement_documents,
         metrics=metrics,
         evidence_set_id=evidence_set_id,
         evidence_set_ref=evidence_set_path_ref,
+        claim_set_id=claim_set_id,
+        claim_set_ref=claim_set_path_ref,
     )

--- a/src/tallylot/application/normalization/translation.py
+++ b/src/tallylot/application/normalization/translation.py
@@ -23,6 +23,7 @@ from tallylot.application.compatibility import (
     project_translation_batch_from_claim_set,
     reconstruct_translation_input_plan,
 )
+from tallylot.application.claim.contracts import CoinbaseClaimBuildResult
 from tallylot.application.claim.coinbase_builder import build_coinbase_claim_set
 from tallylot.application.evidence.evidence_sets import build_evidence_set_for_profile
 from tallylot.application.evidence.statement_extraction import (
@@ -38,6 +39,12 @@ from tallylot.application.normalization.translation_inputs.artifacts import (
     TranslationArtifactContext,
     write_translation_input_candidates,
     write_translation_input_issues,
+)
+from tallylot.domain.assessment.models import (
+    gap_explanations_payload,
+    gap_records_payload,
+    review_explanations_payload,
+    review_records_payload,
 )
 from tallylot.ports.evidence_sets import EvidenceSetRepositoryPort
 from tallylot.ports.artifacts import ArtifactStorePort
@@ -206,23 +213,11 @@ def execute_translation(
                 context.workspace_root, claim_set_id
             )
             context.claim_sets.write_claim_set(claim_set_path, claim_build.claim_set)
-            context.artifacts.write_json(
-                claim_set_gap_records_file(context.workspace_root, claim_set_id),
-                [record.to_payload() for record in claim_build.gap_records],
-            )
-            context.artifacts.write_json(
-                claim_set_gap_explanations_file(context.workspace_root, claim_set_id),
-                [record.to_payload() for record in claim_build.gap_explanations],
-            )
-            context.artifacts.write_json(
-                claim_set_review_records_file(context.workspace_root, claim_set_id),
-                [record.to_payload() for record in claim_build.review_records],
-            )
-            context.artifacts.write_json(
-                claim_set_review_explanations_file(
-                    context.workspace_root, claim_set_id
-                ),
-                [record.to_payload() for record in claim_build.review_explanations],
+            _write_claim_assessment_sidecars(
+                artifacts=context.artifacts,
+                workspace_root=context.workspace_root,
+                claim_set_id=claim_set_id,
+                claim_build=claim_build,
             )
             context.artifacts.write_json(
                 claim_set_compatibility_draft_projection_fields_file(
@@ -258,4 +253,29 @@ def execute_translation(
         evidence_set_ref=evidence_set_path_ref,
         claim_set_id=claim_set_id,
         claim_set_ref=claim_set_path_ref,
+    )
+
+
+def _write_claim_assessment_sidecars(
+    *,
+    artifacts: ArtifactStorePort,
+    workspace_root: Path,
+    claim_set_id: str,
+    claim_build: CoinbaseClaimBuildResult,
+) -> None:
+    artifacts.write_json(
+        claim_set_gap_records_file(workspace_root, claim_set_id),
+        cast(JsonValue, gap_records_payload(claim_build.gap_records)),
+    )
+    artifacts.write_json(
+        claim_set_gap_explanations_file(workspace_root, claim_set_id),
+        cast(JsonValue, gap_explanations_payload(claim_build.gap_explanations)),
+    )
+    artifacts.write_json(
+        claim_set_review_records_file(workspace_root, claim_set_id),
+        cast(JsonValue, review_records_payload(claim_build.review_records)),
+    )
+    artifacts.write_json(
+        claim_set_review_explanations_file(workspace_root, claim_set_id),
+        cast(JsonValue, review_explanations_payload(claim_build.review_explanations)),
     )

--- a/src/tallylot/application/normalization/translation.py
+++ b/src/tallylot/application/normalization/translation.py
@@ -246,6 +246,8 @@ def execute_translation(
                 gap_explanations=claim_build.gap_explanations,
                 review_records=claim_build.review_records,
                 review_explanations=claim_build.review_explanations,
+                compatibility_issue_records=claim_build.compatibility_issue_records,
+                compatibility_review_records=claim_build.compatibility_review_records,
             )
             claim_set_path_ref = claim_set_ref(context.workspace_root, claim_set_id)
     return TranslationExecutionResult(

--- a/src/tallylot/domain/assessment/__init__.py
+++ b/src/tallylot/domain/assessment/__init__.py
@@ -1,0 +1,29 @@
+"""Assessment sidecar models."""
+
+from .models import (
+    ASSESSMENT_SCHEMA_VERSION,
+    GapConfidence,
+    GapExplanation,
+    GapKind,
+    GapMateriality,
+    GapRecord,
+    GapStatus,
+    ReviewConfidence,
+    ReviewExplanation,
+    ReviewRecord,
+    ReviewStatus,
+)
+
+__all__ = [
+    "ASSESSMENT_SCHEMA_VERSION",
+    "GapConfidence",
+    "GapExplanation",
+    "GapKind",
+    "GapMateriality",
+    "GapRecord",
+    "GapStatus",
+    "ReviewConfidence",
+    "ReviewExplanation",
+    "ReviewRecord",
+    "ReviewStatus",
+]

--- a/src/tallylot/domain/assessment/models.py
+++ b/src/tallylot/domain/assessment/models.py
@@ -1,0 +1,258 @@
+"""Assessment sidecar models and payload helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+from tallylot.domain.types import JsonValue
+
+ASSESSMENT_SCHEMA_VERSION = 1
+_STAGE_ORDER = {
+    "claim": 0,
+    "economics": 1,
+    "reconciliation": 2,
+    "checkpoint": 3,
+    "journal": 4,
+    "tax": 5,
+}
+
+
+class GapKind(StrEnum):
+    MISSING_EVIDENCE = "missing_evidence"
+    UNRESOLVED_IDENTITY = "unresolved_identity"
+    UNRESOLVED_LINKAGE = "unresolved_linkage"
+    CONTRADICTION = "contradiction"
+    POLICY_DECISION_REQUIRED = "policy_decision_required"
+    MANUAL_DECISION_REQUIRED = "manual_decision_required"
+
+
+class GapStatus(StrEnum):
+    OPEN = "open"
+    RESOLVED = "resolved"
+    SUPERSEDED = "superseded"
+
+
+class GapMateriality(StrEnum):
+    MATERIAL = "material"
+    SUPPORTING = "supporting"
+    INFORMATIONAL = "informational"
+
+
+class GapConfidence(StrEnum):
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+class ReviewStatus(StrEnum):
+    OPEN = "open"
+    ACKNOWLEDGED = "acknowledged"
+    RESOLVED = "resolved"
+    SUPERSEDED = "superseded"
+
+
+class ReviewConfidence(StrEnum):
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+def _stage_sort_key(stage: str) -> tuple[int, str]:
+    return (_STAGE_ORDER.get(stage, len(_STAGE_ORDER)), stage)
+
+
+@dataclass(frozen=True)
+class GapRecord:
+    gap_id: str
+    owner_stage: str
+    blocking_stages: tuple[str, ...]
+    scope_kind: str
+    scope_ref: str | None
+    subject_ref: tuple[str, ...] | None
+    gap_kind: GapKind
+    gap_key: str
+    status: GapStatus
+    materiality: GapMateriality
+    confidence: GapConfidence
+
+    def __post_init__(self) -> None:
+        if self.scope_kind != "claim_scope":
+            raise ValueError("this slice supports only scope_kind='claim_scope'")
+        if self.subject_ref is not None:
+            raise ValueError("this slice requires subject_ref=None")
+
+    def to_payload(self) -> dict[str, JsonValue]:
+        return {
+            "gap_id": self.gap_id,
+            "owner_stage": self.owner_stage,
+            "blocking_stages": list(
+                stage for stage in sorted(self.blocking_stages, key=_stage_sort_key)
+            ),
+            "scope_kind": self.scope_kind,
+            "scope_ref": self.scope_ref,
+            "subject_ref": None,
+            "gap_kind": self.gap_kind.value,
+            "gap_key": self.gap_key,
+            "status": self.status.value,
+            "materiality": self.materiality.value,
+            "confidence": self.confidence.value,
+        }
+
+
+@dataclass(frozen=True)
+class GapExplanation:
+    gap_id: str
+    known_facts: tuple[str, ...]
+    missing_inputs: tuple[str, ...]
+    possible_meanings: tuple[str, ...]
+    required_evidence: tuple[str, ...]
+    resolution_options: tuple[str, ...]
+    next_action: str
+    provenance_refs: tuple[str, ...]
+
+    def to_payload(self) -> dict[str, JsonValue]:
+        return {
+            "gap_id": self.gap_id,
+            "known_facts": list(self.known_facts),
+            "missing_inputs": list(self.missing_inputs),
+            "possible_meanings": list(self.possible_meanings),
+            "required_evidence": list(self.required_evidence),
+            "resolution_options": list(self.resolution_options),
+            "next_action": self.next_action,
+            "provenance_refs": list(sorted(self.provenance_refs)),
+        }
+
+
+@dataclass(frozen=True)
+class ReviewRecord:
+    review_id: str
+    owner_stage: str
+    scope_kind: str
+    scope_ref: str | None
+    subject_ref: tuple[str, ...] | None
+    review_kind: str
+    review_key: str
+    status: ReviewStatus
+    confidence: ReviewConfidence
+    gap_ids: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if self.scope_kind != "claim_scope":
+            raise ValueError("this slice supports only scope_kind='claim_scope'")
+        if self.subject_ref is not None:
+            raise ValueError("this slice requires subject_ref=None")
+
+    def to_payload(self) -> dict[str, JsonValue]:
+        return {
+            "review_id": self.review_id,
+            "owner_stage": self.owner_stage,
+            "scope_kind": self.scope_kind,
+            "scope_ref": self.scope_ref,
+            "subject_ref": None,
+            "review_kind": self.review_kind,
+            "review_key": self.review_key,
+            "status": self.status.value,
+            "confidence": self.confidence.value,
+            "gap_ids": list(sorted(self.gap_ids)),
+        }
+
+
+@dataclass(frozen=True)
+class ReviewExplanation:
+    review_id: str
+    headline: str
+    known_facts: tuple[str, ...]
+    follow_up: tuple[str, ...]
+    provenance_refs: tuple[str, ...]
+
+    def to_payload(self) -> dict[str, JsonValue]:
+        return {
+            "review_id": self.review_id,
+            "headline": self.headline,
+            "known_facts": list(self.known_facts),
+            "follow_up": list(self.follow_up),
+            "provenance_refs": list(sorted(self.provenance_refs)),
+        }
+
+
+def stable_gap_id(
+    *,
+    owner_stage: str,
+    scope_kind: str,
+    scope_ref: str,
+    gap_kind: GapKind,
+    gap_key: str,
+) -> str:
+    return ":".join((owner_stage, scope_kind, scope_ref, gap_kind.value, gap_key))
+
+
+def stable_review_id(
+    *,
+    owner_stage: str,
+    scope_kind: str,
+    scope_ref: str,
+    review_kind: str,
+    review_key: str,
+) -> str:
+    return ":".join((owner_stage, scope_kind, scope_ref, review_kind, review_key))
+
+
+def canonical_gap_records(records: tuple[GapRecord, ...]) -> tuple[GapRecord, ...]:
+    return tuple(
+        sorted(
+            records,
+            key=lambda item: (
+                item.owner_stage,
+                item.scope_kind,
+                item.subject_ref or (),
+                item.scope_ref or "",
+                item.gap_kind.value,
+                item.gap_id,
+            ),
+        )
+    )
+
+
+def canonical_review_records(
+    records: tuple[ReviewRecord, ...],
+) -> tuple[ReviewRecord, ...]:
+    return tuple(
+        sorted(
+            records,
+            key=lambda item: (
+                item.owner_stage,
+                item.scope_kind,
+                item.subject_ref or (),
+                item.scope_ref or "",
+                item.review_kind,
+                item.review_id,
+            ),
+        )
+    )
+
+
+def gap_records_payload(records: tuple[GapRecord, ...]) -> list[JsonValue]:
+    return [record.to_payload() for record in canonical_gap_records(records)]
+
+
+def gap_explanations_payload(
+    explanations: tuple[GapExplanation, ...],
+) -> list[JsonValue]:
+    return [
+        explanation.to_payload()
+        for explanation in sorted(explanations, key=lambda item: item.gap_id)
+    ]
+
+
+def review_records_payload(records: tuple[ReviewRecord, ...]) -> list[JsonValue]:
+    return [record.to_payload() for record in canonical_review_records(records)]
+
+
+def review_explanations_payload(
+    explanations: tuple[ReviewExplanation, ...],
+) -> list[JsonValue]:
+    return [
+        explanation.to_payload()
+        for explanation in sorted(explanations, key=lambda item: item.review_id)
+    ]

--- a/src/tallylot/domain/assessment/models.py
+++ b/src/tallylot/domain/assessment/models.py
@@ -79,6 +79,8 @@ class GapRecord:
     def __post_init__(self) -> None:
         if self.scope_kind != "claim_scope":
             raise ValueError("this slice supports only scope_kind='claim_scope'")
+        if not self.scope_ref:
+            raise ValueError("claim_scope gap records require scope_ref")
         if self.subject_ref is not None:
             raise ValueError("this slice requires subject_ref=None")
 
@@ -140,6 +142,8 @@ class ReviewRecord:
     def __post_init__(self) -> None:
         if self.scope_kind != "claim_scope":
             raise ValueError("this slice supports only scope_kind='claim_scope'")
+        if not self.scope_ref:
+            raise ValueError("claim_scope review records require scope_ref")
         if self.subject_ref is not None:
             raise ValueError("this slice requires subject_ref=None")
 

--- a/src/tallylot/domain/claim/__init__.py
+++ b/src/tallylot/domain/claim/__init__.py
@@ -1,0 +1,27 @@
+"""Claim product models."""
+
+from .models import (
+    CLAIM_SET_SCHEMA_VERSION,
+    ClaimBundleDecisionBasis,
+    ClaimBundleDecisionOutcome,
+    ClaimBundleDecisionRecord,
+    ClaimBundleRecord,
+    ClaimKind,
+    ClaimLegSpec,
+    ClaimRecord,
+    ClaimRecordStatus,
+    ClaimSet,
+)
+
+__all__ = [
+    "CLAIM_SET_SCHEMA_VERSION",
+    "ClaimBundleDecisionBasis",
+    "ClaimBundleDecisionOutcome",
+    "ClaimBundleDecisionRecord",
+    "ClaimBundleRecord",
+    "ClaimKind",
+    "ClaimLegSpec",
+    "ClaimRecord",
+    "ClaimRecordStatus",
+    "ClaimSet",
+]

--- a/src/tallylot/domain/claim/models.py
+++ b/src/tallylot/domain/claim/models.py
@@ -1,0 +1,428 @@
+"""ClaimSet domain models and JSON payload helpers."""
+
+# pylint: disable=too-many-arguments,too-many-instance-attributes
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from decimal import Decimal
+from enum import StrEnum
+from hashlib import sha256
+import json
+from typing import cast
+
+from tallylot.domain.temporal import TemporalPrecision
+from tallylot.domain.types import JsonValue
+from tallylot.domain.value_objects import format_decimal, format_temporal_value
+
+CLAIM_SET_SCHEMA_VERSION = 1
+
+
+class ClaimKind(StrEnum):
+    ACTIVITY = "activity"
+    BALANCE = "balance"
+    INSTRUMENT = "instrument"
+    LOCATION = "location"
+    BENEFICIAL_OWNER = "beneficial_owner"
+    VALUATION = "valuation"
+
+
+class ClaimRecordStatus(StrEnum):
+    ASSERTED = "asserted"
+    SUPERSEDED = "superseded"
+
+
+class ClaimBundleDecisionOutcome(StrEnum):
+    ACCEPTED = "accepted"
+    BLOCKED = "blocked"
+    DEFERRED = "deferred"
+    SUPERSEDED = "superseded"
+
+
+class ClaimBundleDecisionBasis(StrEnum):
+    SINGLE_BUNDLE = "single_bundle"
+    INSUFFICIENT_IDENTITY = "insufficient_identity"
+    INSUFFICIENT_TEMPORAL_PRECISION = "insufficient_temporal_precision"
+    CONFLICTING_CLAIMS = "conflicting_claims"
+    UPSTREAM_GAP = "upstream_gap"
+    POLICY_DECISION_REQUIRED = "policy_decision_required"
+    LATER_BUNDLE_SELECTED = "later_bundle_selected"
+
+
+def _hash_payload(payload: JsonValue) -> str:
+    return sha256(
+        json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def _optional_temporal(
+    value: datetime | None,
+    *,
+    precision: TemporalPrecision | None,
+    label: str,
+) -> str:
+    if value is None or precision is None:
+        return ""
+    return format_temporal_value(value, precision=precision, label=label)
+
+
+def _sorted_texts(values: tuple[str, ...]) -> list[JsonValue]:
+    return list(sorted(values))
+
+
+@dataclass(frozen=True)
+class ClaimLegSpec:
+    slot: int
+    role: str
+    quantity: Decimal
+    instrument_claim_refs: tuple[str, ...]
+    location_claim_ref: str
+    subtype: str
+    attributed_to_slot: int | None = None
+
+    def to_payload(self) -> dict[str, JsonValue]:
+        return {
+            "slot": self.slot,
+            "role": self.role,
+            "quantity": format_decimal(self.quantity),
+            "instrument_claim_refs": _sorted_texts(self.instrument_claim_refs),
+            "location_claim_ref": self.location_claim_ref,
+            "subtype": self.subtype,
+            "attributed_to_slot": self.attributed_to_slot,
+        }
+
+
+def _is_set(value: object) -> bool:
+    if value in ("", (), None):
+        return False
+    return True
+
+
+@dataclass(frozen=True)
+class ClaimRecord:
+    claim_set_id: str
+    scope_id: str
+    bundle_id: str
+    claim_id: str
+    kind: ClaimKind
+    status: ClaimRecordStatus
+    key: tuple[str, ...]
+    member_refs: tuple[str, ...]
+    observation_refs: tuple[str, ...]
+    effective_at: datetime | None
+    precision: TemporalPrecision | None
+    provenance_refs: tuple[str, ...]
+    activity_label: str = ""
+    location_claim_ref: str = ""
+    leg_specs: tuple[ClaimLegSpec, ...] = ()
+    instrument_claim_refs: tuple[str, ...] = ()
+    balance_kind: str = ""
+    quantity: Decimal | None = None
+    observed_at: datetime | None = None
+    scheme: str = ""
+    value: str = ""
+    venue: str = ""
+    instrument_kind: str = ""
+    name: str = ""
+    location_ref: str = ""
+    location_group_label: str = ""
+    location_label: str = ""
+    beneficial_owner_ref: str = ""
+    purpose: str = ""
+    amount: Decimal | None = None
+    currency: str = ""
+    valued_at: datetime | None = None
+
+    def __post_init__(self) -> None:
+        self._validate_kind_fields()
+
+    def _validate_kind_fields(self) -> None:
+        balance_fields = (
+            self.instrument_claim_refs,
+            self.balance_kind,
+            self.quantity,
+            self.observed_at,
+        )
+        instrument_fields = (
+            self.scheme,
+            self.value,
+            self.venue,
+            self.instrument_kind,
+            self.name,
+        )
+        location_fields = (
+            self.location_ref,
+            self.location_group_label,
+            self.location_label,
+        )
+        beneficial_owner_fields = (self.beneficial_owner_ref,)
+        valuation_fields = (self.purpose, self.amount, self.currency, self.valued_at)
+        if self.kind is ClaimKind.ACTIVITY and any(
+            _is_set(value)
+            for value in (
+                *balance_fields,
+                *instrument_fields,
+                *location_fields,
+                *beneficial_owner_fields,
+                *valuation_fields,
+            )
+        ):
+            raise ValueError("activity claims must not set balance fields")
+        if self.kind is ClaimKind.BALANCE and not all(
+            (
+                self.location_claim_ref,
+                self.instrument_claim_refs,
+                self.balance_kind,
+                self.quantity is not None,
+                self.observed_at is not None,
+                self.precision is not None,
+            )
+        ):
+            raise ValueError(
+                "balance claims require location, instrument, quantity, observed_at, and precision"
+            )
+        if self.kind is ClaimKind.INSTRUMENT and not all(
+            (self.scheme, self.value, self.instrument_kind)
+        ):
+            raise ValueError(
+                "instrument claims require scheme, value, and instrument_kind"
+            )
+        if self.kind is ClaimKind.LOCATION and not self.location_ref:
+            raise ValueError("location claims require location_ref")
+        if self.kind is ClaimKind.BENEFICIAL_OWNER and not self.beneficial_owner_ref:
+            raise ValueError("beneficial_owner claims require beneficial_owner_ref")
+        if self.kind is ClaimKind.VALUATION and not all(
+            (
+                self.purpose,
+                self.amount is not None,
+                self.currency,
+                self.valued_at is not None,
+                self.location_claim_ref,
+                self.instrument_claim_refs,
+            )
+        ):
+            raise ValueError(
+                "valuation claims require purpose, amount, currency, valued_at, location, and instruments"
+            )
+
+    def semantic_payload(self) -> dict[str, JsonValue]:
+        payload: dict[str, JsonValue] = {
+            "kind": self.kind.value,
+            "status": self.status.value,
+            "key": list(self.key),
+            "member_refs": _sorted_texts(self.member_refs),
+            "observation_refs": _sorted_texts(self.observation_refs),
+            "effective_at": _optional_temporal(
+                self.effective_at,
+                precision=self.precision,
+                label="claim effective_at",
+            ),
+            "precision": "" if self.precision is None else self.precision.value,
+            "provenance_refs": _sorted_texts(self.provenance_refs),
+        }
+        if self.kind is ClaimKind.ACTIVITY:
+            payload.update(
+                {
+                    "activity_label": self.activity_label,
+                    "location_claim_ref": self.location_claim_ref,
+                    "leg_specs": [
+                        spec.to_payload()
+                        for spec in sorted(self.leg_specs, key=lambda item: item.slot)
+                    ],
+                }
+            )
+        elif self.kind is ClaimKind.BALANCE:
+            payload.update(
+                {
+                    "location_claim_ref": self.location_claim_ref,
+                    "instrument_claim_refs": _sorted_texts(self.instrument_claim_refs),
+                    "balance_kind": self.balance_kind,
+                    "quantity": format_decimal(self.quantity),
+                    "observed_at": _optional_temporal(
+                        self.observed_at,
+                        precision=self.precision,
+                        label="claim observed_at",
+                    ),
+                }
+            )
+        elif self.kind is ClaimKind.INSTRUMENT:
+            payload.update(
+                {
+                    "scheme": self.scheme,
+                    "value": self.value,
+                    "venue": self.venue,
+                    "instrument_kind": self.instrument_kind,
+                    "name": self.name,
+                }
+            )
+        elif self.kind is ClaimKind.LOCATION:
+            payload.update(
+                {
+                    "location_ref": self.location_ref,
+                    "location_group_label": self.location_group_label,
+                    "location_label": self.location_label,
+                }
+            )
+        elif self.kind is ClaimKind.BENEFICIAL_OWNER:
+            payload["beneficial_owner_ref"] = self.beneficial_owner_ref
+        elif self.kind is ClaimKind.VALUATION:
+            payload.update(
+                {
+                    "purpose": self.purpose,
+                    "amount": format_decimal(self.amount),
+                    "currency": self.currency,
+                    "valued_at": _optional_temporal(
+                        self.valued_at,
+                        precision=self.precision,
+                        label="claim valued_at",
+                    ),
+                    "location_claim_ref": self.location_claim_ref,
+                    "instrument_claim_refs": _sorted_texts(self.instrument_claim_refs),
+                }
+            )
+        return payload
+
+    def to_payload(self) -> dict[str, JsonValue]:
+        return {
+            "claim_set_id": self.claim_set_id,
+            "scope_id": self.scope_id,
+            "bundle_id": self.bundle_id,
+            "claim_id": self.claim_id,
+            **self.semantic_payload(),
+        }
+
+
+@dataclass(frozen=True)
+class ClaimBundleRecord:
+    claim_set_id: str
+    scope_id: str
+    bundle_id: str
+    key: str
+    scope_key: tuple[str, ...]
+    claim_refs: tuple[str, ...]
+
+    def to_payload(self) -> dict[str, JsonValue]:
+        return {
+            "claim_set_id": self.claim_set_id,
+            "scope_id": self.scope_id,
+            "bundle_id": self.bundle_id,
+            "key": self.key,
+            "scope_key": list(self.scope_key),
+            "claim_refs": _sorted_texts(self.claim_refs),
+        }
+
+
+@dataclass(frozen=True)
+class ClaimBundleDecisionRecord:
+    claim_set_id: str
+    scope_id: str
+    decision_id: str
+    outcome: ClaimBundleDecisionOutcome
+    accepted_bundle_ref: str
+    rejected_bundle_refs: tuple[str, ...]
+    deferred_bundle_refs: tuple[str, ...]
+    basis: ClaimBundleDecisionBasis
+    blocking_gap_refs: tuple[str, ...]
+
+    def to_payload(self) -> dict[str, JsonValue]:
+        return {
+            "claim_set_id": self.claim_set_id,
+            "scope_id": self.scope_id,
+            "decision_id": self.decision_id,
+            "outcome": self.outcome.value,
+            "accepted_bundle_ref": self.accepted_bundle_ref,
+            "rejected_bundle_refs": _sorted_texts(self.rejected_bundle_refs),
+            "deferred_bundle_refs": _sorted_texts(self.deferred_bundle_refs),
+            "basis": self.basis.value,
+            "blocking_gap_refs": _sorted_texts(self.blocking_gap_refs),
+        }
+
+
+def canonical_claim_records(
+    records: tuple[ClaimRecord, ...],
+) -> tuple[ClaimRecord, ...]:
+    return tuple(
+        sorted(
+            records,
+            key=lambda item: (
+                item.bundle_id,
+                item.kind.value,
+                _optional_temporal(
+                    item.effective_at, precision=item.precision, label="claim sort"
+                ),
+                "" if item.precision is None else item.precision.value,
+                item.claim_id,
+            ),
+        )
+    )
+
+
+def canonical_claim_bundle_records(
+    records: tuple[ClaimBundleRecord, ...],
+) -> tuple[ClaimBundleRecord, ...]:
+    return tuple(
+        sorted(records, key=lambda item: (item.scope_id, item.key, item.bundle_id))
+    )
+
+
+def canonical_claim_bundle_decision_records(
+    records: tuple[ClaimBundleDecisionRecord, ...],
+) -> tuple[ClaimBundleDecisionRecord, ...]:
+    return tuple(sorted(records, key=lambda item: (item.scope_id, item.decision_id)))
+
+
+@dataclass(frozen=True)
+class ClaimSet:
+    claim_set_id: str
+    evidence_set_ref: str
+    emitter_id: str
+    claim_records: tuple[ClaimRecord, ...]
+    claim_bundle_records: tuple[ClaimBundleRecord, ...]
+    claim_bundle_decision_records: tuple[ClaimBundleDecisionRecord, ...]
+
+    def to_payload(self) -> dict[str, JsonValue]:
+        return {
+            "claim_set_id": self.claim_set_id,
+            "schema_version": CLAIM_SET_SCHEMA_VERSION,
+            "evidence_set_ref": self.evidence_set_ref,
+            "emitter_id": self.emitter_id,
+            "claim_records": [
+                record.to_payload()
+                for record in canonical_claim_records(self.claim_records)
+            ],
+            "claim_bundle_records": [
+                record.to_payload()
+                for record in canonical_claim_bundle_records(self.claim_bundle_records)
+            ],
+            "claim_bundle_decision_records": [
+                record.to_payload()
+                for record in canonical_claim_bundle_decision_records(
+                    self.claim_bundle_decision_records
+                )
+            ],
+        }
+
+
+def stable_claim_set_id(*, evidence_set_id: str, emitter_id: str) -> str:
+    return ":".join((evidence_set_id, emitter_id))
+
+
+def stable_claim_scope_id(*, claim_set_id: str, scope_key: tuple[str, ...]) -> str:
+    return ":".join((claim_set_id, *scope_key))
+
+
+def stable_claim_bundle_id(*, scope_id: str, key: str) -> str:
+    return ":".join((scope_id, key))
+
+
+def stable_claim_id(*, bundle_id: str, kind: ClaimKind, key: tuple[str, ...]) -> str:
+    return ":".join((bundle_id, kind.value, *key))
+
+
+def stable_claim_bundle_decision_id(*, scope_id: str) -> str:
+    return scope_id
+
+
+def claim_set_fingerprint(claim_set: ClaimSet) -> str:
+    return _hash_payload(cast(JsonValue, claim_set.to_payload()))

--- a/src/tallylot/domain/claim/models.py
+++ b/src/tallylot/domain/claim/models.py
@@ -138,6 +138,14 @@ class ClaimRecord:
         self._validate_kind_fields()
 
     def _validate_kind_fields(self) -> None:
+        if self.effective_at is not None and self.precision is None:
+            raise ValueError("claim effective_at requires precision")
+        if (
+            self.valued_at is not None
+            and self.precision is None
+            and self.kind is not ClaimKind.VALUATION
+        ):
+            raise ValueError("claim valued_at requires precision")
         balance_fields = (
             self.instrument_claim_refs,
             self.balance_kind,
@@ -158,6 +166,12 @@ class ClaimRecord:
         )
         beneficial_owner_fields = (self.beneficial_owner_ref,)
         valuation_fields = (self.purpose, self.amount, self.currency, self.valued_at)
+        if self.kind is ClaimKind.ACTIVITY and not all(
+            (self.activity_label, self.location_claim_ref, self.leg_specs)
+        ):
+            raise ValueError(
+                "activity claims require activity_label, location_claim_ref, and leg_specs"
+            )
         if self.kind is ClaimKind.ACTIVITY and any(
             _is_set(value)
             for value in (
@@ -188,8 +202,12 @@ class ClaimRecord:
             raise ValueError(
                 "instrument claims require scheme, value, and instrument_kind"
             )
-        if self.kind is ClaimKind.LOCATION and not self.location_ref:
-            raise ValueError("location claims require location_ref")
+        if self.kind is ClaimKind.LOCATION and not all(
+            (self.location_ref, self.location_group_label, self.location_label)
+        ):
+            raise ValueError(
+                "location claims require location_ref, location_group_label, and location_label"
+            )
         if self.kind is ClaimKind.BENEFICIAL_OWNER and not self.beneficial_owner_ref:
             raise ValueError("beneficial_owner claims require beneficial_owner_ref")
         if self.kind is ClaimKind.VALUATION and not all(
@@ -198,12 +216,13 @@ class ClaimRecord:
                 self.amount is not None,
                 self.currency,
                 self.valued_at is not None,
+                self.precision is not None,
                 self.location_claim_ref,
                 self.instrument_claim_refs,
             )
         ):
             raise ValueError(
-                "valuation claims require purpose, amount, currency, valued_at, location, and instruments"
+                "valuation claims require purpose, amount, currency, valued_at, precision, location, and instruments"
             )
 
     def semantic_payload(self) -> dict[str, JsonValue]:

--- a/src/tallylot/infrastructure/composition/runtime.py
+++ b/src/tallylot/infrastructure/composition/runtime.py
@@ -41,6 +41,7 @@ from tallylot.infrastructure.discovery import (
 )
 from tallylot.infrastructure.serialization import FilesystemArtifactStore
 from tallylot.infrastructure.storage import (
+    FilesystemClaimSetRepository,
     FilesystemEvidenceRepository,
     FilesystemEvidenceSetRepository,
     FilesystemFactRepository,
@@ -55,6 +56,7 @@ def runtime_dependencies() -> tuple[
     FilesystemFactRepository,
     FilesystemEvidenceRepository,
     FilesystemEvidenceSetRepository,
+    FilesystemClaimSetRepository,
 ]:
     return (
         build_registry(),
@@ -63,21 +65,24 @@ def runtime_dependencies() -> tuple[
         FilesystemFactRepository(),
         FilesystemEvidenceRepository(),
         FilesystemEvidenceSetRepository(),
+        FilesystemClaimSetRepository(),
     )
 
 
 def build_manifest_use_case() -> BuildManifestUseCase:
-    _, _, artifacts, _, _, _ = runtime_dependencies()
+    _, _, artifacts, _, _, _, _ = runtime_dependencies()
     return BuildManifestUseCase(artifacts)
 
 
 def build_profile_use_case() -> BuildProfileUseCase:
-    registry, _, artifacts, _, _, _ = runtime_dependencies()
+    registry, _, artifacts, _, _, _, _ = runtime_dependencies()
     return BuildProfileUseCase(registry, artifacts)
 
 
 def normalize_source_use_case() -> NormalizeSourceUseCase:
-    registry, _, artifacts, facts, evidence, evidence_sets = runtime_dependencies()
+    registry, _, artifacts, facts, evidence, evidence_sets, claim_sets = (
+        runtime_dependencies()
+    )
     return NormalizeSourceUseCase(
         NormalizationDependencies(
             source_registry=registry,
@@ -85,53 +90,54 @@ def normalize_source_use_case() -> NormalizeSourceUseCase:
             facts=facts,
             evidence=evidence,
             evidence_sets=evidence_sets,
+            claim_sets=claim_sets,
             artifacts=artifacts,
         )
     )
 
 
 def assemble_source_use_case() -> AssembleSourceUseCase:
-    _, _, artifacts, _, _, _ = runtime_dependencies()
+    _, _, artifacts, _, _, _, _ = runtime_dependencies()
     return AssembleSourceUseCase(artifacts)
 
 
 def plan_intake_use_case() -> PlanIntakeUseCase:
-    registry, _, artifacts, _, _, _ = runtime_dependencies()
+    registry, _, artifacts, _, _, _, _ = runtime_dependencies()
     return PlanIntakeUseCase(registry, artifacts)
 
 
 def apply_intake_use_case() -> ApplyIntakeUseCase:
-    registry, _, artifacts, _, _, _ = runtime_dependencies()
+    registry, _, artifacts, _, _, _, _ = runtime_dependencies()
     return ApplyIntakeUseCase(registry, artifacts)
 
 
 def render_output_use_case() -> RenderOutputUseCase:
-    registry, _, _, facts, _, _ = runtime_dependencies()
+    registry, _, _, facts, _, _, _ = runtime_dependencies()
     return RenderOutputUseCase(registry, facts)
 
 
 def rebuild_location_inventory_use_case() -> RebuildLocationInventoryUseCase:
-    _, _, artifacts, _, _, _ = runtime_dependencies()
+    _, _, artifacts, _, _, _, _ = runtime_dependencies()
     return RebuildLocationInventoryUseCase(artifacts)
 
 
 def extract_pdf_balances_use_case() -> ExtractPdfBalancesUseCase:
-    registry, _, artifacts, _, _, _ = runtime_dependencies()
+    registry, _, artifacts, _, _, _, _ = runtime_dependencies()
     return ExtractPdfBalancesUseCase(registry, artifacts)
 
 
 def scaffold_balance_submission_use_case() -> ScaffoldBalanceSubmissionUseCase:
-    _, _, artifacts, _, _, _ = runtime_dependencies()
+    _, _, artifacts, _, _, _, _ = runtime_dependencies()
     return ScaffoldBalanceSubmissionUseCase(artifacts)
 
 
 def submit_balances_use_case() -> SubmitBalancesUseCase:
-    _, _, artifacts, _, evidence, _ = runtime_dependencies()
+    _, _, artifacts, _, evidence, _, _ = runtime_dependencies()
     return SubmitBalancesUseCase(evidence, artifacts)
 
 
 def balance_inspect_workflow() -> BalanceInspectWorkflow:
-    _, _, artifacts, facts, evidence, _ = runtime_dependencies()
+    _, _, artifacts, facts, evidence, _, _ = runtime_dependencies()
     return BalanceInspectWorkflow(
         facts=facts,
         evidence=evidence,
@@ -140,7 +146,7 @@ def balance_inspect_workflow() -> BalanceInspectWorkflow:
 
 
 def balance_check_workflow() -> BalanceCheckWorkflow:
-    _, providers, artifacts, facts, evidence, _ = runtime_dependencies()
+    _, providers, artifacts, facts, evidence, _, _ = runtime_dependencies()
     return BalanceCheckWorkflow(
         facts=facts,
         evidence=evidence,
@@ -150,7 +156,7 @@ def balance_check_workflow() -> BalanceCheckWorkflow:
 
 
 def balance_summary_workflow() -> BalanceSummaryWorkflow:
-    _, _, artifacts, _, _, _ = runtime_dependencies()
+    _, _, artifacts, _, _, _, _ = runtime_dependencies()
     return BalanceSummaryWorkflow(artifacts)
 
 

--- a/src/tallylot/infrastructure/storage/__init__.py
+++ b/src/tallylot/infrastructure/storage/__init__.py
@@ -1,10 +1,12 @@
 """Storage implementations."""
 
+from .claim_sets import FilesystemClaimSetRepository
 from .evidence_sets import FilesystemEvidenceSetRepository
 from .filesystem import FilesystemEvidenceRepository, FilesystemFactRepository
 from .sqlite_stub import SqliteStorageStub
 
 __all__ = [
+    "FilesystemClaimSetRepository",
     "FilesystemEvidenceRepository",
     "FilesystemEvidenceSetRepository",
     "FilesystemFactRepository",

--- a/src/tallylot/infrastructure/storage/claim_sets.py
+++ b/src/tallylot/infrastructure/storage/claim_sets.py
@@ -1,0 +1,224 @@
+"""Filesystem ClaimSet repository."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import cast
+
+from tallylot.domain.claim import (
+    CLAIM_SET_SCHEMA_VERSION,
+    ClaimBundleDecisionBasis,
+    ClaimBundleDecisionOutcome,
+    ClaimBundleDecisionRecord,
+    ClaimBundleRecord,
+    ClaimKind,
+    ClaimLegSpec,
+    ClaimRecord,
+    ClaimRecordStatus,
+    ClaimSet,
+)
+from tallylot.domain.temporal import TemporalPrecision, parse_temporal_precision
+from tallylot.domain.value_objects import parse_decimal, parse_temporal_value
+from tallylot.infrastructure.serialization.filesystem import FilesystemArtifactStore
+
+
+class FilesystemClaimSetRepository:
+    def __init__(self) -> None:
+        self._artifacts = FilesystemArtifactStore()
+
+    def write_claim_set(self, path: Path, claim_set: ClaimSet) -> None:
+        self._artifacts.write_json(path, claim_set.to_payload())
+
+    def read_claim_set(self, path: Path) -> ClaimSet:
+        payload = _required_dict(
+            json.loads(path.read_text(encoding="utf-8")), "payload"
+        )
+        schema_version = payload.get("schema_version")
+        if schema_version != CLAIM_SET_SCHEMA_VERSION:
+            rendered = "<missing>" if schema_version in (None, "") else schema_version
+            raise ValueError(
+                "unsupported claim set schema_version: "
+                f"{rendered}; expected {CLAIM_SET_SCHEMA_VERSION}"
+            )
+        return ClaimSet(
+            claim_set_id=_required_text(payload, "claim_set_id"),
+            evidence_set_ref=_required_text(payload, "evidence_set_ref"),
+            emitter_id=_required_text(payload, "emitter_id"),
+            claim_records=tuple(
+                _claim_record_from_payload(item)
+                for item in _required_list(payload, "claim_records")
+            ),
+            claim_bundle_records=tuple(
+                _claim_bundle_from_payload(item)
+                for item in _required_list(payload, "claim_bundle_records")
+            ),
+            claim_bundle_decision_records=tuple(
+                _claim_bundle_decision_from_payload(item)
+                for item in _required_list(payload, "claim_bundle_decision_records")
+            ),
+        )
+
+
+def _claim_record_from_payload(payload: object) -> ClaimRecord:
+    raw = _required_dict(payload, "claim")
+    precision = parse_temporal_precision(_optional_text(raw, "precision"))
+    leg_specs = tuple(
+        ClaimLegSpec(
+            slot=int(_required_number(spec, "slot")),
+            role=_required_text(spec, "role"),
+            quantity=_required_decimal(spec, "quantity"),
+            instrument_claim_refs=_required_text_tuple(spec, "instrument_claim_refs"),
+            location_claim_ref=_required_text(spec, "location_claim_ref"),
+            subtype=_required_text(spec, "subtype"),
+            attributed_to_slot=(
+                None
+                if spec.get("attributed_to_slot") is None
+                else int(_required_number(spec, "attributed_to_slot"))
+            ),
+        )
+        for spec in (
+            _required_dict(item, "claim leg spec")
+            for item in _required_list(raw, "leg_specs", default=[])
+        )
+    )
+    return ClaimRecord(
+        claim_set_id=_required_text(raw, "claim_set_id"),
+        scope_id=_required_text(raw, "scope_id"),
+        bundle_id=_required_text(raw, "bundle_id"),
+        claim_id=_required_text(raw, "claim_id"),
+        kind=ClaimKind(_required_text(raw, "kind")),
+        status=ClaimRecordStatus(_required_text(raw, "status")),
+        key=_required_text_tuple(raw, "key"),
+        member_refs=_required_text_tuple(raw, "member_refs"),
+        observation_refs=_required_text_tuple(raw, "observation_refs"),
+        effective_at=_optional_temporal(raw, "effective_at", precision=precision),
+        precision=precision,
+        provenance_refs=_required_text_tuple(raw, "provenance_refs"),
+        activity_label=_optional_text(raw, "activity_label"),
+        location_claim_ref=_optional_text(raw, "location_claim_ref"),
+        leg_specs=leg_specs,
+        instrument_claim_refs=_required_text_tuple(
+            raw, "instrument_claim_refs", default=()
+        ),
+        balance_kind=_optional_text(raw, "balance_kind"),
+        quantity=parse_decimal(_optional_text(raw, "quantity")),
+        observed_at=_optional_temporal(raw, "observed_at", precision=precision),
+        scheme=_optional_text(raw, "scheme"),
+        value=_optional_text(raw, "value"),
+        venue=_optional_text(raw, "venue"),
+        instrument_kind=_optional_text(raw, "instrument_kind"),
+        name=_optional_text(raw, "name"),
+        location_ref=_optional_text(raw, "location_ref"),
+        location_group_label=_optional_text(raw, "location_group_label"),
+        location_label=_optional_text(raw, "location_label"),
+        beneficial_owner_ref=_optional_text(raw, "beneficial_owner_ref"),
+        purpose=_optional_text(raw, "purpose"),
+        amount=parse_decimal(_optional_text(raw, "amount")),
+        currency=_optional_text(raw, "currency"),
+        valued_at=_optional_temporal(raw, "valued_at", precision=precision),
+    )
+
+
+def _claim_bundle_from_payload(payload: object) -> ClaimBundleRecord:
+    raw = _required_dict(payload, "claim bundle")
+    return ClaimBundleRecord(
+        claim_set_id=_required_text(raw, "claim_set_id"),
+        scope_id=_required_text(raw, "scope_id"),
+        bundle_id=_required_text(raw, "bundle_id"),
+        key=_required_text(raw, "key"),
+        scope_key=_required_text_tuple(raw, "scope_key"),
+        claim_refs=_required_text_tuple(raw, "claim_refs"),
+    )
+
+
+def _claim_bundle_decision_from_payload(payload: object) -> ClaimBundleDecisionRecord:
+    raw = _required_dict(payload, "claim bundle decision")
+    return ClaimBundleDecisionRecord(
+        claim_set_id=_required_text(raw, "claim_set_id"),
+        scope_id=_required_text(raw, "scope_id"),
+        decision_id=_required_text(raw, "decision_id"),
+        outcome=ClaimBundleDecisionOutcome(_required_text(raw, "outcome")),
+        accepted_bundle_ref=_optional_text(raw, "accepted_bundle_ref"),
+        rejected_bundle_refs=_required_text_tuple(
+            raw, "rejected_bundle_refs", default=()
+        ),
+        deferred_bundle_refs=_required_text_tuple(
+            raw, "deferred_bundle_refs", default=()
+        ),
+        basis=ClaimBundleDecisionBasis(_required_text(raw, "basis")),
+        blocking_gap_refs=_required_text_tuple(raw, "blocking_gap_refs", default=()),
+    )
+
+
+def _required_dict(value: object, label: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ValueError(f"invalid claim set {label}: expected object")
+    raw = cast(dict[object, object], value)
+    return {str(raw_key): raw_value for raw_key, raw_value in raw.items()}
+
+
+def _required_list(
+    payload: dict[str, object], key: str, *, default: list[object] | None = None
+) -> list[object]:
+    value = payload.get(key, default)
+    if not isinstance(value, list):
+        raise ValueError(f"invalid claim set {key}: expected array")
+    return cast(list[object], value)
+
+
+def _required_text(payload: dict[str, object], key: str) -> str:
+    value = payload.get(key, "")
+    if not isinstance(value, str) or value == "":
+        raise ValueError(f"invalid claim set {key}: expected non-empty string")
+    return value
+
+
+def _optional_text(payload: dict[str, object], key: str) -> str:
+    value = payload.get(key, "")
+    if value in (None, ""):
+        return ""
+    if not isinstance(value, str):
+        raise ValueError(f"invalid claim set {key}: expected string")
+    return value
+
+
+def _required_text_tuple(
+    payload: dict[str, object], key: str, *, default: tuple[str, ...] | None = None
+) -> tuple[str, ...]:
+    value = payload.get(key, list(default or ()))
+    if not isinstance(value, list):
+        raise ValueError(f"invalid claim set {key}: expected array")
+    items = cast(list[object], value)
+    if not all(isinstance(item, str) for item in items):
+        raise ValueError(f"invalid claim set {key}: expected string array")
+    return tuple(cast(list[str], items))
+
+
+def _required_number(payload: dict[str, object], key: str) -> int:
+    value = payload.get(key)
+    if not isinstance(value, int):
+        raise ValueError(f"invalid claim set {key}: expected integer")
+    return value
+
+
+def _required_decimal(payload: dict[str, object], key: str) -> Decimal:
+    value = parse_decimal(_required_text(payload, key))
+    if value is None:
+        raise ValueError(f"invalid claim set {key}: expected decimal")
+    return value
+
+
+def _optional_temporal(
+    payload: dict[str, object], key: str, *, precision: TemporalPrecision | None
+) -> datetime | None:
+    text = _optional_text(payload, key)
+    if not text:
+        return None
+    if precision is None:
+        raise ValueError(
+            f"invalid claim set {key}: precision is required when a temporal value is present"
+        )
+    return parse_temporal_value(text, precision=precision)

--- a/src/tallylot/infrastructure/storage/claim_sets.py
+++ b/src/tallylot/infrastructure/storage/claim_sets.py
@@ -72,7 +72,7 @@ def _claim_record_from_payload(payload: object) -> ClaimRecord:
             quantity=_required_decimal(spec, "quantity"),
             instrument_claim_refs=_required_text_tuple(spec, "instrument_claim_refs"),
             location_claim_ref=_required_text(spec, "location_claim_ref"),
-            subtype=_required_text(spec, "subtype"),
+            subtype=_optional_text(spec, "subtype"),
             attributed_to_slot=(
                 None
                 if spec.get("attributed_to_slot") is None

--- a/src/tallylot/ports/__init__.py
+++ b/src/tallylot/ports/__init__.py
@@ -14,6 +14,7 @@ from .adapter_contracts import AdapterCapability, AdapterManifest
 from .ai import ModelGateway, ReviewRequest, ReviewResponse
 from .annotations import AdapterMetadata
 from .artifacts import ArtifactStorePort
+from .claim_sets import ClaimSetRepositoryPort
 from .evidence import EvidenceRepositoryPort, LocationInventoryRecord
 from .evidence_sets import EvidenceSetRepositoryPort
 from .facts import FactRepositoryPort
@@ -48,6 +49,7 @@ __all__ = [
     "AdapterManifest",
     "AdapterMetadata",
     "ArtifactStorePort",
+    "ClaimSetRepositoryPort",
     "EconomicActivityDraft",
     "EconomicLegDraft",
     "EvidenceRepositoryPort",

--- a/src/tallylot/ports/claim_sets.py
+++ b/src/tallylot/ports/claim_sets.py
@@ -1,0 +1,14 @@
+"""ClaimSet repository port."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Protocol
+
+from tallylot.domain.claim import ClaimSet
+
+
+class ClaimSetRepositoryPort(Protocol):
+    def read_claim_set(self, path: Path) -> ClaimSet: ...
+
+    def write_claim_set(self, path: Path, claim_set: ClaimSet) -> None: ...

--- a/tests/fixtures/adapter_packs/coinbase/missing_retail_csv/expected/normalization_summary.json
+++ b/tests/fixtures/adapter_packs/coinbase/missing_retail_csv/expected/normalization_summary.json
@@ -1,5 +1,7 @@
 {
   "adapter_id": "coinbase",
+  "claim_set_id": "",
+  "claim_set_ref": "",
   "evidence_set_id": "",
   "evidence_set_ref": "",
   "fact_count": 0,

--- a/tests/fixtures/adapter_packs/coinbase/mixed_statement_aux_pdfs/expected/normalization_summary.json
+++ b/tests/fixtures/adapter_packs/coinbase/mixed_statement_aux_pdfs/expected/normalization_summary.json
@@ -1,5 +1,7 @@
 {
   "adapter_id": "coinbase",
+  "claim_set_id": "coinbase:coinbase:01HV4A5H7VJH7M3Y5A6B7C8D9E:f84859432a1b4be7c8a1caaa15c66c0ad4ffac7d8be60747ca40670a6aa9a92a:coinbase:coinbase:claim",
+  "claim_set_ref": "working/products/claim_sets/coinbase:coinbase:01HV4A5H7VJH7M3Y5A6B7C8D9E:f84859432a1b4be7c8a1caaa15c66c0ad4ffac7d8be60747ca40670a6aa9a92a:coinbase:coinbase:claim/claim_set.json",
   "evidence_set_id": "coinbase:coinbase:01HV4A5H7VJH7M3Y5A6B7C8D9E:f84859432a1b4be7c8a1caaa15c66c0ad4ffac7d8be60747ca40670a6aa9a92a",
   "evidence_set_ref": "working/products/evidence_sets/coinbase:coinbase:01HV4A5H7VJH7M3Y5A6B7C8D9E:f84859432a1b4be7c8a1caaa15c66c0ad4ffac7d8be60747ca40670a6aa9a92a/evidence_set.json",
   "fact_count": 1,

--- a/tests/fixtures/adapter_packs/coinbase/retail_buy_renamed/expected/normalization_summary.json
+++ b/tests/fixtures/adapter_packs/coinbase/retail_buy_renamed/expected/normalization_summary.json
@@ -1,5 +1,7 @@
 {
   "adapter_id": "coinbase",
+  "claim_set_id": "Future Exchange:coinbase:01HV4A5H7VJH7M3Y5A6B7C8D9E:32df8a8250bc9b25f23791d013f2b14a7868aa1e2f11442a02d659951979c619:Future Exchange:coinbase:claim",
+  "claim_set_ref": "working/products/claim_sets/Future Exchange:coinbase:01HV4A5H7VJH7M3Y5A6B7C8D9E:32df8a8250bc9b25f23791d013f2b14a7868aa1e2f11442a02d659951979c619:Future Exchange:coinbase:claim/claim_set.json",
   "evidence_set_id": "Future Exchange:coinbase:01HV4A5H7VJH7M3Y5A6B7C8D9E:32df8a8250bc9b25f23791d013f2b14a7868aa1e2f11442a02d659951979c619",
   "evidence_set_ref": "working/products/evidence_sets/Future Exchange:coinbase:01HV4A5H7VJH7M3Y5A6B7C8D9E:32df8a8250bc9b25f23791d013f2b14a7868aa1e2f11442a02d659951979c619/evidence_set.json",
   "fact_count": 1,

--- a/tests/support/services.py
+++ b/tests/support/services.py
@@ -15,6 +15,7 @@ from tallylot.domain.types import AdapterId, JsonValue, SourceId
 from tallylot.infrastructure.discovery import build_registry
 from tallylot.infrastructure.serialization import FilesystemArtifactStore
 from tallylot.infrastructure.storage import (
+    FilesystemClaimSetRepository,
     FilesystemEvidenceRepository,
     FilesystemEvidenceSetRepository,
     FilesystemFactRepository,
@@ -82,6 +83,7 @@ def build_normalization_service(
             facts=FilesystemFactRepository(),
             evidence=FilesystemEvidenceRepository(),
             evidence_sets=FilesystemEvidenceSetRepository(),
+            claim_sets=FilesystemClaimSetRepository(),
             artifacts=resolved_artifacts,
         )
     )

--- a/tests/unit/application/claim/test_assessment_mapping.py
+++ b/tests/unit/application/claim/test_assessment_mapping.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from tallylot.application.claim.assessment import (
+    map_claim_issue_to_scope,
+    map_claim_review_to_scope,
+)
+from tallylot.domain.claim import ClaimBundleDecisionOutcome
+from tallylot.domain.issues import IssueRecord, NormalizationReviewRecord
+
+
+def test_unsupported_selected_retail_row_maps_to_blocked_claim_scope_and_compatibility_issue() -> (
+    None
+):
+    mapping = map_claim_issue_to_scope(
+        issue=IssueRecord(
+            issue_id="coinbase:retail.csv:row:4",
+            source="coinbase",
+            adapter_id="coinbase",
+            severity="high",
+            kind="unsupported_row",
+            message="Unsupported Coinbase retail transaction type: Convert",
+            raw_file="retail.csv",
+            raw_row_ref="row:4",
+        ),
+        claim_set_id="claim-set-1",
+        retail_member_id="member-1",
+    )
+
+    assert mapping is not None
+    assert mapping.bundle_decision.outcome is ClaimBundleDecisionOutcome.BLOCKED
+    assert mapping.gap_record.scope_kind == "claim_scope"
+    assert mapping.compatibility_issue.kind == "unsupported_row"
+
+
+def test_advisory_review_maps_to_review_record_and_compatibility_review() -> None:
+    mapping = map_claim_review_to_scope(
+        review=NormalizationReviewRecord(
+            review_id="review-1",
+            source="coinbase",
+            adapter_id="coinbase",
+            scope="translation",
+            kind="fee_attribution",
+            message="Fee allocation needs review",
+            raw_file="retail.csv",
+            raw_row_ref="row:4",
+            field_name="fee",
+            original_value="10",
+            normalized_value="quote_leg",
+        ),
+        claim_set_id="claim-set-1",
+        retail_member_id="member-1",
+    )
+
+    assert mapping is not None
+    assert mapping.review_record.scope_kind == "claim_scope"
+    assert mapping.compatibility_review.kind == "fee_attribution"
+
+
+def test_selection_stage_blockers_do_not_create_claim_scope_assessment() -> None:
+    assert (
+        map_claim_issue_to_scope(
+            issue=IssueRecord(
+                issue_id="coinbase:missing_retail_csv",
+                source="coinbase",
+                adapter_id="coinbase",
+                severity="high",
+                kind="missing_required_input",
+                message="Coinbase retail all-time CSV is required for deterministic normalization.",
+            ),
+            claim_set_id="claim-set-1",
+            retail_member_id="member-1",
+        )
+        is None
+    )

--- a/tests/unit/application/claim/test_coinbase_builder.py
+++ b/tests/unit/application/claim/test_coinbase_builder.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from dataclasses import replace
 from pathlib import Path
 
+import pytest
 from reportlab.pdfgen import canvas
 
 from tallylot.adapters.sources.platforms.coinbase.adapter import _CoinbaseAdapter
@@ -329,6 +330,76 @@ def test_no_selected_candidate_yields_no_claim_set(tmp_path: Path) -> None:
     raw_dir.mkdir()
 
     assert _build_claim_result(raw_dir) is None
+
+
+def test_nested_selected_retail_file_still_builds_claims(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "raw"
+    nested_dir = raw_dir / "nested"
+    nested_dir.mkdir(parents=True)
+    (nested_dir / "retail.csv").write_text(
+        _retail_csv(
+            "tx-1,2024-02-08 16:31:22 UTC,Buy,BTC,0.01000000,CAD,$60000.00,$600.00,$610.00,$10.00,"
+            "Bought 0.01 BTC for 610 CAD\n"
+        ),
+        encoding="utf-8",
+    )
+
+    result = _build_claim_result(raw_dir)
+
+    assert result is not None
+    assert any(
+        claim.kind is ClaimKind.ACTIVITY for claim in result.claim_set.claim_records
+    )
+
+
+def test_claim_builder_rejects_unmapped_selected_draft_raw_file(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "retail.csv").write_text(
+        _retail_csv(
+            "tx-1,2024-02-08 16:31:22 UTC,Buy,BTC,0.01000000,CAD,$60000.00,$600.00,$610.00,$10.00,"
+            "Bought 0.01 BTC for 610 CAD\n"
+        ),
+        encoding="utf-8",
+    )
+    registry = build_registry()
+    adapter = _CoinbaseAdapter()
+    profile = _coinbase_profile(raw_dir)
+    planning_result = plan_translation_inputs(
+        profile=profile,
+        candidates=adapter.describe_translation_inputs(profile, raw_dir),
+    )
+    statement_documents = StatementExtractionService(
+        registry
+    ).collect_source_statement_documents(profile, raw_dir)
+    evidence_set = build_evidence_set_for_profile(
+        profile=profile,
+        capture_uid="capture-1",
+        capture_manifest_fingerprint="manifest-1",
+        planner_result=planning_result,
+        statement_documents=statement_documents,
+    )
+    assert evidence_set is not None
+    batch = adapter.translate_selected_inputs(profile, raw_dir, planning_result.plan)
+    broken_batch = replace(
+        batch,
+        drafts=(replace(batch.drafts[0], raw_file="missing-retail.csv"),),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="claim builder could not map draft raw_file 'missing-retail.csv'",
+    ):
+        build_coinbase_claim_set(
+            profile=profile,
+            evidence_set=evidence_set,
+            evidence_set_ref=(
+                f"working/products/evidence_sets/{evidence_set.evidence_set_id}/"
+                "evidence_set.json"
+            ),
+            planning_result=planning_result,
+            batch=broken_batch,
+        )
 
 
 def test_replay_with_unchanged_evidence_preserves_payload_and_fingerprint(

--- a/tests/unit/application/claim/test_coinbase_builder.py
+++ b/tests/unit/application/claim/test_coinbase_builder.py
@@ -1,0 +1,436 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+from reportlab.pdfgen import canvas
+
+from tallylot.adapters.sources.platforms.coinbase.adapter import _CoinbaseAdapter
+from tallylot.application.claim import (
+    CoinbaseClaimBuildResult,
+    build_coinbase_claim_set,
+)
+from tallylot.application.evidence.evidence_sets import build_evidence_set_for_profile
+from tallylot.application.evidence.statement_extraction import (
+    StatementExtractionService,
+)
+from tallylot.application.normalization.translation_inputs import (
+    plan_translation_inputs,
+)
+from tallylot.application.profiling import BuildProfileUseCase
+from tallylot.domain.claim import ClaimBundleDecisionOutcome, ClaimKind
+from tallylot.domain.claim.models import claim_set_fingerprint
+from tallylot.infrastructure.discovery import build_registry
+from tallylot.infrastructure.serialization.filesystem import FilesystemArtifactStore
+from tallylot.ports.source_profiles import SourceProfile
+
+
+def _coinbase_profile(raw_dir: Path) -> SourceProfile:
+    return BuildProfileUseCase(
+        build_registry(), FilesystemArtifactStore()
+    ).create_profile(
+        "coinbase",
+        raw_dir,
+    )
+
+
+def _make_pdf(path: Path, *lines: str) -> None:
+    pdf = canvas.Canvas(str(path))
+    y = 750
+    for line in lines:
+        pdf.drawString(72, y, line)
+        y -= 15
+    pdf.save()
+
+
+def _retail_csv(*rows: str) -> str:
+    return (
+        "Transactions\n"
+        "User,Example User,acct\n"
+        "ID,Timestamp,Transaction Type,Asset,Quantity Transacted,Price Currency,"
+        "Price at Transaction,Subtotal,Total (inclusive of fees and/or spread),"
+        "Fees and/or Spread,Notes\n"
+        f"{''.join(rows)}"
+    )
+
+
+def _build_claim_result(raw_dir: Path) -> CoinbaseClaimBuildResult | None:
+    registry = build_registry()
+    adapter = _CoinbaseAdapter()
+    profile = _coinbase_profile(raw_dir)
+    planning_result = plan_translation_inputs(
+        profile=profile,
+        candidates=adapter.describe_translation_inputs(profile, raw_dir),
+    )
+    statement_documents = StatementExtractionService(
+        registry
+    ).collect_source_statement_documents(profile, raw_dir)
+    evidence_set = build_evidence_set_for_profile(
+        profile=profile,
+        capture_uid="capture-1",
+        capture_manifest_fingerprint="manifest-1",
+        planner_result=planning_result,
+        statement_documents=statement_documents,
+    )
+    if planning_result.plan.blocked:
+        batch = adapter.translate_selected_inputs(
+            profile, raw_dir, planning_result.plan
+        )
+        assert evidence_set is not None
+        return build_coinbase_claim_set(
+            profile=profile,
+            evidence_set=evidence_set,
+            evidence_set_ref=f"working/products/evidence_sets/{evidence_set.evidence_set_id}/evidence_set.json",
+            planning_result=planning_result,
+            batch=batch,
+        )
+    if evidence_set is None:
+        batch = adapter.translate_selected_inputs(
+            profile, raw_dir, planning_result.plan
+        )
+        return build_coinbase_claim_set(
+            profile=profile,
+            evidence_set=None,
+            evidence_set_ref="",
+            planning_result=planning_result,
+            batch=batch,
+        )
+    batch = adapter.translate_selected_inputs(profile, raw_dir, planning_result.plan)
+    return build_coinbase_claim_set(
+        profile=profile,
+        evidence_set=evidence_set,
+        evidence_set_ref=f"working/products/evidence_sets/{evidence_set.evidence_set_id}/evidence_set.json",
+        planning_result=planning_result,
+        batch=batch,
+    )
+
+
+def _claim_kinds(result: CoinbaseClaimBuildResult) -> tuple[str, ...]:
+    assert result is not None
+    return tuple(claim.kind.value for claim in result.claim_set.claim_records)
+
+
+def test_buy_row_builds_expected_claim_bundle(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "retail.csv").write_text(
+        _retail_csv(
+            "tx-1,2024-02-08 16:31:22 UTC,Buy,BTC,0.01000000,CAD,$60000.00,$600.00,$610.00,$10.00,"
+            "Bought 0.01 BTC for 610 CAD\n"
+        ),
+        encoding="utf-8",
+    )
+
+    result = _build_claim_result(raw_dir)
+
+    assert result is not None
+    assert _claim_kinds(result) == (
+        "activity",
+        "beneficial_owner",
+        "instrument",
+        "instrument",
+        "location",
+    )
+    assert (
+        result.claim_set.claim_bundle_decision_records[0].outcome
+        is ClaimBundleDecisionOutcome.ACCEPTED
+    )
+    assert len(result.draft_projection_field_records) == 1
+    assert not result.gap_records
+    assert not result.review_records
+
+
+def test_sell_row_builds_expected_claim_bundle(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "retail.csv").write_text(
+        _retail_csv(
+            "tx-sell,2024-02-08 16:31:22 UTC,Sell,BTC,0.01000000,CAD,$60000.00,$600.00,$590.00,$10.00,"
+            "Sold 0.01 BTC for 590 CAD\n"
+        ),
+        encoding="utf-8",
+    )
+
+    result = _build_claim_result(raw_dir)
+
+    assert result is not None
+    activity_claim = next(
+        claim
+        for claim in result.claim_set.claim_records
+        if claim.kind is ClaimKind.ACTIVITY
+    )
+    assert activity_claim.activity_label == "sell"
+    assert len(activity_claim.leg_specs) == 3
+
+
+def test_reward_income_row_builds_expected_claim_bundle(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "retail.csv").write_text(
+        _retail_csv(
+            "reward-1,2023-03-18 01:28:49 UTC,Reward Income,ADA,0.000021,CAD,$0.48,$0.00,$0.00,$0.00,"
+            "Received 0.000021 ADA from Coinbase Rewards\n"
+        ),
+        encoding="utf-8",
+    )
+
+    result = _build_claim_result(raw_dir)
+
+    assert result is not None
+    activity_claim = next(
+        claim
+        for claim in result.claim_set.claim_records
+        if claim.kind is ClaimKind.ACTIVITY
+    )
+    assert activity_claim.activity_label == "reward_income"
+    assert len(activity_claim.leg_specs) == 1
+
+
+def test_receive_row_builds_expected_claim_bundle(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "retail.csv").write_text(
+        _retail_csv(
+            "tx-receive,2024-02-09 10:00:00 UTC,Receive,ETH,1.50000000,CAD,$0.00,$0.00,$0.00,$0.00,"
+            "Received ETH\n"
+        ),
+        encoding="utf-8",
+    )
+
+    result = _build_claim_result(raw_dir)
+
+    assert result is not None
+    activity_claim = next(
+        claim
+        for claim in result.claim_set.claim_records
+        if claim.kind is ClaimKind.ACTIVITY
+    )
+    assert activity_claim.activity_label == "receive"
+
+
+def test_send_row_builds_expected_claim_bundle(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "retail.csv").write_text(
+        _retail_csv(
+            "tx-send,2024-02-08 17:31:22 UTC,Send,ETH,-0.50000000,CAD,$0.00,$0.00,$0.00,$0.00,"
+            "Sent ETH\n"
+        ),
+        encoding="utf-8",
+    )
+
+    result = _build_claim_result(raw_dir)
+
+    assert result is not None
+    activity_claim = next(
+        claim
+        for claim in result.claim_set.claim_records
+        if claim.kind is ClaimKind.ACTIVITY
+    )
+    assert activity_claim.activity_label == "send"
+
+
+def test_asset_migration_rows_build_expected_claim_bundle(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "retail.csv").write_text(
+        _retail_csv(
+            "migration-neg,2025-10-17 13:38:17 UTC,Asset Migration,MATIC,-1.65526374,CAD,$0.25,-$0.42,-$0.42,$0.00,\n"
+            "migration-pos,2025-10-17 13:38:17 UTC,Asset Migration,POL,1.65526374,CAD,$0.25,$0.42,$0.42,$0.00,\n"
+        ),
+        encoding="utf-8",
+    )
+
+    result = _build_claim_result(raw_dir)
+
+    assert result is not None
+    activity_claim = next(
+        claim
+        for claim in result.claim_set.claim_records
+        if claim.kind is ClaimKind.ACTIVITY
+    )
+    assert activity_claim.activity_label == "asset_migration"
+    assert tuple(spec.role for spec in activity_claim.leg_specs) == (
+        "asset_in",
+        "asset_out",
+    )
+    assert (
+        result.draft_projection_field_records[0].description
+        == "Coinbase Asset Migration"
+    )
+
+
+def test_statement_row_builds_balance_claims_when_retail_is_selected(
+    tmp_path: Path,
+) -> None:
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "retail.csv").write_text(
+        _retail_csv(
+            "tx-1,2024-02-08 16:31:22 UTC,Buy,BTC,0.01000000,CAD,$60000.00,$600.00,$610.00,$10.00,"
+            "Bought 0.01 BTC for 610 CAD\n"
+        ),
+        encoding="utf-8",
+    )
+    _make_pdf(
+        raw_dir / "statement.pdf",
+        "Coinbase Canada, Inc.",
+        "Transaction History Report",
+        "Closing Balance as of 2026-03-22 23:59:59 UTC 0 CAD",
+        "Portfolio summary balances are as of 2026-03-22 23:59:59 UTC",
+        "ETH 0.001181807820874 N/A 2,817.007569 CAD/ETH 3.33 CAD",
+    )
+
+    result = _build_claim_result(raw_dir)
+
+    assert result is not None
+    balance_claim = next(
+        claim
+        for claim in result.claim_set.claim_records
+        if claim.kind is ClaimKind.BALANCE
+    )
+    location_claim = next(
+        claim
+        for claim in result.claim_set.claim_records
+        if claim.kind is ClaimKind.LOCATION and claim.location_group_label == "Coinbase"
+    )
+    assert len(balance_claim.observation_refs) == 2
+    assert balance_claim.balance_kind in {"asset_balance", "cash_closing_balance"}
+    assert location_claim.location_label in {"Coinbase", "Coinbase Cash"}
+
+
+def test_unsupported_selected_row_creates_blocked_claim_scope_and_compatibility_issue(
+    tmp_path: Path,
+) -> None:
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "retail.csv").write_text(
+        _retail_csv(
+            "tx-unsupported,2024-02-10 12:00:00 UTC,Convert,BTC,0.01000000,CAD,$60000.00,$600.00,$610.00,$10.00,"
+            "Unsupported convert row\n"
+        ),
+        encoding="utf-8",
+    )
+
+    result = _build_claim_result(raw_dir)
+
+    assert result is not None
+    assert not result.claim_set.claim_records
+    assert (
+        result.claim_set.claim_bundle_decision_records[0].outcome
+        is ClaimBundleDecisionOutcome.BLOCKED
+    )
+    assert len(result.gap_records) == 1
+    assert len(result.compatibility_issue_records) == 1
+
+
+def test_no_selected_candidate_yields_no_claim_set(tmp_path: Path) -> None:
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+
+    assert _build_claim_result(raw_dir) is None
+
+
+def test_replay_with_unchanged_evidence_preserves_payload_and_fingerprint(
+    tmp_path: Path,
+) -> None:
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "retail.csv").write_text(
+        _retail_csv(
+            "tx-1,2024-02-08 16:31:22 UTC,Buy,BTC,0.01000000,CAD,$60000.00,$600.00,$610.00,$10.00,"
+            "Bought 0.01 BTC for 610 CAD\n"
+        ),
+        encoding="utf-8",
+    )
+
+    first = _build_claim_result(raw_dir)
+    second = _build_claim_result(raw_dir)
+
+    assert first is not None and second is not None
+    assert first.claim_set.to_payload() == second.claim_set.to_payload()
+    assert claim_set_fingerprint(first.claim_set) == claim_set_fingerprint(
+        second.claim_set
+    )
+
+
+def test_inventory_order_changes_do_not_change_claim_payload_or_fingerprint(
+    tmp_path: Path,
+) -> None:
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "older.csv").write_text(
+        _retail_csv(
+            "legacy-1,2021-12-30 08:56:53 UTC,Receive,FET,1.9859001,CAD,$0.64,$1.27098,$1.27098,$0.00,"
+            "Received 1.9859001 FET\n"
+        ),
+        encoding="utf-8",
+    )
+    (raw_dir / "2026-03-23 Statement - All Time.csv").write_text(
+        _retail_csv(
+            "legacy-1,2021-12-30 08:56:53 UTC,Receive,FET,1.9859001,CAD,$0.64,$1.27098,$1.27098,$0.00,"
+            "Received 1.9859001 FET\n"
+            "tx-1,2024-02-08 16:31:22 UTC,Buy,BTC,0.01000000,CAD,$60000.00,$600.00,$610.00,$10.00,"
+            "Bought 0.01 BTC for 610 CAD\n"
+        ),
+        encoding="utf-8",
+    )
+    registry = build_registry()
+    adapter = _CoinbaseAdapter()
+    profile = _coinbase_profile(raw_dir)
+    reversed_profile = replace(
+        profile,
+        file_inventory=tuple(reversed(profile.file_inventory)),
+    )
+    statement_documents = StatementExtractionService(
+        registry
+    ).collect_source_statement_documents(profile, raw_dir)
+    planning_result = plan_translation_inputs(
+        profile=profile,
+        candidates=adapter.describe_translation_inputs(profile, raw_dir),
+    )
+    reversed_planning_result = plan_translation_inputs(
+        profile=reversed_profile,
+        candidates=adapter.describe_translation_inputs(reversed_profile, raw_dir),
+    )
+    evidence_set = build_evidence_set_for_profile(
+        profile=profile,
+        capture_uid="capture-1",
+        capture_manifest_fingerprint="manifest-1",
+        planner_result=planning_result,
+        statement_documents=statement_documents,
+    )
+    reversed_evidence_set = build_evidence_set_for_profile(
+        profile=reversed_profile,
+        capture_uid="capture-1",
+        capture_manifest_fingerprint="manifest-1",
+        planner_result=reversed_planning_result,
+        statement_documents=statement_documents,
+    )
+    assert evidence_set is not None and reversed_evidence_set is not None
+    first = build_coinbase_claim_set(
+        profile=profile,
+        evidence_set=evidence_set,
+        evidence_set_ref=f"working/products/evidence_sets/{evidence_set.evidence_set_id}/evidence_set.json",
+        planning_result=planning_result,
+        batch=adapter.translate_selected_inputs(profile, raw_dir, planning_result.plan),
+    )
+    second = build_coinbase_claim_set(
+        profile=reversed_profile,
+        evidence_set=reversed_evidence_set,
+        evidence_set_ref=(
+            f"working/products/evidence_sets/{reversed_evidence_set.evidence_set_id}/evidence_set.json"
+        ),
+        planning_result=reversed_planning_result,
+        batch=adapter.translate_selected_inputs(
+            reversed_profile,
+            raw_dir,
+            reversed_planning_result.plan,
+        ),
+    )
+
+    assert first is not None and second is not None
+    assert first.claim_set.to_payload() == second.claim_set.to_payload()
+    assert claim_set_fingerprint(first.claim_set) == claim_set_fingerprint(
+        second.claim_set
+    )

--- a/tests/unit/application/claim/test_compatibility_projection.py
+++ b/tests/unit/application/claim/test_compatibility_projection.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tallylot.adapters.sources.platforms.coinbase.adapter import _CoinbaseAdapter
+from tallylot.adapters.support.drafts import compile_activity_drafts
+from tallylot.application.claim import build_coinbase_claim_set
+from tallylot.application.compatibility import project_translation_batch_from_claim_set
+from tallylot.application.evidence.evidence_sets import build_evidence_set_for_profile
+from tallylot.application.evidence.statement_extraction import (
+    StatementExtractionService,
+)
+from tallylot.application.normalization.translation_inputs import (
+    plan_translation_inputs,
+)
+from tallylot.application.profiling import BuildProfileUseCase
+from tallylot.infrastructure.discovery import build_registry
+from tallylot.infrastructure.serialization.filesystem import FilesystemArtifactStore
+from tallylot.ports.source_profiles import SourceProfile
+from tallylot.domain.transactions import TransactionFact
+
+
+def _coinbase_profile(raw_dir: Path) -> SourceProfile:
+    return BuildProfileUseCase(
+        build_registry(), FilesystemArtifactStore()
+    ).create_profile(
+        "coinbase",
+        raw_dir,
+    )
+
+
+def _projected_facts(
+    raw_dir: Path,
+) -> tuple[tuple[TransactionFact, ...], tuple[TransactionFact, ...]]:
+    registry = build_registry()
+    adapter = _CoinbaseAdapter()
+    profile = _coinbase_profile(raw_dir)
+    planning_result = plan_translation_inputs(
+        profile=profile,
+        candidates=adapter.describe_translation_inputs(profile, raw_dir),
+    )
+    statement_documents = StatementExtractionService(
+        registry
+    ).collect_source_statement_documents(profile, raw_dir)
+    evidence_set = build_evidence_set_for_profile(
+        profile=profile,
+        capture_uid="capture-1",
+        capture_manifest_fingerprint="manifest-1",
+        planner_result=planning_result,
+        statement_documents=statement_documents,
+    )
+    assert evidence_set is not None
+    selected_batch = adapter.translate_selected_inputs(
+        profile, raw_dir, planning_result.plan
+    )
+    claim_build = build_coinbase_claim_set(
+        profile=profile,
+        evidence_set=evidence_set,
+        evidence_set_ref=f"working/products/evidence_sets/{evidence_set.evidence_set_id}/evidence_set.json",
+        planning_result=planning_result,
+        batch=selected_batch,
+    )
+    assert claim_build is not None
+    projected = project_translation_batch_from_claim_set(
+        claim_set=claim_build.claim_set,
+        evidence_set=evidence_set,
+        draft_projection_field_records=claim_build.draft_projection_field_records,
+        gap_records=claim_build.gap_records,
+        gap_explanations=claim_build.gap_explanations,
+        review_records=claim_build.review_records,
+        review_explanations=claim_build.review_explanations,
+    )
+    return compile_activity_drafts(selected_batch.drafts), compile_activity_drafts(
+        projected.drafts
+    )
+
+
+def test_claim_projection_preserves_supported_coinbase_bridge_values(
+    tmp_path: Path,
+) -> None:
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "retail.csv").write_text(
+        "Transactions\nUser,Example User,acct\n"
+        "ID,Timestamp,Transaction Type,Asset,Quantity Transacted,Price Currency,Price at Transaction,"
+        "Subtotal,Total (inclusive of fees and/or spread),Fees and/or Spread,Notes\n"
+        "tx-buy,2024-02-08 16:31:22 UTC,Buy,BTC,0.01000000,CAD,$60000.00,$600.00,$610.00,$10.00,Bought 0.01 BTC\n"
+        "tx-sell,2024-02-08 16:31:22 UTC,Sell,BTC,0.01000000,CAD,$60000.00,$600.00,$590.00,$10.00,Sold 0.01 BTC\n"
+        "reward-1,2023-03-18 01:28:49 UTC,Reward Income,ADA,0.000021,CAD,$0.48,$0.00,$0.00,$0.00,Received ADA\n"
+        "tx-receive,2024-02-09 10:00:00 UTC,Receive,ETH,1.50000000,CAD,$0.00,$0.00,$0.00,$0.00,Received ETH\n"
+        "tx-send,2024-02-08 17:31:22 UTC,Send,ETH,-0.50000000,CAD,$0.00,$0.00,$0.00,$0.00,Sent ETH\n"
+        "migration-neg,2025-10-17 13:38:17 UTC,Asset Migration,MATIC,-1.65526374,CAD,$0.25,-$0.42,-$0.42,$0.00,\n"
+        "migration-pos,2025-10-17 13:38:17 UTC,Asset Migration,POL,1.65526374,CAD,$0.25,$0.42,$0.42,$0.00,\n",
+        encoding="utf-8",
+    )
+
+    expected, projected = _projected_facts(raw_dir)
+
+    for projected_fact, expected_fact in zip(projected, expected, strict=True):
+        projected_row = projected_fact.to_row()
+        expected_row = expected_fact.to_row()
+        for key in (
+            "fact_id",
+            "timestamp",
+            "location_id",
+            "economic_kind",
+            "projection_hint",
+            "accounting_intent_hint",
+            "tax_treatment_hint",
+            "description",
+            "provider_operation_key",
+            "tx_hash",
+            "raw_file",
+            "raw_row_ref",
+            "legs",
+        ):
+            assert projected_row[key] == expected_row[key]

--- a/tests/unit/application/claim/test_compatibility_projection.py
+++ b/tests/unit/application/claim/test_compatibility_projection.py
@@ -4,7 +4,10 @@ from pathlib import Path
 
 from tallylot.adapters.sources.platforms.coinbase.adapter import _CoinbaseAdapter
 from tallylot.adapters.support.drafts import compile_activity_drafts
-from tallylot.application.claim import build_coinbase_claim_set
+from tallylot.application.claim import (
+    CoinbaseClaimBuildResult,
+    build_coinbase_claim_set,
+)
 from tallylot.application.compatibility import project_translation_batch_from_claim_set
 from tallylot.application.evidence.evidence_sets import build_evidence_set_for_profile
 from tallylot.application.evidence.statement_extraction import (
@@ -14,27 +17,32 @@ from tallylot.application.normalization.translation_inputs import (
     plan_translation_inputs,
 )
 from tallylot.application.profiling import BuildProfileUseCase
+from tallylot.domain.evidence import EvidenceSet
+from tallylot.domain.issues import NormalizationReviewRecord
 from tallylot.infrastructure.discovery import build_registry
 from tallylot.infrastructure.serialization.filesystem import FilesystemArtifactStore
 from tallylot.ports.source_profiles import SourceProfile
+from tallylot.ports.source_translation import SourceTranslationBatch
 from tallylot.domain.transactions import TransactionFact
 
 
-def _coinbase_profile(raw_dir: Path) -> SourceProfile:
+def _coinbase_profile(raw_dir: Path, *, source: str = "coinbase") -> SourceProfile:
     return BuildProfileUseCase(
         build_registry(), FilesystemArtifactStore()
     ).create_profile(
-        "coinbase",
+        source,
         raw_dir,
     )
 
 
-def _projected_facts(
+def _claim_build(
     raw_dir: Path,
-) -> tuple[tuple[TransactionFact, ...], tuple[TransactionFact, ...]]:
+    *,
+    source: str = "coinbase",
+) -> tuple[SourceTranslationBatch, CoinbaseClaimBuildResult, EvidenceSet]:
     registry = build_registry()
     adapter = _CoinbaseAdapter()
-    profile = _coinbase_profile(raw_dir)
+    profile = _coinbase_profile(raw_dir, source=source)
     planning_result = plan_translation_inputs(
         profile=profile,
         candidates=adapter.describe_translation_inputs(profile, raw_dir),
@@ -61,6 +69,13 @@ def _projected_facts(
         batch=selected_batch,
     )
     assert claim_build is not None
+    return selected_batch, claim_build, evidence_set
+
+
+def _projected_facts(
+    raw_dir: Path,
+) -> tuple[tuple[TransactionFact, ...], tuple[TransactionFact, ...]]:
+    selected_batch, claim_build, evidence_set = _claim_build(raw_dir)
     projected = project_translation_batch_from_claim_set(
         claim_set=claim_build.claim_set,
         evidence_set=evidence_set,
@@ -69,6 +84,8 @@ def _projected_facts(
         gap_explanations=claim_build.gap_explanations,
         review_records=claim_build.review_records,
         review_explanations=claim_build.review_explanations,
+        compatibility_issue_records=claim_build.compatibility_issue_records,
+        compatibility_review_records=claim_build.compatibility_review_records,
     )
     return compile_activity_drafts(selected_batch.drafts), compile_activity_drafts(
         projected.drafts
@@ -115,3 +132,84 @@ def test_claim_projection_preserves_supported_coinbase_bridge_values(
             "legs",
         ):
             assert projected_row[key] == expected_row[key]
+
+
+def test_claim_projection_preserves_nested_raw_file_and_source_labels(
+    tmp_path: Path,
+) -> None:
+    raw_dir = tmp_path / "raw"
+    nested_dir = raw_dir / "nested"
+    nested_dir.mkdir(parents=True)
+    (nested_dir / "retail.csv").write_text(
+        "Transactions\nUser,Example User,acct\n"
+        "ID,Timestamp,Transaction Type,Asset,Quantity Transacted,Price Currency,Price at Transaction,"
+        "Subtotal,Total (inclusive of fees and/or spread),Fees and/or Spread,Notes\n"
+        "tx-buy,2024-02-08 16:31:22 UTC,Buy,BTC,0.01000000,CAD,$60000.00,$600.00,$610.00,$10.00,Bought 0.01 BTC\n",
+        encoding="utf-8",
+    )
+
+    selected_batch, claim_build, evidence_set = _claim_build(
+        raw_dir,
+        source="Future: Exchange",
+    )
+    projected = project_translation_batch_from_claim_set(
+        claim_set=claim_build.claim_set,
+        evidence_set=evidence_set,
+        draft_projection_field_records=claim_build.draft_projection_field_records,
+        gap_records=claim_build.gap_records,
+        gap_explanations=claim_build.gap_explanations,
+        review_records=claim_build.review_records,
+        review_explanations=claim_build.review_explanations,
+        compatibility_issue_records=claim_build.compatibility_issue_records,
+        compatibility_review_records=claim_build.compatibility_review_records,
+    )
+
+    assert selected_batch.drafts[0].raw_file == "retail.csv"
+    assert projected.drafts[0].raw_file == selected_batch.drafts[0].raw_file
+    assert selected_batch.drafts[0].source == "Future: Exchange"
+    assert projected.drafts[0].source == selected_batch.drafts[0].source
+
+
+def test_claim_projection_uses_exact_compatibility_issue_and_review_rows_when_supplied(
+    tmp_path: Path,
+) -> None:
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / "retail.csv").write_text(
+        "Transactions\nUser,Example User,acct\n"
+        "ID,Timestamp,Transaction Type,Asset,Quantity Transacted,Price Currency,Price at Transaction,"
+        "Subtotal,Total (inclusive of fees and/or spread),Fees and/or Spread,Notes\n"
+        "tx-buy,2024-02-08 16:31:22 UTC,Buy,BTC,0.01000000,CAD,$60000.00,$600.00,$610.00,$10.00,Bought 0.01 BTC\n"
+        "tx-bad,2024-02-10 12:00:00 UTC,Convert,BTC,0.01000000,CAD,$60000.00,$600.00,$610.00,$10.00,"
+        "Unsupported convert row\n",
+        encoding="utf-8",
+    )
+
+    _, claim_build, evidence_set = _claim_build(raw_dir)
+    exact_review = NormalizationReviewRecord(
+        review_id="claim-exact-review",
+        source="coinbase",
+        adapter_id="coinbase",
+        scope="claim_scope",
+        kind="manual_check",
+        message="Exact compatibility review",
+        raw_file="retail.csv",
+        raw_row_ref="row:4",
+        field_name="notes",
+        original_value="unsupported",
+        normalized_value="",
+    )
+    projected = project_translation_batch_from_claim_set(
+        claim_set=claim_build.claim_set,
+        evidence_set=evidence_set,
+        draft_projection_field_records=claim_build.draft_projection_field_records,
+        gap_records=claim_build.gap_records,
+        gap_explanations=claim_build.gap_explanations,
+        review_records=claim_build.review_records,
+        review_explanations=claim_build.review_explanations,
+        compatibility_issue_records=claim_build.compatibility_issue_records,
+        compatibility_review_records=(exact_review,),
+    )
+
+    assert projected.issues == claim_build.compatibility_issue_records
+    assert projected.reviews == (exact_review,)

--- a/tests/unit/application/normalization/test_claim_set_integration.py
+++ b/tests/unit/application/normalization/test_claim_set_integration.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tallylot.application.normalization import NormalizeRequest
+from tallylot.application.resource_refs import to_resource_ref
+from repo_support.capture_roots import materialize_capture_root
+from tests.support.adapter_packs import fixture_raw_dir
+from tests.support.services import build_normalization_service
+
+
+def test_coinbase_normalization_writes_claim_set_outputs_and_summary_fields(
+    tmp_path: Path,
+) -> None:
+    raw_dir = materialize_capture_root(
+        tmp_path,
+        source="coinbase",
+        source_dir=fixture_raw_dir("coinbase", "retail_buy_renamed"),
+    )
+    output_dir = tmp_path / "normalized"
+
+    response = build_normalization_service().execute(
+        NormalizeRequest(
+            source="coinbase",
+            raw_capture_ref=to_resource_ref(raw_dir),
+            normalized_output_ref=to_resource_ref(output_dir),
+        )
+    )
+
+    claim_root = (
+        tmp_path
+        / "workspace"
+        / "working"
+        / "products"
+        / "claim_sets"
+        / response.claim_set_id
+    )
+    summary = json.loads(
+        (output_dir / "normalization_summary.json").read_text(encoding="utf-8")
+    )
+
+    assert response.claim_set_id
+    assert summary["claim_set_id"] == response.claim_set_id
+    assert summary["claim_set_ref"] == response.claim_set_ref
+    assert (claim_root / "claim_set.json").exists()
+    assert (claim_root / "assessment" / "gap" / "gap_records.json").exists()
+    assert (claim_root / "assessment" / "review" / "review_records.json").exists()
+    assert (claim_root / "compatibility" / "draft_projection_fields.json").exists()
+
+
+def test_coinbase_blocked_planning_writes_no_claim_set_root(tmp_path: Path) -> None:
+    raw_dir = materialize_capture_root(tmp_path, source="coinbase")
+    (raw_dir / "2021 statement a.csv").write_text(
+        "Transactions\nUser,Example User,acct\n"
+        "ID,Timestamp,Transaction Type,Asset,Quantity Transacted,Price Currency,Price at Transaction,"
+        "Subtotal,Total (inclusive of fees and/or spread),Fees and/or Spread,Notes\n"
+        "tx-a,2021-12-30 08:56:53 UTC,Receive,FET,1.00000000,CAD,$0.64,$1.27098,$1.27098,$0.00,Received FET\n",
+        encoding="utf-8",
+    )
+    (raw_dir / "2021 statement b.csv").write_text(
+        "Transactions\nUser,Example User,acct\n"
+        "ID,Timestamp,Transaction Type,Asset,Quantity Transacted,Price Currency,Price at Transaction,"
+        "Subtotal,Total (inclusive of fees and/or spread),Fees and/or Spread,Notes\n"
+        "tx-b,2021-12-30 08:56:53 UTC,Receive,FET,2.00000000,CAD,$0.64,$1.27098,$1.27098,$0.00,Received FET\n",
+        encoding="utf-8",
+    )
+
+    try:
+        build_normalization_service().execute(
+            NormalizeRequest(
+                source="coinbase",
+                raw_capture_ref=to_resource_ref(raw_dir),
+                normalized_output_ref=to_resource_ref(tmp_path / "normalized"),
+            )
+        )
+    except ValueError:
+        pass
+
+    assert not (tmp_path / "workspace" / "working" / "products" / "claim_sets").exists()
+
+
+def test_coinbase_missing_retail_input_writes_no_claim_set_root(tmp_path: Path) -> None:
+    raw_dir = materialize_capture_root(
+        tmp_path,
+        source="coinbase",
+        source_dir=fixture_raw_dir("coinbase", "missing_retail_csv"),
+    )
+    output_dir = tmp_path / "normalized"
+
+    response = build_normalization_service().execute(
+        NormalizeRequest(
+            source="coinbase",
+            raw_capture_ref=to_resource_ref(raw_dir),
+            normalized_output_ref=to_resource_ref(output_dir),
+        )
+    )
+
+    assert response.claim_set_id == ""
+    assert response.claim_set_ref == ""
+    assert not (tmp_path / "workspace" / "working" / "products" / "claim_sets").exists()
+
+
+def test_non_claim_set_adapter_keeps_empty_claim_fields(tmp_path: Path) -> None:
+    raw_dir = materialize_capture_root(
+        tmp_path,
+        source="Future Broker",
+        source_dir=fixture_raw_dir("wealthsimple", "broker_trade"),
+    )
+    output_dir = tmp_path / "normalized"
+
+    response = build_normalization_service().execute(
+        NormalizeRequest(
+            source="Future Broker",
+            raw_capture_ref=to_resource_ref(raw_dir),
+            normalized_output_ref=to_resource_ref(output_dir),
+        )
+    )
+
+    assert response.claim_set_id == ""
+    assert response.claim_set_ref == ""

--- a/tests/unit/application/normalization/test_claim_set_integration.py
+++ b/tests/unit/application/normalization/test_claim_set_integration.py
@@ -3,8 +3,26 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from tallylot.application.claim.contracts import CoinbaseClaimBuildResult
 from tallylot.application.normalization import NormalizeRequest
+from tallylot.application.normalization.translation import (
+    _write_claim_assessment_sidecars,
+)
 from tallylot.application.resource_refs import to_resource_ref
+from tallylot.domain.assessment import (
+    GapConfidence,
+    GapExplanation,
+    GapKind,
+    GapMateriality,
+    GapRecord,
+    GapStatus,
+    ReviewConfidence,
+    ReviewExplanation,
+    ReviewRecord,
+    ReviewStatus,
+)
+from tallylot.domain.claim import ClaimSet
+from tallylot.infrastructure.serialization.filesystem import FilesystemArtifactStore
 from repo_support.capture_roots import materialize_capture_root
 from tests.support.adapter_packs import fixture_raw_dir
 from tests.support.services import build_normalization_service
@@ -119,3 +137,149 @@ def test_non_claim_set_adapter_keeps_empty_claim_fields(tmp_path: Path) -> None:
 
     assert response.claim_set_id == ""
     assert response.claim_set_ref == ""
+
+
+def test_claim_assessment_sidecars_write_in_canonical_order(tmp_path: Path) -> None:
+    _write_claim_assessment_sidecars(
+        artifacts=FilesystemArtifactStore(),
+        workspace_root=tmp_path,
+        claim_set_id="claim-set-1",
+        claim_build=CoinbaseClaimBuildResult(
+            claim_set=ClaimSet(
+                claim_set_id="claim-set-1",
+                evidence_set_ref="working/products/evidence_sets/evidence-set-1/evidence_set.json",
+                emitter_id="coinbase:coinbase:claim",
+                claim_records=(),
+                claim_bundle_records=(),
+                claim_bundle_decision_records=(),
+            ),
+            gap_records=(
+                GapRecord(
+                    gap_id="gap-2",
+                    owner_stage="claim",
+                    blocking_stages=("economics",),
+                    scope_kind="claim_scope",
+                    scope_ref="scope-2",
+                    subject_ref=None,
+                    gap_kind=GapKind.CONTRADICTION,
+                    gap_key="contradiction",
+                    status=GapStatus.OPEN,
+                    materiality=GapMateriality.MATERIAL,
+                    confidence=GapConfidence.LOW,
+                ),
+                GapRecord(
+                    gap_id="gap-1",
+                    owner_stage="claim",
+                    blocking_stages=("claim",),
+                    scope_kind="claim_scope",
+                    scope_ref="scope-1",
+                    subject_ref=None,
+                    gap_kind=GapKind.MISSING_EVIDENCE,
+                    gap_key="missing",
+                    status=GapStatus.OPEN,
+                    materiality=GapMateriality.SUPPORTING,
+                    confidence=GapConfidence.HIGH,
+                ),
+            ),
+            gap_explanations=(
+                GapExplanation(
+                    gap_id="gap-2",
+                    known_facts=("fact-2",),
+                    missing_inputs=(),
+                    possible_meanings=(),
+                    required_evidence=(),
+                    resolution_options=(),
+                    next_action="review",
+                    provenance_refs=("prov-2",),
+                ),
+                GapExplanation(
+                    gap_id="gap-1",
+                    known_facts=("fact-1",),
+                    missing_inputs=(),
+                    possible_meanings=(),
+                    required_evidence=(),
+                    resolution_options=(),
+                    next_action="review",
+                    provenance_refs=("prov-1",),
+                ),
+            ),
+            review_records=(
+                ReviewRecord(
+                    review_id="review-2",
+                    owner_stage="claim",
+                    scope_kind="claim_scope",
+                    scope_ref="scope-2",
+                    subject_ref=None,
+                    review_kind="mapping",
+                    review_key="second",
+                    status=ReviewStatus.OPEN,
+                    confidence=ReviewConfidence.LOW,
+                    gap_ids=(),
+                ),
+                ReviewRecord(
+                    review_id="review-1",
+                    owner_stage="claim",
+                    scope_kind="claim_scope",
+                    scope_ref="scope-1",
+                    subject_ref=None,
+                    review_kind="mapping",
+                    review_key="first",
+                    status=ReviewStatus.ACKNOWLEDGED,
+                    confidence=ReviewConfidence.HIGH,
+                    gap_ids=("gap-b", "gap-a"),
+                ),
+            ),
+            review_explanations=(
+                ReviewExplanation(
+                    review_id="review-2",
+                    headline="Second",
+                    known_facts=("fact-2",),
+                    follow_up=(),
+                    provenance_refs=("prov-2",),
+                ),
+                ReviewExplanation(
+                    review_id="review-1",
+                    headline="First",
+                    known_facts=("fact-1",),
+                    follow_up=(),
+                    provenance_refs=("prov-1",),
+                ),
+            ),
+            draft_projection_field_records=(),
+            compatibility_issue_records=(),
+            compatibility_review_records=(),
+        ),
+    )
+
+    claim_root = tmp_path / "working" / "products" / "claim_sets" / "claim-set-1"
+    gap_records_payload = json.loads(
+        (claim_root / "assessment" / "gap" / "gap_records.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    gap_explanations_payload = json.loads(
+        (claim_root / "assessment" / "gap" / "gap_explanations.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    review_records_payload = json.loads(
+        (claim_root / "assessment" / "review" / "review_records.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    review_explanations_payload = json.loads(
+        (claim_root / "assessment" / "review" / "review_explanations.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert [item["gap_id"] for item in gap_records_payload] == ["gap-1", "gap-2"]
+    assert [item["gap_id"] for item in gap_explanations_payload] == ["gap-1", "gap-2"]
+    assert [item["review_id"] for item in review_records_payload] == [
+        "review-1",
+        "review-2",
+    ]
+    assert [item["review_id"] for item in review_explanations_payload] == [
+        "review-1",
+        "review-2",
+    ]

--- a/tests/unit/application/normalization/test_evidence_set_integration.py
+++ b/tests/unit/application/normalization/test_evidence_set_integration.py
@@ -38,6 +38,14 @@ def test_coinbase_normalization_writes_evidence_set_product_outputs(
         / "evidence_sets"
         / response.evidence_set_id
     )
+    claim_root = (
+        tmp_path
+        / "workspace"
+        / "working"
+        / "products"
+        / "claim_sets"
+        / response.claim_set_id
+    )
     evidence_payload = json.loads(
         (evidence_root / "evidence_set.json").read_text(encoding="utf-8")
     )
@@ -55,8 +63,12 @@ def test_coinbase_normalization_writes_evidence_set_product_outputs(
     )
 
     assert response.evidence_set_id
+    assert response.claim_set_id
     assert response.evidence_set_ref == (
         f"working/products/evidence_sets/{response.evidence_set_id}/evidence_set.json"
+    )
+    assert response.claim_set_ref == (
+        f"working/products/claim_sets/{response.claim_set_id}/claim_set.json"
     )
     assert evidence_payload["evidence_set_id"] == response.evidence_set_id
     assert (
@@ -72,6 +84,14 @@ def test_coinbase_normalization_writes_evidence_set_product_outputs(
     )
     assert summary_payload["evidence_set_id"] == response.evidence_set_id
     assert summary_payload["evidence_set_ref"] == response.evidence_set_ref
+    assert claim_root.joinpath("claim_set.json").exists()
+    assert claim_root.joinpath("assessment", "gap", "gap_records.json").exists()
+    assert claim_root.joinpath("assessment", "gap", "gap_explanations.json").exists()
+    assert claim_root.joinpath("assessment", "review", "review_records.json").exists()
+    assert claim_root.joinpath(
+        "assessment", "review", "review_explanations.json"
+    ).exists()
+    assert claim_root.joinpath("compatibility", "draft_projection_fields.json").exists()
 
 
 def test_coinbase_blocked_normalization_leaves_evidence_set_product_outputs(
@@ -117,6 +137,7 @@ def test_coinbase_blocked_normalization_leaves_evidence_set_product_outputs(
     assert (output_dir / "translation_input_issues.csv").exists()
     assert not (output_dir / "facts.csv").exists()
     assert not (output_dir / "normalization_summary.json").exists()
+    assert not (tmp_path / "workspace" / "working" / "products" / "claim_sets").exists()
 
 
 def test_coinbase_missing_retail_input_skips_empty_evidence_set_outputs(
@@ -141,8 +162,11 @@ def test_coinbase_missing_retail_input_skips_empty_evidence_set_outputs(
 
     assert response.evidence_set_id == ""
     assert response.evidence_set_ref == ""
+    assert response.claim_set_id == ""
+    assert response.claim_set_ref == ""
     assert response.issue_count == 1
     assert not evidence_root.exists()
+    assert not (tmp_path / "workspace" / "working" / "products" / "claim_sets").exists()
 
 
 def _coinbase_retail_csv() -> str:

--- a/tests/unit/application/normalization/test_normalization_service.py
+++ b/tests/unit/application/normalization/test_normalization_service.py
@@ -215,17 +215,32 @@ def test_normalization_service_rewrites_stale_output_profile_with_live_adapter_s
         (
             "Future Exchange",
             fixture_raw_dir("coinbase", "retail_buy_renamed"),
-            {"fact_count": 1, "issue_count": 0, "expects_evidence_set": True},
+            {
+                "fact_count": 1,
+                "issue_count": 0,
+                "expects_evidence_set": True,
+                "expects_claim_set": True,
+            },
         ),
         (
             "Future Broker",
             fixture_raw_dir("wealthsimple", "broker_trade"),
-            {"fact_count": 1, "issue_count": 0, "expects_evidence_set": False},
+            {
+                "fact_count": 1,
+                "issue_count": 0,
+                "expects_evidence_set": False,
+                "expects_claim_set": False,
+            },
         ),
         (
             "Binance",
             fixture_raw_dir("binance", "mixed_history"),
-            {"fact_count": 5, "issue_count": 1, "expects_evidence_set": False},
+            {
+                "fact_count": 5,
+                "issue_count": 1,
+                "expects_evidence_set": False,
+                "expects_claim_set": False,
+            },
         ),
     ),
 )
@@ -253,6 +268,7 @@ def test_normalization_service_supports_explicit_windows_for_fixture_adapters(
     assert response.fact_count == expected["fact_count"]
     assert response.issue_count == expected["issue_count"]
     assert (response.evidence_set_id != "") is expected["expects_evidence_set"]
+    assert (response.claim_set_id != "") is expected["expects_claim_set"]
     if expected["expects_evidence_set"]:
         assert response.evidence_set_ref == (
             "working/products/evidence_sets/"
@@ -260,6 +276,12 @@ def test_normalization_service_supports_explicit_windows_for_fixture_adapters(
         )
     else:
         assert response.evidence_set_ref == ""
+    if expected["expects_claim_set"]:
+        assert response.claim_set_ref == (
+            f"working/products/claim_sets/{response.claim_set_id}/claim_set.json"
+        )
+    else:
+        assert response.claim_set_ref == ""
     assert (output_dir / "facts.csv").exists()
     assert (
         json.loads(

--- a/tests/unit/domain/assessment/__init__.py
+++ b/tests/unit/domain/assessment/__init__.py
@@ -1,0 +1,1 @@
+"""Assessment domain tests."""

--- a/tests/unit/domain/assessment/test_models.py
+++ b/tests/unit/domain/assessment/test_models.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+from tallylot.domain.assessment import (
+    ASSESSMENT_SCHEMA_VERSION,
+    GapConfidence,
+    GapExplanation,
+    GapKind,
+    GapMateriality,
+    GapRecord,
+    GapStatus,
+    ReviewConfidence,
+    ReviewExplanation,
+    ReviewRecord,
+    ReviewStatus,
+)
+from tallylot.domain.assessment.models import (
+    canonical_gap_records,
+    canonical_review_records,
+    gap_explanations_payload,
+    gap_records_payload,
+    review_explanations_payload,
+    review_records_payload,
+    stable_gap_id,
+    stable_review_id,
+)
+
+
+def test_assessment_models_use_declared_field_sets_and_stable_ids() -> None:
+    gap = GapRecord(
+        gap_id=stable_gap_id(
+            owner_stage="claim",
+            scope_kind="claim_scope",
+            scope_ref="scope-1",
+            gap_kind=GapKind.MISSING_EVIDENCE,
+            gap_key="unsupported_row",
+        ),
+        owner_stage="claim",
+        blocking_stages=("claim", "economics"),
+        scope_kind="claim_scope",
+        scope_ref="scope-1",
+        subject_ref=None,
+        gap_kind=GapKind.MISSING_EVIDENCE,
+        gap_key="unsupported_row",
+        status=GapStatus.OPEN,
+        materiality=GapMateriality.MATERIAL,
+        confidence=GapConfidence.HIGH,
+    )
+    review = ReviewRecord(
+        review_id=stable_review_id(
+            owner_stage="claim",
+            scope_kind="claim_scope",
+            scope_ref="scope-1",
+            review_kind="advisory_mapping",
+            review_key="fee_allocation",
+        ),
+        owner_stage="claim",
+        scope_kind="claim_scope",
+        scope_ref="scope-1",
+        subject_ref=None,
+        review_kind="advisory_mapping",
+        review_key="fee_allocation",
+        status=ReviewStatus.OPEN,
+        confidence=ReviewConfidence.MEDIUM,
+        gap_ids=("gap-b", "gap-a"),
+    )
+
+    assert set(gap.to_payload()) == {
+        "gap_id",
+        "owner_stage",
+        "blocking_stages",
+        "scope_kind",
+        "scope_ref",
+        "subject_ref",
+        "gap_kind",
+        "gap_key",
+        "status",
+        "materiality",
+        "confidence",
+    }
+    assert set(review.to_payload()) == {
+        "review_id",
+        "owner_stage",
+        "scope_kind",
+        "scope_ref",
+        "subject_ref",
+        "review_kind",
+        "review_key",
+        "status",
+        "confidence",
+        "gap_ids",
+    }
+    assert review.to_payload()["gap_ids"] == ["gap-a", "gap-b"]
+
+
+def test_assessment_ordering_and_explanation_serialization_are_deterministic() -> None:
+    gap_records = canonical_gap_records(
+        (
+            GapRecord(
+                gap_id="gap-2",
+                owner_stage="claim",
+                blocking_stages=("economics",),
+                scope_kind="claim_scope",
+                scope_ref="scope-2",
+                subject_ref=None,
+                gap_kind=GapKind.CONTRADICTION,
+                gap_key="contradiction",
+                status=GapStatus.OPEN,
+                materiality=GapMateriality.MATERIAL,
+                confidence=GapConfidence.LOW,
+            ),
+            GapRecord(
+                gap_id="gap-1",
+                owner_stage="claim",
+                blocking_stages=("claim",),
+                scope_kind="claim_scope",
+                scope_ref="scope-1",
+                subject_ref=None,
+                gap_kind=GapKind.MISSING_EVIDENCE,
+                gap_key="missing",
+                status=GapStatus.OPEN,
+                materiality=GapMateriality.SUPPORTING,
+                confidence=GapConfidence.HIGH,
+            ),
+        )
+    )
+    review_records = canonical_review_records(
+        (
+            ReviewRecord(
+                review_id="review-2",
+                owner_stage="claim",
+                scope_kind="claim_scope",
+                scope_ref="scope-2",
+                subject_ref=None,
+                review_kind="mapping",
+                review_key="fee",
+                status=ReviewStatus.ACKNOWLEDGED,
+                confidence=ReviewConfidence.LOW,
+                gap_ids=(),
+            ),
+            ReviewRecord(
+                review_id="review-1",
+                owner_stage="claim",
+                scope_kind="claim_scope",
+                scope_ref="scope-1",
+                subject_ref=None,
+                review_kind="mapping",
+                review_key="location",
+                status=ReviewStatus.OPEN,
+                confidence=ReviewConfidence.HIGH,
+                gap_ids=("gap-1",),
+            ),
+        )
+    )
+    gap_explanation = GapExplanation(
+        gap_id="gap-1",
+        known_facts=("fact-b", "fact-a"),
+        missing_inputs=("input-b", "input-a"),
+        possible_meanings=("meaning-1",),
+        required_evidence=("evidence-1",),
+        resolution_options=("option-1",),
+        next_action="inspect row",
+        provenance_refs=("prov-b", "prov-a"),
+    )
+    review_explanation = ReviewExplanation(
+        review_id="review-1",
+        headline="Needs review",
+        known_facts=("fact-b", "fact-a"),
+        follow_up=("follow-up-b", "follow-up-a"),
+        provenance_refs=("prov-b", "prov-a"),
+    )
+
+    assert tuple(record.gap_id for record in gap_records) == ("gap-1", "gap-2")
+    assert tuple(record.review_id for record in review_records) == (
+        "review-1",
+        "review-2",
+    )
+    assert gap_explanation.to_payload()["provenance_refs"] == ["prov-a", "prov-b"]
+    assert review_explanation.to_payload()["provenance_refs"] == ["prov-a", "prov-b"]
+    assert gap_records_payload(gap_records) == [
+        record.to_payload() for record in gap_records
+    ]
+    assert gap_explanations_payload((gap_explanation,)) == [
+        gap_explanation.to_payload()
+    ]
+    assert review_records_payload(review_records) == [
+        record.to_payload() for record in review_records
+    ]
+    assert review_explanations_payload((review_explanation,)) == [
+        review_explanation.to_payload()
+    ]
+    assert ASSESSMENT_SCHEMA_VERSION == 1
+
+
+def test_assessment_payload_helpers_preserve_deterministic_empty_arrays() -> None:
+    assert gap_records_payload(()) == []
+    assert gap_explanations_payload(()) == []
+    assert review_records_payload(()) == []
+    assert review_explanations_payload(()) == []

--- a/tests/unit/domain/assessment/test_models.py
+++ b/tests/unit/domain/assessment/test_models.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from tallylot.domain.assessment import (
     ASSESSMENT_SCHEMA_VERSION,
     GapConfidence,
@@ -196,3 +198,35 @@ def test_assessment_payload_helpers_preserve_deterministic_empty_arrays() -> Non
     assert gap_explanations_payload(()) == []
     assert review_records_payload(()) == []
     assert review_explanations_payload(()) == []
+
+
+def test_assessment_records_require_non_empty_claim_scope_ref() -> None:
+    with pytest.raises(ValueError, match="claim_scope gap records require scope_ref"):
+        GapRecord(
+            gap_id="gap-1",
+            owner_stage="claim",
+            blocking_stages=("claim",),
+            scope_kind="claim_scope",
+            scope_ref="",
+            subject_ref=None,
+            gap_kind=GapKind.MISSING_EVIDENCE,
+            gap_key="missing",
+            status=GapStatus.OPEN,
+            materiality=GapMateriality.MATERIAL,
+            confidence=GapConfidence.HIGH,
+        )
+    with pytest.raises(
+        ValueError, match="claim_scope review records require scope_ref"
+    ):
+        ReviewRecord(
+            review_id="review-1",
+            owner_stage="claim",
+            scope_kind="claim_scope",
+            scope_ref=None,
+            subject_ref=None,
+            review_kind="mapping",
+            review_key="fee",
+            status=ReviewStatus.OPEN,
+            confidence=ReviewConfidence.HIGH,
+            gap_ids=(),
+        )

--- a/tests/unit/domain/claim/__init__.py
+++ b/tests/unit/domain/claim/__init__.py
@@ -1,0 +1,1 @@
+"""Claim domain tests."""

--- a/tests/unit/domain/claim/test_models.py
+++ b/tests/unit/domain/claim/test_models.py
@@ -273,7 +273,7 @@ def test_claim_model_supports_zero_row_valuation_and_exact_decision_vocabulary()
         member_refs=("member-1",),
         observation_refs=("observation-1",),
         effective_at=None,
-        precision=None,
+        precision=TemporalPrecision.DATE,
         provenance_refs=(),
         purpose="statement_balance",
         amount=Decimal("2500.00"),
@@ -284,6 +284,7 @@ def test_claim_model_supports_zero_row_valuation_and_exact_decision_vocabulary()
     )
 
     assert valuation.to_payload()["amount"] == "2500"
+    assert valuation.to_payload()["valued_at"] == "2026-03-23"
     assert tuple(item.value for item in ClaimBundleDecisionOutcome) == (
         "accepted",
         "blocked",
@@ -309,8 +310,119 @@ def test_claim_record_rejects_invalid_kind_owned_field_combinations() -> None:
             provenance_refs=(),
             activity_label="buy",
             location_claim_ref="claim-location",
-            leg_specs=(),
+            leg_specs=(
+                ClaimLegSpec(
+                    slot=0,
+                    role="asset_in",
+                    quantity=Decimal("1"),
+                    instrument_claim_refs=("claim-instrument",),
+                    location_claim_ref="claim-location",
+                    subtype="base",
+                ),
+            ),
             quantity=Decimal("1.00"),
             balance_kind="asset_balance",
             observed_at=datetime(2026, 3, 23, tzinfo=UTC),
+        )
+    with pytest.raises(
+        ValueError,
+        match="activity claims require activity_label, location_claim_ref, and leg_specs",
+    ):
+        ClaimRecord(
+            claim_set_id="claim-set-1",
+            scope_id="scope-1",
+            bundle_id="bundle-1",
+            claim_id="claim-activity",
+            kind=ClaimKind.ACTIVITY,
+            status=ClaimRecordStatus.ASSERTED,
+            key=("scope-key", "activity", "0"),
+            member_refs=("member-1",),
+            observation_refs=(),
+            effective_at=datetime(2026, 3, 23, tzinfo=UTC),
+            precision=TemporalPrecision.TIMESTAMP,
+            provenance_refs=(),
+            activity_label="buy",
+            location_claim_ref="",
+            leg_specs=(),
+        )
+    with pytest.raises(
+        ValueError,
+        match="claim effective_at requires precision",
+    ):
+        ClaimRecord(
+            claim_set_id="claim-set-1",
+            scope_id="scope-1",
+            bundle_id="bundle-1",
+            claim_id="claim-activity",
+            kind=ClaimKind.ACTIVITY,
+            status=ClaimRecordStatus.ASSERTED,
+            key=("scope-key", "activity", "0"),
+            member_refs=("member-1",),
+            observation_refs=(),
+            effective_at=datetime(2026, 3, 23, tzinfo=UTC),
+            precision=None,
+            provenance_refs=(),
+            activity_label="buy",
+            location_claim_ref="claim-location",
+            leg_specs=(
+                ClaimLegSpec(
+                    slot=0,
+                    role="asset_in",
+                    quantity=Decimal("1"),
+                    instrument_claim_refs=("claim-instrument",),
+                    location_claim_ref="claim-location",
+                    subtype="base",
+                ),
+            ),
+        )
+    with pytest.raises(
+        ValueError,
+        match=(
+            "valuation claims require purpose, amount, currency, valued_at, "
+            "precision, location, and instruments"
+        ),
+    ):
+        ClaimRecord(
+            claim_set_id="claim-set-1",
+            scope_id="scope-1",
+            bundle_id="bundle-1",
+            claim_id="claim-valuation",
+            kind=ClaimKind.VALUATION,
+            status=ClaimRecordStatus.ASSERTED,
+            key=("scope-key", "valuation", "0"),
+            member_refs=("member-1",),
+            observation_refs=(),
+            effective_at=None,
+            precision=None,
+            provenance_refs=(),
+            purpose="statement_balance",
+            amount=Decimal("100"),
+            currency="USD",
+            valued_at=datetime(2026, 3, 23, tzinfo=UTC),
+            location_claim_ref="claim-location",
+            instrument_claim_refs=("claim-instrument",),
+        )
+    with pytest.raises(
+        ValueError,
+        match=(
+            "location claims require location_ref, location_group_label, and "
+            "location_label"
+        ),
+    ):
+        ClaimRecord(
+            claim_set_id="claim-set-1",
+            scope_id="scope-1",
+            bundle_id="bundle-1",
+            claim_id="claim-location",
+            kind=ClaimKind.LOCATION,
+            status=ClaimRecordStatus.ASSERTED,
+            key=("scope-key", "location", "0"),
+            member_refs=("member-1",),
+            observation_refs=(),
+            effective_at=None,
+            precision=None,
+            provenance_refs=(),
+            location_ref="coinbase:primary",
+            location_group_label="",
+            location_label="Primary",
         )

--- a/tests/unit/domain/claim/test_models.py
+++ b/tests/unit/domain/claim/test_models.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import cast
+
+import pytest
+
+from tallylot.domain.claim import (
+    CLAIM_SET_SCHEMA_VERSION,
+    ClaimBundleDecisionBasis,
+    ClaimBundleDecisionOutcome,
+    ClaimBundleDecisionRecord,
+    ClaimBundleRecord,
+    ClaimKind,
+    ClaimLegSpec,
+    ClaimRecord,
+    ClaimRecordStatus,
+    ClaimSet,
+)
+from tallylot.domain.claim.models import (
+    canonical_claim_bundle_decision_records,
+    canonical_claim_bundle_records,
+    canonical_claim_records,
+    claim_set_fingerprint,
+    stable_claim_bundle_decision_id,
+    stable_claim_bundle_id,
+    stable_claim_id,
+    stable_claim_scope_id,
+    stable_claim_set_id,
+)
+from tallylot.domain.temporal import TemporalPrecision
+
+
+def _activity_claim(*, claim_id: str = "claim-activity") -> ClaimRecord:
+    return ClaimRecord(
+        claim_set_id="claim-set-1",
+        scope_id="scope-1",
+        bundle_id="bundle-1",
+        claim_id=claim_id,
+        kind=ClaimKind.ACTIVITY,
+        status=ClaimRecordStatus.ASSERTED,
+        key=("scope-key", "activity", "0"),
+        member_refs=("member-b", "member-a"),
+        observation_refs=("observation-b", "observation-a"),
+        effective_at=datetime(2026, 3, 23, 12, 0, tzinfo=UTC),
+        precision=TemporalPrecision.TIMESTAMP,
+        provenance_refs=("prov-b", "prov-a"),
+        activity_label="buy",
+        location_claim_ref="claim-location",
+        leg_specs=(
+            ClaimLegSpec(
+                slot=1,
+                role="asset_out",
+                quantity=Decimal("-100.00"),
+                instrument_claim_refs=("claim-quote",),
+                location_claim_ref="claim-location",
+                subtype="quote",
+                attributed_to_slot=None,
+            ),
+            ClaimLegSpec(
+                slot=0,
+                role="asset_in",
+                quantity=Decimal("1.2500"),
+                instrument_claim_refs=("claim-base",),
+                location_claim_ref="claim-location",
+                subtype="base",
+                attributed_to_slot=None,
+            ),
+        ),
+    )
+
+
+def test_claim_stable_id_helpers_use_declared_recipes() -> None:
+    claim_set_id = stable_claim_set_id(
+        evidence_set_id="evidence-set-1",
+        emitter_id="coinbase:coinbase:claim",
+    )
+
+    assert claim_set_id == "evidence-set-1:coinbase:coinbase:claim"
+    assert (
+        stable_claim_scope_id(
+            claim_set_id=claim_set_id,
+            scope_key=("member-1", "row:1"),
+        )
+        == "evidence-set-1:coinbase:coinbase:claim:member-1:row:1"
+    )
+    assert (
+        stable_claim_bundle_id(
+            scope_id="scope-1",
+            key="default",
+        )
+        == "scope-1:default"
+    )
+    assert (
+        stable_claim_id(
+            bundle_id="bundle-1",
+            kind=ClaimKind.ACTIVITY,
+            key=("member-1", "row:1", "activity", "0"),
+        )
+        == "bundle-1:activity:member-1:row:1:activity:0"
+    )
+    assert stable_claim_bundle_decision_id(scope_id="scope-1") == "scope-1"
+
+
+def test_claim_record_payload_preserves_decimal_temporal_precision_and_sorted_refs() -> (
+    None
+):
+    payload = _activity_claim().to_payload()
+
+    assert payload["member_refs"] == ["member-a", "member-b"]
+    assert payload["observation_refs"] == ["observation-a", "observation-b"]
+    assert payload["provenance_refs"] == ["prov-a", "prov-b"]
+    assert payload["effective_at"] == "2026-03-23 12:00:00"
+    assert payload["precision"] == TemporalPrecision.TIMESTAMP.value
+    leg_specs = cast(list[dict[str, object]], payload["leg_specs"])
+    assert isinstance(leg_specs, list)
+    assert leg_specs[0]["quantity"] == "1.25"
+    assert leg_specs[1]["quantity"] == "-100"
+
+
+def test_claim_set_fingerprint_uses_canonical_ordering() -> None:
+    first = ClaimSet(
+        claim_set_id="claim-set-1",
+        evidence_set_ref="working/products/evidence_sets/evidence-1/evidence_set.json",
+        emitter_id="coinbase:coinbase:claim",
+        claim_records=(
+            ClaimRecord(
+                claim_set_id="claim-set-1",
+                scope_id="scope-1",
+                bundle_id="bundle-1",
+                claim_id="claim-location",
+                kind=ClaimKind.LOCATION,
+                status=ClaimRecordStatus.ASSERTED,
+                key=("scope-key", "location", "0"),
+                member_refs=("member-1",),
+                observation_refs=(),
+                effective_at=None,
+                precision=None,
+                provenance_refs=(),
+                location_ref="coinbase:primary",
+                location_group_label="Coinbase",
+                location_label="Primary",
+            ),
+            _activity_claim(),
+        ),
+        claim_bundle_records=(
+            ClaimBundleRecord(
+                claim_set_id="claim-set-1",
+                scope_id="scope-1",
+                bundle_id="bundle-1",
+                key="default",
+                scope_key=("member-1", "row:1"),
+                claim_refs=("claim-location", "claim-activity"),
+            ),
+        ),
+        claim_bundle_decision_records=(
+            ClaimBundleDecisionRecord(
+                claim_set_id="claim-set-1",
+                scope_id="scope-1",
+                decision_id="scope-1",
+                outcome=ClaimBundleDecisionOutcome.ACCEPTED,
+                accepted_bundle_ref="bundle-1",
+                rejected_bundle_refs=(),
+                deferred_bundle_refs=(),
+                basis=ClaimBundleDecisionBasis.SINGLE_BUNDLE,
+                blocking_gap_refs=(),
+            ),
+        ),
+    )
+    second = ClaimSet(
+        claim_set_id=first.claim_set_id,
+        evidence_set_ref=first.evidence_set_ref,
+        emitter_id=first.emitter_id,
+        claim_records=tuple(reversed(first.claim_records)),
+        claim_bundle_records=first.claim_bundle_records,
+        claim_bundle_decision_records=first.claim_bundle_decision_records,
+    )
+
+    assert claim_set_fingerprint(first) == claim_set_fingerprint(second)
+    assert first.to_payload()["schema_version"] == CLAIM_SET_SCHEMA_VERSION
+
+
+def test_claim_ordering_helpers_sort_canonically() -> None:
+    activity = _activity_claim()
+    location = ClaimRecord(
+        claim_set_id="claim-set-1",
+        scope_id="scope-1",
+        bundle_id="bundle-1",
+        claim_id="claim-location",
+        kind=ClaimKind.LOCATION,
+        status=ClaimRecordStatus.ASSERTED,
+        key=("scope-key", "location", "0"),
+        member_refs=("member-1",),
+        observation_refs=(),
+        effective_at=None,
+        precision=None,
+        provenance_refs=(),
+        location_ref="coinbase:primary",
+        location_group_label="Coinbase",
+        location_label="Primary",
+    )
+    decisions = canonical_claim_bundle_decision_records(
+        (
+            ClaimBundleDecisionRecord(
+                claim_set_id="claim-set-1",
+                scope_id="scope-2",
+                decision_id="scope-2",
+                outcome=ClaimBundleDecisionOutcome.BLOCKED,
+                accepted_bundle_ref="",
+                rejected_bundle_refs=(),
+                deferred_bundle_refs=(),
+                basis=ClaimBundleDecisionBasis.UPSTREAM_GAP,
+                blocking_gap_refs=("gap-2", "gap-1"),
+            ),
+            ClaimBundleDecisionRecord(
+                claim_set_id="claim-set-1",
+                scope_id="scope-1",
+                decision_id="scope-1",
+                outcome=ClaimBundleDecisionOutcome.ACCEPTED,
+                accepted_bundle_ref="bundle-1",
+                rejected_bundle_refs=(),
+                deferred_bundle_refs=(),
+                basis=ClaimBundleDecisionBasis.SINGLE_BUNDLE,
+                blocking_gap_refs=(),
+            ),
+        )
+    )
+
+    assert tuple(
+        record.claim_id for record in canonical_claim_records((activity, location))
+    ) == (
+        "claim-activity",
+        "claim-location",
+    )
+    assert tuple(
+        record.bundle_id
+        for record in canonical_claim_bundle_records(
+            (
+                ClaimBundleRecord(
+                    claim_set_id="claim-set-1",
+                    scope_id="scope-2",
+                    bundle_id="bundle-2",
+                    key="default",
+                    scope_key=("member-2", "row:2"),
+                    claim_refs=("claim-2",),
+                ),
+                ClaimBundleRecord(
+                    claim_set_id="claim-set-1",
+                    scope_id="scope-1",
+                    bundle_id="bundle-1",
+                    key="default",
+                    scope_key=("member-1", "row:1"),
+                    claim_refs=("claim-1",),
+                ),
+            )
+        )
+    ) == ("bundle-1", "bundle-2")
+    assert tuple(record.scope_id for record in decisions) == ("scope-1", "scope-2")
+
+
+def test_claim_model_supports_zero_row_valuation_and_exact_decision_vocabulary() -> (
+    None
+):
+    valuation = ClaimRecord(
+        claim_set_id="claim-set-1",
+        scope_id="scope-1",
+        bundle_id="bundle-1",
+        claim_id="claim-valuation",
+        kind=ClaimKind.VALUATION,
+        status=ClaimRecordStatus.SUPERSEDED,
+        key=("scope-key", "valuation", "0"),
+        member_refs=("member-1",),
+        observation_refs=("observation-1",),
+        effective_at=None,
+        precision=None,
+        provenance_refs=(),
+        purpose="statement_balance",
+        amount=Decimal("2500.00"),
+        currency="USD",
+        valued_at=datetime(2026, 3, 23, tzinfo=UTC),
+        location_claim_ref="claim-location",
+        instrument_claim_refs=("claim-base",),
+    )
+
+    assert valuation.to_payload()["amount"] == "2500"
+    assert tuple(item.value for item in ClaimBundleDecisionOutcome) == (
+        "accepted",
+        "blocked",
+        "deferred",
+        "superseded",
+    )
+
+
+def test_claim_record_rejects_invalid_kind_owned_field_combinations() -> None:
+    with pytest.raises(ValueError, match="activity claims must not set balance fields"):
+        ClaimRecord(
+            claim_set_id="claim-set-1",
+            scope_id="scope-1",
+            bundle_id="bundle-1",
+            claim_id="claim-invalid",
+            kind=ClaimKind.ACTIVITY,
+            status=ClaimRecordStatus.ASSERTED,
+            key=("scope-key", "activity", "0"),
+            member_refs=("member-1",),
+            observation_refs=(),
+            effective_at=None,
+            precision=None,
+            provenance_refs=(),
+            activity_label="buy",
+            location_claim_ref="claim-location",
+            leg_specs=(),
+            quantity=Decimal("1.00"),
+            balance_kind="asset_balance",
+            observed_at=datetime(2026, 3, 23, tzinfo=UTC),
+        )

--- a/tests/unit/infrastructure/storage/test_claim_set_repository.py
+++ b/tests/unit/infrastructure/storage/test_claim_set_repository.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+
+from tallylot.domain.claim import (
+    CLAIM_SET_SCHEMA_VERSION,
+    ClaimBundleDecisionBasis,
+    ClaimBundleDecisionOutcome,
+    ClaimBundleDecisionRecord,
+    ClaimBundleRecord,
+    ClaimKind,
+    ClaimRecord,
+    ClaimRecordStatus,
+    ClaimSet,
+)
+from tallylot.domain.temporal import TemporalPrecision
+from tallylot.infrastructure.storage import FilesystemClaimSetRepository
+
+
+def _sample_claim_set() -> ClaimSet:
+    return ClaimSet(
+        claim_set_id="claim-set-1",
+        evidence_set_ref="working/products/evidence_sets/evidence-set-1/evidence_set.json",
+        emitter_id="coinbase:coinbase:claim",
+        claim_records=(
+            ClaimRecord(
+                claim_set_id="claim-set-1",
+                scope_id="scope-1",
+                bundle_id="bundle-1",
+                claim_id="claim-1",
+                kind=ClaimKind.BALANCE,
+                status=ClaimRecordStatus.ASSERTED,
+                key=("scope-key", "balance", "0"),
+                member_refs=("member-1",),
+                observation_refs=("observation-1",),
+                effective_at=datetime(2026, 3, 23, tzinfo=UTC),
+                precision=TemporalPrecision.DATE,
+                provenance_refs=("prov-1",),
+                location_claim_ref="claim-location",
+                instrument_claim_refs=("claim-instrument",),
+                balance_kind="asset_balance",
+                quantity=Decimal("1.2500"),
+                observed_at=datetime(2026, 3, 23, tzinfo=UTC),
+            ),
+        ),
+        claim_bundle_records=(
+            ClaimBundleRecord(
+                claim_set_id="claim-set-1",
+                scope_id="scope-1",
+                bundle_id="bundle-1",
+                key="default",
+                scope_key=("member-1", "row:1"),
+                claim_refs=("claim-1",),
+            ),
+        ),
+        claim_bundle_decision_records=(
+            ClaimBundleDecisionRecord(
+                claim_set_id="claim-set-1",
+                scope_id="scope-1",
+                decision_id="scope-1",
+                outcome=ClaimBundleDecisionOutcome.ACCEPTED,
+                accepted_bundle_ref="bundle-1",
+                rejected_bundle_refs=(),
+                deferred_bundle_refs=(),
+                basis=ClaimBundleDecisionBasis.SINGLE_BUNDLE,
+                blocking_gap_refs=(),
+            ),
+        ),
+    )
+
+
+def test_claim_set_repository_round_trips_json_payload(tmp_path: Path) -> None:
+    repository = FilesystemClaimSetRepository()
+    claim_set = _sample_claim_set()
+    path = (
+        tmp_path
+        / "working"
+        / "products"
+        / "claim_sets"
+        / "claim-set-1"
+        / "claim_set.json"
+    )
+
+    repository.write_claim_set(path, claim_set)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    round_trip = repository.read_claim_set(path)
+
+    assert payload["schema_version"] == CLAIM_SET_SCHEMA_VERSION
+    assert round_trip == claim_set
+
+
+def test_claim_set_repository_rejects_missing_schema_version(tmp_path: Path) -> None:
+    path = tmp_path / "claim_set.json"
+    payload = _sample_claim_set().to_payload()
+    payload.pop("schema_version")
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "unsupported claim set schema_version: <missing>; expected "
+            f"{CLAIM_SET_SCHEMA_VERSION}"
+        ),
+    ):
+        FilesystemClaimSetRepository().read_claim_set(path)
+
+
+def test_claim_set_repository_rejects_wrong_schema_version(tmp_path: Path) -> None:
+    path = tmp_path / "claim_set.json"
+    payload = _sample_claim_set().to_payload()
+    payload["schema_version"] = 999
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "unsupported claim set schema_version: 999; expected "
+            f"{CLAIM_SET_SCHEMA_VERSION}"
+        ),
+    ):
+        FilesystemClaimSetRepository().read_claim_set(path)
+
+
+def test_claim_set_repository_rejects_non_object_payload(tmp_path: Path) -> None:
+    path = tmp_path / "claim_set.json"
+    path.write_text('["not", "an", "object"]', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="invalid claim set payload: expected object"):
+        FilesystemClaimSetRepository().read_claim_set(path)
+
+
+def test_claim_set_repository_rejects_malformed_record_arrays(tmp_path: Path) -> None:
+    path = tmp_path / "claim_set.json"
+    payload = _sample_claim_set().to_payload()
+    payload["claim_records"] = {"not": "an array"}
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(
+        ValueError, match="invalid claim set claim_records: expected array"
+    ):
+        FilesystemClaimSetRepository().read_claim_set(path)

--- a/tests/unit/test_commit_message_validator.py
+++ b/tests/unit/test_commit_message_validator.py
@@ -11,6 +11,18 @@ from tools.validate_commit_message import (
 )
 
 
+def _roadmap_label() -> str:
+    return "roadmap"
+
+
+def _phase_label() -> str:
+    return "Phase 2"
+
+
+def _phase_word_label() -> str:
+    return "-".join(("phase", "zero"))
+
+
 def test_commit_message_without_scope_is_rejected() -> None:
     message = """\
 docs: route agents to narrow standards
@@ -167,6 +179,7 @@ Included checkpoints:
 
 
 def test_commit_message_rejects_roadmap_label_in_subject() -> None:
+    roadmap_label = _roadmap_label()
     message = """\
 docs(roadmap): harden planning guidance
 
@@ -179,16 +192,18 @@ What:
 Checks:
 - make pytest
 """
+    message = message.replace("roadmap", roadmap_label, 1)
 
     errors = _validate_commit_message_text(message)
 
     assert errors == (
         "commit message must not use roadmap/phase labels on durable metadata "
-        "surfaces: roadmap",
+        f"surfaces: {roadmap_label}",
     )
 
 
 def test_commit_message_rejects_phase_label_in_body() -> None:
+    phase_label = _phase_label()
     message = """\
 docs(standards): harden planning guidance
 
@@ -201,16 +216,18 @@ What:
 Checks:
 - make pytest
 """
+    message = message.replace("Phase 2", phase_label)
 
     errors = _validate_commit_message_text(message)
 
     assert errors == (
         "commit message must not use roadmap/phase labels on durable metadata "
-        "surfaces: Phase 2",
+        f"surfaces: {phase_label}",
     )
 
 
 def test_commit_message_rejects_spelled_out_phase_label_in_body() -> None:
+    phase_word_label = _phase_word_label()
     message = """\
 docs(standards): harden planning guidance
 
@@ -223,12 +240,13 @@ What:
 Checks:
 - make pytest
 """
+    message = message.replace("phase-zero", phase_word_label)
 
     errors = _validate_commit_message_text(message)
 
     assert errors == (
         "commit message must not use roadmap/phase labels on durable metadata "
-        "surfaces: phase-zero",
+        f"surfaces: {phase_word_label}",
     )
 
 

--- a/tests/unit/test_docs_audit.py
+++ b/tests/unit/test_docs_audit.py
@@ -8,6 +8,7 @@ import repo_support.docs_audit as docs_audit
 from repo_support.docs_audit.model import DocsAuditFinding, DocsAuditRule
 from repo_support.docs_audit.rules import forward_contracts_matrix
 from repo_support.docs_audit.rules import forward_contracts_support
+from repo_support.docs_audit.rules import policy_alignment
 from repo_support.docs_audit.reporting import report_payload
 from tools import audit_docs as audit_docs_tool
 
@@ -39,6 +40,14 @@ def _bridge_row(
     }
     row.update(overrides)
     return row
+
+
+def _phase_label() -> str:
+    return " ".join(("Phase", "2"))
+
+
+def _phase_word_label() -> str:
+    return "-".join(("phase", "zero"))
 
 
 def test_run_docs_audit_full_repo_with_no_findings(
@@ -231,6 +240,54 @@ def test_target_naming_catalog_path_triggers_full_repo_sweep(
     assert report.evaluated_rule_ids == (
         "routes.example",
         "forward_contracts.example",
+    )
+
+
+def test_durable_doc_policy_rule_rejects_ephemeral_delivery_labels(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    phase_label = _phase_label()
+    phase_word_label = _phase_word_label()
+    payloads = {
+        "docs/status/current-state.md": f"Current runtime keeps {phase_label} wording out.",
+        "docs/reference/evidence-claim-contract.md": (
+            f"Bounded contract keeps {phase_word_label} wording out."
+        ),
+        "docs/concepts/architecture-overview.md": "This surface only links `ROADMAP.md`.",
+    }
+
+    monkeypatch.setattr(
+        policy_alignment,
+        "_durable_non_planning_surface_texts",
+        lambda: tuple(payloads.items()),
+    )
+
+    findings = next(
+        rule.run()
+        for rule in policy_alignment.POLICY_ALIGNMENT_RULES
+        if rule.rule_id
+        == "policy_alignment.durable_non_planning_surfaces_do_not_use_ephemeral_delivery_labels"
+    )
+
+    assert findings == (
+        DocsAuditFinding(
+            "policy_alignment.durable_non_planning_surfaces_do_not_use_ephemeral_delivery_labels",
+            "docs/status/current-state.md",
+            (
+                "docs/status/current-state.md uses forbidden roadmap/phase delivery labels: "
+                f"{phase_label}"
+            ),
+            None,
+        ),
+        DocsAuditFinding(
+            "policy_alignment.durable_non_planning_surfaces_do_not_use_ephemeral_delivery_labels",
+            "docs/reference/evidence-claim-contract.md",
+            (
+                "docs/reference/evidence-claim-contract.md uses forbidden "
+                f"roadmap/phase delivery labels: {phase_word_label}"
+            ),
+            None,
+        ),
     )
 
 

--- a/tests/unit/test_pr_metadata_validator.py
+++ b/tests/unit/test_pr_metadata_validator.py
@@ -10,6 +10,18 @@ from tools.validate_pr_metadata import (
 )
 
 
+def _phase_label() -> str:
+    return " ".join(("Phase", "2"))
+
+
+def _phase_word_label() -> str:
+    return "-".join(("phase", "zero"))
+
+
+def _roadmap_label() -> str:
+    return "roadmap"
+
+
 def _body(
     *,
     why: str = "- keep multi-checkpoint history visible on main",
@@ -104,20 +116,22 @@ def test_pr_branch_rejects_uppercase_root_or_slug() -> None:
 
 
 def test_pr_branch_rejects_phase_label() -> None:
-    errors = validate_branch_name("docs/phase-0-hardening")
+    phase_label = "-".join(("phase", "0"))
+    errors = validate_branch_name(f"docs/{phase_label}-hardening")
 
     assert errors == (
         "branch name must not use roadmap/phase labels on durable metadata "
-        "surfaces: phase-0",
+        f"surfaces: {phase_label}",
     )
 
 
 def test_pr_branch_rejects_spelled_out_phase_label() -> None:
-    errors = validate_branch_name("docs/phase-zero-hardening")
+    phase_word_label = _phase_word_label()
+    errors = validate_branch_name(f"docs/{phase_word_label}-hardening")
 
     assert errors == (
         "branch name must not use roadmap/phase labels on durable metadata "
-        "surfaces: phase-zero",
+        f"surfaces: {phase_word_label}",
     )
 
 
@@ -128,20 +142,22 @@ def test_pr_body_with_required_sections_is_valid() -> None:
 
 
 def test_pr_title_rejects_phase_label() -> None:
-    errors = _validate_pr_title("docs(standards): Phase 2 hardening")
+    phase_label = _phase_label()
+    errors = _validate_pr_title(f"docs(standards): {phase_label} hardening")
 
     assert errors == (
         "PR title must not use roadmap/phase labels on durable metadata "
-        "surfaces: Phase 2",
+        f"surfaces: {phase_label}",
     )
 
 
 def test_pr_title_rejects_spelled_out_phase_label() -> None:
-    errors = _validate_pr_title("docs(standards): Phase Zero hardening")
+    phase_word_title = " ".join(("Phase", "Zero"))
+    errors = _validate_pr_title(f"docs(standards): {phase_word_title} hardening")
 
     assert errors == (
         "PR title must not use roadmap/phase labels on durable metadata "
-        "surfaces: Phase Zero",
+        f"surfaces: {phase_word_title}",
     )
 
 
@@ -174,24 +190,26 @@ Issue linkage:
 
 
 def test_pr_body_rejects_roadmap_label() -> None:
+    roadmap_label = _roadmap_label()
     errors = _validate_pr_body(
-        _body(why="- keep roadmap references out of PR metadata")
+        _body(why=f"- keep {roadmap_label} references out of PR metadata")
     )
 
     assert errors == (
         "PR body must not use roadmap/phase labels on durable metadata "
-        "surfaces: roadmap",
+        f"surfaces: {roadmap_label}",
     )
 
 
 def test_pr_body_rejects_spelled_out_phase_label() -> None:
+    phase_word_label = _phase_word_label()
     errors = _validate_pr_body(
-        _body(why="- keep phase-zero references out of PR metadata")
+        _body(why=f"- keep {phase_word_label} references out of PR metadata")
     )
 
     assert errors == (
         "PR body must not use roadmap/phase labels on durable metadata "
-        "surfaces: phase-zero",
+        f"surfaces: {phase_word_label}",
     )
 
 


### PR DESCRIPTION
Why:
- the bounded ClaimSet slice needed to become the authority for evidence-local Coinbase meaning without pulling EconomicFacts, ReconciliationState, or later-stage work into this branch
- completed EvidenceSet work needed to move out of future-tense planning surfaces while durable docs and delivery metadata stayed phase-free
- the hardening loop found projection-parity, kernel-validation, and deterministic-persistence risks that needed repair before review handoff

What:
- retire merged EvidenceSet planning language and tighten durable doc auditing around ephemeral delivery labels on non-planning surfaces
- add ClaimSet and claim-stage assessment kernels, storage, Coinbase claim emission, compatibility projection, and normalization wiring for the bounded slice
- harden compatibility projection parity, ClaimSet and assessment record validation, and deterministic assessment sidecar writes

Checks:
- make audit-pr-review
- make docs-check
- make naming-check
- make docs-audit
- make quality
- make pr-review-full

Issue linkage:
- None: no existing open issue tracks the bounded ClaimSet authority slice or the red-team hardening fixes that landed in this branch

Included checkpoints:
- `docs(claimset): retire merged evidence-set planning language`
- `feat(claimset): add claim and assessment kernels`
- `feat(claimset): build coinbase claim sets`
- `feat(normalization): derive bridge outputs from claim sets`
- `fix(claimset): preserve compatibility projection parity`
- `fix(claimset): harden kernels and deterministic sidecars`
